### PR TITLE
[Feature](bangc-ops):Add new op roi_crop_backward

### DIFF
--- a/bangc-ops/kernels/fill_zero/fill_zero.mlu
+++ b/bangc-ops/kernels/fill_zero/fill_zero.mlu
@@ -1,0 +1,31 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "mlu_op_kernel.h"
+
+__mlu_global__ void MLUBlockKernelGdramFillZero(void *gdram_ptr,
+                                                const int num) {
+  uint32_t seg_n = num / taskDim;
+  uint32_t rem_n = num % taskDim;
+  int n_first_per = seg_n * taskId + (taskId > rem_n ? rem_n : taskId);
+  float zero = 0.0;
+  if (taskId < rem_n) {
+    seg_n += 1;
+  }
+  __gdramset((float *)gdram_ptr + n_first_per, seg_n, zero);
+}
+
+void MLUOP_WIN_API mluOpBlockKernelFillZero(cnrtDim3_t k_dim,
+                                            cnrtFunctionType_t k_type,
+                                            cnrtQueue_t queue, const int num,
+                                            void *gdram_ptr) {
+  MLUBlockKernelGdramFillZero<<<k_dim, k_type, queue>>>(gdram_ptr, num);
+}

--- a/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
+++ b/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
@@ -93,14 +93,14 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       continue;
 
     if (is_first_bin) {
-      // load the first inout to nram
+      // load the first input to nram
       is_first_bin = false;
       i_tl_offset = i_offset + i_tl_y * width * channel + i_tl_x * channel;
       i_tr_offset = i_tl_offset + channel;
       i_bl_offset = i_tl_offset + width * channel;
       i_br_offset = i_tl_offset + width * channel + channel;
       __nramset(nram_ping, 4 * c_limit, 0);
-      __asm__ volatile("sync;\n\t");
+      __asm__ volatile("sync;\n");
       if (topLeftIsIn) {
         __memcpy_async(nram_ping, input + i_tl_offset, c_slice * sizeof(T),
                        GDRAM2NRAM);
@@ -119,7 +119,7 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       }
     }
     __nramset(nram_pong, 4 * c_limit, 0);
-    __asm__ volatile("sync;\n\t");
+    __asm__ volatile("sync;\n");
     while (c_rem > 0) {
       c_slice = c_slice < c_rem ? c_slice : c_rem;
       // load the next input to nram
@@ -216,7 +216,131 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       c_offset += c_slice;
       swap(nram_ping, nram_pong);
       __nramset(nram_pong, 4 * c_limit, 0);
-      __asm__ volatile("sync;");
+      __asm__ volatile("sync;\n");
+    }
+  }
+}
+
+template <typename T>
+__mlu_global__ void MLUKernelRoiCropBackward(
+    const T *grad_output, const int output_h, const int output_w, const T *grid,
+    const int grid_n, T *grad_input, const int batch, const int height,
+    const int width, const int channel) {
+  if (coreId == 0x80) {
+    return;
+  }
+  int align_base_128 = NFU_ALIGN_SIZE / sizeof(T);
+  int channel_align = CEIL_ALIGN(channel, align_base_128);
+  int c_limit = FLOOR_ALIGN(MAX_NRAM_SIZE / sizeof(T) / 10, align_base_128);
+  c_limit = c_limit > channel_align ? channel_align : c_limit;
+
+  T *nram_ping = (T *)nram_buffer;
+  T *nram_pong = nram_ping + c_limit * 5;
+  T *nram_output = nullptr;
+
+  int bin_first = taskId;
+  int bin_end = grid_n * output_h * output_w;
+  bool is_first_bin = true;
+
+  for (int bin_i = bin_first; bin_i < bin_end; bin_i += taskDim) {
+    int i_tl_x, i_tl_y;
+    T i_tl_x_weight, i_tl_y_weight;
+    int c_rem = channel;
+    int c_slice = c_limit < c_rem ? c_limit : c_rem;
+    int c_offset = 0;
+    // bin info
+    int gw = bin_i % output_w;
+    int gh = bin_i / output_w % output_h;
+    int gn = bin_i / output_w / output_h;
+    // batch index under input
+    int i_batch_idx = gn / (grid_n / batch);
+    // value of grid data
+    T gy = grid[gn * output_h * output_w * 2 + gh * output_w * 2 + gw * 2];
+    T gx = grid[gn * output_h * output_w * 2 + gh * output_w * 2 + gw * 2 + 1];
+    // coordinates and weights under grad_input data
+    getTopLeft(gx, width, &i_tl_x_weight, &i_tl_x);
+    getTopLeft(gy, height, &i_tl_y_weight, &i_tl_y);
+
+    int go_offset = gn * output_h * output_w * channel +
+                    gh * output_w * channel + gw * channel;
+    int gi_offset = i_batch_idx * height * width * channel;
+    int gi_tl_offset = gi_offset + i_tl_y * width * channel + i_tl_x * channel;
+    int gi_tr_offset = gi_tl_offset + channel;
+    int gi_bl_offset = gi_tl_offset + width * channel;
+    int gi_br_offset = gi_tl_offset + width * channel + channel;
+
+    bool topLeftIsIn =
+        between(i_tl_x, 0, width - 1) && between(i_tl_y, 0, height - 1);
+    bool topRightIsIn =
+        between(i_tl_x + 1, 0, width - 1) && between(i_tl_y, 0, height - 1);
+    bool bottomLeftIsIn =
+        between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
+    bool bottomRightIsIn =
+        between(i_tl_x + 1, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
+    if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
+      continue;
+
+    // load the first input to nram
+    if (is_first_bin) {
+      is_first_bin = false;
+      __memcpy(nram_ping, grad_output + go_offset, c_slice * sizeof(T),
+               GDRAM2NRAM);
+    }
+    nram_output = nram_ping + c_limit;
+    while (c_rem > 0) {
+      c_slice = c_slice < c_rem ? c_slice : c_rem;
+      // load the next input to nram
+      if (c_rem - c_slice > 0) {
+        // load the rest channel to nram
+        int pongc_slice =
+            (c_rem - c_slice > c_slice) ? c_slice : c_rem - c_slice;
+        __memcpy_async(nram_pong, grad_output + go_offset + c_offset + c_slice,
+                       pongc_slice * sizeof(T), GDRAM2NRAM);
+      } else if (bin_i + taskDim < bin_end) {
+        // load next bin
+        gw = (bin_i + taskDim) % output_w;
+        gh = (bin_i + taskDim) / output_w % output_h;
+        gn = (bin_i + taskDim) / output_w / output_h;
+        go_offset = gn * output_h * output_w * channel +
+                    gh * output_w * channel + gw * channel;
+
+        int pongc_slice = c_limit < channel ? c_limit : channel;
+        __memcpy_async(nram_pong, grad_output + go_offset,
+                       pongc_slice * sizeof(T), GDRAM2NRAM);
+      }
+      // compute
+      if (topLeftIsIn) {
+        __bang_mul_const(nram_output, nram_ping, i_tl_x_weight * i_tl_y_weight,
+                         c_limit);
+        __bang_atomic_add(nram_output, grad_input + gi_tl_offset + c_offset,
+                          nram_output, c_slice);
+      }
+      if (topRightIsIn) {
+        __bang_mul_const(nram_output + c_limit, nram_ping,
+                         (1 - i_tl_x_weight) * i_tl_y_weight, c_limit);
+        __bang_atomic_add(nram_output + c_limit,
+                          grad_input + gi_tr_offset + c_offset,
+                          nram_output + c_limit, c_slice);
+      }
+      if (bottomLeftIsIn) {
+        __bang_mul_const(nram_output + 2 * c_limit, nram_ping,
+                         i_tl_x_weight * (1 - i_tl_y_weight), c_limit);
+        __bang_atomic_add(nram_output + 2 * c_limit,
+                          grad_input + gi_bl_offset + c_offset,
+                          nram_output + 2 * c_limit, c_slice);
+      }
+      if (bottomRightIsIn) {
+        __bang_mul_const(nram_output + 3 * c_limit, nram_ping,
+                         (1 - i_tl_x_weight) * (1 - i_tl_y_weight), c_limit);
+        __bang_atomic_add(nram_output + 3 * c_limit,
+                          grad_input + gi_br_offset + c_offset,
+                          nram_output + 3 * c_limit, c_slice);
+      }
+      c_rem -= c_slice;
+      c_offset += c_slice;
+      swap(nram_ping, nram_pong);
+      nram_output = nram_ping + c_limit;
+      __asm__ volatile("sync;\n");
     }
   }
 }
@@ -229,4 +353,14 @@ void MLUOP_WIN_API mluOpBlockKernelRoiCropForwardFloat(
   MLUKernelRoiCropForward<<<k_dim, k_type, queue>>>(
       (float *)input, batch, height, width, channels, (float *)grid, grid_n,
       (float *)output, output_h, output_w);
+}
+
+void MLUOP_WIN_API mluOpBlockKernelRoiCropBackwardFloat(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const void *grad_output, const void *grid, const int batch,
+    const int height, const int width, const int channels, const int grid_n,
+    const int output_h, const int output_w, void *grad_input) {
+  MLUKernelRoiCropBackward<<<k_dim, k_type, queue>>>(
+      (float *)grad_output, output_h, output_w, (float *)grid, grid_n,
+      (float *)grad_input, batch, height, width, channels);
 }

--- a/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
+++ b/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
@@ -100,7 +100,7 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       i_bl_offset = i_tl_offset + width * channel;
       i_br_offset = i_tl_offset + width * channel + channel;
       __nramset(nram_ping, 4 * c_limit, 0);
-      __asm__ volatile("sync;\n");
+      __asm__ volatile("sync;\n\t");
       if (topLeftIsIn) {
         __memcpy_async(nram_ping, input + i_tl_offset, c_slice * sizeof(T),
                        GDRAM2NRAM);
@@ -119,7 +119,7 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       }
     }
     __nramset(nram_pong, 4 * c_limit, 0);
-    __asm__ volatile("sync;\n");
+    __asm__ volatile("sync;\n\t");
     while (c_rem > 0) {
       c_slice = c_slice < c_rem ? c_slice : c_rem;
       // load the next input to nram
@@ -216,7 +216,7 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       c_offset += c_slice;
       swap(nram_ping, nram_pong);
       __nramset(nram_pong, 4 * c_limit, 0);
-      __asm__ volatile("sync;\n");
+      __asm__ volatile("sync;\n\t");
     }
   }
 }
@@ -340,7 +340,7 @@ __mlu_global__ void MLUKernelRoiCropBackward(
       c_offset += c_slice;
       swap(nram_ping, nram_pong);
       nram_output = nram_ping + c_limit;
-      __asm__ volatile("sync;\n");
+      __asm__ volatile("sync;\n\t");
     }
   }
 }

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -257,12 +257,13 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *
  * @par Scale Limitation
  * - The input tensor, grid tensor and ouput tensor must have four dimensions.
- * - The second dimension of grid tensor and output tensor must be the same
- *   size.
+ * - Size of the first dimension of input tensor is divisibled by size of the
+ *   first dimension of grid tensor. 
+ * - The second dimension of grid tensor and output tensor must be the same size.
  * - The third dimension of grid tensor and output tensor must be the same size.
- * - Size of the fourth dimension of input tensor is divisibled by size of the
- *   fourth dimension of grid tensor. Grid tensor \b grid must meet the following
- *   data range:
+ * - The fourth dimension of input tensor and output tensor must be the same size. 
+ * - Size of the fourth dimension of grid tensor must be equal to 2.
+ * - Grid tensor \b grid must meet the following data range:
  *   - Float: [-1.0,1.0].
  * @par Requirements
  * - None.
@@ -277,6 +278,81 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(
     mluOpHandle_t handle, const mluOpTensorDescriptor_t input_desc,
     const void *input, const mluOpTensorDescriptor_t grid_desc,
     const void *grid, const mluOpTensorDescriptor_t output_desc, void *output);
+
+/*!
+ * @brief Computes the gradients of images \b grad_input based on the gradients
+ *   \b grad_output and coordinate mapping parameter \b grid to perform the
+ *   backpropagation.
+ *
+ * @param[in] handle
+ *   Input. Handle to a MLUOP context that is used to manage MLU devices and
+ *   queues in ::mluOpRoiCropBackward operation. For detailed information, see
+ *   ::mluOpHandle_t.
+ * @param[in] grad_output_desc
+ *   Input. The descriptor of the grad_output tensor. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] grad_output
+ *   Input. Pointer to the MLU memory that stores the gradient tensor \b grad_output
+ *   in the backpropagation process.
+ * @param[in] grid_desc
+ *   Input. The descriptor of the grid tensor. For detailed information, see
+ *   ::mluOpTensorDescriptor_t.
+ * @param[in] grid
+ *   Input. Pointer to the MLU memory that stores the coordinate mapping
+ *   tensor.
+ * @param[in] grad_input_desc
+ *   Input. The descriptor of the grad_input tensor. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[out] grad_input
+ *   Output. Pointer to the MLU memory that stores the gradient tensor of the
+ *   original images.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par Formula
+ * - See "RoI Crop Operation" section in "Cambricon MLUOP User Guide" for
+ *   details.
+ *
+ * @par Data Type
+ * - Data types of all tensors must be the same.
+ * - The supported data types of all tensors are as follows:
+ *   - Grad_input tensor: float.
+ *   - Grad_output tensor: float.
+ *   - Grid tensor: float.
+ * @par Data Layout
+ * - The supported data layout of \b grad_output , \b grid , \b grad_input are as
+ *   follows.
+ *   - Grad_output tensor: \p MLUOP_LAYOUT_NHWC.
+ *   - Grid tensor: \p MLUOP_LAYOUT_ARRAY.
+ *   - Grad_input tensor: \p MLUOP_LAYOUT_NHWC.
+ *
+ * @par Scale Limitation
+ * - The grad_output tensor, grid tensor and grad_input tensor must have four
+ *   dimensions.
+ * - Size of the first dimension of grad_input tensor is divisibled by size of
+ *   the first dimension of grid tensor.
+ * - The second dimension of grid tensor and grad_output tensor must be the same size.
+ * - The third dimension of grid tensor and grad_output tensor must be the same size.
+ * - The fourth dimension of grad_input \b grad_input tensor and grad_output tensor 
+ *   \b grad_output must be the same size. 
+ * - Size of the fourth dimension of grid tensor \b grid must be equal to 2.
+ * - Grid tensor \b grid must meet the following data range:
+ *   - Float: [-1.0,1.0].
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://github.com/princewang1994/R-FCN.pytorch/tree/master/lib/model/roi_crop
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpRoiCropBackward(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t grad_output_desc,
+    const void *grad_output, const mluOpTensorDescriptor_t grid_desc,
+    const void *grid, const mluOpTensorDescriptor_t grad_input_desc,
+    void *grad_input);
 
 /*!
  * @brief Computes sqrt on input tensor \b x, and returns the results in the

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -53,6 +53,12 @@ void MLUOP_WIN_API mluOpBlockKernel3StagePipelineDivFloatFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *x, const void *y, void *z, int num);
 
+/* FillZero*/
+void MLUOP_WIN_API mluOpBlockKernelFillZero(cnrtDim3_t k_dim,
+                                            cnrtFunctionType_t k_type,
+                                            cnrtQueue_t queue, const int num,
+                                            void *gdram_ptr);
+
 /* Log */
 void MLUOP_WIN_API mluOpBlockKernel3StagePipelineLogHalfFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
@@ -80,6 +86,11 @@ void MLUOP_WIN_API mluOpBlockKernelRoiCropForwardFloat(
     const void *input, const void *grid, const int batch, const int height,
     const int width, const int channels, const int grid_n, const int output_h,
     const int output_w, void *output);
+void MLUOP_WIN_API mluOpBlockKernelRoiCropBackwardFloat(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const void *grad_output, const void *grid, const int batch, const int height,
+    const int width, const int channels, const int grid_n, const int output_h,
+    const int output_w, void *grad_input);
 
 /* Sqrt */
 void MLUOP_WIN_API mluOpBlockKernel3StagePipelineSqrtHalfFast(

--- a/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
+++ b/bangc-ops/test/mlu_op_gtest/mlu_op_test_proto/mlu_op_test.proto
@@ -118,7 +118,6 @@ message Node {
   optional DivParam    div_param                      = 4001;   // param
   optional LogParam    log_param                      = 4002;     // param
   optional SqrtParam   sqrt_param                     = 4003;  // param
-  optional RoiCropForwardParam  roi_crop_forward_param = 4004;  //param
 }
 
 
@@ -189,6 +188,3 @@ message DivParam {
   optional ComputationPreference prefer = 1 [default = COMPUTATION_HIGH_PRECISION];
 }
 
-message RoiCropForwardParam {
-  optional ComputationPreference prefer = 1 [default = COMPUTATION_HIGH_PRECISION];
-}

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.cpp
@@ -1,0 +1,172 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "roi_crop_backward.h"
+
+#include "mlu_op.h"
+
+namespace mluoptest {
+void RoiCropBackwardExecutor::paramCheck() {
+  GTEST_CHECK(parser_->inputs().size() == 2,
+              "[RoiCropBackwardExecutor] input number is wrong. ");
+  GTEST_CHECK(parser_->outputs().size() == 1,
+              "[RoiCropBackwardExecutor] output number is wrong. ");
+}
+
+void RoiCropBackwardExecutor::initData() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call initData() begin.";
+  grad_output_data_ptr_ = data_vector_[0].device_ptr;
+  grid_data_ptr_ = data_vector_[1].device_ptr;
+  grad_input_data_ptr_ = data_vector_[2].device_ptr;
+  grad_output_desc_ = tensor_desc_[0].tensor;
+  grid_desc_ = tensor_desc_[1].tensor;
+  grad_input_desc_ = tensor_desc_[2].tensor;
+  grad_output_h_ = grad_output_desc_->dims[1];
+  grad_output_w_ = grad_output_desc_->dims[2];
+  grid_batch_roi_ = grid_desc_->dims[0];
+  grad_input_batch_ = grad_input_desc_->dims[0];
+  grad_input_h_ = grad_input_desc_->dims[1];
+  grad_input_w_ = grad_input_desc_->dims[2];
+  grad_input_c_ = grad_input_desc_->dims[3];
+  VLOG(4) << "[RoiCropBackwardExecutor] call initData() end.";
+}
+
+void RoiCropBackwardExecutor::printDataInfo() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call printDataInfo() begin.";
+  VLOG(4) << "grid_batch_roi_  " << grid_batch_roi_;
+  VLOG(4) << "grad_output_h_        " << grad_output_h_;
+  VLOG(4) << "grad_output_w_        " << grad_output_w_;
+  VLOG(4) << "grad_input_batch_     " << grad_input_batch_;
+  VLOG(4) << "grad_input_h_         " << grad_input_h_;
+  VLOG(4) << "grad_input_w_         " << grad_input_w_;
+  VLOG(4) << "grad_input_c_         " << grad_input_c_;
+  VLOG(4) << "[RoiCropBackwardExecutor] call printDataInfo() end.";
+}
+
+int RoiCropBackwardExecutor::getTopLeft(const float grid_yx_value,
+                                        const int input_h_w, float* weight) {
+  float xcoord = (grid_yx_value + 1) * (input_h_w - 1) / 2;
+  int point = floor(xcoord);
+  *weight = 1 - (xcoord - point);
+  return point;
+}
+
+void RoiCropBackwardExecutor::compute() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call compute() begin.";
+  initData();
+  printDataInfo();
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpRoiCropBackward(
+      handle_, grad_output_desc_, grad_output_data_ptr_, grid_desc_,
+      grid_data_ptr_, grad_input_desc_, grad_input_data_ptr_));
+  interface_timer_.stop();
+  VLOG(4) << "[RoiCropBackwardExecutor] call compute() end.";
+}
+
+void RoiCropBackwardExecutor::cpuCompute() {
+  VLOG(4) << "[RoiCropBackwardExecutor] call cpuCompute() begin.";
+  float* grad_output_cpu_ptr = cpu_fp32_input_[0];
+  float* grid_cpu_ptr = cpu_fp32_input_[1];
+  float* grad_input_cpu_ptr = cpu_fp32_output_[0];
+  int grad_output_nums =
+      grid_batch_roi_ * grad_output_h_ * grad_output_w_ * grad_input_c_;
+  int roi_per_img = grid_batch_roi_ / grad_input_batch_;
+  int grad_output_stride_batch =
+      grad_output_h_ * grad_output_w_ * grad_input_c_;
+  int grad_output_stride_h = grad_output_w_ * grad_input_c_;
+  int grad_output_stride_w = grad_input_c_;
+  int grid_stride_batch = grad_output_h_ * grad_output_w_ * 2;
+  int grid_stride_h = grad_output_w_ * 2;
+  int gride_stride_w = 2;
+  int grad_input_stride_batch = grad_input_h_ * grad_input_w_ * grad_input_c_;
+  int grad_input_stride_h = grad_input_w_ * grad_input_c_;
+  int grad_input_stride_w = grad_input_c_;
+  int i_tl_x = 0;
+  int i_tl_y = 0;
+  float i_tl_x_weight = 0.0;
+  float i_tl_y_weight = 0.0;
+  float i_tl = 0;
+  float i_tr = 0;
+  float i_bl = 0;
+  float i_br = 0;
+  for (int index = 0; index < grad_output_nums; ++index) {
+    // coordinates of each position in grad_output data
+    int goc = index % grad_input_c_;
+    int gow = (index / grad_output_stride_w) % grad_output_w_;
+    int goh = (index / grad_output_stride_h) % grad_output_h_;
+    int gon = index / grad_output_stride_batch;
+    // data offset in grad_output
+    const int output_offset = gon * grad_output_stride_batch +
+                              goh * grad_output_stride_h +
+                              gow * grad_output_stride_w + goc;
+    float grad_output_value = grad_output_cpu_ptr[output_offset];
+
+    // batch dimension index in grad_output
+    int grad_input_n = gon / roi_per_img;
+    // data value in grid
+    float yf = grid_cpu_ptr[gon * grid_stride_batch + goh * grid_stride_h +
+                            gow * gride_stride_w];
+    float xf = grid_cpu_ptr[gon * grid_stride_batch + goh * grid_stride_h +
+                            gow * gride_stride_w + 1];
+    // grad_input data information
+    i_tl_x = getTopLeft(xf, grad_input_w_, &i_tl_x_weight);
+    i_tl_y = getTopLeft(yf, grad_input_h_, &i_tl_y_weight);
+
+    const int i_tl_offset = grad_input_n * grad_input_stride_batch +
+                            i_tl_y * grad_input_stride_h +
+                            i_tl_x * grad_input_stride_w + goc;
+    float i_tl_xy_weight = i_tl_x_weight * i_tl_y_weight;
+    bool topLeftIsIn = i_tl_x >= 0 && i_tl_x <= (grad_input_w_ - 1) &&
+                       i_tl_y >= 0 && i_tl_y <= (grad_input_h_ - 1);
+    if (topLeftIsIn) {
+      grad_input_cpu_ptr[i_tl_offset] += i_tl_xy_weight * grad_output_value;
+    }
+
+    const int i_tr_offset = i_tl_offset + grad_input_stride_w;
+    float i_tr_xy_weight = (1 - i_tl_x_weight) * i_tl_y_weight;
+    bool topRightIsIn = i_tl_x >= 0 && i_tl_x <= (grad_input_w_ - 1) &&
+                        (i_tl_y + 1) >= 0 &&
+                        (i_tl_y + 1) <= (grad_input_h_ - 1);
+    if (topRightIsIn) {
+      grad_input_cpu_ptr[i_tr_offset] += i_tr_xy_weight * grad_output_value;
+    }
+
+    const int i_bl_offset = i_tl_offset + grad_input_stride_h;
+    float i_bl_xy_weight = i_tl_x_weight * (1 - i_tl_y_weight);
+    bool bottomLeftIsIn = (i_tl_x + 1) >= 0 &&
+                          (i_tl_x + 1) <= (grad_input_w_ - 1) && i_tl_y >= 0 &&
+                          i_tl_y <= (grad_input_h_ - 1);
+    if (bottomLeftIsIn) {
+      grad_input_cpu_ptr[i_bl_offset] += i_bl_xy_weight * grad_output_value;
+    }
+
+    const int i_br_offset =
+        i_tl_offset + grad_input_stride_h + grad_input_stride_w;
+    float i_br_xy_weight = (1 - i_tl_x_weight) * (1 - i_tl_y_weight);
+    bool bottomRightIsIn =
+        (i_tl_x + 1) >= 0 && (i_tl_x + 1) <= (grad_input_w_ - 1) &&
+        (i_tl_y + 1) >= 0 && (i_tl_y + 1) <= (grad_input_h_ - 1);
+    if (bottomRightIsIn) {
+      grad_input_cpu_ptr[i_br_offset] += i_br_xy_weight * grad_output_value;
+    }
+  }
+  VLOG(4) << "[RoiCropBackwardExecutor] call cpuCompute() end.";
+}
+
+int64_t RoiCropBackwardExecutor::getTheoryOps() {
+  const int cp_count = 8;
+  theory_ops_ = parser_->getInputDataCount(0) * cp_count;
+  VLOG(4) << "[RoiCropBackwardExecutor] getTheoryOps: " << theory_ops_
+          << " ops.";
+  return theory_ops_;
+}
+
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.h
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/roi_crop_backward.h
@@ -1,0 +1,48 @@
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon, Inc. All rights reserved.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_BACKWARD_ROI_CROP_BACKEARD_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_BACKWARD_ROI_CROP_BACKEARD_H_
+
+#include "executor.h"
+
+namespace mluoptest {
+class RoiCropBackwardExecutor : public Executor {
+ public:
+  RoiCropBackwardExecutor() {}
+  ~RoiCropBackwardExecutor() {}
+  void paramCheck() override;
+  void compute() override;
+  void cpuCompute() override;
+  int64_t getTheoryOps() override;
+
+ private:
+  void initData();
+  void printDataInfo();
+  int getTopLeft(const float grid_yx_value, const int input_hw, float* weight);
+  void* grad_output_data_ptr_;
+  void* grid_data_ptr_;
+  void* grad_input_data_ptr_;
+  mluOpTensorDescriptor_t grad_output_desc_;
+  mluOpTensorDescriptor_t grid_desc_;
+  mluOpTensorDescriptor_t grad_input_desc_;
+  int grad_input_batch_;
+  int grad_input_h_;
+  int grad_input_w_;
+  int grad_input_c_;
+  int grid_batch_roi_;
+  int grad_output_h_;
+  int grad_output_w_;
+  int64_t theory_ops_;
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_ROI_CROP_BACKWARD_ROI_CROP_BACKEARD_H_

--- a/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/src/zoo/roi_crop_backward/test_case/case_0.prototxt
@@ -1,0 +1,53 @@
+op_name: "roi_crop_backward"
+input {
+  id: "input1"
+  shape: {
+    dims: 1
+    dims: 5
+    dims: 5
+    dims: 500
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 23
+    upper_bound: -5.0
+    lower_bound: 5.0
+    distribution: UNIFORM
+  }
+}
+input {
+  id: "input2"
+  shape: {
+    dims: 1
+    dims: 5
+    dims: 5
+    dims: 2
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 20
+    upper_bound: -1.0
+    lower_bound:  1.0
+    distribution: UNIFORM
+  }
+}
+output {
+  id: "output"
+  shape: {
+    dims: 1
+    dims: 32
+    dims: 32
+    dims: 500
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 0.003
+  error_threshold: 0.003
+  baseline_device: CPU
+}


### PR DESCRIPTION
### **1. 修改描述**
新增roi_crop_backward算子，是roi_crop_forward算子的反向

- **影响范围/算子**：roi_crop_backward
- **影响版本/分支**：master
##### 1.1 精度验收标准
算子采用静态阈值标准：diffs=[diff1，diff2]，diff1<=3e-3 && diff2 <= 3e-3。
##### 1.2 算子方案CheckList
|      序号      |           需求           |      需求详情       |
|----|----|----|
|1|支持硬件 |MLU290、MLU370|
|2|job类型|U1|
|3|DimXYZ|支持DimXYZ|
|4|可变|不支持各个维度可变|
|5|layout|gradInput和gradOutput:支持NHWC<br>grid:支持ARRAY|
|6|多维|不支持多维|
|7|0元素|不支持0元素|
|8|转数提前|否|
|9|片外数据类型|float|
|10|片上数据类型|float|
|11|融合|否|
|12|规模限制|否|
|13|c不感知对齐|否|
|14|原位测试对齐|不支持|
##### 1.3 新特性测例
|测试点|验收标准|测试结果(精度)|
|----|----|----|
|数据类型测试|FLOAT|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|多维张量测试|支持4维|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|Layout测试|支持NHWC|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|不同规模 / 整数余数端段 / 对齐不对齐||[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|零维张量测试/0元素测试|不支持0元素测试|[Error]:"MLUOP_STATUS_BAD_PARAM in mluOpRoiCropBackward( handle_, gradOutput_desc, gradOutput_data_ptr, grid_desc, grid_data_ptr, gradInput_desc, gradInput_data_ptr)"  [ /tudejiang/mlu-ops/bangc-ops/core/logging.cpp:240  pid:55350]|
|稳定性测试|gtest 多线程+repeat 使用--gtest_repeat=NUM --thread=NUM |[----------] Global test environment tear-down[ SUMMARY  ] Total 200 cases of 200 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (670 ms total).[  PASSED  ] 1 test case.|
|多平台测试|支持MLU290、MLU370|[----------] Global test environment tear-down[ SUMMARY  ] Total 1381 cases of 1 op(s).ALL PASSED.[==========] 1381 test cases from 1 test suite ran. (153401 ms total)[  PASSED  ] 1381 test cases.|
|gen_case模块测试|gen_case模块生成的测试通过|[----------] Global test environment tear-down[ SUMMARY  ] Total 1 cases of 1 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (54 ms total)[  PASSED  ] 1 test case..|
|其他测试点|||
##### 1.4 参数检查
提交新算子时，给出测试点，并说明测试结果。
|测试点|验收标准|测试结果(出错信息)|
|----|----|----|
|不符合算子限制|正常报错|1、gradOutput、grid和gradInput的数据类型应该一致:<br>[Error]:[mluOpRoiCropBackward] Check failed: gradOutput_desc->dtype == MLUOP_DTYPE_FLOAT.   [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:50  pid:55352]<br>2、gradOutput和gradInput的layout必须为NHWC：<br>[Error]:[mluOpRoiCropBackward] Check failed: gradOutput_desc->layout == MLUOP_LAYOUT_NHWC.   [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:54  pid:55354]<br>3、grid的最后维度必须是2:<br>[Error]:[mluOpRoiCropBackward] Check failed: grid_desc->dims[3] should be equal to 2.  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:71  pid:55356]<br>4、gradOutput和gradInput的最后一维必须一致:<br>[Error]:[mluOpRoiCropBackward] Check failed: gradOutput_desc->dims[3] should be equal to gradInput_desc->dims[3].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:65  pid:55358]<br>5、grid和gradOutput的第一、第二、第三维度必须一致:<br>[Error]:[mluOpRoiCropBackward]Check failed: gradOutput_desc->dims[0] should be equal to grid_desc->dims[0].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:59  pid:55360];<br>[Error]:[mluOpRoiCropBackward]Check failed: gradOutput_desc->dims[1] should be equal to grid_desc->dims[1].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:59  pid:55362];<br>[Error]:[mluOpRoiCropBackward]Check failed: gradOutput_desc->dims[2] should be equal to grid_desc->dims[2].  [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_backward/roi_crop_backward.mlu:59  pid:55364]|
|非法参数传递|正常报错||
### 2. 性能测试
- 要排除机器环境的影响。
- 用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试。
- 建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理。
- 算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。
##### 2.1 算子io利用率、计算效率
注释: 
io_efficiency = theory_io_size / (latency * IO_BANDWIDTH)
**theory_is_size:** 从算法上需要访问的数据量(与实现无关), **lantency:**算子运行的实际时间, **IO_BANGWIDTH:**硬件的理论带宽.
compute_efficiency = theory_compute_ops / (latency * peak_compute_force)
**theory_compute_ops:** 该算子从算法上需要执行多少次操作(与实际无关), **lantency:** 表示算子运行的实际时间, **peak_compute_force:** 硬件平台的峰值算力, 其单位是op/s(每秒执行多少操作)
|operator|mlu_hardware_time|mlu_interface_time|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size|count|gradOutput|grid|gradInput|
|----|----|----|----|----|----|----|----|----|----|
|roi_crop_forward|8|49.861|1.66016e-05|1.46484e-06|0|1|1,3,1,1|1,3,1,2|1,5,5,1|
|roi_crop_forward|9|47.254|0.005623|6.5104e-05|0|1|1,3,1,50|1,3,1,2|1,16,16,50|
|roi_crop_forward|14|48.225|0.014648|0.000348|0|1|1,5,5,50|1,5,5,2|1,32,32,50|
|roi_crop_forward|22|48.435|0.09313|0.002219|0|1|1,5,5,500|1,5,5,2|1,32,32,500|
|roi_crop_forward|1184|51.405|0.173|0.004124|0|1|1,5,5,50000|1,5,5,2|1,32,32,50000|
|roi_crop_forward|185|51.366|0.125957|0.01784|0|1|1,13,13,5000|1,13,13,2|1,32,32,5000|
|roi_crop_forward|662|50.343|0.04865|0.01843|0|1|1,25,25,5000|1,25,25,2|1,32,32,5000|
|roi_crop_forward|903|57.475|0.03057|0.021662|0|1|16,25,25,500|16.25,25,2|4,32,32,500|
|roi_crop_forward|498|49.236|0.03653|0.02039|0|1|16,13,25,500|16,13,25,2|4,32,32,500|
|roi_crop_forward|49|51.355|0.168|0.0047|0|1|8,3,5,500|8,3,5,2|4,32,32,500|

##### 2.2 内存泄露
暂不支持
##### 2.3 代码覆盖率
这里得把代码中分支都跑一边，就需要增加测试用例个数，去覆盖到所有代码
通过测试roi_crop_backward算子的代码覆盖率：80.0%
### 3. 总结分析
总结分析主要需要考虑以下几点：
1、该算子暂时不支持half类型的数据，grid不支持NaN和INF数据，主要因为硬件原因，jira有人已经提了需求；
2、该算子的源码只支持torch版本为0.3.0，高于该版本源码会出现各种问题；
3、roi_crop_backward算子做梯度计算时用到atomic，在kernel中计算需先给gradInput进行刷0，但限于MLU-OPS没有刷0的接口，只能先自己写一个kernel调用__gdramset()进行刷0。
