### PR TITLE
[Feature](bangc-ops):Add new op roi_crop_backward

### DIFF
--- a/bangc-ops/kernels/fill_zero/fill_zero.mlu
+++ b/bangc-ops/kernels/fill_zero/fill_zero.mlu
@@ -1,0 +1,32 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#include "mlu_op_kernel.h"
+
+__mlu_global__ void MLUKernelGdramSetZero(void *gdram_ptr, const int num) {
+  uint32_t seg_n = num / taskDim;
+  uint32_t rem_n = num % taskDim;
+  if (taskId < rem_n) {
+    seg_n += 1;
+  }
+  int n_first_per =
+      (num / taskDim) * taskId + (taskId > rem_n ? rem_n : taskId);
+  float zero = 0.0;
+  __gdramset((float *)gdram_ptr + n_first_per, seg_n, zero);
+}
+
+void MLUOP_WIN_API mluOpBlockKernelFreeZero(cnrtDim3_t k_dim,
+                                            cnrtFunctionType_t k_type,
+                                            cnrtQueue_t queue, const int num,
+                                            void *gdram_ptr) {
+  MLUKernelGdramSetZero<<<k_dim, k_type, queue>>>(gdram_ptr, num);
+}

--- a/bangc-ops/kernels/fill_zero/fill_zero.mlu
+++ b/bangc-ops/kernels/fill_zero/fill_zero.mlu
@@ -24,7 +24,7 @@ __mlu_global__ void MLUKernelGdramSetZero(void *gdram_ptr, const int num) {
   __gdramset((float *)gdram_ptr + n_first_per, seg_n, zero);
 }
 
-void MLUOP_WIN_API mluOpBlockKernelFreeZero(cnrtDim3_t k_dim,
+void MLUOP_WIN_API mluOpBlockKernelFillZero(cnrtDim3_t k_dim,
                                             cnrtFunctionType_t k_type,
                                             cnrtQueue_t queue, const int num,
                                             void *gdram_ptr) {

--- a/bangc-ops/kernels/roi_crop/roi_crop.cpp
+++ b/bangc-ops/kernels/roi_crop/roi_crop.cpp
@@ -1,0 +1,134 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <string>
+#include "core/context.h"
+#include "core/logging.h"
+#include "core/runtime/device.h"
+#include "core/tensor.h"
+#include "core/type.h"
+#include "mlu_op.h"
+#include "mlu_op_kernel.h"
+
+static void policyFunc(const mluOpHandle_t handle, int bin_num,
+                       cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
+  uint32_t cluster_num = mluop::runtime::getClusterLimitCapability(handle);
+  uint32_t core_in_cluster = handle->core_num_per_cluster;
+  *k_type = CNRT_FUNC_TYPE_UNION1;
+  k_dim->x = core_in_cluster;
+  uint32_t use_cluster = (bin_num + core_in_cluster - 1) / core_in_cluster;
+  k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
+  k_dim->z = 1;
+}
+
+/* user param check
+ * step1:check desc and data ptr is not nullptr_t
+ * step2:check shape and data type
+ * step3:check zero element
+ * */
+mluOpStatus_t RoiCropBackwardParamCheck(
+    const std::string &op_name, const mluOpHandle_t handle,
+    const mluOpTensorDescriptor_t gradOutput_desc, const void *gradOutput,
+    const mluOpTensorDescriptor_t grid_desc, const void *grid,
+    const mluOpTensorDescriptor_t gradInput_desc, const void *gradInput) {
+  // check descriptor and data
+  PARAM_CHECK(op_name, handle != NULL);
+  PARAM_CHECK(op_name, gradOutput_desc != NULL);
+  PARAM_CHECK(op_name, grid_desc != NULL);
+  PARAM_CHECK(op_name, gradInput_desc != NULL);
+  // check data type
+  PARAM_CHECK(op_name, gradOutput_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(op_name, gradOutput_desc->dim == 4);
+  PARAM_CHECK(op_name, grid_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(op_name, grid_desc->dim == 4);
+  PARAM_CHECK(op_name, gradInput_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(op_name, gradInput_desc->dim == 4);
+  // check shape and layout
+  PARAM_CHECK(op_name, gradOutput_desc->layout == MLUOP_LAYOUT_NHWC);
+  PARAM_CHECK(op_name, gradInput_desc->layout == MLUOP_LAYOUT_NHWC);
+  for (int i = 0; i < gradOutput_desc->dim - 1; ++i) {
+    if (gradOutput_desc->dims[i] != grid_desc->dims[i]) {
+      LOG(ERROR) << op_name << " Check failed: gradOutput_desc->dims[" << i
+                 << "] should be equal to grid_desc->dims[" << i << "].";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+  }
+  if (gradOutput_desc->dims[3] != gradInput_desc->dims[3]) {
+    LOG(ERROR) << op_name
+               << " Check failed: gradOutput_desc->dims[3] should be "
+                  "equal to gradInput_desc->dims[3].";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (grid_desc->dims[3] != 2) {
+    LOG(ERROR) << op_name
+               << " Check failed: grid_desc->dims[3] should be equal to 2.";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  const size_t max_input_num = 2147483648;  // 2^31 2G num
+  if ((mluOpGetTensorElementNum(gradOutput_desc) >= max_input_num) ||
+      (mluOpGetTensorElementNum(grid_desc) >= max_input_num) ) {
+    LOG(ERROR) << op_name << " Overflow max tensor num."
+               <<" Currently, MLU-OPS supports tensor num smaller than 2^31.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+  // check zero element
+  if ((mluOpGetTensorElementNum(gradInput_desc) == 0) ||
+      (mluOpGetTensorElementNum(grid_desc) == 0) ||
+      (mluOpGetTensorElementNum(gradOutput_desc) == 0)) {
+    VLOG(5) << op_name << " skip zero element tensor.";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  PARAM_CHECK(op_name, gradOutput != NULL);
+  PARAM_CHECK(op_name, grid != NULL);
+  PARAM_CHECK(op_name, gradInput != NULL);
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpRoiCropBackward(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t gradOutput_desc,
+    const void *gradOutput, const mluOpTensorDescriptor_t grid_desc,
+    const void *grid, const mluOpTensorDescriptor_t gradInput_desc,
+    void *gradInput) {
+  // check params
+  mluOpStatus_t param_check = RoiCropBackwardParamCheck(
+      "[mluOpRoiCropBackward]", handle, gradOutput_desc, gradOutput, grid_desc,
+      grid, gradInput_desc, gradInput);
+  if (param_check != MLUOP_STATUS_SUCCESS) {
+    return param_check;
+  }
+
+  uint32_t batch = gradInput_desc->dims[0];
+  uint32_t height = gradInput_desc->dims[1];
+  uint32_t width = gradInput_desc->dims[2];
+  uint32_t channels = gradInput_desc->dims[3];
+  uint32_t grid_n = grid_desc->dims[0];
+  uint32_t output_h = gradOutput_desc->dims[1];
+  uint32_t output_w = gradOutput_desc->dims[2];
+  uint32_t bin_num = grid_n * output_h * output_w;
+
+  cnrtDim3_t k_dim;
+  cnrtFunctionType_t k_type;
+
+  policyFunc(handle, bin_num, &k_dim, &k_type);
+  VLOG(5) << " [mluOpRoiCropBackward] launch kernel policyFUnc[" << k_dim.x
+          << ", " << k_dim.y << ", " << k_dim.z << "].";
+  // gdram set zero
+  int gd_num = channels * width * height * batch;
+  KERNEL_CHECK((mluOpBlockKernelFreeZero(k_dim, k_type, handle->queue, gd_num,
+                                         gradInput)));
+  VLOG(5) << " kernel mluOpBlockKernelFreeZero";
+
+  KERNEL_CHECK((mluOpBlockKernelRoiCropBackwardFloat(
+      k_dim, k_type, handle->queue, gradOutput, grid, batch, height, width,
+      channels, grid_n, output_h, output_w, gradInput)));
+  VLOG(5) << " kernel mluOpBlockKernelRoiCropBackwardFloat";
+  return MLUOP_STATUS_SUCCESS;
+}

--- a/bangc-ops/kernels/roi_crop/roi_crop.cpp
+++ b/bangc-ops/kernels/roi_crop/roi_crop.cpp
@@ -122,9 +122,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropBackward(
           << ", " << k_dim.y << ", " << k_dim.z << "].";
   // gdram set zero
   int gd_num = channels * width * height * batch;
-  KERNEL_CHECK((mluOpBlockKernelFreeZero(k_dim, k_type, handle->queue, gd_num,
+  KERNEL_CHECK((mluOpBlockKernelFillZero(k_dim, k_type, handle->queue, gd_num,
                                          gradInput)));
-  VLOG(5) << " kernel mluOpBlockKernelFreeZero";
+  VLOG(5) << " kernel mluOpBlockKernelFillZero";
 
   KERNEL_CHECK((mluOpBlockKernelRoiCropBackwardFloat(
       k_dim, k_type, handle->queue, gradOutput, grid, batch, height, width,

--- a/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
+++ b/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
@@ -1,0 +1,170 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#include "kernels/kernel.h"
+#include "mlu_op_kernel.h"
+
+__nram__ char nram_buffer[MAX_NRAM_SIZE];
+
+template <typename T>
+__mlu_func__ void swap(T &a, T &b) {
+  T tmp = a;
+  a = b;
+  b = tmp;
+}
+
+template <typename T>
+__mlu_func__ void getTopLeft(const T grid_yx_value, const int input_hw,
+                             T *weight, int *point) {
+  T xcoord = (grid_yx_value + 1) * (input_hw - 1) / 2;
+  *point = floor(xcoord);
+  *weight = 1 - (xcoord - (T)(*point));
+}
+
+__mlu_func__ bool between(const int value, const int lowerBound,
+                          const int upperBound) {
+  return (value >= lowerBound && value <= upperBound);
+}
+
+template <typename T>
+__mlu_global__ void MLUKernelRoiCropBackward(
+    const T *gradOutput, const int output_h, const int output_w, const T *grid,
+    const int grid_n, T *gradInput, const int batch, const int height,
+    const int width, const int channel) {
+  if (coreId == 0x80) {
+    return;
+  }
+  int align_base_128 = NFU_ALIGN_SIZE / sizeof(T);
+  int channel_align = CEIL_ALIGN(channel, align_base_128);
+  int c_limit = FLOOR_ALIGN(MAX_NRAM_SIZE / sizeof(T) / 10, align_base_128);
+  c_limit = c_limit > channel_align ? channel_align : c_limit;
+
+  T *nram_ping = (T *)nram_buffer;
+  T *nram_pong = nram_ping + c_limit * 5;
+  T *nram_output = nullptr;
+
+  int bin_first = taskId;
+  int bin_end = grid_n * output_h * output_w;
+  bool is_first_bin = true;
+
+  for (int bin_i = bin_first; bin_i < bin_end; bin_i += taskDim) {
+    int i_tl_x, i_tl_y;
+    T i_tl_x_weight, i_tl_y_weight;
+    int c_rem = channel;
+    int c_slice = c_limit < c_rem ? c_limit : c_rem;
+    int c_offset = 0;
+    // bin info
+    int gw = bin_i % output_w;
+    int gh = bin_i / output_w % output_h;
+    int gn = bin_i / output_w / output_h;
+    // batch index under input
+    int i_batch_idx = gn / (grid_n / batch);
+    // value of grid data
+    T gy = grid[gn * output_h * output_w * 2 + gh * output_w * 2 + gw * 2];
+    T gx = grid[gn * output_h * output_w * 2 + gh * output_w * 2 + gw * 2 + 1];
+    // coordinates and weights under gradInput data
+    getTopLeft((T)gx, width, (T *)&i_tl_x_weight, &i_tl_x);
+    getTopLeft((T)gy, height, (T *)&i_tl_y_weight, &i_tl_y);
+
+    int go_offset = gn * output_h * output_w * channel +
+                    gh * output_w * channel + gw * channel;
+    int gi_offset = i_batch_idx * height * width * channel;
+    int gi_tl_offset = gi_offset + i_tl_y * width * channel + i_tl_x * channel;
+    int gi_tr_offset = gi_tl_offset + channel;
+    int gi_bl_offset = gi_tl_offset + width * channel;
+    int gi_br_offset = gi_tl_offset + width * channel + channel;
+
+    bool topLeftIsIn =
+        between(i_tl_x, 0, width - 1) && between(i_tl_y, 0, height - 1);
+    bool topRightIsIn =
+        between(i_tl_x + 1, 0, width - 1) && between(i_tl_y, 0, height - 1);
+    bool bottomLeftIsIn =
+        between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
+    bool bottomRightIsIn =
+        between(i_tl_x + 1, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
+    if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
+      continue;
+
+    // load the first input to nram
+    if (is_first_bin) {
+      is_first_bin = false;
+      __memcpy(nram_ping, gradOutput + go_offset, c_slice * sizeof(T),
+               GDRAM2NRAM);
+    }
+    nram_output = nram_ping + c_limit;
+    while (c_rem > 0) {
+      c_slice = c_slice < c_rem ? c_slice : c_rem;
+      // load the next input to nram
+      if (c_rem - c_slice > 0) {
+        // load the rest channel to nram
+        int pongc_slice =
+            (c_rem - c_slice > c_slice) ? c_slice : c_rem - c_slice;
+        __memcpy_async(nram_pong, gradOutput + go_offset + c_offset + c_slice,
+                       pongc_slice * sizeof(T), GDRAM2NRAM);
+      } else if (bin_i + taskDim < bin_end) {
+        // load next bin
+        gw = (bin_i + taskDim) % output_w;
+        gh = (bin_i + taskDim) / output_w % output_h;
+        gn = (bin_i + taskDim) / output_w / output_h;
+        go_offset = gn * output_h * output_w * channel +
+                    gh * output_w * channel + gw * channel;
+
+        int pongc_slice = c_limit < channel ? c_limit : channel;
+        __memcpy_async(nram_pong, gradOutput + go_offset,
+                       pongc_slice * sizeof(T), GDRAM2NRAM);
+      }
+      // compute
+      if (topLeftIsIn) {
+        __bang_mul_const(nram_output, nram_ping, i_tl_x_weight * i_tl_y_weight,
+                         c_limit);
+        __bang_atomic_add(nram_output, gradInput + gi_tl_offset + c_offset,
+                          nram_output, c_slice);
+      }
+      if (topRightIsIn) {
+        __bang_mul_const(nram_output + c_limit, nram_ping,
+                         (1 - i_tl_x_weight) * i_tl_y_weight, c_limit);
+        __bang_atomic_add(nram_output + c_limit,
+                          gradInput + gi_tr_offset + c_offset,
+                          nram_output + c_limit, c_slice);
+      }
+      if (bottomLeftIsIn) {
+        __bang_mul_const(nram_output + 2 * c_limit, nram_ping,
+                         i_tl_x_weight * (1 - i_tl_y_weight), c_limit);
+        __bang_atomic_add(nram_output + 2 * c_limit,
+                          gradInput + gi_bl_offset + c_offset,
+                          nram_output + 2 * c_limit, c_slice);
+      }
+      if (bottomRightIsIn) {
+        __bang_mul_const(nram_output + 3 * c_limit, nram_ping,
+                         (1 - i_tl_x_weight) * (1 - i_tl_y_weight), c_limit);
+        __bang_atomic_add(nram_output + 3 * c_limit,
+                          gradInput + gi_br_offset + c_offset,
+                          nram_output + 3 * c_limit, c_slice);
+      }
+      c_rem -= c_slice;
+      c_offset += c_slice;
+      swap(nram_ping, nram_pong);
+      nram_output = nram_ping + c_limit;
+      __asm__ volatile("sync;");
+    }
+  }
+}
+
+void MLUOP_WIN_API mluOpBlockKernelRoiCropBackwardFloat(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const void *gradOutput, const void *grid, const int batch, const int height,
+    const int width, const int channels, const int grid_n, const int output_h,
+    const int output_w, void *gradInput) {
+  MLUKernelRoiCropBackward<<<k_dim, k_type, queue>>>(
+      (float *)gradOutput, output_h, output_w, (float *)grid, grid_n,
+      (float *)gradInput, batch, height, width, channels);
+}

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -43,7 +43,7 @@ typedef enum {
 
 /*!
  * @brief Computes the absolute value for every element of the input tensor \b x
- * and returns in \b y.
+ *   and returns in \b y.
  *
  * @param[in] handle
  *   Input. Handle to a MLUOP context that is used to manage MLU devices and
@@ -98,7 +98,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpAbs(mluOpHandle_t handle,
 
 /*!
  * @brief Computes logarithm of input tensor \b x, and returns the results in
- * the output tensor \b y.
+ *   the output tensor \b y.
  *
  * @param[in] handle
  *   Input. Handle to a MLUOP context that is used to manage MLU devices and
@@ -156,7 +156,7 @@ mluOpLog(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
 
 /*!
  * @brief Computes division on input tensor \b x and \b y, and returns the
- * results in the output tensor \b output.
+ *   results in the output tensor \b output.
  *
  * @param[in] handle
  *   Input. Handle to a MLUOP context that is used to manage MLU devices and
@@ -217,8 +217,80 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
          const mluOpTensorDescriptor_t z_desc, void *z);
 
 /*!
+ * @brief Computes the gradients of images \b gradInput based on the gradients
+ *   \b gradOutput and coordinate mapping parameter \b grid to perform the
+ *   backpropagation.
+ *
+ * @param[in] handle
+ *   Input. Handle to a MLUOP context that is used to manage MLU devices and
+ *   queues in ::mluOpRoiCropBackward operation. For detailed information, see
+ *   ::mluOpHandle_t.
+ * @param[in] gradOutput_desc
+ *   Input. The descriptor of the gradOutput tensor. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] gradOutput
+ *   Input. Pointer to the MLU memory that stores the gradient tensor in the
+ *   backpropagation process.
+ * @param[in] grid_desc
+ *   Input. The descriptor of the grid tensor. For detailed information, see
+ *   ::mluOpTensorDescriptor_t.
+ * @param[in] grid
+ *   Input. Pointer to the MLU memory that stores the coordinate mapping
+ *   tensor.NaN and INF datas are not supported.
+ * @param[in] gradInput_desc
+ *   Input. The descriptor of the gradInput tensor. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[out] gridInput
+ *   Output. Pointer to the MLU memory that stores the gradient tensor of the
+ *   original images.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par Formula
+ * - See "RoI Crop Operation" section in "Cambricon MLUOP User Guide" for
+ *   details.
+ *
+ * @par Data Type
+ * - Data types of all tensors must be the same.
+ * - The supported data types of all tensors are as follows:
+ *   - Input tensor: float.
+ *   - Output tensor: float.
+ * @par Data Layout
+ * - The supported data layout of \b gradOutput , \b grad , \b gradInput are as
+ *   follows.
+ *   - gradOutput tensor: \p MLUOP_LAYOUT_NHWC.
+ *   - grid tensor: \p MLUOP_LAYOUT_ARRAY.
+ *   - gradInput tensor: \p MLUOP_LAYOUT_NHWC.
+ *
+ * @par Scale Limitation
+ * - The gradOutput tensor , grid tensor and gradInput tensor must have four
+ *   dimensions.
+ * - The second dimension of grid tensor and gradoutput tensor must be the same
+ *   size.
+ * - The third dimmension of grid tensor and gradoutput tensor must be the same.
+ * - Size of the fourth dimension of gradInput tensor is divisibled by size of
+ *   the fourth dimension of grid tensor.
+ * - Grid tensor \b grid must meet the following data range:
+ *   - Float: [-1.0,1.0].
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://github.com/princewang1994/R-FCN.pytorch/tree/master/lib/model/roi_crop
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpRoiCropBackward(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t gradOutput_desc,
+    const void *gradOutput, const mluOpTensorDescriptor_t grid_desc,
+    const void *grid, const mluOpTensorDescriptor_t gradInput_desc,
+    void *gradInput);
+    
+/*!
  * @brief Computes sqrt on input tensor \b x, and returns the results in the
- * output tensor \b y.
+ *   output tensor \b y.
  *
  * @param[in] handle
  *   Input. Handle to a MLUOP context that is used to manage MLU devices and
@@ -273,7 +345,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrt(mluOpHandle_t handle,
 
 /*!
  * @brief Computes gradient of sqrt on input tensor \b y and \b diff_y, and
- * returns the results in the output tensor \b diff_x.
+ *   returns the results in the output tensor \b diff_x.
  *
  * @param[in] handle
  *   Input. Handle to a MLUOP context that is used to manage MLU devices and
@@ -300,7 +372,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrt(mluOpHandle_t handle,
  *
  * @par Formula
  * - See "Sqrt Backward Operation" section in "Cambricon MLUOP User Guide" for
- * details.
+ *   details.
  *
  * @par Data Type
  * - Data types of input tensors and output tensor must be the same.

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -53,6 +53,12 @@ void MLUOP_WIN_API mluOpBlockKernel3StagePipelineDivFloatFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *x, const void *y, void *z, int num);
 
+/* FreeZero*/
+void MLUOP_WIN_API mluOpBlockKernelFreeZero(cnrtDim3_t k_dim,
+                                            cnrtFunctionType_t k_type,
+                                            cnrtQueue_t queue, const int num,
+                                            void *gdram_ptr);
+
 /* Log */
 void MLUOP_WIN_API mluOpBlockKernel3StagePipelineLogHalfFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
@@ -73,6 +79,13 @@ void MLUOP_WIN_API mluOpBlockKernel5StagePipelineLogHalfHighAcc(
 void MLUOP_WIN_API mluOpBlockKernel5StagePipelineLogFloatFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *x, void *y, int num, float coef);
+
+/* RoICrop*/
+void MLUOP_WIN_API mluOpBlockKernelRoiCropBackwardFloat(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const void *gradOutput, const void *grid, const int batch, const int height,
+    const int width, const int channels, const int grid_n, const int output_h,
+    const int output_w, void *gradInput);
 
 /* Sqrt */
 void MLUOP_WIN_API mluOpBlockKernel3StagePipelineSqrtHalfFast(

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -53,8 +53,8 @@ void MLUOP_WIN_API mluOpBlockKernel3StagePipelineDivFloatFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *x, const void *y, void *z, int num);
 
-/* FreeZero*/
-void MLUOP_WIN_API mluOpBlockKernelFreeZero(cnrtDim3_t k_dim,
+/* FillZero*/
+void MLUOP_WIN_API mluOpBlockKernelFillZero(cnrtDim3_t k_dim,
                                             cnrtFunctionType_t k_type,
                                             cnrtQueue_t queue, const int num,
                                             void *gdram_ptr);

--- a/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
+++ b/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
@@ -118,6 +118,7 @@ message Node {
   optional DivParam    div_param                      = 4001;   // param
   optional LogParam    log_param                      = 4002;     // param
   optional SqrtParam   sqrt_param                     = 4003;  // param
+  optional RoiCropBackwardParam     roi_crop_backward_param = 4006; 
 }
 
 
@@ -185,5 +186,9 @@ message SqrtParam {
 }
 
 message DivParam {
+  optional ComputationPreference prefer = 1 [default = COMPUTATION_HIGH_PRECISION];
+}
+
+message RoiCropBackwardParam {
   optional ComputationPreference prefer = 1 [default = COMPUTATION_HIGH_PRECISION];
 }

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.cpp
@@ -1,0 +1,171 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "roi_crop_backward.h"
+
+#include "mlu_op.h"
+
+namespace mluoptest {
+void RoiCropBackwardExecutor::paramCheck() {
+  GTEST_CHECK(parser_->inputs().size() == 2,
+              "[RoiCropBackwardExecutor] input number is wrong. ");
+  GTEST_CHECK(parser_->outputs().size() == 1,
+              "[RoiCropBackwardExecutor] output number is wrong. ");
+}
+
+void RoiCropBackwardExecutor::initData() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call initData() Begin.";
+  gradOutput_data_ptr_ = data_vector_[0].device_ptr;
+  grid_data_ptr_ = data_vector_[1].device_ptr;
+  gradInput_data_ptr_ = data_vector_[2].device_ptr;
+  gradOutput_desc_ = tensor_desc_[0].tensor;
+  grid_desc_ = tensor_desc_[1].tensor;
+  gradInput_desc_ = tensor_desc_[2].tensor;
+  gradOutput_h_ = gradOutput_desc_->dims[1];
+  gradOutput_w_ = gradOutput_desc_->dims[2];
+  grid_batch_roi_ = grid_desc_->dims[0];
+  gradInput_batch_ = gradInput_desc_->dims[0];
+  gradInput_h_ = gradInput_desc_->dims[1];
+  gradInput_w_ = gradInput_desc_->dims[2];
+  gradInput_c_ = gradInput_desc_->dims[3];
+  VLOG(4) << "[RoiCropBackwardExecutor] call initData() End.";
+}
+
+void RoiCropBackwardExecutor::printDataInfo() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call printDataInfo() Begin.";
+  VLOG(4) << "grid_batch_roi_  " << grid_batch_roi_;
+  VLOG(4) << "gradOutput_h_        " << gradOutput_h_;
+  VLOG(4) << "gradOutput_w_        " << gradOutput_w_;
+  VLOG(4) << "gradInput_batch_     " << gradInput_batch_;
+  VLOG(4) << "gradInput_h_         " << gradInput_h_;
+  VLOG(4) << "gradInput_w_         " << gradInput_w_;
+  VLOG(4) << "gradInput_c_         " << gradInput_c_;
+  VLOG(4) << "[RoiCropBackwardExecutor] call printDataInfo() End.";
+}
+
+int RoiCropBackwardExecutor::getTopLeft(const float grid_yx_value,
+                                        const int input_h_w, float* weight) {
+  float xcoord = (grid_yx_value + 1) * (input_h_w - 1) / 2;
+  int point = floor(xcoord);
+  *weight = 1 - (xcoord - point);
+  return point;
+}
+
+void RoiCropBackwardExecutor::compute() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call compute() Begin.";
+  initData();
+  printDataInfo();
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpRoiCropBackward(
+      handle_, gradOutput_desc_, gradOutput_data_ptr_, grid_desc_,
+      grid_data_ptr_, gradInput_desc_, gradInput_data_ptr_));
+  interface_timer_.stop();
+  VLOG(4) << "[RoiCropBackwardExecutor] call compute() End.";
+}
+
+void RoiCropBackwardExecutor::cpuCompute() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call cpuCompute() Begin.";
+  float* gradOutput_cpu_ptr = cpu_fp32_input_[0];
+  float* grid_cpu_ptr = cpu_fp32_input_[1];
+  float* gradInput_c_pu_ptr = cpu_fp32_output_[0];
+  int gradOutput_nums =
+      grid_batch_roi_ * gradOutput_h_ * gradOutput_w_ * gradInput_c_;
+  int roi_per_img = grid_batch_roi_ / gradInput_batch_;
+  int gradOutput_stride_batch = gradOutput_h_ * gradOutput_w_ * gradInput_c_;
+  int gradOutput_stride_h = gradOutput_w_ * gradInput_c_;
+  int gradOutput_stride_w = gradInput_c_;
+  int grid_stride_batch = gradOutput_h_ * gradOutput_w_ * 2;
+  int grid_stride_h = gradOutput_w_ * 2;
+  int gride_stride_w = 2;
+  int gradInput_stride_batch = gradInput_h_ * gradInput_w_ * gradInput_c_;
+  int gradInput_stride_h = gradInput_w_ * gradInput_c_;
+  int gradInput_stride_w = gradInput_c_;
+  int i_tl_x = 0;
+  int i_tl_y = 0;
+  float i_tl_x_weight = 0.0;
+  float i_tl_y_weight = 0.0;
+  float i_tl = 0;
+  float i_tr = 0;
+  float i_bl = 0;
+  float i_br = 0;
+  for (int index = 0; index < gradOutput_nums; ++index) {
+    // coordinates of each position in gradOutput data
+    int goc = index % gradInput_c_;
+    int gow = (index / gradOutput_stride_w) % gradOutput_w_;
+    int goh = (index / gradOutput_stride_h) % gradOutput_h_;
+    int gon = index / gradOutput_stride_batch;
+    // data offset in gradoutput
+    const int output_offset = gon * gradOutput_stride_batch +
+                              goh * gradOutput_stride_h +
+                              gow * gradOutput_stride_w + goc;
+    float gradOutput_value = gradOutput_cpu_ptr[output_offset];
+
+    // batch dimension index in gradOutput
+    int gradInput_n = gon / roi_per_img;
+    // data value in grid
+    float yf = grid_cpu_ptr[gon * grid_stride_batch + goh * grid_stride_h +
+                            gow * gride_stride_w];
+    float xf = grid_cpu_ptr[gon * grid_stride_batch + goh * grid_stride_h +
+                            gow * gride_stride_w + 1];
+    // gradInput data information
+    i_tl_x = getTopLeft(xf, gradInput_w_, &i_tl_x_weight);
+    i_tl_y = getTopLeft(yf, gradInput_h_, &i_tl_y_weight);
+
+    // field information
+    const int i_tl_offset = gradInput_n * gradInput_stride_batch +
+                            i_tl_y * gradInput_stride_h +
+                            i_tl_x * gradInput_stride_w + goc;
+    float i_tl_xy_weight = i_tl_x_weight * i_tl_y_weight;
+    bool topLeftIsIn = i_tl_x >= 0 && i_tl_x <= (gradInput_w_ - 1) &&
+                       i_tl_y >= 0 && i_tl_y <= (gradInput_h_ - 1);
+    if (topLeftIsIn) {
+      gradInput_c_pu_ptr[i_tl_offset] += i_tl_xy_weight * gradOutput_value;
+    }
+
+    const int i_tr_offset = i_tl_offset + gradInput_stride_w;
+    float i_tr_xy_weight = (1 - i_tl_x_weight) * i_tl_y_weight;
+    bool topRightIsIn = i_tl_x >= 0 && i_tl_x <= (gradInput_w_ - 1) &&
+                        (i_tl_y + 1) >= 0 && (i_tl_y + 1) <= (gradInput_h_ - 1);
+    if (topRightIsIn) {
+      gradInput_c_pu_ptr[i_tr_offset] += i_tr_xy_weight * gradOutput_value;
+    }
+
+    const int i_bl_offset = i_tl_offset + gradInput_stride_h;
+    float i_bl_xy_weight = i_tl_x_weight * (1 - i_tl_y_weight);
+    bool bottomLeftIsIn = (i_tl_x + 1) >= 0 &&
+                          (i_tl_x + 1) <= (gradInput_w_ - 1) && i_tl_y >= 0 &&
+                          i_tl_y <= (gradInput_h_ - 1);
+    if (bottomLeftIsIn) {
+      gradInput_c_pu_ptr[i_bl_offset] += i_bl_xy_weight * gradOutput_value;
+    }
+
+    const int i_br_offset =
+        i_tl_offset + gradInput_stride_h + gradInput_stride_w;
+    float i_br_xy_weight = (1 - i_tl_x_weight) * (1 - i_tl_y_weight);
+    bool bottomRightIsIn =
+        (i_tl_x + 1) >= 0 && (i_tl_x + 1) <= (gradInput_w_ - 1) &&
+        (i_tl_y + 1) >= 0 && (i_tl_y + 1) <= (gradInput_h_ - 1);
+    if (bottomRightIsIn) {
+      gradInput_c_pu_ptr[i_br_offset] += i_br_xy_weight * gradOutput_value;
+    }
+  }
+  VLOG(4) << "[RoiCropBackwardExecutor] call cpuCompute() End.";
+}
+
+int64_t RoiCropBackwardExecutor::getTheoryOps() {
+  const int cp_count = 8;
+  theory_ops_ = parser_->getInputDataCount(0) * cp_count;
+  VLOG(4) << "[RoiCropBackwardExecutor] getTheoryOps: " << theory_ops_
+          << " ops.";
+  return theory_ops_;
+}
+
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.h
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.h
@@ -1,0 +1,48 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_BACKWARD_ROI_CROP_BACKEARD_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_BACKWARD_ROI_CROP_BACKEARD_H_
+
+#include "executor.h"
+
+namespace mluoptest {
+class RoiCropBackwardExecutor : public Executor {
+ public:
+  RoiCropBackwardExecutor() {}
+  ~RoiCropBackwardExecutor() {}
+  void paramCheck() override;
+  void compute() override;
+  void cpuCompute() override;
+  int64_t getTheoryOps() override;
+
+ private:
+  void initData();
+  void printDataInfo();
+  int getTopLeft(const float grid_yx_value, const int input_hw, float* weight);
+  void* gradOutput_data_ptr_;
+  void* grid_data_ptr_;
+  void* gradInput_data_ptr_;
+  mluOpTensorDescriptor_t gradOutput_desc_;
+  mluOpTensorDescriptor_t grid_desc_;
+  mluOpTensorDescriptor_t gradInput_desc_;
+  int gradInput_batch_;
+  int gradInput_h_;
+  int gradInput_w_;
+  int gradInput_c_;
+  int grid_batch_roi_;
+  int gradOutput_h_;
+  int gradOutput_w_;
+  int64_t theory_ops_;
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_BACKWARD_ROI_CROP_BACKEARD_H_

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/test_case/case_0.prototxt
@@ -1,0 +1,53 @@
+op_name: "roi_crop_backward"
+input {
+  id: "input1"
+  shape: {
+    dims: 1
+    dims: 5
+    dims: 5
+    dims: 500
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 23
+    upper_bound: -5.0
+    lower_bound: 5.0
+    distribution: UNIFORM
+  }
+}
+input {
+  id: "input2"
+  shape: {
+    dims: 1
+    dims: 5
+    dims: 5
+    dims: 2
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 20
+    upper_bound: -1.0
+    lower_bound:  1.0
+    distribution: UNIFORM
+  }
+}
+output {
+  id: "output"
+  shape: {
+    dims: 1
+    dims: 32
+    dims: 32
+    dims: 500
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 0.003
+  error_threshold: 0.003
+  baseline_device: CPU
+}


### PR DESCRIPTION
### **1. 修改描述**
新增roi_crop_backward算子，是roi_crop_forward算子的反向

- **影响范围/算子**：roi_crop_backward
- **影响版本/分支**：master
##### 1.1 精度验收标准
算子采用静态阈值标准：diffs=[diff1，diff2]，diff1<=3e-3 && diff2 <= 3e-3。
##### 1.2 算子方案CheckList
|      序号      |           需求           |      需求详情       |
|----|----|----|
|1|支持硬件 |MLU290、MLU370|
|2|job类型|U1|
|3|DimXYZ|支持DimXYZ|
|4|可变|不支持各个维度可变|
|5|layout|gradInput和gradOutput:支持NHWC<br>grid:支持ARRAY|
|6|多维|不支持多维|
|7|0元素|不支持0元素|
|8|转数提前|否|
|9|片外数据类型|float|
|10|片上数据类型|float|
|11|融合|否|
|12|规模限制|否|
|13|c不感知对齐|否|
|14|原位测试对齐|不支持|
##### 1.3 新特性测例
|测试点|验收标准|测试结果(精度)|
|----|----|----|
|数据类型测试|FLOAT|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|多维张量测试|支持4维|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|Layout测试|支持NHWC|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|不同规模 / 整数余数端段 / 对齐不对齐||[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|零维张量测试/0元素测试|不支持0元素测试|[Error]:"MLUOP_STATUS_BAD_PARAM in mluOpRoiCropBackward( handle_, gradOutput_desc, gradOutput_data_ptr, grid_desc, grid_data_ptr, gradInput_desc, gradInput_data_ptr)"  [ /tudejiang/mlu-ops/bangc-ops/core/logging.cpp:240  pid:55350]|
|稳定性测试|gtest 多线程+repeat 使用--gtest_repeat=NUM --thread=NUM |[----------] Global test environment tear-down[ SUMMARY  ] Total 200 cases of 200 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (670 ms total).[  PASSED  ] 1 test case.|
|多平台测试|支持MLU290、MLU370|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|gen_case模块测试|gen_case模块生成的测试通过|[----------] Global test environment tear-down[ SUMMARY  ] Total 1 cases of 1 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (54 ms total)[  PASSED  ] 1 test case..|
|其他测试点|||
##### 1.4 参数检查
提交新算子时，给出测试点，并说明测试结果。
|测试点|验收标准|测试结果(出错信息)|
|----|----|----|
|不符合算子限制|正常报错|1、gradOutput、grid和gradInput的数据类型应该一致:<br>[Error]:[mluOpRoiCropBackward] Check failed: gradOutput_desc->dtype == MLUOP_DTYPE_FLOAT.   [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:50  pid:55352]<br>2、gradOutput和gradInput的layout必须为NHWC：<br>[Error]:[mluOpRoiCropBackward] Check failed: gradOutput_desc->layout == MLUOP_LAYOUT_NHWC.   [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:54  pid:55354]<br>3、grid的最后维度必须是2:<br>[Error]:[mluOpRoiCropBackward] Check failed: grid_desc->dims[3] should be equal to 2.  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:71  pid:55356]<br>4、gradOutput和gradInput的最后一维必须一致:<br>[Error]:[mluOpRoiCropBackward] Check failed: gradOutput_desc->dims[3] should be equal to gradInput_desc->dims[3].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:65  pid:55358]<br>5、grid和gradOutput的第一、第二、第三维度必须一致:<br>[Error]:[mluOpRoiCropBackward]Check failed: gradOutput_desc->dims[0] should be equal to grid_desc->dims[0].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:59  pid:55360];<br>[Error]:[mluOpRoiCropBackward]Check failed: gradOutput_desc->dims[1] should be equal to grid_desc->dims[1].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:59  pid:55362];<br>[Error]:[mluOpRoiCropBackward]Check failed: gradOutput_desc->dims[2] should be equal to grid_desc->dims[2].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:59  pid:55364]|
|非法参数传递|正常报错||
### 2. 性能测试
- 要排除机器环境的影响。
- 用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试。
- 建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理。
- 算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。
##### 2.1 算子io利用率、计算效率
注释: 
io_efficiency = theory_io_size / (latency * IO_BANDWIDTH)
**theory_is_size:** 从算法上需要访问的数据量(与实现无关), **lantency:**算子运行的实际时间, **IO_BANGWIDTH:**硬件的理论带宽.
compute_efficiency = theory_compute_ops / (latency * peak_compute_force)
**theory_compute_ops:** 该算子从算法上需要执行多少次操作(与实际无关), **lantency:** 表示算子运行的实际时间, **peak_compute_force:** 硬件平台的峰值算力, 其单位是op/s(每秒执行多少操作)
|operator|mlu_hardware_time|mlu_interface_time|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size|count|gradOutput|grid|gradInput|
|----|----|----|----|----|----|----|----|----|----|
|roi_crop_forward|8|49.861|1.66016e-05|1.46484e-06|0|1|1,3,1,1|1,3,1,2|1,5,5,1|
|roi_crop_forward|9|47.254|0.005623|6.5104e-05|0|1|1,3,1,50|1,3,1,2|1,16,16,50|
|roi_crop_forward|14|48.225|0.014648|0.000348|0|1|1,5,5,50|1,5,5,2|1,32,32,50|
|roi_crop_forward|22|48.435|0.09313|0.002219|0|1|1,5,5,500|1,5,5,2|1,32,32,500|
|roi_crop_forward|1184|51.405|0.173|0.004124|0|1|1,5,5,50000|1,5,5,2|1,32,32,50000|
|roi_crop_forward|185|51.366|0.125957|0.01784|0|1|1,13,13,5000|1,13,13,2|1,32,32,5000|
|roi_crop_forward|662|50.343|0.04865|0.01843|0|1|1,25,25,5000|1,25,25,2|1,32,32,5000|
|roi_crop_forward|903|57.475|0.03057|0.021662|0|1|16,25,25,500|16.25,25,2|4,32,32,500|
|roi_crop_forward|498|49.236|0.03653|0.02039|0|1|16,13,25,500|16,13,25,2|4,32,32,500|
|roi_crop_forward|49|51.355|0.168|0.0047|0|1|8,3,5,500|8,3,5,2|4,32,32,500|

##### 2.2 内存泄露
暂不支持
##### 2.3 代码覆盖率
这里得把代码中分支都跑一边，就需要增加测试用例个数，去覆盖到所有代码
通过测试roi_crop_backward算子的代码覆盖率：80.0%
### 3. 总结分析
总结分析主要需要考虑以下几点：
1、该算子暂时不支持half类型的数据，grid不支持NaN和INF数据，主要因为硬件原因，jira有人已经提了需求；
2、该算子的源码只支持torch版本为0.3.0，高于该版本源码会出现各种问题；
3、roi_crop_backward算子做梯度计算时用到atomic，在kernel中计算需先给gradInput进行刷0，但限于MLU-OPS没有刷0的接口，只能先自己写一个kernel调用__gdramset()进行刷0。
