### PR TITLE
fix(bangc-ops): set nightly test at 15:00 according to time of CI's execution on GitHub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 15 * * *'
 
 jobs:
   test:


### PR DESCRIPTION
1. set nightly test at 15:00 according to time of CI's execution on Github.