### PR TITLE
feat(nonzro):Fix nonzero small output cases are not supported

### DIFF
--- a/bangpy-ops/ops/nonzero/nonzero_count.py
+++ b/bangpy-ops/ops/nonzero/nonzero_count.py
@@ -27,7 +27,7 @@ from bangpy.tcp.util import round_up, round_down
 from bangpy.platform.bang_config import TARGET
 
 DTYPES = [bp.float16, bp.float32]
-TARGET_LIST = ["mlu370-s4", "mlu290"]
+TARGET_LIST = ["mlu370-s4", "mlu290", "mlu270"]
 
 # Align to 64.
 ALIGN_SIZE = 64


### PR DESCRIPTION
原有 NonZero算子，遇到shape较大的输入时，每次计算self.nram_size大小，如果迭代一次计算的输出为零，memcpy会出现错误。本次提交修复这个问题。