### PR TITLE
[CNNLCORE-7405]fix(roi_crop_forward):fix tensor annotation and grid d…

### DIFF
--- a/bangc-ops/kernels/roi_crop/roi_crop.cpp
+++ b/bangc-ops/kernels/roi_crop/roi_crop.cpp
@@ -49,7 +49,7 @@ mluOpStatus_t RoiCropForwardParamCheck(
   PARAM_CHECK(op_name, input_desc->dtype == MLUOP_DTYPE_FLOAT);
   PARAM_CHECK(op_name, input_desc->dim == 4);
   PARAM_CHECK(op_name, grid_desc->dtype == MLUOP_DTYPE_FLOAT);
-  PARAM_CHECK(op_name, output_desc->dim == 4);
+  PARAM_CHECK(op_name, grid_desc->dim == 4);
   PARAM_CHECK(op_name, output_desc->dtype == MLUOP_DTYPE_FLOAT);
   PARAM_CHECK(op_name, output_desc->dim == 4);
   // check shape and layout

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -254,6 +254,11 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *   - Input tensor: float.
  *   - Grid tensor: float.
  *   - Output tensor: float.
+ * @par Data Layout
+ * - The supported data layout of \b input , \b grid , \b output are as follows:
+ *   - Input tensor: \p MLUOP_LAYOUT_NHWC.
+ *   - Grid tensor: \p MLUOP_LAYOUT_ARRAY.
+ *   - Output tensor: \p MLUOP_LAYOUT_NHWC.
  *
  * @par Scale Limitation
  * - The input tensor, grid tensor and ouput tensor must have four dimensions.


### PR DESCRIPTION
### **1. 修改描述**
新增roi_crop_forward算子，提供获取感兴趣区域特征值的功能

- **影响范围/算子**：roi_crop_forward
- **影响版本/分支**：master
##### 1.1 精度验收标准
算子采用静态阈值标准：diffs=[diff1，diff2]，diff1<=3e-3 && diff2 <= 3e-3。
##### 1.2 算子方案CheckList
|      序号      |           需求           |      需求详情       |
|----|----|----|
|1|支持硬件 |MLU290、MLU370|
|2|job类型|U1|
|3|DimXYZ|支持DimXYZ|
|4|可变|不支持各个维度可变|
|5|layout|input:支持NHWC<br>grid:支持ARRAY|
|6|多维|不支持多维|
|7|0元素|不支持0元素|
|8|转数提前|否|
|9|片外数据类型|float|
|10|片上数据类型|float|
|11|融合|否|
|12|规模限制|否|
|13|c不感知对齐|否|
|14|原位测试对齐|不支持|
##### 1.3 新特性测例
|测试点|验收标准|测试结果(精度)|
|----|----|----|
|数据类型测试|FLOAT|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|多维张量测试|支持4维|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|Layout测试|支持NHWC|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down [ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED.[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|不同规模 / 整数余数端段 / 对齐不对齐||[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED.[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|零维张量测试/0元素测试|不支持0元素测试|2022-05-23 12:25:20.412141: [cnrtError] [55874] [Card : 0] cnrtMemcpy: Input argument 'dst' or 'src' is NULL. Please check the input arguments.[/tudejiang/mlu-ops/bangc-ops/test/mlu_op_gtes/src/executor.cpp:1375] CNRT error, code=632003(invalid argument.) "cnrtMemcpy(db->device_origin_ptr, db->host_ptr,db->size, CNRT_MEM_TRANS_DIR_HOST2DEV)"|
|稳定性测试|gtest 多线程+repeat 使用--gtest_repeat=NUM --thread=NUM |[^ OK ] ../../test/mlu_op_gtest/src/zoo/roi_crop_forward/case_test/case_0.prototxt[ OK ] roi_crop_forward/TestSuite.mluOp/0 (1673 ms)[----------] 1 test from roi_crop_forward/TestSuite (1673 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 200 cases of 200 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (1676 ms total)[ PASSED ] 1 test case. |
|多平台测试|支持MLU290、MLU370|[ OK ] roi_crop_forward/TestSuite.mluOp/1227 (3 ms)[----------] 1228 tests from roi_crop_forward/TestSuite (148200 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1228 cases of 1 op(s).ALL PASSED.[==========] 1228 test cases from 1 test suite ran. (148265 ms total)[ PASSED ] 1228 test cases.|
|gen_case模块测试|gen_case模块生成的测试通过|[ OK ] roi_crop_forward/TestSuite.mluOp/0 (3 ms)[----------] 1 test from roi_crop_forward/TestSuite (3 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 1 cases of 1 op(s).ALL PASSED.[==========] 1 test case from 1 test suite ran. (73 ms total)[ PASSED ] 1 test case.|
|其他测试点|||
##### 1.4 参数检查
提交新算子时，给出测试点，并说明测试结果。
|测试点|验收标准|测试结果(出错信息)|
|----|----|----|
|不符合算子限制|正常报错|1、input、grid和output的数据类型应该一致:<br>[2022-5-23 20:51:44] [MLUOP] [Error]：[mluOpRoiCropForward] Check failed: input_desc->dtype == output_desc->dtype. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:74 pid:55878]<br>2、input、grid和output的layout必须为NHWC：<br>[2022-5-23 20:52:26] [MLUOP] [Error]:[mluOpRoiCropForward] Check failed: output_desc->layout == MLUOP_LAYOUT_NHWC. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:85 pid:55880]<br>3、grid的最后维度必须是2:<br>[2022-5-23 20:53:6] [MLUOP] [Error]:[mluOpRoiCropForward]:Check failed: grid_desc->dims[3] should be equal to 2. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:96 pid:55882]<br>4、input和output的最后一维必须一致:<br>[2022-5-23 20:53:31] [MLUOP] [Error]:[mluOpRoiCropForward]:Check failed: output_desc->dims[3] should be equal to input_desc->dims[3]. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:91 pid:55884]<br>5、grid和output的第一、第二、第三维度必须一致:<br>[2022-5-23 20:54:15] [MLUOP] [Error]:[mluOpRoiCropForward]:Check failed: output_desc->dims[0]/[1]/[2] should be equal to grid_desc->dims[0]/[1]/[2]. [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop_forward/roi_crop_forward.mlu:87 pid:55886]<br>6、input、grid和output的数据维度为4维:<br>[2022-7-11 11:35:45] [MLUOP] [Error]:[mluOpRoiCropForward] Check failed: input_desc->dim == 4.   [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop/roi_crop.cpp:50  pid:721]<br>[2022-7-11 11:36:41] [MLUOP] [Error]:[mluOpRoiCropForward] Check failed: grid_desc->dim == 4.   [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop/roi_crop.cpp:52  pid:723]<br>[2022-7-11 11:38:1] [MLUOP] [Error]:[mluOpRoiCropForward] Check failed: output_desc->dim == 4.   [ /tudejiang/mlu-ops/bangc-ops/kernels/roi_crop/roi_crop.cpp:54  pid:725]|
|非法参数传递|正常报错||
### 2. 性能测试
- 要排除机器环境的影响。
- 用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试。
- 建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理。
- 算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。
##### 2.1 算子io利用率、计算效率
注释: 
io_efficiency = theory_io_size / (latency * IO_BANDWIDTH)
**theory_is_size:** 从算法上需要访问的数据量(与实现无关), **lantency:**算子运行的实际时间, **IO_BANGWIDTH:**硬件的理论带宽.
compute_efficiency = theory_compute_ops / (latency * peak_compute_force)
**theory_compute_ops:** 该算子从算法上需要执行多少次操作(与实际无关), **lantency:** 表示算子运行的实际时间, **peak_compute_force:** 硬件平台的峰值算力, 其单位是op/s(每秒执行多少操作)
|operator|mlu_hardware_time|mlu_interface_time|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size|count|input|grid|output|
|----|----|----|----|----|----|----|----|----|----|
|roi_crop_forward|6|21.468|2.21e-5|0.00011|0|1|1,5,5,1|1,3,1,2|1,3,1,1|
|roi_crop_forward|6|20.817|0.00843|0.0604|0|1|1,16,16,50|1,3,1,2|1,3,1,50|
|roi_crop_forward|9|24.546|0.0227865|0.16|0|1|1,32,32,50|1,5,5,2|1,5,5,50|
|roi_crop_forward|10|22.109|0.204902|1.45|0|1|1,32,32,500|1,5,5,2|1,5,5,500|
|roi_crop_forward|96|38.829|2.1342|15.104|0|1|1,32,32,50000|1,5,5,2|1,5,5,50000|
|roi_crop_forward|62|59.818|0.5540|3.7419|0|1|16,32,32,500|48,5,5,2|48,5,5,500|
|roi_crop_forward|33|34.934|0.995|7.03|0|1|16,32,32,500|48,3,3,2|48,3,3,500|
|roi_crop_forward|44|32.661|0.759|5.2727|0|1|16,32,32,500|48.3,5,2|48,3,5,500|
|roi_crop_forward|273|32.723|0.1637|0.8498|0|1|16,32,32,500|48,9,15,500|48,9,15,500|
|roi_crop_forward|633|71.129|1.111|7.33|0|1|8,64,64,5000|24,9,15,2|24,9,15,5000|

##### 2.2 内存泄露
暂不支持
##### 2.3 代码覆盖率
这里得把代码中分支都跑一边，就需要增加测试用例个数，去覆盖到所有代码
通过测试roi_crop_forward算子的代码覆盖率：79.0%
### 3. 总结分析
总结分析主要需要考虑以下几点：
1、roi_crop算子包含正反向，该算子roi_crop_forward功能为给定input、grid计算得到output。roi_crop_backward功能后续会加入。
2、该算子暂时不支持half类型的数据，grid不支持NaN和INF数据，主要因为硬件原因，jira有人已经提了需求。
3、该算子的源码只支持torch版本为0.3.0，高于该版本源码会出现各种问题。
