### PR TITLE
[Feature](bangc_ops): Add new operator named roi_crop_forward

### DIFF
--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.h
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.h
@@ -11,21 +11,12 @@
  *************************************************************************/
 #ifndef KERNELS_ROI_CROP_FORWARD_ROI_CROP_FORWARD_H_
 #define KERNELS_ROI_CROP_FORWARD_ROI_CROP_FORWARD_H_
-#include "kernels/kernel.h"
 #include "core/mlu_op_core.h"
-  
-__mlu_global__ void MLUKernelRoiCropForward(const void *input,
-                                            int batch,
-                                            int height,
-                                            int width,
-                                            int channels,
-                                            const void *grid,
-                                            int grid_n,
-                                            void *output,
-                                            int output_h,
-                                            int output_w,
-                                            mluOpDataType_t data_type);
-  
-#endif  // KERNELS_ROI_CROP_FORWARD_ROI_CROP_FORWARD_H_
+#include "kernels/kernel.h"
 
+__mlu_global__ void MLUKernelRoiCropForward(
+    const void *input, const int batch, const int height, const int width,
+    const int channels, const void *grid, const int grid_n, void *output,
+    const int output_h, const int output_w, const mluOpDataType_t data_type);
+#endif  // KERNELS_ROI_CROP_FORWARD_ROI_CROP_FORWARD_H_
 

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.h
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.h
@@ -1,0 +1,31 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef KERNELS_ROI_CROP_FORWARD_ROI_CROP_FORWARD_H_
+#define KERNELS_ROI_CROP_FORWARD_ROI_CROP_FORWARD_H_
+#include "kernels/kernel.h"
+#include "core/mlu_op_core.h"
+  
+__mlu_global__ void MLUKernelRoiCropForward(const void *input,
+                                            int batch,
+                                            int height,
+                                            int width,
+                                            int channels,
+                                            const void *grid,
+                                            int grid_n,
+                                            void *output,
+                                            int output_h,
+                                            int output_w,
+                                            mluOpDataType_t data_type);
+  
+#endif  // KERNELS_ROI_CROP_FORWARD_ROI_CROP_FORWARD_H_
+
+

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
@@ -28,13 +28,12 @@
                         int bin_num,
                         cnrtDim3_t *k_dim,
                         cnrtFunctionType_t *k_type){
-  //unsigned int cluster_num = mluop::runtime::getClusterLimitCapability(handle);
+  unsigned int cluster_num = mluop::runtime::getClusterLimitCapability(handle);
   unsigned int core_in_cluster = handle->core_num_per_cluster;
   *k_type = CNRT_FUNC_TYPE_UNION1; 
   k_dim->x = core_in_cluster;
-  //unsigned int use_cluster = (bin_num + core_in_cluster -1) / core_in_cluster;
-  //k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
-  k_dim->y = 1;
+  unsigned int use_cluster = (bin_num + core_in_cluster -1) / core_in_cluster;
+  k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
   k_dim->z = 1;
 
 }
@@ -49,6 +48,20 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(mluOpHandle_t handle,
   //check params
   const std::string op_name = "[mluOpRoiCropForward]";
 
+  // check 0 element
+  if ((mluOpGetTensorElementNum(input_desc) == 0) ||
+      (mluOpGetTensorElementNum(grid_desc) == 0) ||
+      (mluOpGetTensorElementNum(output_desc) == 0)) {
+    VLOG(5) << op_name << " skip zero element tensor.";
+    return MLUOP_STATUS_SUCCESS;
+  }
+  int input_dims = input_desc->dims[0]*input_desc->dims[1]*input_desc->dims[2]*input_desc->dims[3];
+  PARAM_CHECK(op_name,input_dims != 0);
+  int grid_dims = grid_desc->dims[0]*grid_desc->dims[1]*grid_desc->dims[2]*grid_desc->dims[3];
+  PARAM_CHECK(op_name,grid_dims != 0);
+  int output_dims = output_desc->dims[0]*output_desc->dims[1]*output_desc->dims[2]*output_desc->dims[3];
+  PARAM_CHECK(op_name,output_dims != 0);
+
   // check descriptor
   PARAM_CHECK(op_name, handle != NULL);
   PARAM_CHECK(op_name, input_desc != NULL);
@@ -58,6 +71,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(mluOpHandle_t handle,
   // check dtype equal
   PARAM_CHECK_EQ(op_name, input_desc->dtype, grid_desc->dtype);
   PARAM_CHECK_EQ(op_name, input_desc->dtype, output_desc->dtype);
+  PARAM_CHECK(op_name, input_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(op_name, grid_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(op_name, output_desc->dtype == MLUOP_DTYPE_FLOAT);
 
   // check dim and layout
   PARAM_CHECK_EQ(op_name, input_desc->dim, 4);
@@ -74,19 +90,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(mluOpHandle_t handle,
     LOG(ERROR) << op_name << ":Check failed: output_desc->dims[3] should be equal to input_desc->dims[3].";
     return MLUOP_STATUS_BAD_PARAM;
   }
-  if (grid_desc->dims[0]!=2)
+  if (grid_desc->dims[3]!=2)
   {
-    LOG(ERROR) << op_name << ":Check failed: grid_desc->dims[0] should be equal to 2.";
+    LOG(ERROR) << op_name << ":Check failed: grid_desc->dims[3] should be equal to 2.";
     return MLUOP_STATUS_BAD_PARAM;
   }
   
-    // check 0 element
-  if ((mluOpGetTensorElementNum(input_desc) == 0) ||
-      (mluOpGetTensorElementNum(grid_desc) == 0) ||
-      (mluOpGetTensorElementNum(output_desc) == 0)) {
-    VLOG(5) << op_name << " skip zero element tensor.";
-    return MLUOP_STATUS_SUCCESS;
-  }
   // check device pointer
   PARAM_CHECK(op_name, input != NULL);
   PARAM_CHECK(op_name, grid != NULL);

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
@@ -1,0 +1,105 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "roi_crop_forward.h"
+  
+#include <string>
+#include <iostream>
+  
+#include "core/context.h"
+#include "core/logging.h"
+#include "core/runtime/device.h"
+#include "core/tensor.h"
+#include "core/type.h"
+#include "kernels/binary_op/binary_op_host.h"
+#include "kernels/kernel.h"
+
+#include "mlu_op.h"
+
+ static void policyFunc(const mluOpHandle_t &handle,
+                        int bin_num,
+                        cnrtDim3_t *k_dim,
+                        cnrtFunctionType_t *k_type){
+  unsigned int cluster_num = mluop::runtime::getClusterLimitCapability(handle);
+  unsigned int core_in_cluster = handle->core_num_per_cluster;
+  *k_type = CNRT_FUNC_TYPE_UNION1; 
+  k_dim->x = core_in_cluster;
+  unsigned int use_cluster = (bin_num + core_in_cluster -1) / core_in_cluster;
+  k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
+  k_dim->z = 1;
+
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(mluOpHandle_t handle,
+                                                const mluOpTensorDescriptor_t input_desc,
+                                                const void *input,
+                                                const mluOpTensorDescriptor_t grid_desc,
+                                                const void *grid,
+                                                const mluOpTensorDescriptor_t output_desc,
+                                                void *output) {
+  //check params
+  const std::string op_name = "[mluOpRoiCropForward]";
+
+  // check descriptor
+  PARAM_CHECK(op_name, handle != NULL);
+  PARAM_CHECK(op_name, input_desc != NULL);
+  PARAM_CHECK(op_name, grid_desc != NULL);
+  PARAM_CHECK(op_name, output_desc != NULL);
+
+  // check dtype equal
+  PARAM_CHECK_EQ(op_name, input_desc->dtype, grid_desc->dtype);
+  PARAM_CHECK_EQ(op_name, input_desc->dtype, output_desc->dtype);
+
+  // check dim 
+  PARAM_CHECK_EQ(op_name, input_desc->dim, 4);
+  PARAM_CHECK_EQ(op_name, grid_desc->dim, 4);
+  PARAM_CHECK_EQ(op_name, output_desc->dim, 4);
+  if (output_desc->dims[0] != grid_desc->dims[0]) {
+    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[0] should be equal to grid_desc->dims[0].";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+    // check 0 element
+  if ((mluOpGetTensorElementNum(input_desc) == 0) ||
+      (mluOpGetTensorElementNum(grid_desc) == 0) ||
+      (mluOpGetTensorElementNum(output_desc) == 0)) {
+    VLOG(5) << op_name << " skip zero element tensor.";
+    return MLUOP_STATUS_SUCCESS;
+  }
+  // check device pointer
+  PARAM_CHECK(op_name, input != NULL);
+  PARAM_CHECK(op_name, grid != NULL);
+  PARAM_CHECK(op_name, output != NULL);
+
+  uint32_t batch = input_desc->dims[0];
+  uint32_t height = input_desc->dims[1];
+  uint32_t width = input_desc->dims[2];
+  uint32_t channels = input_desc->dims[3];
+
+  uint32_t grid_n = grid_desc->dims[0];
+  
+  uint32_t output_h = output_desc->dims[1];
+  uint32_t output_w = output_desc->dims[2];
+
+  uint32_t bin_num = grid_n * output_h * output_w;
+
+  cnrtDim3_t k_dim;
+  cnrtFunctionType_t k_type;
+  policyFunc(handle, bin_num, &k_dim, &k_type);
+
+  mluOpDataType_t data_type = input_desc->dtype;
+ 
+
+  VLOG(5) << "[mluOpRoiCropForward] launch kernel policyFUnc[" << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << "]";
+  KERNEL_CHECK((MLUKernelRoiCropForward<<<k_dim, k_type, handle->queue>>>(input, batch, height, width, channels, grid, grid_n, output, output_h, output_w, data_type)));
+  
+  return MLUOP_STATUS_SUCCESS;
+}

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
@@ -10,10 +10,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
 #include "roi_crop_forward.h"
-  
 #include <string>
 #include <iostream>
-  
 #include "core/context.h"
 #include "core/logging.h"
 #include "core/runtime/device.h"
@@ -21,107 +19,109 @@
 #include "core/type.h"
 #include "kernels/binary_op/binary_op_host.h"
 #include "kernels/kernel.h"
-
 #include "mlu_op.h"
 
- static void policyFunc(const mluOpHandle_t &handle,
-                        int bin_num,
-                        cnrtDim3_t *k_dim,
-                        cnrtFunctionType_t *k_type){
+static void policyFunc(const mluOpHandle_t &handle, int bin_num,
+                       cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
   unsigned int cluster_num = mluop::runtime::getClusterLimitCapability(handle);
   unsigned int core_in_cluster = handle->core_num_per_cluster;
-  *k_type = CNRT_FUNC_TYPE_UNION1; 
+  *k_type = CNRT_FUNC_TYPE_UNION1;
   k_dim->x = core_in_cluster;
-  unsigned int use_cluster = (bin_num + core_in_cluster -1) / core_in_cluster;
+  unsigned int use_cluster = (bin_num + core_in_cluster - 1) / core_in_cluster;
   k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
   k_dim->z = 1;
-
 }
 
-mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(mluOpHandle_t handle,
-                                                const mluOpTensorDescriptor_t input_desc,
-                                                const void *input,
-                                                const mluOpTensorDescriptor_t grid_desc,
-                                                const void *grid,
-                                                const mluOpTensorDescriptor_t output_desc,
-                                                void *output) {
-  //check params
-  const std::string op_name = "[mluOpRoiCropForward]";
-
-  // check 0 element
-  if ((mluOpGetTensorElementNum(input_desc) == 0) ||
-      (mluOpGetTensorElementNum(grid_desc) == 0) ||
-      (mluOpGetTensorElementNum(output_desc) == 0)) {
-    VLOG(5) << op_name << " skip zero element tensor.";
-    return MLUOP_STATUS_SUCCESS;
-  }
-  int input_dims = input_desc->dims[0]*input_desc->dims[1]*input_desc->dims[2]*input_desc->dims[3];
-  PARAM_CHECK(op_name,input_dims != 0);
-  int grid_dims = grid_desc->dims[0]*grid_desc->dims[1]*grid_desc->dims[2]*grid_desc->dims[3];
-  PARAM_CHECK(op_name,grid_dims != 0);
-  int output_dims = output_desc->dims[0]*output_desc->dims[1]*output_desc->dims[2]*output_desc->dims[3];
-  PARAM_CHECK(op_name,output_dims != 0);
-
-  // check descriptor
+/* user param check
+ * step1:check desc and data ptr is not nullptr_t
+ * step2:check shape and data type
+ * step3:check zero element
+ * */
+mluOpStatus_t RoiCropForwardParamCheck(
+    const std::string &op_name, const mluOpHandle_t &handle,
+    const mluOpTensorDescriptor_t &input_desc, const void *input,
+    const mluOpTensorDescriptor_t &grid_desc, const void *grid,
+    const mluOpTensorDescriptor_t &output_desc, const void *output,
+    bool &zero_element) {
+  // check descriptor and data
   PARAM_CHECK(op_name, handle != NULL);
   PARAM_CHECK(op_name, input_desc != NULL);
   PARAM_CHECK(op_name, grid_desc != NULL);
   PARAM_CHECK(op_name, output_desc != NULL);
-
-  // check dtype equal
-  PARAM_CHECK_EQ(op_name, input_desc->dtype, grid_desc->dtype);
-  PARAM_CHECK_EQ(op_name, input_desc->dtype, output_desc->dtype);
+  // check data type
   PARAM_CHECK(op_name, input_desc->dtype == MLUOP_DTYPE_FLOAT);
   PARAM_CHECK(op_name, grid_desc->dtype == MLUOP_DTYPE_FLOAT);
   PARAM_CHECK(op_name, output_desc->dtype == MLUOP_DTYPE_FLOAT);
-
-  // check dim and layout
-  PARAM_CHECK_EQ(op_name, input_desc->dim, 4);
+  // check shape and layout
   PARAM_CHECK(op_name, input_desc->layout == MLUOP_LAYOUT_NHWC);
-  PARAM_CHECK_EQ(op_name, grid_desc->dim, 4);
   PARAM_CHECK(op_name, grid_desc->layout == MLUOP_LAYOUT_NHWC);
-  PARAM_CHECK_EQ(op_name, output_desc->dim, 4);
   PARAM_CHECK(op_name, output_desc->layout == MLUOP_LAYOUT_NHWC);
-  if (output_desc->dims[0] != grid_desc->dims[0]||output_desc->dims[1] != grid_desc->dims[1]||output_desc->dims[2] != grid_desc->dims[2]) {
-    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[0]/[1]/[2] should be equal to grid_desc->dims[0]/[1]/[2].";
+  if (output_desc->dims[0] != grid_desc->dims[0] ||
+      output_desc->dims[1] != grid_desc->dims[1] ||
+      output_desc->dims[2] != grid_desc->dims[2]) {
+    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[0]/[1]/[2] "
+                             "should be equal to grid_desc->dims[0]/[1]/[2].";
     return MLUOP_STATUS_BAD_PARAM;
   }
   if (output_desc->dims[3] != input_desc->dims[3]) {
-    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[3] should be equal to input_desc->dims[3].";
+    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[3] should be "
+                             "equal to input_desc->dims[3].";
     return MLUOP_STATUS_BAD_PARAM;
   }
-  if (grid_desc->dims[3]!=2)
-  {
-    LOG(ERROR) << op_name << ":Check failed: grid_desc->dims[3] should be equal to 2.";
+  if (grid_desc->dims[3] != 2) {
+    LOG(ERROR) << op_name
+               << ":Check failed: grid_desc->dims[3] should be equal to 2.";
     return MLUOP_STATUS_BAD_PARAM;
   }
-  
-  // check device pointer
+  // check zero element
+  if ((mluOpGetTensorElementNum(input_desc) == 0) ||
+      (mluOpGetTensorElementNum(grid_desc) == 0) ||
+      (mluOpGetTensorElementNum(output_desc) == 0)) {
+    VLOG(5) << op_name << " skip zero element tensor.";
+    zero_element = true;
+    return MLUOP_STATUS_BAD_PARAM;
+  }
   PARAM_CHECK(op_name, input != NULL);
   PARAM_CHECK(op_name, grid != NULL);
   PARAM_CHECK(op_name, output != NULL);
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t input_desc,
+    const void *input, const mluOpTensorDescriptor_t grid_desc,
+    const void *grid, const mluOpTensorDescriptor_t output_desc, void *output) {
+  // check params
+  bool zero_element = false;
+  mluOpStatus_t param_check = RoiCropForwardParamCheck(
+      "[mluOpRoiCropForward]", handle, input_desc, input, grid_desc, grid,
+      output_desc, output, zero_element);
+  if (zero_element == true) {
+    return MLUOP_STATUS_SUCCESS;
+  }
+  if (param_check != MLUOP_STATUS_SUCCESS) {
+    return param_check;
+  }
 
   uint32_t batch = input_desc->dims[0];
   uint32_t height = input_desc->dims[1];
   uint32_t width = input_desc->dims[2];
   uint32_t channels = input_desc->dims[3];
-
   uint32_t grid_n = grid_desc->dims[0];
-  
   uint32_t output_h = output_desc->dims[1];
   uint32_t output_w = output_desc->dims[2];
-
   uint32_t bin_num = grid_n * output_h * output_w;
-
   cnrtDim3_t k_dim;
   cnrtFunctionType_t k_type;
+
   policyFunc(handle, bin_num, &k_dim, &k_type);
 
   mluOpDataType_t data_type = input_desc->dtype;
- 
-
-  VLOG(5) << "[mluOpRoiCropForward] launch kernel policyFUnc[" << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << "]";
-  KERNEL_CHECK((MLUKernelRoiCropForward<<<k_dim, k_type, handle->queue>>>(input, batch, height, width, channels, grid, grid_n, output, output_h, output_w, data_type)));
-  
+  VLOG(5) << "[mluOpRoiCropForward] launch kernel policyFUnc[" << k_dim.x
+          << ", " << k_dim.y << ", " << k_dim.z << "].";
+  KERNEL_CHECK((MLUKernelRoiCropForward<<<k_dim, k_type, handle->queue>>>(
+      input, batch, height, width, channels, grid, grid_n, output, output_h,
+      output_w, data_type)));
   return MLUOP_STATUS_SUCCESS;
 }
+

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu
@@ -28,12 +28,13 @@
                         int bin_num,
                         cnrtDim3_t *k_dim,
                         cnrtFunctionType_t *k_type){
-  unsigned int cluster_num = mluop::runtime::getClusterLimitCapability(handle);
+  //unsigned int cluster_num = mluop::runtime::getClusterLimitCapability(handle);
   unsigned int core_in_cluster = handle->core_num_per_cluster;
   *k_type = CNRT_FUNC_TYPE_UNION1; 
   k_dim->x = core_in_cluster;
-  unsigned int use_cluster = (bin_num + core_in_cluster -1) / core_in_cluster;
-  k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
+  //unsigned int use_cluster = (bin_num + core_in_cluster -1) / core_in_cluster;
+  //k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
+  k_dim->y = 1;
   k_dim->z = 1;
 
 }
@@ -58,15 +59,27 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(mluOpHandle_t handle,
   PARAM_CHECK_EQ(op_name, input_desc->dtype, grid_desc->dtype);
   PARAM_CHECK_EQ(op_name, input_desc->dtype, output_desc->dtype);
 
-  // check dim 
+  // check dim and layout
   PARAM_CHECK_EQ(op_name, input_desc->dim, 4);
+  PARAM_CHECK(op_name, input_desc->layout == MLUOP_LAYOUT_NHWC);
   PARAM_CHECK_EQ(op_name, grid_desc->dim, 4);
+  PARAM_CHECK(op_name, grid_desc->layout == MLUOP_LAYOUT_NHWC);
   PARAM_CHECK_EQ(op_name, output_desc->dim, 4);
-  if (output_desc->dims[0] != grid_desc->dims[0]) {
-    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[0] should be equal to grid_desc->dims[0].";
+  PARAM_CHECK(op_name, output_desc->layout == MLUOP_LAYOUT_NHWC);
+  if (output_desc->dims[0] != grid_desc->dims[0]||output_desc->dims[1] != grid_desc->dims[1]||output_desc->dims[2] != grid_desc->dims[2]) {
+    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[0]/[1]/[2] should be equal to grid_desc->dims[0]/[1]/[2].";
     return MLUOP_STATUS_BAD_PARAM;
   }
-
+  if (output_desc->dims[3] != input_desc->dims[3]) {
+    LOG(ERROR) << op_name << ":Check failed: output_desc->dims[3] should be equal to input_desc->dims[3].";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (grid_desc->dims[0]!=2)
+  {
+    LOG(ERROR) << op_name << ":Check failed: grid_desc->dims[0] should be equal to 2.";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  
     // check 0 element
   if ((mluOpGetTensorElementNum(input_desc) == 0) ||
       (mluOpGetTensorElementNum(grid_desc) == 0) ||

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward_device.mlu
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward_device.mlu
@@ -1,0 +1,513 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "roi_crop_forward.h"
+  
+#ifndef PAD_DOWN
+#define PAD_DOWN(x, y) (((x) / (y)) * (y))
+#endif
+  
+#ifndef PAD_UP
+#define PAD_UP(x, y) (((x) / (y) + (int)((x) % (y) > 0)) * (y))
+#endif
+  
+__nram__ char nram_buffer[MAX_NRAM_SIZE];
+
+template<typename T>
+__mlu_func__ void getInputTopLeft(T grid_yx_value, 
+                                  int input_hw, 
+                                  T * weight,
+                                  int * left_value){
+  T i_top_left_coord = (grid_yx_value + 1) * ((T)input_hw - 1) / 2;
+  *left_value = (int)floor(i_top_left_coord);
+  *weight = 1 - (i_top_left_coord - (T)(*left_value));
+}
+template<typename T>
+__mlu_func__ void processPipeline_bin( T* input,
+                                      int batch,
+                                      int height,
+                                      int width,
+                                      int channels,
+                                      T * grid,
+                                      int grid_n,
+                                      T * output,
+                                      int output_h,
+                                      int output_w,
+                                      int bins_first_per,
+                                      int bin_n_seg){
+  
+  const int c_align = PAD_UP(channels, NFU_ALIGN_SIZE / sizeof(T));
+  
+  const int repeat_bin = bin_n_seg;
+  T * nram_ping = (T*)nram_buffer;
+  int offset = 0;
+
+  //parameter definition
+  int gw, gh, gn, input_batch_index;
+  int i_top_left_x, i_top_left_y;
+  T gy, gx;
+  T i_top_left_x_weight, i_top_left_y_weight;
+  T i_top_left_xy_weight, i_top_right_xy_weight, i_bottom_left_xy_weight, i_bottom_right_xy_weight;
+  int i_top_left_offset, i_top_right_offset, i_bottom_left_offset, i_bottom_right_offset;
+  int o_offset_ping, o_offset_pong;
+
+  if (repeat_bin > 0){
+    //corrdinates of bin 
+    gw = bins_first_per % output_w;
+    gh = (bins_first_per / output_w) % output_h;
+    gn = bins_first_per / output_w / output_h;
+
+    // batch index under input
+    input_batch_index = gn / (grid_n / batch);
+
+    //value of grid data
+    gy = grid[gn * output_h * output_w * 2 + gh * output_w * 2 +gw * 2];
+    gx = grid[gn * output_h * output_w * 2 + gh * output_w * 2 +gw * 2 +1];
+
+    //coordinates and weights under input data
+    getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
+    getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
+
+    i_top_left_offset = input_batch_index * height * width * channels + i_top_left_y * width * channels + i_top_left_x * channels;
+    i_top_right_offset = i_top_left_offset + channels;
+    i_bottom_left_offset = i_top_left_offset + width*channels;
+    i_bottom_right_offset = i_top_left_offset + width*channels + channels;
+    //offset of output data
+    o_offset_ping = gn * output_h * output_w * channels + gh * output_w * channels + gw * channels;
+
+    //T0->L
+    __memcpy_async(nram_ping, input + i_top_left_offset, channels * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + c_align, input + i_top_right_offset, channels * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + 2 * c_align, input + i_bottom_left_offset, channels * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + 3 * c_align, input + i_bottom_right_offset, channels * sizeof(T), GDRAM2NRAM);
+
+  }
+  __asm__ volatile("sync;\n\t");
+  if (repeat_bin > 1)
+  {
+    i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
+    i_top_right_xy_weight = (1-i_top_left_x_weight) * i_top_left_y_weight;
+    i_bottom_left_xy_weight = i_top_left_x_weight * (1-i_top_left_y_weight);
+    i_bottom_right_xy_weight = (1-i_top_left_x_weight) * (1-i_top_left_y_weight);
+
+    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
+    if (!topLeftIsIn){
+      i_top_left_xy_weight = 0 ;
+    }
+    bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
+    if (!topRightIsIn){
+      i_top_right_xy_weight = 0;
+    }
+    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
+    if (!bottomLeftIsIn){
+      i_bottom_left_xy_weight = 0;
+    }
+    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
+    if (!bottomRightIsIn){
+      i_bottom_right_xy_weight = 0;
+    }
+    //T1->C
+    __bang_mul_const(nram_ping, nram_ping, i_top_left_xy_weight, c_align);
+    __bang_mul_const(nram_ping + c_align, nram_ping + c_align, i_top_right_xy_weight, c_align);
+    __bang_mul_const(nram_ping + 2 * c_align, nram_ping + 2 * c_align, i_bottom_left_xy_weight, c_align);
+    __bang_mul_const(nram_ping + 3 * c_align, nram_ping + 3 * c_align, i_bottom_right_xy_weight, c_align);
+    __bang_add(nram_ping, nram_ping, nram_ping + c_align, c_align);
+    __bang_add(nram_ping + 2 * c_align, nram_ping + 2 * c_align, nram_ping + 3 * c_align, c_align);
+    __bang_add(nram_ping, nram_ping, nram_ping + 2 * c_align, c_align);
+    
+    gw = (bins_first_per+1) % output_w;
+    gh = ((bins_first_per+1) / output_w) % output_h;
+    gn = (bins_first_per+1) / output_w / output_h;
+    input_batch_index = gn / (grid_n / batch);
+    gy = grid[gn * output_h * output_w * 2 + gh * output_w * 2 +gw * 2];
+    gx = grid[gn *output_h * output_w * 2 + gh * output_w * 2 +gw * 2 +1];
+    getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
+    getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
+    i_top_left_offset = input_batch_index * height * width * channels + i_top_left_y * width * channels + i_top_left_x * channels;
+    i_top_right_offset = i_top_left_offset + channels;
+    i_bottom_left_offset = i_top_left_offset + width*channels;
+    i_bottom_right_offset = i_top_left_offset + width*channels + channels;
+    o_offset_pong = gn * output_h * output_w * channels + gh * output_w * channels + gw * channels;
+
+    //T1->L
+    offset = 1 % 2 * c_align * 4 ; 
+    __memcpy_async(nram_ping + offset, input + i_top_left_offset, channels * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + c_align, input + i_top_right_offset, channels * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 2 * c_align, input + i_bottom_left_offset, channels * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 3 * c_align, input + i_bottom_right_offset, channels * sizeof(T), GDRAM2NRAM);
+  }
+  __asm__ volatile("sync;\n\t");
+  for (int i = 0; i < repeat_bin -2; i++){
+    //Ti->S
+    offset = i % 2 * c_align * 4;
+    if (i % 2 == 0){
+      __memcpy_async(output + o_offset_ping, nram_ping + offset, channels * sizeof(T), NRAM2GDRAM); 
+    }
+    else{
+      __memcpy_async(output + o_offset_pong, nram_ping + offset, channels * sizeof(T), NRAM2GDRAM);
+    }
+    //Ti->C
+    offset = (i + 1) % 2 * c_align * 4;
+    i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
+    i_top_right_xy_weight = (1-i_top_left_x_weight)*i_top_left_y_weight;
+    i_bottom_left_xy_weight = i_top_left_x_weight*(1-i_top_left_y_weight);
+    i_bottom_right_xy_weight = (1-i_top_left_x_weight)*(1-i_top_left_y_weight);
+    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
+    if (!topLeftIsIn){
+      i_top_left_xy_weight = 0 ;
+    }
+    bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
+    if (!topRightIsIn){
+      i_top_right_xy_weight = 0;
+    }
+    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
+    if (!bottomLeftIsIn){
+      i_bottom_left_xy_weight = 0;
+    }
+    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
+    if (!bottomRightIsIn){
+      i_bottom_right_xy_weight = 0;
+    }
+    __bang_mul_const(nram_ping + offset, nram_ping + offset, i_top_left_xy_weight, c_align);
+    __bang_mul_const(nram_ping + offset + c_align, nram_ping + offset + c_align, i_top_right_xy_weight, c_align);
+    __bang_mul_const(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, i_bottom_left_xy_weight, c_align);
+    __bang_mul_const(nram_ping + offset + 3 * c_align, nram_ping + offset + 3 * c_align, i_bottom_right_xy_weight, c_align);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + c_align, c_align);
+    __bang_add(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, nram_ping + offset + 3 * c_align, c_align);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * c_align, c_align);
+    
+    //Ti->L
+    offset = i % 2 * c_align * 4;
+    gw = (bins_first_per+2+i) % output_w;
+    gh = ((bins_first_per+2+i) / output_w) % output_h;
+    gn = (bins_first_per+2+i) / output_w / output_h;
+    input_batch_index = gn / (grid_n / batch);
+    gy = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2];
+    gx = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2 +1];
+    getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
+    getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
+    i_top_left_offset = input_batch_index*height*width*channels + i_top_left_y*width*channels + i_top_left_x*channels;
+    i_top_right_offset = i_top_left_offset + channels;
+    i_bottom_left_offset = i_top_left_offset +width* channels;
+    i_bottom_right_offset = i_top_left_offset + width*channels + channels;
+    if (i % 2 == 0){
+      o_offset_ping = gn * output_h * output_w * channels + gh*output_w*channels + gw*channels;
+    }
+    else{
+      o_offset_pong = gn * output_h * output_w * channels + gh*output_w*channels + gw*channels;
+    }
+    __memcpy_async(nram_ping + offset, input + i_top_left_offset, c_align * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + c_align, input + i_top_right_offset, c_align * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 2 * c_align, input + i_bottom_left_offset, c_align * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 3 * c_align, input + i_bottom_right_offset, c_align * sizeof(T), GDRAM2NRAM);
+    __asm__ volatile("sync;\n\t");
+
+  }
+  __asm__ volatile("sync;\n\t");
+
+  if (repeat_bin>1){
+    offset = (repeat_bin-2) % 2 * c_align * 4;
+    //T(end-1)->S
+    if ((repeat_bin-2) % 2 == 0){
+      __memcpy_async(output + o_offset_ping, nram_ping + offset, channels*sizeof(T),NRAM2GDRAM);
+    }
+    else{
+      __memcpy_async(output + o_offset_pong, nram_ping + offset, channels*sizeof(T),NRAM2GDRAM);
+    }
+  }
+  __asm__ volatile("sync;\n\t");
+  //T(end-1)->c
+  if (repeat_bin>0){
+    offset = (repeat_bin - 1) % 2 * c_align * 4;
+    i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
+    i_top_right_xy_weight = (1-i_top_left_x_weight)*i_top_left_y_weight;
+    i_bottom_left_xy_weight = i_top_left_x_weight*(1-i_top_left_y_weight);
+    i_bottom_right_xy_weight = (1-i_top_left_x_weight)*(1-i_top_left_y_weight);
+    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
+    if (!topLeftIsIn){
+      i_top_left_xy_weight = 0 ;
+    }
+    bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
+    if (!topRightIsIn){
+      i_top_right_xy_weight = 0;
+    }
+    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1)<= (height-1);
+    if (!bottomLeftIsIn){
+      i_bottom_left_xy_weight = 0;
+    }
+    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
+    if (!bottomRightIsIn){
+      i_bottom_right_xy_weight = 0;
+    }
+
+    __bang_mul_const(nram_ping + offset, nram_ping + offset, i_top_left_xy_weight, c_align);
+    __bang_mul_const(nram_ping + offset + c_align, nram_ping + offset + c_align, i_top_right_xy_weight, c_align);
+    __bang_mul_const(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, i_bottom_left_xy_weight, c_align);
+    __bang_mul_const(nram_ping + offset + 3 * c_align, nram_ping + offset + 3 * c_align, i_bottom_right_xy_weight, c_align);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + c_align, c_align);
+    __bang_add(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, nram_ping + offset + 3 * c_align, c_align);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * c_align, c_align);
+
+    __asm__ volatile("sync;\n\t");
+    //T(end)->S
+    if ((repeat_bin-1) % 2==0){
+      __memcpy_async(output + o_offset_ping, nram_ping + offset, channels*sizeof(T), NRAM2GDRAM);
+    }
+    else{
+      __memcpy_async(output + o_offset_pong, nram_ping + offset, channels*sizeof(T), NRAM2GDRAM);
+    }
+  }   
+
+}
+
+template<typename T>
+__mlu_func__ void processPipeline_c(T * input,
+                                    T * output,
+                                    T * nram_ping,
+                                    int nram_limit,
+                                    int repeat,
+                                    int remin,
+                                    int remin_align,
+                                    T * weight_arr,
+                                    int * offset_arr){
+  int offset = 0;                                      
+  //T0->L
+  if (repeat > 0){
+    __memcpy_async(nram_ping, input + offset_arr[0] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + nram_limit, input + offset_arr[1] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + 2 * nram_limit, input + offset_arr[2] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + 3 * nram_limit, input + offset_arr[3] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+  }
+   __asm__ volatile("sync;\n\t");
+  //T1->CL
+  if (repeat > 1){
+    
+    __bang_mul_const(nram_ping, nram_ping, weight_arr[0], nram_limit);
+    __bang_mul_const(nram_ping + nram_limit, nram_ping + nram_limit,  weight_arr[1], nram_limit);
+    __bang_mul_const(nram_ping + 2 * nram_limit, nram_ping + 2 * nram_limit,  weight_arr[2], nram_limit);
+    __bang_mul_const(nram_ping + 3 * nram_limit, nram_ping + 3 * nram_limit,  weight_arr[3], nram_limit);
+    __bang_add(nram_ping, nram_ping, nram_ping + nram_limit, nram_limit);
+    __bang_add(nram_ping + 2 * nram_limit, nram_ping + 2 * nram_limit, nram_ping + 3 * nram_limit, nram_limit);
+    __bang_add(nram_ping, nram_ping, nram_ping + 2 * nram_limit, nram_limit);
+    offset = 1 % 2 * nram_limit * 4;
+    __memcpy_async(nram_ping + offset, input + offset_arr[0] + 1 * nram_limit, nram_limit *sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + nram_limit, input + offset_arr[1] + 1 * nram_limit, nram_limit*sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 2 * nram_limit, input + offset_arr[2] + 1 * nram_limit, nram_limit*sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 3 * nram_limit, input + offset_arr[3] + 1 * nram_limit, nram_limit*sizeof(T), GDRAM2NRAM);
+  }
+   __asm__ volatile("sync;\n\t");
+  for (int i = 0; i < (repeat-2); ++i) {
+    //Ti->S
+    offset = i % 2 * nram_limit * 4;
+    __memcpy_async(output + offset_arr[4] + i * nram_limit, nram_ping + offset, nram_limit * sizeof(T), NRAM2GDRAM);
+
+    //Ti->C
+    offset = (i + 1) % 2 * nram_limit * 4;
+    __bang_mul_const(nram_ping + offset, nram_ping + offset, weight_arr[0], nram_limit);
+    __bang_mul_const(nram_ping + offset + nram_limit, nram_ping + offset + nram_limit, weight_arr[1], nram_limit);
+    __bang_mul_const(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, weight_arr[2], nram_limit);
+    __bang_mul_const(nram_ping + offset + 3 * nram_limit, nram_ping + offset + 3 * nram_limit, weight_arr[3], nram_limit);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + nram_limit, nram_limit);
+    __bang_add(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, nram_ping + offset + 3 * nram_limit, nram_limit);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * nram_limit, nram_limit);
+    
+    //Ti->L
+    offset = i % 2 * nram_limit * 4;
+    __memcpy_async(nram_ping + offset, input + offset_arr[0] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + nram_limit, input + offset_arr[1] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 2 * nram_limit, input + offset_arr[2] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 3 * nram_limit, input + offset_arr[3] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
+    __asm__ volatile("sync;\n\t");
+  }
+  __asm__ volatile("sync;\n\t");
+  
+  if (repeat>1){
+    //T(end-2)->S
+    offset = (repeat-2) % 2 * nram_limit * 4;
+    __memcpy_async(output + offset_arr[4] + (repeat-2) * nram_limit, nram_ping + offset, nram_limit * sizeof(T), NRAM2GDRAM);
+  }
+
+  if (repeat>0){
+    //T(end-2)->c
+    offset = (repeat - 1) % 2 * nram_limit * 4;
+    __bang_mul_const(nram_ping + offset, nram_ping + offset, weight_arr[0], nram_limit);
+    __bang_mul_const(nram_ping + offset + nram_limit, nram_ping + offset + nram_limit, weight_arr[1], nram_limit);
+    __bang_mul_const(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, weight_arr[2], nram_limit);
+    __bang_mul_const(nram_ping + offset + 3 * nram_limit, nram_ping + offset + 3 * nram_limit, weight_arr[3], nram_limit);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + nram_limit, nram_limit);
+    __bang_add(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, nram_ping + offset + 3 * nram_limit, nram_limit);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * nram_limit, nram_limit);
+  }
+  if (remin > 0){
+    //T(remin end-2)->L
+    offset = repeat % 2 * nram_limit * 4; 
+    __memcpy_async(nram_ping + offset, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + nram_limit, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 2 * nram_limit, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
+    __memcpy_async(nram_ping + offset + 3 * nram_limit, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
+  }
+  __asm__ volatile("sync;\n\t");
+
+  if (repeat > 0){
+    //T(end-1)->s
+    offset = (repeat - 1) % 2 * nram_limit * 4;
+    __memcpy_async(output + offset_arr[4] + (repeat-1) * nram_limit, nram_ping + offset, nram_limit * sizeof(T), NRAM2GDRAM);
+  }
+  if (remin > 0){
+    //T(end-1)->c
+    offset = repeat % 2 * nram_limit * 4;
+    __bang_mul_const(nram_ping + offset, nram_ping + offset, weight_arr[0], remin_align);
+    __bang_mul_const(nram_ping + offset + nram_limit, nram_ping + offset + nram_limit, weight_arr[1], remin_align);
+    __bang_mul_const(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, weight_arr[2], remin_align);
+    __bang_mul_const(nram_ping + offset + 3 * nram_limit, nram_ping + offset + 3 * nram_limit, weight_arr[3], remin_align);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + nram_limit, remin_align);
+    __bang_add(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, nram_ping + offset + 3 * nram_limit, remin_align);
+    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * nram_limit, remin_align);
+    __asm__ volatile("sync;\n\t");
+    //T(end)->L
+    __memcpy(output + offset_arr[4] + (repeat-1) * nram_limit, nram_ping + offset, remin * sizeof(T), NRAM2GDRAM);
+  }
+
+}
+
+template<typename T> 
+__mlu_func__ void compute(T * input,
+                          int batch,
+                          int height,
+                          int width,
+                          int channels,
+                          T * grid,
+                          int grid_n,
+                          T * output,
+                          int output_h,
+                          int output_w){
+  // evenly distribute BIN to IPU
+  const uint32_t bin_n = grid_n * output_h * output_w;
+  const uint32_t bin_n_seg = bin_n / taskDim + (taskId == taskDim - 1) * (bin_n % taskDim);
+  int bins_first_per = bin_n/taskDim*taskId;
+  int bins_loop_per = bins_first_per + bin_n_seg;
+
+  //nram is divided into 8 copies
+  int nram_limit = PAD_DOWN(MAX_NRAM_SIZE / 8 / sizeof(T),NFU_ALIGN_SIZE / sizeof(T));
+
+  //Data alignment and calculate the number of repeatitions
+  int repeat = channels / nram_limit;
+  int remin = channels % nram_limit;
+  int remin_align = PAD_UP(remin, NFU_ALIGN_SIZE / sizeof(T));
+  
+  if (repeat == 0 )
+  {
+    //BIN is subject to three-level pipeline operation
+   processPipeline_bin((T*)input, batch, height, width, channels, (T*)grid, grid_n, (T*)output, output_h, output_w, bins_first_per, bin_n_seg);                                  
+  }
+  else
+  {
+    //parameter definition
+    int gw, gh, gn, input_batch_index;
+    int i_top_left_x, i_top_left_y;
+    T gy, gx;
+    T i_top_left_x_weight, i_top_left_y_weight;
+    T i_top_left_xy_weight, i_top_right_xy_weight, i_bottom_left_xy_weight, i_bottom_right_xy_weight;
+    int i_top_left_offset, i_top_right_offset, i_bottom_left_offset, i_bottom_right_offset;
+    int o_offset;
+    T * nram_ping = (T*)nram_buffer;
+
+    for (int bin_i = bins_first_per; bin_i < bins_loop_per; bin_i++)
+    {
+      //corrdinates of bin 
+      gw = bin_i % output_w;
+      gh = (bin_i / output_w) % output_h;
+      gn = bin_i / output_w / output_h;
+
+      // batch index under input
+      input_batch_index = gn / (grid_n / batch);
+
+      //value of grid data 
+      gy = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2];
+      gx = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2 +1];
+      
+      //coordinates and weights under input data
+      getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
+      getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
+      
+      //(x,y)
+      i_top_left_offset = input_batch_index*height*width*channels + i_top_left_y*width*channels + i_top_left_x*channels;
+      i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
+
+      //(x,y+1)
+      i_top_right_offset = i_top_left_offset + channels;
+      i_top_right_xy_weight = (1-i_top_left_x_weight)*i_top_left_y_weight;
+    
+      //(x+1 ,y)
+      i_bottom_left_offset = i_top_left_offset + width*channels;
+      i_bottom_left_xy_weight = i_top_left_x_weight*(1-i_top_left_y_weight);
+      
+      //(x+1,y+1)
+      i_bottom_right_offset = i_top_left_offset + width*channels + channels;
+      i_bottom_right_xy_weight = (1-i_top_left_x_weight)*(1-i_top_left_y_weight);
+
+      bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
+      if (!topLeftIsIn){
+        i_top_left_xy_weight = 0 ;
+      }
+      bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
+      if (!topRightIsIn){
+        i_top_right_xy_weight = 0;
+      }
+      bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
+      if (!bottomLeftIsIn){
+        i_bottom_left_xy_weight = 0;
+      }
+      bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
+      if (!bottomRightIsIn){
+        i_bottom_right_xy_weight = 0;
+      }
+      //offset of output data
+      o_offset = gn * output_h * output_w * channels + gh * output_w * channels + gw * channels;
+
+      T weight_arr[4] = {i_top_left_xy_weight, i_top_right_xy_weight, i_bottom_left_xy_weight, i_bottom_right_xy_weight};
+      int offset_arr[5] = {i_top_left_offset, i_top_right_offset, i_bottom_left_offset, i_bottom_right_offset, o_offset};
+      
+      //The data under channels is subject to three-level pipeline operation
+      processPipeline_c((T *)input, (T *)output, (T *)nram_ping, nram_limit, repeat, remin, remin_align, (T*)weight_arr, offset_arr);
+      
+    }
+    
+  }
+
+}
+  
+__mlu_global__ void MLUKernelRoiCropForward(const void *input,
+                                            int batch,
+                                            int height,
+                                            int width,
+                                            int channels,
+                                            const void *grid,
+                                            int grid_n,
+                                            void *output,
+                                            int output_h,
+                                            int output_w,
+                                            mluOpDataType_t data_type){
+
+  if (coreId == 0x80) {
+    return;
+  }
+
+  if (MLUOP_DTYPE_FLOAT == data_type){
+    
+    compute((float*)input, batch, height, width, channels, (float*)grid, grid_n, (float*)output, output_h, output_w); 
+
+  }else{
+
+    compute((half*)input, batch, height, width, channels, (half*)grid, grid_n, (half*)output, output_h, output_w); 
+  }
+  
+}

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward_device.mlu
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward_device.mlu
@@ -10,504 +10,368 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
 #include "roi_crop_forward.h"
-  
+
 #ifndef PAD_DOWN
 #define PAD_DOWN(x, y) (((x) / (y)) * (y))
 #endif
-  
 #ifndef PAD_UP
 #define PAD_UP(x, y) (((x) / (y) + (int)((x) % (y) > 0)) * (y))
 #endif
-  
+
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
-template<typename T>
-__mlu_func__ void getInputTopLeft(T grid_yx_value, 
-                                  int input_hw, 
-                                  T * weight,
-                                  int * left_value){
+template <typename T>
+__mlu_func__ void getInputTopLeft(const T grid_yx_value, const int input_hw,
+                                  T *weight, int *left_value) {
   T i_top_left_coord = (grid_yx_value + 1) * ((T)input_hw - 1) / 2;
   *left_value = (int)floor(i_top_left_coord);
   *weight = 1 - (i_top_left_coord - (T)(*left_value));
 }
-template<typename T>
-__mlu_func__ void processPipeline_bin( T* input,
-                                      int batch,
-                                      int height,
-                                      int width,
-                                      int channels,
-                                      T * grid,
-                                      int grid_n,
-                                      T * output,
-                                      int output_h,
-                                      int output_w,
-                                      int bins_first_per,
-                                      int bin_n_seg){
-  
-  const int c_align = PAD_UP(channels, NFU_ALIGN_SIZE / sizeof(T));
-  
-  const int repeat_bin = bin_n_seg;
-  T * nram_ping = (T*)nram_buffer;
-  int offset = 0;
 
-  //parameter definition
+template <typename T>
+__mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
+                                          const int height, const int width,
+                                          const int channels, const T *grid,
+                                          const int grid_n, T *output,
+                                          const int output_h,
+                                          const int output_w) {
+  // evenly distribute BIN to IPU
+  const uint32_t bin_n = grid_n * output_h * output_w;
+  uint32_t task_bins = bin_n / taskDim;
+  uint32_t rem_bins = bin_n % taskDim;
+  if (taskId < rem_bins) {
+    task_bins += 1;
+  }
+  int bins_first_per =
+      (bin_n / taskDim) * taskId + (taskId > rem_bins ? rem_bins : taskId);
+  int bins_loop_per = bins_first_per + task_bins;
+
+  // nram is divided into 8 copies
+  int nram_limit =
+      PAD_DOWN(MAX_NRAM_SIZE / 8 / sizeof(T), NFU_ALIGN_SIZE / sizeof(T));
+  // Data alignment and calculate the number of repeatitions
+  int repeat = channels / nram_limit;
+  const int remin = channels % nram_limit;
+  int remin_num = 0;
+  int remin_align = 0;
+  int bin_i = 0;
+  int c_align = 0;
+  if (repeat == 0) {
+    c_align = PAD_UP(channels, NFU_ALIGN_SIZE / sizeof(T));
+  } else {
+    if (remin != 0) {
+      remin_num += 1;
+      remin_align = PAD_UP(remin, NFU_ALIGN_SIZE / sizeof(T));
+    }
+  }
+
   int gw, gh, gn, input_batch_index;
   int i_top_left_x, i_top_left_y;
   T gy, gx;
   T i_top_left_x_weight, i_top_left_y_weight;
-  T i_top_left_xy_weight, i_top_right_xy_weight, i_bottom_left_xy_weight, i_bottom_right_xy_weight;
-  int i_top_left_offset, i_top_right_offset, i_bottom_left_offset, i_bottom_right_offset;
+  T i_top_left_xy_weight, i_top_right_xy_weight, i_bottom_left_xy_weight,
+      i_bottom_right_xy_weight;
+  T i_top_left_xy_weight_pre, i_top_right_xy_weight_pre,
+      i_bottom_left_xy_weight_pre, i_bottom_right_xy_weight_pre;
+  int i_top_left_offset, i_top_right_offset, i_bottom_left_offset,
+      i_bottom_right_offset;
+  int o_offset = 0;
+  int offset = 0;
   int o_offset_ping, o_offset_pong;
+  T *nram_ping = (T *)nram_buffer;
 
-  if (repeat_bin > 0){
-    //corrdinates of bin 
-    gw = bins_first_per % output_w;
-    gh = (bins_first_per / output_w) % output_h;
-    gn = bins_first_per / output_w / output_h;
-
+  for (int bin_index = bins_first_per; bin_index < bins_loop_per; bin_index++) {
+    // corrdinates of bin
+    gw = bin_index % output_w;
+    gh = (bin_index / output_w) % output_h;
+    gn = bin_index / output_w / output_h;
     // batch index under input
     input_batch_index = gn / (grid_n / batch);
-
-    //value of grid data
-    gy = grid[gn * output_h * output_w * 2 + gh * output_w * 2 +gw * 2];
-    gx = grid[gn * output_h * output_w * 2 + gh * output_w * 2 +gw * 2 +1];
-
-    //coordinates and weights under input data
-    getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
-    getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
-
-    i_top_left_offset = input_batch_index * height * width * channels + i_top_left_y * width * channels + i_top_left_x * channels;
+    // value of grid data
+    gy = grid[gn * output_h * output_w * 2 + gh * output_w * 2 + gw * 2];
+    gx = grid[gn * output_h * output_w * 2 + gh * output_w * 2 + gw * 2 + 1];
+    // coordinates and weights under input data
+    getInputTopLeft((T)gx, width, (T *)&i_top_left_x_weight, &i_top_left_x);
+    getInputTopLeft((T)gy, height, (T *)&i_top_left_y_weight, &i_top_left_y);
+    i_top_left_offset = input_batch_index * height * width * channels +
+                        i_top_left_y * width * channels +
+                        i_top_left_x * channels;
+    i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
     i_top_right_offset = i_top_left_offset + channels;
-    i_bottom_left_offset = i_top_left_offset + width*channels;
-    i_bottom_right_offset = i_top_left_offset + width*channels + channels;
-    //offset of output data
-    o_offset_ping = gn * output_h * output_w * channels + gh * output_w * channels + gw * channels;
+    i_top_right_xy_weight = (1 - i_top_left_x_weight) * i_top_left_y_weight;
+    i_bottom_left_offset = i_top_left_offset + width * channels;
+    i_bottom_left_xy_weight = i_top_left_x_weight * (1 - i_top_left_y_weight);
+    i_bottom_right_offset = i_top_left_offset + width * channels + channels;
+    i_bottom_right_xy_weight =
+        (1 - i_top_left_x_weight) * (1 - i_top_left_y_weight);
 
-    //T0->L
-    __memcpy_async(nram_ping, input + i_top_left_offset, channels * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + c_align, input + i_top_right_offset, channels * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + 2 * c_align, input + i_bottom_left_offset, channels * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + 3 * c_align, input + i_bottom_right_offset, channels * sizeof(T), GDRAM2NRAM);
+    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width - 1) &&
+                       i_top_left_y >= 0 && i_top_left_y <= (height - 1);
+    bool topRightIsIn = (i_top_left_x + 1) >= 0 &&
+                        (i_top_left_x + 1) <= (width - 1) &&
+                        i_top_left_y >= 0 && i_top_left_y <= (height - 1);
+    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width - 1) &&
+                          (i_top_left_y + 1) >= 0 &&
+                          (i_top_left_y + 1) <= (height - 1);
+    bool bottomRightIsIn =
+        (i_top_left_x + 1) >= 0 && (i_top_left_x + 1) <= (width - 1) &&
+        (i_top_left_y + 1) >= 0 && (i_top_left_y + 1) <= (height - 1);
+    if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
+      continue;
+    // offset of output data
+    o_offset = gn * output_h * output_w * channels + gh * output_w * channels +
+               gw * channels;
+    if (repeat == 0) {
+      if (bin_i < task_bins) {
+        // Store
+        if (bin_i >= 2) {
+          offset = (bin_i - 2) % 2 * c_align * 4;
+          if ((bin_i - 2) % 2 == 0) {
+            __memcpy_async(output + o_offset_ping, nram_ping + offset,
+                           channels * sizeof(T), NRAM2GDRAM);
+          } else {
+            __memcpy_async(output + o_offset_pong, nram_ping + offset,
+                           channels * sizeof(T), NRAM2GDRAM);
+          }
+        }
+        // Compute
+        if (bin_i >= 1) {
+          // C (i-1)
+          offset = (bin_i - 1) % 2 * c_align * 4;
+          __bang_mul_const(nram_ping + offset, nram_ping + offset,
+                           i_top_left_xy_weight_pre, c_align);
+          __bang_mul_const(nram_ping + offset + c_align,
+                           nram_ping + offset + c_align,
+                           i_top_right_xy_weight_pre, c_align);
+          __bang_mul_const(nram_ping + offset + 2 * c_align,
+                           nram_ping + offset + 2 * c_align,
+                           i_bottom_left_xy_weight_pre, c_align);
+          __bang_mul_const(nram_ping + offset + 3 * c_align,
+                           nram_ping + offset + 3 * c_align,
+                           i_bottom_right_xy_weight_pre, c_align);
+          __bang_add(nram_ping + offset, nram_ping + offset,
+                     nram_ping + offset + c_align, c_align);
+          __bang_add(nram_ping + offset + 2 * c_align,
+                     nram_ping + offset + 2 * c_align,
+                     nram_ping + offset + 3 * c_align, c_align);
+          __bang_add(nram_ping + offset, nram_ping + offset,
+                     nram_ping + offset + 2 * c_align, c_align);
+        }
+        // Load
+        // L (bin_index)
+        offset = (bin_i) % 2 * c_align * 4;
+        __nramset(nram_ping + offset, c_align, 0);
+        __nramset(nram_ping + offset + c_align, c_align, 0);
+        __nramset(nram_ping + offset + 2 * c_align, c_align, 0);
+        __nramset(nram_ping + offset + 3 * c_align, c_align, 0);
+        if (topLeftIsIn) {
+          __memcpy_async(nram_ping + offset, input + i_top_left_offset,
+                         c_align * sizeof(T), GDRAM2NRAM);
+        }
+        if (topRightIsIn) {
+          __memcpy_async(nram_ping + offset + c_align,
+                         input + i_top_right_offset, c_align * sizeof(T),
+                         GDRAM2NRAM);
+        }
+        if (bottomLeftIsIn) {
+          __memcpy_async(nram_ping + offset + 2 * c_align,
+                         input + i_bottom_left_offset, c_align * sizeof(T),
+                         GDRAM2NRAM);
+        }
+        if (bottomRightIsIn) {
+          __memcpy_async(nram_ping + offset + 3 * c_align,
+                         input + i_bottom_right_offset, c_align * sizeof(T),
+                         GDRAM2NRAM);
+        }
+        __asm__ volatile("sync;\n\t");
+      }
+      if (bin_i % 2 == 0) {
+        o_offset_ping = o_offset;
+      } else {
+        o_offset_pong = o_offset;
+      }
+      i_top_left_xy_weight_pre = i_top_left_xy_weight;
+      i_top_right_xy_weight_pre = i_top_right_xy_weight;
+      i_bottom_left_xy_weight_pre = i_bottom_left_xy_weight;
+      i_bottom_right_xy_weight_pre = i_bottom_right_xy_weight;
+      bin_i++;
+      __asm__ volatile("sync;\n\t");
+    } else {
+      for (int i = 0; i < repeat + 2 + remin_num; ++i) {
+        // Store
+        if (i >= 2) {
+          if (i < repeat + 2 + remin_num - 1 || remin_num == 0) {
+            // S (i-2)
+            offset = (i - 2) % 2 * nram_limit * 4;
+            __memcpy_async(output + o_offset + (i - 2) * nram_limit,
+                           nram_ping + offset, nram_limit * sizeof(T),
+                           NRAM2GDRAM);
+          } else if (remin_num == 1) {
+            // S_rem (i-2)
+            offset = (i - 2) % 2 * nram_limit * 4;
+            __memcpy_async(output + o_offset + (i - 2) * nram_limit,
+                           nram_ping + offset, remin * sizeof(T), NRAM2GDRAM);
+          }
+        }
+        // Compute
+        if (i >= 1 && i < repeat + 1 + remin_num) {
+          if (i < repeat + 1 + remin_num - 1 || remin_num == 0) {
+            // C (i-1)
+            offset = (i - 1) % 2 * nram_limit * 4;
+            __bang_mul_const(nram_ping + offset, nram_ping + offset,
+                             i_top_left_xy_weight, nram_limit);
+            __bang_mul_const(nram_ping + offset + nram_limit,
+                             nram_ping + offset + nram_limit,
+                             i_top_right_xy_weight, nram_limit);
+            __bang_mul_const(nram_ping + offset + 2 * nram_limit,
+                             nram_ping + offset + 2 * nram_limit,
+                             i_bottom_left_xy_weight, nram_limit);
+            __bang_mul_const(nram_ping + offset + 3 * nram_limit,
+                             nram_ping + offset + 3 * nram_limit,
+                             i_bottom_right_xy_weight, nram_limit);
+            __bang_add(nram_ping + offset, nram_ping + offset,
+                       nram_ping + offset + nram_limit, nram_limit);
+            __bang_add(nram_ping + offset + 2 * nram_limit,
+                       nram_ping + offset + 2 * nram_limit,
+                       nram_ping + offset + 3 * nram_limit, nram_limit);
+            __bang_add(nram_ping + offset, nram_ping + offset,
+                       nram_ping + offset + 2 * nram_limit, nram_limit);
+          } else if (remin_num == 1) {
+            // C_rem (i-1)
+            offset = (i - 1) % 2 * nram_limit * 4;
+            __bang_mul_const(nram_ping + offset, nram_ping + offset,
+                             i_top_left_xy_weight, remin_align);
+            __bang_mul_const(nram_ping + offset + nram_limit,
+                             nram_ping + offset + nram_limit,
+                             i_top_right_xy_weight, remin_align);
+            __bang_mul_const(nram_ping + offset + 2 * nram_limit,
+                             nram_ping + offset + 2 * nram_limit,
+                             i_bottom_left_xy_weight, remin_align);
+            __bang_mul_const(nram_ping + offset + 3 * nram_limit,
+                             nram_ping + offset + 3 * nram_limit,
+                             i_bottom_right_xy_weight, remin_align);
+            __bang_add(nram_ping + offset, nram_ping + offset,
+                       nram_ping + offset + nram_limit, remin_align);
+            __bang_add(nram_ping + offset + 2 * nram_limit,
+                       nram_ping + offset + 2 * nram_limit,
+                       nram_ping + offset + 3 * nram_limit, remin_align);
+            __bang_add(nram_ping + offset, nram_ping + offset,
+                       nram_ping + offset + 2 * nram_limit, remin_align);
+          }
+        }
+        // Load
+        if (i < repeat + remin_num) {
+          if (i < repeat + remin_num - 1 || remin_num == 0) {
+            // L (i)
+            offset = (i) % 2 * nram_limit * 4;
+            __nramset(nram_ping + offset, nram_limit, 0);
+            __nramset(nram_ping + offset + nram_limit, nram_limit, 0);
+            __nramset(nram_ping + offset + 2 * nram_limit, nram_limit, 0);
+            __nramset(nram_ping + offset + 3 * nram_limit, nram_limit, 0);
+            if (topLeftIsIn) {
+              __memcpy_async(nram_ping + offset,
+                             input + i_top_left_offset + i * nram_limit,
+                             nram_limit * sizeof(T), GDRAM2NRAM);
+            }
+            if (topRightIsIn) {
+              __memcpy_async(nram_ping + offset + nram_limit,
+                             input + i_top_right_offset + i * nram_limit,
+                             nram_limit * sizeof(T), GDRAM2NRAM);
+            }
+            if (bottomLeftIsIn) {
+              __memcpy_async(nram_ping + offset + 2 * nram_limit,
+                             input + i_bottom_left_offset + i * nram_limit,
+                             nram_limit * sizeof(T), GDRAM2NRAM);
+            }
+            if (bottomRightIsIn) {
+              __memcpy_async(nram_ping + offset + 3 * nram_limit,
+                             input + i_bottom_right_offset + i * nram_limit,
+                             nram_limit * sizeof(T), GDRAM2NRAM);
+            }
 
+          } else if (remin_num == 1) {
+            // L_rem (i-1)
+            offset = (i) % 2 * nram_limit * 4;
+            __nramset(nram_ping + offset, remin_align, 0);
+            __nramset(nram_ping + offset + nram_limit, remin_align, 0);
+            __nramset(nram_ping + offset + 2 * nram_limit, remin_align, 0);
+            __nramset(nram_ping + offset + 3 * nram_limit, remin_align, 0);
+            if (topLeftIsIn) {
+              __memcpy_async(nram_ping + offset,
+                             input + i_top_left_offset + i * nram_limit,
+                             remin * sizeof(T), GDRAM2NRAM);
+            }
+            if (topRightIsIn) {
+              __memcpy_async(nram_ping + offset + nram_limit,
+                             input + i_top_right_offset + i * nram_limit,
+                             remin * sizeof(T), GDRAM2NRAM);
+            }
+            if (bottomLeftIsIn) {
+              __memcpy_async(nram_ping + offset + 2 * nram_limit,
+                             input + i_bottom_left_offset + i * nram_limit,
+                             remin * sizeof(T), GDRAM2NRAM);
+            }
+            if (bottomRightIsIn) {
+              __memcpy_async(nram_ping + offset + 3 * nram_limit,
+                             input + i_bottom_right_offset + i * nram_limit,
+                             remin * sizeof(T), GDRAM2NRAM);
+            }
+          }
+        }
+        __asm__ volatile("sync;\n\t");
+      }
+    }
+  }
+  if (repeat == 0 && task_bins > 1) {
+    offset = (bin_i - 2) % 2 * c_align * 4;
+    if ((bin_i - 2) % 2 == 0) {
+      __memcpy_async(output + o_offset_ping, nram_ping + offset,
+                     channels * sizeof(T), NRAM2GDRAM);
+    } else {
+      __memcpy_async(output + o_offset_pong, nram_ping + offset,
+                     channels * sizeof(T), NRAM2GDRAM);
+    }
   }
   __asm__ volatile("sync;\n\t");
-  if (repeat_bin > 1)
-  {
-    i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
-    i_top_right_xy_weight = (1-i_top_left_x_weight) * i_top_left_y_weight;
-    i_bottom_left_xy_weight = i_top_left_x_weight * (1-i_top_left_y_weight);
-    i_bottom_right_xy_weight = (1-i_top_left_x_weight) * (1-i_top_left_y_weight);
-
-    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
-    if (!topLeftIsIn){
-      i_top_left_xy_weight = 0 ;
-    }
-    bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
-    if (!topRightIsIn){
-      i_top_right_xy_weight = 0;
-    }
-    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
-    if (!bottomLeftIsIn){
-      i_bottom_left_xy_weight = 0;
-    }
-    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
-    if (!bottomRightIsIn){
-      i_bottom_right_xy_weight = 0;
-    }
-    //T1->C
-    __bang_mul_const(nram_ping, nram_ping, i_top_left_xy_weight, c_align);
-    __bang_mul_const(nram_ping + c_align, nram_ping + c_align, i_top_right_xy_weight, c_align);
-    __bang_mul_const(nram_ping + 2 * c_align, nram_ping + 2 * c_align, i_bottom_left_xy_weight, c_align);
-    __bang_mul_const(nram_ping + 3 * c_align, nram_ping + 3 * c_align, i_bottom_right_xy_weight, c_align);
-    __bang_add(nram_ping, nram_ping, nram_ping + c_align, c_align);
-    __bang_add(nram_ping + 2 * c_align, nram_ping + 2 * c_align, nram_ping + 3 * c_align, c_align);
-    __bang_add(nram_ping, nram_ping, nram_ping + 2 * c_align, c_align);
-    
-    gw = (bins_first_per+1) % output_w;
-    gh = ((bins_first_per+1) / output_w) % output_h;
-    gn = (bins_first_per+1) / output_w / output_h;
-    input_batch_index = gn / (grid_n / batch);
-    gy = grid[gn * output_h * output_w * 2 + gh * output_w * 2 +gw * 2];
-    gx = grid[gn *output_h * output_w * 2 + gh * output_w * 2 +gw * 2 +1];
-    getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
-    getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
-    i_top_left_offset = input_batch_index * height * width * channels + i_top_left_y * width * channels + i_top_left_x * channels;
-    i_top_right_offset = i_top_left_offset + channels;
-    i_bottom_left_offset = i_top_left_offset + width*channels;
-    i_bottom_right_offset = i_top_left_offset + width*channels + channels;
-    o_offset_pong = gn * output_h * output_w * channels + gh * output_w * channels + gw * channels;
-
-    //T1->L
-    offset = 1 % 2 * c_align * 4 ; 
-    __memcpy_async(nram_ping + offset, input + i_top_left_offset, channels * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + c_align, input + i_top_right_offset, channels * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 2 * c_align, input + i_bottom_left_offset, channels * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 3 * c_align, input + i_bottom_right_offset, channels * sizeof(T), GDRAM2NRAM);
-  }
-  __asm__ volatile("sync;\n\t");
-  for (int i = 0; i < repeat_bin -2; i++){
-    //Ti->S
-    offset = i % 2 * c_align * 4;
-    if (i % 2 == 0){
-      __memcpy_async(output + o_offset_ping, nram_ping + offset, channels * sizeof(T), NRAM2GDRAM); 
-    }
-    else{
-      __memcpy_async(output + o_offset_pong, nram_ping + offset, channels * sizeof(T), NRAM2GDRAM);
-    }
-    //Ti->C
-    offset = (i + 1) % 2 * c_align * 4;
-    i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
-    i_top_right_xy_weight = (1-i_top_left_x_weight)*i_top_left_y_weight;
-    i_bottom_left_xy_weight = i_top_left_x_weight*(1-i_top_left_y_weight);
-    i_bottom_right_xy_weight = (1-i_top_left_x_weight)*(1-i_top_left_y_weight);
-    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
-    if (!topLeftIsIn){
-      i_top_left_xy_weight = 0 ;
-    }
-    bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
-    if (!topRightIsIn){
-      i_top_right_xy_weight = 0;
-    }
-    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
-    if (!bottomLeftIsIn){
-      i_bottom_left_xy_weight = 0;
-    }
-    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
-    if (!bottomRightIsIn){
-      i_bottom_right_xy_weight = 0;
-    }
-    __bang_mul_const(nram_ping + offset, nram_ping + offset, i_top_left_xy_weight, c_align);
-    __bang_mul_const(nram_ping + offset + c_align, nram_ping + offset + c_align, i_top_right_xy_weight, c_align);
-    __bang_mul_const(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, i_bottom_left_xy_weight, c_align);
-    __bang_mul_const(nram_ping + offset + 3 * c_align, nram_ping + offset + 3 * c_align, i_bottom_right_xy_weight, c_align);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + c_align, c_align);
-    __bang_add(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, nram_ping + offset + 3 * c_align, c_align);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * c_align, c_align);
-    
-    //Ti->L
-    offset = i % 2 * c_align * 4;
-    gw = (bins_first_per+2+i) % output_w;
-    gh = ((bins_first_per+2+i) / output_w) % output_h;
-    gn = (bins_first_per+2+i) / output_w / output_h;
-    input_batch_index = gn / (grid_n / batch);
-    gy = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2];
-    gx = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2 +1];
-    getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
-    getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
-    i_top_left_offset = input_batch_index*height*width*channels + i_top_left_y*width*channels + i_top_left_x*channels;
-    i_top_right_offset = i_top_left_offset + channels;
-    i_bottom_left_offset = i_top_left_offset +width* channels;
-    i_bottom_right_offset = i_top_left_offset + width*channels + channels;
-    if (i % 2 == 0){
-      o_offset_ping = gn * output_h * output_w * channels + gh*output_w*channels + gw*channels;
-    }
-    else{
-      o_offset_pong = gn * output_h * output_w * channels + gh*output_w*channels + gw*channels;
-    }
-    __memcpy_async(nram_ping + offset, input + i_top_left_offset, c_align * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + c_align, input + i_top_right_offset, c_align * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 2 * c_align, input + i_bottom_left_offset, c_align * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 3 * c_align, input + i_bottom_right_offset, c_align * sizeof(T), GDRAM2NRAM);
+  if (repeat == 0 && task_bins > 0) {
+    offset = (bin_i - 1) % 2 * c_align * 4;
+    __bang_mul_const(nram_ping + offset, nram_ping + offset,
+                     i_top_left_xy_weight_pre, c_align);
+    __bang_mul_const(nram_ping + offset + c_align, nram_ping + offset + c_align,
+                     i_top_right_xy_weight_pre, c_align);
+    __bang_mul_const(nram_ping + offset + 2 * c_align,
+                     nram_ping + offset + 2 * c_align,
+                     i_bottom_left_xy_weight_pre, c_align);
+    __bang_mul_const(nram_ping + offset + 3 * c_align,
+                     nram_ping + offset + 3 * c_align,
+                     i_bottom_right_xy_weight_pre, c_align);
+    __bang_add(nram_ping + offset, nram_ping + offset,
+               nram_ping + offset + c_align, c_align);
+    __bang_add(nram_ping + offset + 2 * c_align,
+               nram_ping + offset + 2 * c_align,
+               nram_ping + offset + 3 * c_align, c_align);
+    __bang_add(nram_ping + offset, nram_ping + offset,
+               nram_ping + offset + 2 * c_align, c_align);
     __asm__ volatile("sync;\n\t");
-
-  }
-  __asm__ volatile("sync;\n\t");
-
-  if (repeat_bin>1){
-    offset = (repeat_bin-2) % 2 * c_align * 4;
-    //T(end-1)->S
-    if ((repeat_bin-2) % 2 == 0){
-      __memcpy_async(output + o_offset_ping, nram_ping + offset, channels*sizeof(T),NRAM2GDRAM);
-    }
-    else{
-      __memcpy_async(output + o_offset_pong, nram_ping + offset, channels*sizeof(T),NRAM2GDRAM);
+    offset = (bin_i - 1) % 2 * c_align * 4;
+    if ((bin_i - 1) % 2 == 0) {
+      __memcpy_async(output + o_offset_ping, nram_ping + offset,
+                     channels * sizeof(T), NRAM2GDRAM);
+    } else {
+      __memcpy_async(output + o_offset_pong, nram_ping + offset,
+                     channels * sizeof(T), NRAM2GDRAM);
     }
   }
-  __asm__ volatile("sync;\n\t");
-  //T(end-1)->c
-  if (repeat_bin>0){
-    offset = (repeat_bin - 1) % 2 * c_align * 4;
-    i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
-    i_top_right_xy_weight = (1-i_top_left_x_weight)*i_top_left_y_weight;
-    i_bottom_left_xy_weight = i_top_left_x_weight*(1-i_top_left_y_weight);
-    i_bottom_right_xy_weight = (1-i_top_left_x_weight)*(1-i_top_left_y_weight);
-    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
-    if (!topLeftIsIn){
-      i_top_left_xy_weight = 0 ;
-    }
-    bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
-    if (!topRightIsIn){
-      i_top_right_xy_weight = 0;
-    }
-    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1)<= (height-1);
-    if (!bottomLeftIsIn){
-      i_bottom_left_xy_weight = 0;
-    }
-    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
-    if (!bottomRightIsIn){
-      i_bottom_right_xy_weight = 0;
-    }
-
-    __bang_mul_const(nram_ping + offset, nram_ping + offset, i_top_left_xy_weight, c_align);
-    __bang_mul_const(nram_ping + offset + c_align, nram_ping + offset + c_align, i_top_right_xy_weight, c_align);
-    __bang_mul_const(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, i_bottom_left_xy_weight, c_align);
-    __bang_mul_const(nram_ping + offset + 3 * c_align, nram_ping + offset + 3 * c_align, i_bottom_right_xy_weight, c_align);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + c_align, c_align);
-    __bang_add(nram_ping + offset + 2 * c_align, nram_ping + offset + 2 * c_align, nram_ping + offset + 3 * c_align, c_align);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * c_align, c_align);
-
-    __asm__ volatile("sync;\n\t");
-    //T(end)->S
-    if ((repeat_bin-1) % 2==0){
-      __memcpy_async(output + o_offset_ping, nram_ping + offset, channels*sizeof(T), NRAM2GDRAM);
-    }
-    else{
-      __memcpy_async(output + o_offset_pong, nram_ping + offset, channels*sizeof(T), NRAM2GDRAM);
-    }
-  }   
-
 }
 
-template<typename T>
-__mlu_func__ void processPipeline_c(T * input,
-                                    T * output,
-                                    T * nram_ping,
-                                    int nram_limit,
-                                    int repeat,
-                                    int remin,
-                                    int remin_align,
-                                    T * weight_arr,
-                                    int * offset_arr){
-  int offset = 0;                                      
-  //T0->L
-  if (repeat > 0){
-    __memcpy_async(nram_ping, input + offset_arr[0] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + nram_limit, input + offset_arr[1] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + 2 * nram_limit, input + offset_arr[2] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + 3 * nram_limit, input + offset_arr[3] + 0 * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-  }
-   __asm__ volatile("sync;\n\t");
-  //T1->CL
-  if (repeat > 1){
-    
-    __bang_mul_const(nram_ping, nram_ping, weight_arr[0], nram_limit);
-    __bang_mul_const(nram_ping + nram_limit, nram_ping + nram_limit,  weight_arr[1], nram_limit);
-    __bang_mul_const(nram_ping + 2 * nram_limit, nram_ping + 2 * nram_limit,  weight_arr[2], nram_limit);
-    __bang_mul_const(nram_ping + 3 * nram_limit, nram_ping + 3 * nram_limit,  weight_arr[3], nram_limit);
-    __bang_add(nram_ping, nram_ping, nram_ping + nram_limit, nram_limit);
-    __bang_add(nram_ping + 2 * nram_limit, nram_ping + 2 * nram_limit, nram_ping + 3 * nram_limit, nram_limit);
-    __bang_add(nram_ping, nram_ping, nram_ping + 2 * nram_limit, nram_limit);
-    offset = 1 % 2 * nram_limit * 4;
-    __memcpy_async(nram_ping + offset, input + offset_arr[0] + 1 * nram_limit, nram_limit *sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + nram_limit, input + offset_arr[1] + 1 * nram_limit, nram_limit*sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 2 * nram_limit, input + offset_arr[2] + 1 * nram_limit, nram_limit*sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 3 * nram_limit, input + offset_arr[3] + 1 * nram_limit, nram_limit*sizeof(T), GDRAM2NRAM);
-  }
-   __asm__ volatile("sync;\n\t");
-  for (int i = 0; i < (repeat-2); ++i) {
-    //Ti->S
-    offset = i % 2 * nram_limit * 4;
-    __memcpy_async(output + offset_arr[4] + i * nram_limit, nram_ping + offset, nram_limit * sizeof(T), NRAM2GDRAM);
-
-    //Ti->C
-    offset = (i + 1) % 2 * nram_limit * 4;
-    __bang_mul_const(nram_ping + offset, nram_ping + offset, weight_arr[0], nram_limit);
-    __bang_mul_const(nram_ping + offset + nram_limit, nram_ping + offset + nram_limit, weight_arr[1], nram_limit);
-    __bang_mul_const(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, weight_arr[2], nram_limit);
-    __bang_mul_const(nram_ping + offset + 3 * nram_limit, nram_ping + offset + 3 * nram_limit, weight_arr[3], nram_limit);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + nram_limit, nram_limit);
-    __bang_add(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, nram_ping + offset + 3 * nram_limit, nram_limit);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * nram_limit, nram_limit);
-    
-    //Ti->L
-    offset = i % 2 * nram_limit * 4;
-    __memcpy_async(nram_ping + offset, input + offset_arr[0] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + nram_limit, input + offset_arr[1] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 2 * nram_limit, input + offset_arr[2] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 3 * nram_limit, input + offset_arr[3] + (i+2) * nram_limit, nram_limit * sizeof(T), GDRAM2NRAM);
-    __asm__ volatile("sync;\n\t");
-  }
-  __asm__ volatile("sync;\n\t");
-  
-  if (repeat>1){
-    //T(end-2)->S
-    offset = (repeat-2) % 2 * nram_limit * 4;
-    __memcpy_async(output + offset_arr[4] + (repeat-2) * nram_limit, nram_ping + offset, nram_limit * sizeof(T), NRAM2GDRAM);
-  }
-
-  if (repeat>0){
-    //T(end-2)->c
-    offset = (repeat - 1) % 2 * nram_limit * 4;
-    __bang_mul_const(nram_ping + offset, nram_ping + offset, weight_arr[0], nram_limit);
-    __bang_mul_const(nram_ping + offset + nram_limit, nram_ping + offset + nram_limit, weight_arr[1], nram_limit);
-    __bang_mul_const(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, weight_arr[2], nram_limit);
-    __bang_mul_const(nram_ping + offset + 3 * nram_limit, nram_ping + offset + 3 * nram_limit, weight_arr[3], nram_limit);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + nram_limit, nram_limit);
-    __bang_add(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, nram_ping + offset + 3 * nram_limit, nram_limit);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * nram_limit, nram_limit);
-  }
-  if (remin > 0){
-    //T(remin end-2)->L
-    offset = repeat % 2 * nram_limit * 4; 
-    __memcpy_async(nram_ping + offset, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + nram_limit, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 2 * nram_limit, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
-    __memcpy_async(nram_ping + offset + 3 * nram_limit, input + offset_arr[0] + repeat * nram_limit, remin * sizeof(T), GDRAM2NRAM);
-  }
-  __asm__ volatile("sync;\n\t");
-
-  if (repeat > 0){
-    //T(end-1)->s
-    offset = (repeat - 1) % 2 * nram_limit * 4;
-    __memcpy_async(output + offset_arr[4] + (repeat-1) * nram_limit, nram_ping + offset, nram_limit * sizeof(T), NRAM2GDRAM);
-  }
-  if (remin > 0){
-    //T(end-1)->c
-    offset = repeat % 2 * nram_limit * 4;
-    __bang_mul_const(nram_ping + offset, nram_ping + offset, weight_arr[0], remin_align);
-    __bang_mul_const(nram_ping + offset + nram_limit, nram_ping + offset + nram_limit, weight_arr[1], remin_align);
-    __bang_mul_const(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, weight_arr[2], remin_align);
-    __bang_mul_const(nram_ping + offset + 3 * nram_limit, nram_ping + offset + 3 * nram_limit, weight_arr[3], remin_align);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + nram_limit, remin_align);
-    __bang_add(nram_ping + offset + 2 * nram_limit, nram_ping + offset + 2 * nram_limit, nram_ping + offset + 3 * nram_limit, remin_align);
-    __bang_add(nram_ping + offset, nram_ping + offset, nram_ping + offset + 2 * nram_limit, remin_align);
-    __asm__ volatile("sync;\n\t");
-    //T(end)->L
-    __memcpy(output + offset_arr[4] + (repeat-1) * nram_limit, nram_ping + offset, remin * sizeof(T), NRAM2GDRAM);
-  }
-
-}
-
-template<typename T> 
-__mlu_func__ void compute(T * input,
-                          int batch,
-                          int height,
-                          int width,
-                          int channels,
-                          T * grid,
-                          int grid_n,
-                          T * output,
-                          int output_h,
-                          int output_w){
-  // evenly distribute BIN to IPU
-  const uint32_t bin_n = grid_n * output_h * output_w;
-  const uint32_t bin_n_seg = bin_n / taskDim + (taskId == taskDim - 1) * (bin_n % taskDim);
-  int bins_first_per = bin_n/taskDim*taskId;
-  int bins_loop_per = bins_first_per + bin_n_seg;
-
-  //nram is divided into 8 copies
-  int nram_limit = PAD_DOWN(MAX_NRAM_SIZE / 8 / sizeof(T),NFU_ALIGN_SIZE / sizeof(T));
-
-  //Data alignment and calculate the number of repeatitions
-  int repeat = channels / nram_limit;
-  int remin = channels % nram_limit;
-  int remin_align = PAD_UP(remin, NFU_ALIGN_SIZE / sizeof(T));
-  
-  if (repeat == 0 )
-  {
-    //BIN is subject to three-level pipeline operation
-   processPipeline_bin((T*)input, batch, height, width, channels, (T*)grid, grid_n, (T*)output, output_h, output_w, bins_first_per, bin_n_seg);                                  
-  }
-  else
-  {
-    //parameter definition
-    int gw, gh, gn, input_batch_index;
-    int i_top_left_x, i_top_left_y;
-    T gy, gx;
-    T i_top_left_x_weight, i_top_left_y_weight;
-    T i_top_left_xy_weight, i_top_right_xy_weight, i_bottom_left_xy_weight, i_bottom_right_xy_weight;
-    int i_top_left_offset, i_top_right_offset, i_bottom_left_offset, i_bottom_right_offset;
-    int o_offset;
-    T * nram_ping = (T*)nram_buffer;
-
-    for (int bin_i = bins_first_per; bin_i < bins_loop_per; bin_i++)
-    {
-      //corrdinates of bin 
-      gw = bin_i % output_w;
-      gh = (bin_i / output_w) % output_h;
-      gn = bin_i / output_w / output_h;
-
-      // batch index under input
-      input_batch_index = gn / (grid_n / batch);
-
-      //value of grid data 
-      gy = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2];
-      gx = grid[gn*output_h*output_w*2 + gh*output_w*2 +gw*2 +1];
-      
-      //coordinates and weights under input data
-      getInputTopLeft((T)gx, width, (T*)&i_top_left_x_weight, &i_top_left_x);
-      getInputTopLeft((T)gy, height, (T*)&i_top_left_y_weight, &i_top_left_y);
-      
-      //(x,y)
-      i_top_left_offset = input_batch_index*height*width*channels + i_top_left_y*width*channels + i_top_left_x*channels;
-      i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
-
-      //(x,y+1)
-      i_top_right_offset = i_top_left_offset + channels;
-      i_top_right_xy_weight = (1-i_top_left_x_weight)*i_top_left_y_weight;
-    
-      //(x+1 ,y)
-      i_bottom_left_offset = i_top_left_offset + width*channels;
-      i_bottom_left_xy_weight = i_top_left_x_weight*(1-i_top_left_y_weight);
-      
-      //(x+1,y+1)
-      i_bottom_right_offset = i_top_left_offset + width*channels + channels;
-      i_bottom_right_xy_weight = (1-i_top_left_x_weight)*(1-i_top_left_y_weight);
-
-      bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && i_top_left_y >= 0 && i_top_left_y <= (height-1);
-      if (!topLeftIsIn){
-        i_top_left_xy_weight = 0 ;
-      }
-      bool topRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width-1) && i_top_left_y>= 0 && i_top_left_y <= (height-1);
-      if (!topRightIsIn){
-        i_top_right_xy_weight = 0;
-      }
-      bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
-      if (!bottomLeftIsIn){
-        i_bottom_left_xy_weight = 0;
-      }
-      bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (width -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (height-1);
-      if (!bottomRightIsIn){
-        i_bottom_right_xy_weight = 0;
-      }
-      //offset of output data
-      o_offset = gn * output_h * output_w * channels + gh * output_w * channels + gw * channels;
-
-      T weight_arr[4] = {i_top_left_xy_weight, i_top_right_xy_weight, i_bottom_left_xy_weight, i_bottom_right_xy_weight};
-      int offset_arr[5] = {i_top_left_offset, i_top_right_offset, i_bottom_left_offset, i_bottom_right_offset, o_offset};
-      
-      //The data under channels is subject to three-level pipeline operation
-      processPipeline_c((T *)input, (T *)output, (T *)nram_ping, nram_limit, repeat, remin, remin_align, (T*)weight_arr, offset_arr);
-      
-    }
-    
-  }
-
-}
-  
-__mlu_global__ void MLUKernelRoiCropForward(const void *input,
-                                            int batch,
-                                            int height,
-                                            int width,
-                                            int channels,
-                                            const void *grid,
-                                            int grid_n,
-                                            void *output,
-                                            int output_h,
-                                            int output_w,
-                                            mluOpDataType_t data_type){
-
+__mlu_global__ void MLUKernelRoiCropForward(
+    const void *input, const int batch, const int height, const int width,
+    const int channels, const void *grid, const int grid_n, void *output,
+    const int output_h, const int output_w, const mluOpDataType_t data_type) {
   if (coreId == 0x80) {
     return;
   }
-
-  if (MLUOP_DTYPE_FLOAT == data_type){
-    
-    compute((float*)input, batch, height, width, channels, (float*)grid, grid_n, (float*)output, output_h, output_w); 
-
-  }else{
-
-    compute((half*)input, batch, height, width, channels, (half*)grid, grid_n, (half*)output, output_h, output_w); 
-  }
-  
+  MLUUnion1RoiCropForward((float *)input, batch, height, width, channels,
+                          (float *)grid, grid_n, (float *)output, output_h,
+                          output_w);
 }

--- a/bangc-ops/kernels/roi_crop_forward/roi_crop_forward_device.mlu
+++ b/bangc-ops/kernels/roi_crop_forward/roi_crop_forward_device.mlu
@@ -22,10 +22,14 @@ __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
 template <typename T>
 __mlu_func__ void getInputTopLeft(const T grid_yx_value, const int input_hw,
-                                  T *weight, int *left_value) {
-  T i_top_left_coord = (grid_yx_value + 1) * ((T)input_hw - 1) / 2;
-  *left_value = (int)floor(i_top_left_coord);
-  *weight = 1 - (i_top_left_coord - (T)(*left_value));
+                                  T *weight, int *point) {
+  T xcoord = (grid_yx_value + 1) * (input_hw - 1) / 2;
+  *point = floor(xcoord);
+  *weight = 1 - (xcoord - (T)(*point));
+}
+__mlu_func__ bool between(const int value, const int lowerBound,
+                          const int upperBound) {
+  return (value >= lowerBound && value <= upperBound);
 }
 
 template <typename T>
@@ -51,17 +55,17 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
       PAD_DOWN(MAX_NRAM_SIZE / 8 / sizeof(T), NFU_ALIGN_SIZE / sizeof(T));
   // Data alignment and calculate the number of repeatitions
   int repeat = channels / nram_limit;
-  const int remin = channels % nram_limit;
-  int remin_num = 0;
-  int remin_align = 0;
+  const int rem = channels % nram_limit;
+  int rem_num = 0;
+  int rem_align = 0;
   int bin_i = 0;
   int c_align = 0;
   if (repeat == 0) {
     c_align = PAD_UP(channels, NFU_ALIGN_SIZE / sizeof(T));
   } else {
-    if (remin != 0) {
-      remin_num += 1;
-      remin_align = PAD_UP(remin, NFU_ALIGN_SIZE / sizeof(T));
+    if (rem != 0) {
+      rem_num += 1;
+      rem_align = PAD_UP(rem, NFU_ALIGN_SIZE / sizeof(T));
     }
   }
 
@@ -77,7 +81,8 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
       i_bottom_right_offset;
   int o_offset = 0;
   int offset = 0;
-  int o_offset_ping, o_offset_pong;
+  int o_offset_ping, o_offset_pong, offset_s, offset_s_rem, offset_c_rem,
+      o_offset_s, o_offset_s_rem;
   T *nram_ping = (T *)nram_buffer;
 
   for (int bin_index = bins_first_per; bin_index < bins_loop_per; bin_index++) {
@@ -93,6 +98,7 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
     // coordinates and weights under input data
     getInputTopLeft((T)gx, width, (T *)&i_top_left_x_weight, &i_top_left_x);
     getInputTopLeft((T)gy, height, (T *)&i_top_left_y_weight, &i_top_left_y);
+    //(x,y)
     i_top_left_offset = input_batch_index * height * width * channels +
                         i_top_left_y * width * channels +
                         i_top_left_x * channels;
@@ -104,18 +110,14 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
     i_bottom_right_offset = i_top_left_offset + width * channels + channels;
     i_bottom_right_xy_weight =
         (1 - i_top_left_x_weight) * (1 - i_top_left_y_weight);
-
-    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width - 1) &&
-                       i_top_left_y >= 0 && i_top_left_y <= (height - 1);
-    bool topRightIsIn = (i_top_left_x + 1) >= 0 &&
-                        (i_top_left_x + 1) <= (width - 1) &&
-                        i_top_left_y >= 0 && i_top_left_y <= (height - 1);
-    bool bottomLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (width - 1) &&
-                          (i_top_left_y + 1) >= 0 &&
-                          (i_top_left_y + 1) <= (height - 1);
-    bool bottomRightIsIn =
-        (i_top_left_x + 1) >= 0 && (i_top_left_x + 1) <= (width - 1) &&
-        (i_top_left_y + 1) >= 0 && (i_top_left_y + 1) <= (height - 1);
+    bool topLeftIsIn = between(i_top_left_x, 0, width - 1) &&
+                       between(i_top_left_y, 0, height - 1);
+    bool topRightIsIn = between(i_top_left_x + 1, 0, width - 1) &&
+                        between(i_top_left_y, 0, height - 1);
+    bool bottomLeftIsIn = between(i_top_left_x, 0, width - 1) &&
+                          between(i_top_left_y + 1, 0, height - 1);
+    bool bottomRightIsIn = between(i_top_left_x + 1, 0, width - 1) &&
+                           between(i_top_left_y + 1, 0, height - 1);
     if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
       continue;
     // offset of output data
@@ -160,30 +162,27 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
         // Load
         // L (bin_index)
         offset = (bin_i) % 2 * c_align * 4;
-        __nramset(nram_ping + offset, c_align, 0);
-        __nramset(nram_ping + offset + c_align, c_align, 0);
-        __nramset(nram_ping + offset + 2 * c_align, c_align, 0);
-        __nramset(nram_ping + offset + 3 * c_align, c_align, 0);
+        __nramset(nram_ping + offset, 4 * c_align, 0);
+        __asm__ volatile("sync;\n\t");
         if (topLeftIsIn) {
           __memcpy_async(nram_ping + offset, input + i_top_left_offset,
-                         c_align * sizeof(T), GDRAM2NRAM);
+                         channels * sizeof(T), GDRAM2NRAM);
         }
         if (topRightIsIn) {
           __memcpy_async(nram_ping + offset + c_align,
-                         input + i_top_right_offset, c_align * sizeof(T),
+                         input + i_top_right_offset, channels * sizeof(T),
                          GDRAM2NRAM);
         }
         if (bottomLeftIsIn) {
           __memcpy_async(nram_ping + offset + 2 * c_align,
-                         input + i_bottom_left_offset, c_align * sizeof(T),
+                         input + i_bottom_left_offset, channels * sizeof(T),
                          GDRAM2NRAM);
         }
         if (bottomRightIsIn) {
           __memcpy_async(nram_ping + offset + 3 * c_align,
-                         input + i_bottom_right_offset, c_align * sizeof(T),
+                         input + i_bottom_right_offset, channels * sizeof(T),
                          GDRAM2NRAM);
         }
-        __asm__ volatile("sync;\n\t");
       }
       if (bin_i % 2 == 0) {
         o_offset_ping = o_offset;
@@ -197,25 +196,63 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
       bin_i++;
       __asm__ volatile("sync;\n\t");
     } else {
-      for (int i = 0; i < repeat + 2 + remin_num; ++i) {
+      for (int i = 0; i < repeat + 2 + rem_num; ++i) {
         // Store
         if (i >= 2) {
-          if (i < repeat + 2 + remin_num - 1 || remin_num == 0) {
+          if (i < repeat + 2 + rem_num - 1 || rem_num == 0) {
             // S (i-2)
-            offset = (i - 2) % 2 * nram_limit * 4;
-            __memcpy_async(output + o_offset + (i - 2) * nram_limit,
-                           nram_ping + offset, nram_limit * sizeof(T),
-                           NRAM2GDRAM);
-          } else if (remin_num == 1) {
+            if (i == repeat + 2 + rem_num - 2 &&
+                bin_index != bins_loop_per - 1) {
+              offset_s = (i - 2) % 2 * nram_limit * 4;
+              o_offset_s = o_offset + (i - 2) * nram_limit;
+            } else {
+              offset = (i - 2) % 2 * nram_limit * 4;
+              __memcpy_async(output + o_offset + (i - 2) * nram_limit,
+                             nram_ping + offset, nram_limit * sizeof(T),
+                             NRAM2GDRAM);
+            }
+          } else if (rem_num == 1) {
             // S_rem (i-2)
-            offset = (i - 2) % 2 * nram_limit * 4;
-            __memcpy_async(output + o_offset + (i - 2) * nram_limit,
-                           nram_ping + offset, remin * sizeof(T), NRAM2GDRAM);
+            if (bin_index == bins_loop_per - 1) {
+              offset = (i - 2) % 2 * nram_limit * 4;
+              __memcpy_async(output + o_offset + (i - 2) * nram_limit,
+                             nram_ping + offset, rem * sizeof(T), NRAM2GDRAM);
+            } else {
+              offset_s_rem = (i - 2) % 2 * nram_limit * 4;
+              o_offset_s_rem = o_offset + (i - 2) * nram_limit;
+            }
           }
         }
+        if (i == 0 && bin_index != bins_first_per) {
+          __memcpy_async(output + o_offset_s, nram_ping + offset_s,
+                         nram_limit * sizeof(T), NRAM2GDRAM);
+          // C_rem (i-1)
+          __bang_mul_const(nram_ping + offset_c_rem, nram_ping + offset_c_rem,
+                           i_top_left_xy_weight_pre, rem_align);
+          __bang_mul_const(nram_ping + offset_c_rem + nram_limit,
+                           nram_ping + offset_c_rem + nram_limit,
+                           i_top_right_xy_weight_pre, rem_align);
+          __bang_mul_const(nram_ping + offset_c_rem + 2 * nram_limit,
+                           nram_ping + offset_c_rem + 2 * nram_limit,
+                           i_bottom_left_xy_weight_pre, rem_align);
+          __bang_mul_const(nram_ping + offset_c_rem + 3 * nram_limit,
+                           nram_ping + offset_c_rem + 3 * nram_limit,
+                           i_bottom_right_xy_weight_pre, rem_align);
+          __bang_add(nram_ping + offset_c_rem, nram_ping + offset_c_rem,
+                     nram_ping + offset_c_rem + nram_limit, rem_align);
+          __bang_add(nram_ping + offset_c_rem + 2 * nram_limit,
+                     nram_ping + offset_c_rem + 2 * nram_limit,
+                     nram_ping + offset_c_rem + 3 * nram_limit, rem_align);
+          __bang_add(nram_ping + offset_c_rem, nram_ping + offset_c_rem,
+                     nram_ping + offset_c_rem + 2 * nram_limit, rem_align);
+        }
+        if (i == 1 && bin_index != bins_first_per) {
+          __memcpy_async(output + o_offset_s_rem, nram_ping + offset_s_rem,
+                         rem * sizeof(T), NRAM2GDRAM);
+        }
         // Compute
-        if (i >= 1 && i < repeat + 1 + remin_num) {
-          if (i < repeat + 1 + remin_num - 1 || remin_num == 0) {
+        if (i >= 1 && i < repeat + 1 + rem_num) {
+          if (i < repeat + 1 + rem_num - 1 || rem_num == 0) {
             // C (i-1)
             offset = (i - 1) % 2 * nram_limit * 4;
             __bang_mul_const(nram_ping + offset, nram_ping + offset,
@@ -236,38 +273,44 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
                        nram_ping + offset + 3 * nram_limit, nram_limit);
             __bang_add(nram_ping + offset, nram_ping + offset,
                        nram_ping + offset + 2 * nram_limit, nram_limit);
-          } else if (remin_num == 1) {
-            // C_rem (i-1)
-            offset = (i - 1) % 2 * nram_limit * 4;
-            __bang_mul_const(nram_ping + offset, nram_ping + offset,
-                             i_top_left_xy_weight, remin_align);
-            __bang_mul_const(nram_ping + offset + nram_limit,
-                             nram_ping + offset + nram_limit,
-                             i_top_right_xy_weight, remin_align);
-            __bang_mul_const(nram_ping + offset + 2 * nram_limit,
-                             nram_ping + offset + 2 * nram_limit,
-                             i_bottom_left_xy_weight, remin_align);
-            __bang_mul_const(nram_ping + offset + 3 * nram_limit,
-                             nram_ping + offset + 3 * nram_limit,
-                             i_bottom_right_xy_weight, remin_align);
-            __bang_add(nram_ping + offset, nram_ping + offset,
-                       nram_ping + offset + nram_limit, remin_align);
-            __bang_add(nram_ping + offset + 2 * nram_limit,
-                       nram_ping + offset + 2 * nram_limit,
-                       nram_ping + offset + 3 * nram_limit, remin_align);
-            __bang_add(nram_ping + offset, nram_ping + offset,
-                       nram_ping + offset + 2 * nram_limit, remin_align);
+          } else if (rem_num == 1) {
+            if (bin_index == bins_loop_per - 1) {
+              offset = (i - 1) % 2 * nram_limit * 4;
+              __bang_mul_const(nram_ping + offset, nram_ping + offset,
+                               i_top_left_xy_weight, rem_align);
+              __bang_mul_const(nram_ping + offset + nram_limit,
+                               nram_ping + offset + nram_limit,
+                               i_top_right_xy_weight, rem_align);
+              __bang_mul_const(nram_ping + offset + 2 * nram_limit,
+                               nram_ping + offset + 2 * nram_limit,
+                               i_bottom_left_xy_weight, rem_align);
+              __bang_mul_const(nram_ping + offset + 3 * nram_limit,
+                               nram_ping + offset + 3 * nram_limit,
+                               i_bottom_right_xy_weight, rem_align);
+              __bang_add(nram_ping + offset, nram_ping + offset,
+                         nram_ping + offset + nram_limit, rem_align);
+              __bang_add(nram_ping + offset + 2 * nram_limit,
+                         nram_ping + offset + 2 * nram_limit,
+                         nram_ping + offset + 3 * nram_limit, rem_align);
+              __bang_add(nram_ping + offset, nram_ping + offset,
+                         nram_ping + offset + 2 * nram_limit, rem_align);
+            } else {
+              offset_c_rem = (i - 1) % 2 * nram_limit * 4;
+              i_top_left_xy_weight_pre = i_top_left_xy_weight;
+              i_top_right_xy_weight_pre = i_top_right_xy_weight;
+              i_bottom_left_xy_weight_pre = i_bottom_left_xy_weight;
+              i_bottom_right_xy_weight_pre = i_bottom_right_xy_weight;
+            }
           }
         }
         // Load
-        if (i < repeat + remin_num) {
-          if (i < repeat + remin_num - 1 || remin_num == 0) {
+        if (i < repeat + rem_num) {
+          if (i < repeat + rem_num - 1 || rem_num == 0) {
             // L (i)
-            offset = (i) % 2 * nram_limit * 4;
-            __nramset(nram_ping + offset, nram_limit, 0);
-            __nramset(nram_ping + offset + nram_limit, nram_limit, 0);
-            __nramset(nram_ping + offset + 2 * nram_limit, nram_limit, 0);
-            __nramset(nram_ping + offset + 3 * nram_limit, nram_limit, 0);
+            offset = ((bin_index - bins_first_per) * (repeat + rem_num) + i) %
+                     2 * nram_limit * 4;
+            __nramset(nram_ping + offset, 4 * nram_limit, 0);
+            __asm__ volatile("sync;\n\t");
             if (topLeftIsIn) {
               __memcpy_async(nram_ping + offset,
                              input + i_top_left_offset + i * nram_limit,
@@ -289,32 +332,34 @@ __mlu_func__ void MLUUnion1RoiCropForward(const T *input, const int batch,
                              nram_limit * sizeof(T), GDRAM2NRAM);
             }
 
-          } else if (remin_num == 1) {
+          } else if (rem_num == 1) {
             // L_rem (i-1)
-            offset = (i) % 2 * nram_limit * 4;
-            __nramset(nram_ping + offset, remin_align, 0);
-            __nramset(nram_ping + offset + nram_limit, remin_align, 0);
-            __nramset(nram_ping + offset + 2 * nram_limit, remin_align, 0);
-            __nramset(nram_ping + offset + 3 * nram_limit, remin_align, 0);
+            offset = ((bin_index - bins_first_per) * (repeat + rem_num) + i) %
+                     2 * nram_limit * 4;
+            __nramset(nram_ping + offset, 4 * nram_limit, 0);
+            __nramset(nram_ping + offset + nram_limit, rem_align, 0);
+            __nramset(nram_ping + offset + 2 * nram_limit, rem_align, 0);
+            __nramset(nram_ping + offset + 3 * nram_limit, rem_align, 0);
+            __asm__ volatile("sync;\n\t");
             if (topLeftIsIn) {
               __memcpy_async(nram_ping + offset,
                              input + i_top_left_offset + i * nram_limit,
-                             remin * sizeof(T), GDRAM2NRAM);
+                             rem * sizeof(T), GDRAM2NRAM);
             }
             if (topRightIsIn) {
               __memcpy_async(nram_ping + offset + nram_limit,
                              input + i_top_right_offset + i * nram_limit,
-                             remin * sizeof(T), GDRAM2NRAM);
+                             rem * sizeof(T), GDRAM2NRAM);
             }
             if (bottomLeftIsIn) {
               __memcpy_async(nram_ping + offset + 2 * nram_limit,
                              input + i_bottom_left_offset + i * nram_limit,
-                             remin * sizeof(T), GDRAM2NRAM);
+                             rem * sizeof(T), GDRAM2NRAM);
             }
             if (bottomRightIsIn) {
               __memcpy_async(nram_ping + offset + 3 * nram_limit,
                              input + i_bottom_right_offset + i * nram_limit,
-                             remin * sizeof(T), GDRAM2NRAM);
+                             rem * sizeof(T), GDRAM2NRAM);
             }
           }
         }

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -351,8 +351,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(mluOpHandle_t handle,
  *   Input. Pointer to the MLU memory that stores the input tensor.
  * @param[in] grid_desc
  *   Input. The descriptor of the grid tensor. For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] grid_y
- *   Input. Pointer to the MLU memory that stores the grid tensor.
+ * @param[in] grid
+ *   Input. Pointer to the MLU memory that stores the grid tensor.NaN and INF datas are not supported.
  * @param[in] output_desc
  *   Input. The descriptor of the output tensor. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] output
@@ -377,7 +377,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(mluOpHandle_t handle,
  * - Size of the third dimmension of grid tensor, output tensor must be the same.
  * - Size of the highest dimension of input tensor is divisible by size of the highest deminsions of grid tensor.
  *   The following grid data range:
- *   - Float: [-1.0,1.0].
+ *   - Float: [-1.0,1.0].    
  * @par Requirements
  * - None.
  *

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -339,6 +339,64 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(mluOpHandle_t handle,
                                            const mluOpTensorDescriptor_t dx_desc,
                                            void *diff_x);
 
+/*!
+ * @brief Generates fixed size feature map for each grid，Each Value in the feature map is interpolated by bilinear sampling 
+ *
+ * @param[in] handle
+ *   Input. Handle to a MLUOP context that is used to manage MLU devices and queues in ::mluOpRoiCropForward operation. 
+ *   For detailed information, see ::mluOpHandle_t.
+ * @param[in] input_desc
+ *   Input. The descriptor of the input tensors. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] input
+ *   Input. Pointer to the MLU memory that stores the input tensor.
+ * @param[in] grid_desc
+ *   Input. The descriptor of the grid tensors. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] grid_y
+ *   Input. Pointer to the MLU memory that stores the grid tensor.
+ * @param[in] output_desc
+ *   Input. The descriptor of the output tensors. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] output
+ *   Output. Pointer to the MLU memory that stores the output tensor.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par Formula
+ * - See "RoiCropForward Operation" section in "Cambricon MLUOP User Guide" for details.
+ *
+ * @par Data Type
+ * - Data types of input tensors and output tensor must be the same.
+ * - The supported data types of input and output tensors are as follows:
+ *   - input tensors: half, float.
+ *   - grid tensor: half, float.
+ *   - output tensor: half, float.
+ *
+ * @par Scale Limitation
+ * - The input tensor, grid tensor and ouput tensor must have four dimensions.
+ * - size of the seconde deminsions of grid tensor, output tensor must be the same.
+ * - size of the third deminsions of grid tensor, output tensor must be the same.
+ * - size of the highest deminsions of input tensor is divisible by size of the highest deminsions of grid tensor.
+ *   the following grid data range:
+ *   - float: [-1,1].
+ *   - half: [-1,1].
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://github.com/princewang1994/R-FCN.pytorch/tree/master/lib/model/roi_crop
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(mluOpHandle_t handle,
+                                                const mluOpTensorDescriptor_t input_desc,
+                                                const void *input,
+                                                const mluOpTensorDescriptor_t grid_desc,
+                                                const void *grid,
+                                                const mluOpTensorDescriptor_t output_desc,
+                                                void *output);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -367,19 +367,17 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(mluOpHandle_t handle,
  * @par Data Type
  * - Data types of input tensors and output tensor must be the same.
  * - The supported data types of input and output tensors are as follows:
- *   - input tensors: half, float.
- *   - grid tensor: half, float.
- *   - output tensor: half, float.
+ *   - Input tensors: float.
+ *   - Grid tensor: float.
+ *   - Output tensor: float.
  *
  * @par Scale Limitation
  * - The input tensor, grid tensor and ouput tensor must have four dimensions.
- * - size of the seconde deminsions of grid tensor, output tensor must be the same.
- * - size of the third deminsions of grid tensor, output tensor must be the same.
- * - size of the highest deminsions of input tensor is divisible by size of the highest deminsions of grid tensor.
- *   the following grid data range:
- *   - float: [-1,1].
- *   - half: [-1,1].
- *
+ * - Size of the second dimension of grid tensor, output tensor must be the same.
+ * - Size of the third dimmension of grid tensor, output tensor must be the same.
+ * - Size of the highest dimension of input tensor is divisible by size of the highest deminsions of grid tensor.
+ *   The following grid data range:
+ *   - Float: [-1.0,1.0].
  * @par Requirements
  * - None.
  *

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -346,15 +346,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(mluOpHandle_t handle,
  *   Input. Handle to a MLUOP context that is used to manage MLU devices and queues in ::mluOpRoiCropForward operation. 
  *   For detailed information, see ::mluOpHandle_t.
  * @param[in] input_desc
- *   Input. The descriptor of the input tensors. For detailed information, see ::mluOpTensorDescriptor_t.
+ *   Input. The descriptor of the input tensor. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] input
  *   Input. Pointer to the MLU memory that stores the input tensor.
  * @param[in] grid_desc
- *   Input. The descriptor of the grid tensors. For detailed information, see ::mluOpTensorDescriptor_t.
+ *   Input. The descriptor of the grid tensor. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] grid_y
  *   Input. Pointer to the MLU memory that stores the grid tensor.
  * @param[in] output_desc
- *   Input. The descriptor of the output tensors. For detailed information, see ::mluOpTensorDescriptor_t.
+ *   Input. The descriptor of the output tensor. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] output
  *   Output. Pointer to the MLU memory that stores the output tensor.
  *

--- a/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
+++ b/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
@@ -119,6 +119,7 @@ message Node {
   optional DivParam        div_param        = 16661;  // param
   optional LogParam    log_param    = 131;   // param
   optional SqrtParam   sqrt_param = 116680;  // param
+  optional RoiCropForwardParam  roi_crop_forward_param = 20220519;  //param
 }
 
 
@@ -180,5 +181,9 @@ message SqrtParam {
 }
 
 message DivParam {
+  optional ComputationPreference prefer = 1 [default = COMPUTATION_HIGH_PRECISION];
+}
+
+message RoiCropForwardParam {
   optional ComputationPreference prefer = 1 [default = COMPUTATION_HIGH_PRECISION];
 }

--- a/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
+++ b/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
@@ -119,7 +119,7 @@ message Node {
   optional DivParam        div_param        = 16661;  // param
   optional LogParam    log_param    = 131;   // param
   optional SqrtParam   sqrt_param = 116680;  // param
-  optional RoiCropForwardParam  roi_crop_forward_param = 20220519;  //param
+  optional RoiCropForwardParam  roi_crop_forward_param = 4004;  //param
 }
 
 

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
@@ -9,172 +9,174 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
-#include "mlu_op.h"
 #include "roi_crop_forward.h"
-#include <iostream> 
+
+#include <iostream>
+#include "mlu_op.h"
 
 #define getTensorDesc(data_index) tensor_desc_[data_index].tensor
-#define getTensorDim(data_index,dim_index) tensor_desc_[data_index].tensor->dims[dim_index]
+#define getTensorDim(data_index, dim_index) \
+  tensor_desc_[data_index].tensor->dims[dim_index]
 #define getTensorData(data_index) data_vector_[data_index].device_ptr
 
 namespace mluoptest {
- 
 void RoiCropForwardExecutor::paramCheck() {
-  GTEST_CHECK(parser_->inputs().size() == 2, "[RoiCropForwardExecutor] input number is wrong. ");
-  GTEST_CHECK(parser_->outputs().size() == 1, "[RoiCropForwardExecutor] output number is wrong. ");
+  GTEST_CHECK(parser_->inputs().size() == 2,
+              "[RoiCropForwardExecutor] input number is wrong. ");
+  GTEST_CHECK(parser_->outputs().size() == 1,
+              "[RoiCropForwardExecutor] output number is wrong. ");
 }
 
-void RoiCropForwardExecutor::initData(){
-  VLOG(4) << "###### [RoiCropForwardExecutor] call initData() Begin ######";
-  
+void RoiCropForwardExecutor::initData() {
+  VLOG(4) << "[RoiCropForwardExecutor] call initData() Begin.";
   input_data_ptr = getTensorData(0);
   grid_data_ptr = getTensorData(1);
   output_data_ptr = getTensorData(2);
-
   input_desc = getTensorDesc(0);
   grid_desc = getTensorDesc(1);
   output_desc = getTensorDesc(2);
-
-  input_batch = getTensorDim(0,0);
-  input_h = getTensorDim(0,1);
-  input_w = getTensorDim(0,2);
-  input_c = getTensorDim(0,3);
-
-  grid_batch_roi = getTensorDim(1,0);
-
-  output_h = getTensorDim(2,1);
-  output_w = getTensorDim(2,2);
-
-  VLOG(4) << "###### [RoiCropForwardExecutor] call initData() End ######";
-  
+  input_batch = getTensorDim(0, 0);
+  input_h = getTensorDim(0, 1);
+  input_w = getTensorDim(0, 2);
+  input_c = getTensorDim(0, 3);
+  grid_batch_roi = getTensorDim(1, 0);
+  output_h = getTensorDim(2, 1);
+  output_w = getTensorDim(2, 2);
+  VLOG(4) << "[RoiCropForwardExecutor] call initData() End.";
 }
 
-void RoiCropForwardExecutor::printDataInfo(){
-  VLOG(4) << "###### [RoiCropForwardExecutor] call printDataInfo() Begin ######";
-  VLOG(4) << "# input_batch     " << input_batch;
-  VLOG(4) << "# input_h         " << input_h;
-  VLOG(4) << "# input_w         " << input_w;
-  VLOG(4) << "# input_c         " << input_c;
-  VLOG(4) << "# grid_batch_roi  " << grid_batch_roi;
-  VLOG(4) << "# output_h        " << output_h;
-  VLOG(4) << "# output_w        " << output_w;   
-  VLOG(4) << "###### [RoiCropForwardExecutor] call printDataInfo() End ######";
+void RoiCropForwardExecutor::printDataInfo() {
+  VLOG(4) << "[RoiCropForwardExecutor] call printDataInfo() Begin.";
+  VLOG(4) << "input_batch     " << input_batch;
+  VLOG(4) << "input_h         " << input_h;
+  VLOG(4) << "input_w         " << input_w;
+  VLOG(4) << "input_c         " << input_c;
+  VLOG(4) << "grid_batch_roi  " << grid_batch_roi;
+  VLOG(4) << "output_h        " << output_h;
+  VLOG(4) << "output_w        " << output_w;
+  VLOG(4) << "[RoiCropForwardExecutor] call printDataInfo() End.";
 }
 
-int RoiCropForwardExecutor::getInputTopLeft(float grid_yx_value,int input_hw,float & weight){
-  VLOG(4) << "###### [RoiCropForwardExecutor] call getInputLeft() Begin ######";
+int RoiCropForwardExecutor::getInputTopLeft(float grid_yx_value, int input_hw,
+                                            float& weight) {
+  VLOG(4) << "[RoiCropForwardExecutor] call getInputLeft() Begin.";
   float i_top_left_coord = (grid_yx_value + 1) * (input_hw - 1) / 2;
   int i_top_left = floor(i_top_left_coord);
   weight = 1 - (i_top_left_coord - i_top_left);
-  VLOG(4) << "###### [RoiCropForwardExecutor] call getInputLeft() End ######";
+  VLOG(4) << "[RoiCropForwardExecutor] call getInputLeft() End.";
   return i_top_left;
- 
 }
- 
+
 void RoiCropForwardExecutor::compute() {
-  VLOG(4) << "###### [RoiCropForwardExecutor] call compute() Begin ######";
+  VLOG(4) << "[RoiCropForwardExecutor] call compute() Begin.";
   paramCheck();
   initData();
   printDataInfo();
   interface_timer_.start();
-  MLUOP_CHECK(mluOpRoiCropForward(handle_, input_desc, input_data_ptr, grid_desc, grid_data_ptr, output_desc, output_data_ptr));
+  MLUOP_CHECK(mluOpRoiCropForward(handle_, input_desc, input_data_ptr,
+                                  grid_desc, grid_data_ptr, output_desc,
+                                  output_data_ptr));
   interface_timer_.stop();
-  
-  VLOG(4) << "###### [RoiCropForwardExecutor] call compute() End ######";
+  VLOG(4) << "[RoiCropForwardExecutor] call compute() End.";
 }
- 
-void RoiCropForwardExecutor::cpuCompute() {
-  
-  VLOG(4) << "###### [RoiCropForwardExecutor] call cpuCompute() Begin ######";
-  float * input_cpu_ptr = cpu_fp32_input_[0];
-  float * grid_cpu_ptr = cpu_fp32_input_[1];
-  float * output_cpu_ptr = cpu_fp32_output_[0];
 
+void RoiCropForwardExecutor::cpuCompute() {
+  VLOG(4) << "[RoiCropForwardExecutor] call cpuCompute() Begin.";
+  float* input_cpu_ptr = cpu_fp32_input_[0];
+  float* grid_cpu_ptr = cpu_fp32_input_[1];
+  float* output_cpu_ptr = cpu_fp32_output_[0];
   int output_nums = grid_batch_roi * output_h * output_w * input_c;
   int roi_per_img = grid_batch_roi / input_batch;
   int output_stride_batch = output_h * output_w * input_c;
   int output_stride_h = output_w * input_c;
   int output_stride_w = input_c;
-
   int grid_stride_batch = output_h * output_w * 2;
   int grid_stride_h = output_w * 2;
   int gride_stride_w = 2;
-
   int input_stride_batch = input_h * input_w * input_c;
   int input_stride_h = input_w * input_c;
   int input_stride_w = input_c;
-
   int i_top_left_x = 0;
   int i_top_left_y = 0;
   float i_top_left_x_weight = 0.0;
   float i_top_left_y_weight = 0.0;
-
   float i_top_left = 0;
-  float i_top_right = 0; 
+  float i_top_right = 0;
   float i_bottom_left = 0;
   float i_bottom_right = 0;
 
-  for (int index = 0; index < output_nums; ++index){
-    //coordinates of each position in output data
+  for (int index = 0; index < output_nums; ++index) {
+    // coordinates of each position in output data
     int oc = index % input_c;
     int ow = (index / output_stride_w) % output_w;
     int oh = (index / output_stride_h) % output_h;
     int on = index / output_stride_batch;
     // data oddset in output
-    const int output_offset = on * output_stride_batch + oh * output_stride_h  + ow * output_stride_w + oc;
+    const int output_offset = on * output_stride_batch + oh * output_stride_h +
+                              ow * output_stride_w + oc;
     // batch dimension index in output
     int input_n = on / roi_per_img;
-    //data value in grid
-    float yf = grid_cpu_ptr[on * grid_stride_batch + oh * grid_stride_h + ow * gride_stride_w];
-    float xf = grid_cpu_ptr[on * grid_stride_batch + oh * grid_stride_h + ow * gride_stride_w +1];
-    //input data information
-    i_top_left_x = getInputTopLeft(xf,input_w,i_top_left_x_weight);
-    i_top_left_y = getInputTopLeft(yf,input_h,i_top_left_y_weight);
-    
-    //field information
-    const int i_top_left_offset = input_n * input_stride_batch + i_top_left_y * input_stride_h + i_top_left_x * input_stride_w + oc;
+    // data value in grid
+    float yf = grid_cpu_ptr[on * grid_stride_batch + oh * grid_stride_h +
+                            ow * gride_stride_w];
+    float xf = grid_cpu_ptr[on * grid_stride_batch + oh * grid_stride_h +
+                            ow * gride_stride_w + 1];
+    // input data information
+    i_top_left_x = getInputTopLeft(xf, input_w, i_top_left_x_weight);
+    i_top_left_y = getInputTopLeft(yf, input_h, i_top_left_y_weight);
+
+    // field information
+    const int i_top_left_offset = input_n * input_stride_batch +
+                                  i_top_left_y * input_stride_h +
+                                  i_top_left_x * input_stride_w + oc;
     float i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
-    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (input_w -1) && i_top_left_y >= 0 && i_top_left_y <= (input_h-1);
-    if (topLeftIsIn){
+    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (input_w - 1) &&
+                       i_top_left_y >= 0 && i_top_left_y <= (input_h - 1);
+    if (topLeftIsIn) {
       i_top_left = input_cpu_ptr[i_top_left_offset];
     }
-    
     const int i_top_right_offset = i_top_left_offset + input_stride_w;
-    float i_top_right_xy_weight = (1 - i_top_left_x_weight) * i_top_left_y_weight;
-    bool topRightIsIn = i_top_left_x >= 0 && i_top_left_x <= (input_w -1) && (i_top_left_y + 1) >= 0 && (i_top_left_y + 1) <= (input_h-1);
-    if (topRightIsIn){
+    float i_top_right_xy_weight =
+        (1 - i_top_left_x_weight) * i_top_left_y_weight;
+    bool topRightIsIn = i_top_left_x >= 0 && i_top_left_x <= (input_w - 1) &&
+                        (i_top_left_y + 1) >= 0 &&
+                        (i_top_left_y + 1) <= (input_h - 1);
+    if (topRightIsIn) {
       i_top_right = input_cpu_ptr[i_top_right_offset];
     }
-  
     const int i_bottom_left_offset = i_top_left_offset + input_stride_h;
-    float i_bottom_left_xy_weight = i_top_left_x_weight * (1 - i_top_left_y_weight);
-    bool bottomLeftIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (input_w -1) && i_top_left_y >= 0 && i_top_left_y <= (input_h-1);
-    if (bottomLeftIsIn){
+    float i_bottom_left_xy_weight =
+        i_top_left_x_weight * (1 - i_top_left_y_weight);
+    bool bottomLeftIsIn = (i_top_left_x + 1) >= 0 &&
+                          (i_top_left_x + 1) <= (input_w - 1) &&
+                          i_top_left_y >= 0 && i_top_left_y <= (input_h - 1);
+    if (bottomLeftIsIn) {
       i_bottom_left = input_cpu_ptr[i_bottom_left_offset];
     }
-    
-    const int i_bottom_right_offset = i_top_left_offset + input_stride_h + input_stride_w;
-    float i_bottom_right_xy_weight = (1 - i_top_left_x_weight) * (1 - i_top_left_y_weight);
-    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (input_w -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (input_h-1);
-    if (bottomRightIsIn){
+    const int i_bottom_right_offset =
+        i_top_left_offset + input_stride_h + input_stride_w;
+    float i_bottom_right_xy_weight =
+        (1 - i_top_left_x_weight) * (1 - i_top_left_y_weight);
+    bool bottomRightIsIn =
+        (i_top_left_x + 1) >= 0 && (i_top_left_x + 1) <= (input_w - 1) &&
+        (i_top_left_y + 1) >= 0 && (i_top_left_y + 1) <= (input_h - 1);
+    if (bottomRightIsIn) {
       i_bottom_right = input_cpu_ptr[i_bottom_right_offset];
     }
-    
-    output_cpu_ptr[output_offset] = i_top_left_xy_weight * i_top_left 
-                                    + i_top_right_xy_weight * i_top_right 
-                                    + i_bottom_left_xy_weight * i_bottom_left
-                                    + i_bottom_right_xy_weight * i_bottom_right;  
+
+    output_cpu_ptr[output_offset] = i_top_left_xy_weight * i_top_left +
+                                    i_top_right_xy_weight * i_top_right +
+                                    i_bottom_left_xy_weight * i_bottom_left +
+                                    i_bottom_right_xy_weight * i_bottom_right;
   }
-  
-  VLOG(4) << "###### [RoiCropForwardExecutor] call cpuCompute() End ######";
-  
+  VLOG(4) << "[RoiCropForwardExecutor] call cpuCompute() End.";
 }
 
 int64_t RoiCropForwardExecutor::getTheoryOps() {
-  int cp_count = 58 ;
+  int cp_count = 58;
   theory_ops = parser_->getInputDataCount(0) * cp_count;
-  VLOG(4) << "getTheoryOps: " << theory_ops << " ops";
+  VLOG(4) << "[RoiCropForwardExecutor] getTheoryOps: " << theory_ops << " ops.";
   return theory_ops;
 }
- 
+
 }  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
@@ -1,0 +1,180 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "mlu_op.h"
+#include "roi_crop_forward.h"
+#include <iostream> 
+
+#define getTensorDesc(data_index) tensor_desc_[data_index].tensor
+#define getTensorDim(data_index,dim_index) tensor_desc_[data_index].tensor->dims[dim_index]
+#define getTensorData(data_index) data_vector_[data_index].device_ptr
+
+namespace mluoptest {
+ 
+void RoiCropForwardExecutor::paramCheck() {
+  GTEST_CHECK(parser_->inputs().size() == 2, "[RoiCropForwardExecutor] input number is wrong. ");
+  GTEST_CHECK(parser_->outputs().size() == 1, "[RoiCropForwardExecutor] output number is wrong. ");
+}
+
+void RoiCropForwardExecutor::initData(){
+  VLOG(4) << "###### [RoiCropForwardExecutor] call initData() Begin ######";
+  
+  input_data_ptr = getTensorData(0);
+  grid_data_ptr = getTensorData(1);
+  output_data_ptr = getTensorData(2);
+
+  input_desc = getTensorDesc(0);
+  grid_desc = getTensorDesc(1);
+  output_desc = getTensorDesc(2);
+
+  input_batch = getTensorDim(0,0);
+  input_h = getTensorDim(0,1);
+  input_w = getTensorDim(0,2);
+  input_c = getTensorDim(0,3);
+
+  grid_batch_roi = getTensorDim(1,0);
+
+  output_h = getTensorDim(2,1);
+  output_w = getTensorDim(2,2);
+
+  VLOG(4) << "###### [RoiCropForwardExecutor] call initData() End ######";
+  
+}
+
+void RoiCropForwardExecutor::printDataInfo(){
+  VLOG(4) << "###### [RoiCropForwardExecutor] call printDataInfo() Begin ######";
+  VLOG(4) << "# input_batch     " << input_batch;
+  VLOG(4) << "# input_h         " << input_h;
+  VLOG(4) << "# input_w         " << input_w;
+  VLOG(4) << "# input_c         " << input_c;
+  VLOG(4) << "# grid_batch_roi  " << grid_batch_roi;
+  VLOG(4) << "# output_h        " << output_h;
+  VLOG(4) << "# output_w        " << output_w;   
+  VLOG(4) << "###### [RoiCropForwardExecutor] call printDataInfo() End ######";
+}
+
+int RoiCropForwardExecutor::getInputTopLeft(float grid_yx_value,int input_hw,float & weight){
+  VLOG(4) << "###### [RoiCropForwardExecutor] call getInputLeft() Begin ######";
+  float i_top_left_coord = (grid_yx_value + 1) * (input_hw - 1) / 2;
+  int i_top_left = floor(i_top_left_coord);
+  weight = 1 - (i_top_left_coord - i_top_left);
+  VLOG(4) << "###### [RoiCropForwardExecutor] call getInputLeft() End ######";
+  return i_top_left;
+ 
+}
+ 
+void RoiCropForwardExecutor::compute() {
+  VLOG(4) << "###### [RoiCropForwardExecutor] call compute() Begin ######";
+  paramCheck();
+  initData();
+  printDataInfo();
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpRoiCropForward(handle_, input_desc, input_data_ptr, grid_desc, grid_data_ptr, output_desc, output_data_ptr));
+  interface_timer_.stop();
+  
+  VLOG(4) << "###### [RoiCropForwardExecutor] call compute() End ######";
+}
+ 
+void RoiCropForwardExecutor::cpuCompute() {
+  
+  VLOG(4) << "###### [RoiCropForwardExecutor] call cpuCompute() Begin ######";
+  float * input_cpu_ptr = cpu_fp32_input_[0];
+  float * grid_cpu_ptr = cpu_fp32_input_[1];
+  float * output_cpu_ptr = cpu_fp32_output_[0];
+
+  int output_nums = grid_batch_roi * output_h * output_w * input_c;
+  int roi_per_img = grid_batch_roi / input_batch;
+  int output_stride_batch = output_h * output_w * input_c;
+  int output_stride_h = output_w * input_c;
+  int output_stride_w = input_c;
+
+  int grid_stride_batch = output_h * output_w * 2;
+  int grid_stride_h = output_w * 2;
+  int gride_stride_w = 2;
+
+  int input_stride_batch = input_h * input_w * input_c;
+  int input_stride_h = input_w * input_c;
+  int input_stride_w = input_c;
+
+  int i_top_left_x = 0;
+  int i_top_left_y = 0;
+  float i_top_left_x_weight = 0.0;
+  float i_top_left_y_weight = 0.0;
+
+  float i_top_left = 0;
+  float i_top_right = 0; 
+  float i_bottom_left = 0;
+  float i_bottom_right = 0;
+
+  for (int index = 0; index < output_nums; ++index){
+    //coordinates of each position in output data
+    int oc = index % input_c;
+    int ow = (index / output_stride_w) % output_w;
+    int oh = (index / output_stride_h) % output_h;
+    int on = index / output_stride_batch;
+    // data oddset in output
+    const int output_offset = on * output_stride_batch + oh * output_stride_h  + ow * output_stride_w + oc;
+    // batch dimension index in output
+    int input_n = on / roi_per_img;
+    //data value in grid
+    float yf = grid_cpu_ptr[on * grid_stride_batch + oh * grid_stride_h + ow * gride_stride_w];
+    float xf = grid_cpu_ptr[on * grid_stride_batch + oh * grid_stride_h + ow * gride_stride_w +1];
+    //input data information
+    i_top_left_x = getInputTopLeft(xf,input_w,i_top_left_x_weight);
+    i_top_left_y = getInputTopLeft(yf,input_h,i_top_left_y_weight);
+    
+    //field information
+    const int i_top_left_offset = input_n * input_stride_batch + i_top_left_y * input_stride_h + i_top_left_x * input_stride_w + oc;
+    float i_top_left_xy_weight = i_top_left_x_weight * i_top_left_y_weight;
+    bool topLeftIsIn = i_top_left_x >= 0 && i_top_left_x <= (input_w -1) && i_top_left_y >= 0 && i_top_left_y <= (input_h-1);
+    if (topLeftIsIn){
+      i_top_left = input_cpu_ptr[i_top_left_offset];
+    }
+    
+    const int i_top_right_offset = i_top_left_offset + input_stride_w;
+    float i_top_right_xy_weight = (1 - i_top_left_x_weight) * i_top_left_y_weight;
+    bool topRightIsIn = i_top_left_x >= 0 && i_top_left_x <= (input_w -1) && (i_top_left_y + 1) >= 0 && (i_top_left_y + 1) <= (input_h-1);
+    if (topRightIsIn){
+      i_top_right = input_cpu_ptr[i_top_right_offset];
+    }
+  
+    const int i_bottom_left_offset = i_top_left_offset + input_stride_h;
+    float i_bottom_left_xy_weight = i_top_left_x_weight * (1 - i_top_left_y_weight);
+    bool bottomLeftIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (input_w -1) && i_top_left_y >= 0 && i_top_left_y <= (input_h-1);
+    if (bottomLeftIsIn){
+      i_bottom_left = input_cpu_ptr[i_bottom_left_offset];
+    }
+    
+    const int i_bottom_right_offset = i_top_left_offset + input_stride_h + input_stride_w;
+    float i_bottom_right_xy_weight = (1 - i_top_left_x_weight) * (1 - i_top_left_y_weight);
+    bool bottomRightIsIn = (i_top_left_x+1) >= 0 && (i_top_left_x+1) <= (input_w -1) && (i_top_left_y+1) >= 0 && (i_top_left_y+1) <= (input_h-1);
+    if (bottomRightIsIn){
+      i_bottom_right = input_cpu_ptr[i_bottom_right_offset];
+    }
+    
+    output_cpu_ptr[output_offset] = i_top_left_xy_weight * i_top_left 
+                                    + i_top_right_xy_weight * i_top_right 
+                                    + i_bottom_left_xy_weight * i_bottom_left
+                                    + i_bottom_right_xy_weight * i_bottom_right;  
+  }
+  
+  VLOG(4) << "###### [RoiCropForwardExecutor] call cpuCompute() End ######";
+  
+}
+
+int64_t RoiCropForwardExecutor::getTheoryOps() {
+  int cp_count = 58 ;
+  theory_ops = parser_->getInputDataCount(0) * cp_count;
+  VLOG(4) << "getTheoryOps: " << theory_ops << " ops";
+  return theory_ops;
+}
+ 
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
@@ -60,11 +60,11 @@ void RoiCropForwardExecutor::printDataInfo() {
 int RoiCropForwardExecutor::getInputTopLeft(float grid_yx_value, int input_hw,
                                             float& weight) {
   VLOG(4) << "[RoiCropForwardExecutor] call getInputLeft() Begin.";
-  float i_top_left_coord = (grid_yx_value + 1) * (input_hw - 1) / 2;
-  int i_top_left = floor(i_top_left_coord);
-  weight = 1 - (i_top_left_coord - i_top_left);
+  float xcoord = (grid_yx_value + 1) * (input_hw - 1) / 2;
+  int point = floor(xcoord);
+  weight = 1 - (xcoord - point);
   VLOG(4) << "[RoiCropForwardExecutor] call getInputLeft() End.";
-  return i_top_left;
+  return point;
 }
 
 void RoiCropForwardExecutor::compute() {
@@ -173,7 +173,7 @@ void RoiCropForwardExecutor::cpuCompute() {
 }
 
 int64_t RoiCropForwardExecutor::getTheoryOps() {
-  int cp_count = 58;
+  int cp_count = 7;
   theory_ops = parser_->getInputDataCount(0) * cp_count;
   VLOG(4) << "[RoiCropForwardExecutor] getTheoryOps: " << theory_ops << " ops.";
   return theory_ops;

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.h
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.h
@@ -1,0 +1,57 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_FORWARD_ROI_CROP_FOREARD_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_FORWARD_ROI_CROP_FOREARD_H_
+#include <vector>
+#include "core/type.h"
+#include "executor.h"
+
+namespace mluoptest {
+
+class RoiCropForwardExecutor : public Executor {
+  public:
+    RoiCropForwardExecutor() {}
+    ~RoiCropForwardExecutor() {}
+
+    void paramCheck();
+    void initData();
+    void printDataInfo();
+    int getInputTopLeft(float grid_yx_value,int input_hw,float & weight);
+    void compute();
+    void cpuCompute();
+    int64_t getTheoryOps() override;
+
+  private:
+    void * input_data_ptr = NULL;
+    void * grid_data_ptr = NULL;
+    void * output_data_ptr = NULL;
+
+    mluOpTensorDescriptor_t input_desc = NULL;
+    mluOpTensorDescriptor_t grid_desc = NULL;
+    mluOpTensorDescriptor_t output_desc = NULL;
+
+    int input_batch;
+    int input_h;
+    int input_w;
+    int input_c;
+
+    int grid_batch_roi;
+
+    int output_h;
+    int output_w;
+
+    int64_t theory_ops = 0;
+
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_FORWARD_ROI_CROP_FOREARD_H_

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.h
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/roi_crop_forward.h
@@ -12,46 +12,40 @@
 #ifndef TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_FORWARD_ROI_CROP_FOREARD_H_
 #define TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_FORWARD_ROI_CROP_FOREARD_H_
 #include <vector>
+
 #include "core/type.h"
 #include "executor.h"
 
 namespace mluoptest {
-
 class RoiCropForwardExecutor : public Executor {
-  public:
-    RoiCropForwardExecutor() {}
-    ~RoiCropForwardExecutor() {}
+ public:
+  RoiCropForwardExecutor() {}
+  ~RoiCropForwardExecutor() {}
+  void paramCheck();
+  void initData();
+  void printDataInfo();
+  int getInputTopLeft(float grid_yx_value, int input_hw, float& weight);
+  void compute();
+  void cpuCompute();
+  int64_t getTheoryOps() override;
 
-    void paramCheck();
-    void initData();
-    void printDataInfo();
-    int getInputTopLeft(float grid_yx_value,int input_hw,float & weight);
-    void compute();
-    void cpuCompute();
-    int64_t getTheoryOps() override;
-
-  private:
-    void * input_data_ptr = NULL;
-    void * grid_data_ptr = NULL;
-    void * output_data_ptr = NULL;
-
-    mluOpTensorDescriptor_t input_desc = NULL;
-    mluOpTensorDescriptor_t grid_desc = NULL;
-    mluOpTensorDescriptor_t output_desc = NULL;
-
-    int input_batch;
-    int input_h;
-    int input_w;
-    int input_c;
-
-    int grid_batch_roi;
-
-    int output_h;
-    int output_w;
-
-    int64_t theory_ops = 0;
-
+ private:
+  void* input_data_ptr                = NULL;
+  void* grid_data_ptr                 = NULL;
+  void* output_data_ptr               = NULL;
+  mluOpTensorDescriptor_t input_desc  = NULL;
+  mluOpTensorDescriptor_t grid_desc   = NULL;
+  mluOpTensorDescriptor_t output_desc = NULL;
+  int input_batch;
+  int input_h;
+  int input_w;
+  int input_c;
+  int grid_batch_roi;
+  int output_h;
+  int output_w;
+  int64_t theory_ops = 0;
 };
 
 }  // namespace mluoptest
 #endif  // TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_FORWARD_ROI_CROP_FOREARD_H_
+

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_forward/test_case/case_0.prototxt
@@ -1,0 +1,53 @@
+op_name: "roi_crop_forward"
+input {
+  id: "input1"
+  shape: {
+    dims: 128
+    dims: 32
+    dims: 32
+    dims: 512
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 23
+    upper_bound: -5.0
+    lower_bound: 5.0
+    distribution: UNIFORM
+  }
+}
+input {
+  id: "input2"
+  shape: {
+    dims: 256
+    dims: 5
+    dims: 5
+    dims: 2
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 20
+    upper_bound: -1.0
+    lower_bound:  1.0
+    distribution: UNIFORM
+  }
+}
+output {
+  id: "output"
+  shape: {
+    dims: 256
+    dims: 5
+    dims: 5
+    dims: 512
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 0.0003
+  error_threshold: 0.0003
+  baseline_device: CPU
+}


### PR DESCRIPTION
### **1. 修改描述**
新增roi_crop_forward算子，提供获取感兴趣区域特征值的功能

- **影响范围/算子**：roi_crop_forward
- **影响版本/分支**：master
##### 1.1 精度验收标准
算子采用静态阈值标准：diffs=[diff1，diff2]，diff1<=3e-3 && diff2 <= 3e-3。
##### 1.2 算子方案CheckList
|      序号      |           需求           |      需求详情       |
|----|----|----|
|1|支持硬件 |MLU290、MLU370|
|2|job类型|U1|
|3|DimXYZ|支持DimXYZ|
|4|可变|不支持各个维度可变|
|5|layout|支持NHWC|
|6|多维|不支持多维|
|7|0元素|不支持0元素|
|8|转数提前|否|
|9|片外数据类型|float|
|10|片上数据类型|float|
|11|融合|否|
|12|规模限制|否|
|13|c不感知对齐|否|
|14|原位测试对齐|不支持|
##### 1.3 新特性测例
|测试点|验收标准|测试结果(精度)|
|----|----|----|
|数据类型测试|FLOAT|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|多维张量测试|支持4维|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|Layout测试|支持NHWC|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down [ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED.[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|不同规模 / 整数余数端段 / 对齐不对齐||[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED.[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|零维张量测试/0元素测试|不支持0元素测试|2022-05-23 12:25:20.412141: [cnrtError] [55874] [Card : 0] cnrtMemcpy: Input argument 'dst' or 'src' is NULL. Please check the input arguments.[/tudejiang/mlu-ops/bangc-ops/test/mlu_op_gtes/src/executor.cpp:1375] CNRT error, code=632003(invalid argument.) "cnrtMemcpy(db->device_origin_ptr, db->host_ptr,db->size, CNRT_MEM_TRANS_DIR_HOST2DEV)"|
|稳定性测试|gtest 多线程+repeat 使用--gtest_repeat=NUM --thread=NUM |[^ OK ] ../../test/mlu_op_gtest/src/zoo/roi_crop_forward/case_test/case_0.prototxt[ OK ] roi_crop_forward/TestSuite.mluOp/0 (1673 ms)[----------] 1 test from roi_crop_forward/TestSuite (1673 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 200 cases of 200 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (1676 ms total)[ PASSED ] 1 test case. |
|多平台测试|支持MLU290、MLU370|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED.[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|gen_case模块测试|gen_case模块生成的测试通过|[ OK ] roi_crop_forward/TestSuite.mluOp/0 (3 ms)[----------] 1 test from roi_crop_forward/TestSuite (3 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1 cases of 1 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (73 ms total)[ PASSED ] 1 test case.|
|其他测试点|||
##### 1.4 参数检查
提交新算子时，给出测试点，并说明测试结果。
|测试点|验收标准|测试结果(出错信息)|
|----|----|----|
|不符合算子限制|正常报错|1、input、grid和output的数据类型应该一致:<br>[2022-5-23 20:51:44] [MLUOP] [Error]：[mluOpRoiCropForward] Check failed: input_desc->dtype == output_desc->dtype. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:74 pid:55878]<br>2、input、grid和output的layout必须为NHWC：<br>[2022-5-23 20:52:26] [MLUOP] [Error]:[mluOpRoiCropForward] Check failed: output_desc->layout == MLUOP_LAYOUT_NHWC. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:85 pid:55880]<br>3、grid的最后维度必须是2:<br>[2022-5-23 20:53:6] [MLUOP] [Error]:[mluOpRoiCropForward]:Check failed: grid_desc->dims[3] should be equal to 2. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:96 pid:55882]<br>4、input和output的最后一维必须一致:<br>[2022-5-23 20:53:31] [MLUOP] [Error]:[mluOpRoiCropForward]:Check failed: output_desc->dims[3] should be equal to input_desc->dims[3]. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:91 pid:55884]<br>5、grid和output的第一、第二、第三维度必须一致:<br>[2022-5-23 20:54:15] [MLUOP] [Error]:[mluOpRoiCropForward]:Check failed: output_desc->dims[0]/[1]/[2] should be equal to grid_desc->dims[0]/[1]/[2]. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:87 pid:55886]|
|非法参数传递|正常报错||
### 2. 性能测试
- 要排除机器环境的影响。
- 用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试。
- 建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理。
- 算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。
##### 2.1 算子io利用率、计算效率
注释: 
io_efficiency = theory_io_size / (latency * IO_BANDWIDTH)
**theory_is_size:** 从算法上需要访问的数据量(与实现无关), **lantency:**算子运行的实际时间, **IO_BANGWIDTH:**硬件的理论带宽.
compute_efficiency = theory_compute_ops / (latency * peak_compute_force)
**theory_compute_ops:** 该算子从算法上需要执行多少次操作(与实际无关), **lantency:** 表示算子运行的实际时间, **peak_compute_force:** 硬件平台的峰值算力, 其单位是op/s(每秒执行多少操作)
|operator|mlu_hardware_time|mlu_interface_time|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size|count|input|grid|output|
|----|----|----|----|----|----|----|----|----|----|
|roi_crop_forward|6|21.468|2.21e-5|0.00011|0|1|1,5,5,1|1,3,1,2|1,3,1,1|
|roi_crop_forward|6|20.817|0.00843|0.0604|0|1|1,16,16,50|1,3,1,2|1,3,1,50|
|roi_crop_forward|9|24.546|0.0227865|0.16|0|1|1,32,32,50|1,5,5,2|1,5,5,50|
|roi_crop_forward|10|22.109|0.204902|1.45|0|1|1,32,32,500|1,5,5,2|1,5,5,500|
|roi_crop_forward|96|38.829|2.1342|15.104|0|1|1,32,32,50000|1,5,5,2|1,5,5,50000|
|roi_crop_forward|62|59.818|0.5540|3.7419|0|1|16,32,32,500|48,5,5,2|48,5,5,500|
|roi_crop_forward|33|34.934|0.995|7.03|0|1|16,32,32,500|48,3,3,2|48,3,3,500|
|roi_crop_forward|44|32.661|0.759|5.2727|0|1|16,32,32,500|48.3,5,2|48,3,5,500|
|roi_crop_forward|273|32.723|0.1637|0.8498|0|1|16,32,32,500|48,9,15,500|48,9,15,500|
|roi_crop_forward|633|71.129|1.111|7.33|0|1|8,64,64,5000|24,9,15,2|24,9,15,5000|

##### 2.2 竞品效率(可选)
##### 2.3 内存泄露
暂不支持
##### 2.4 代码覆盖率
[57.1%][57.1%] 57.1 %271 / 475       87.5 %7 / 8
### 3. 总结分析
总结分析主要需要考虑以下几点：
1、roi_crop算子包含正反向，该算子roi_crop_forward功能为给定input、grid计算得到output。roi_crop_backward功能后续会加入。
2、该竞品算子暂时不支持half类型的数据，grid不支持NaN和INF数据，主要因为硬件原因，jira有人已经提了需求。
3、该算子的源码只支持torch版本为0.3.0，高于该版本竞品源码会出现各种问题。
