### PR TITLE
[Feature]: fix psroipool_forward comment

### DIFF
--- a/bangc-ops/kernels/psroipool_forward/psroipool_forward.cpp
+++ b/bangc-ops/kernels/psroipool_forward/psroipool_forward.cpp
@@ -53,7 +53,7 @@ static mluOpStatus_t paramCheck(
     const mluOpTensorDescriptor_t rois_desc,
     const mluOpTensorDescriptor_t output_desc,
     const mluOpTensorDescriptor_t mapping_channel_desc, void *workspace,
-    const size_t workspace_size) {
+    size_t workspace_size) {
   PARAM_CHECK(api, input_desc != NULL);
   PARAM_CHECK(api, rois_desc != NULL);
   PARAM_CHECK(api, output_desc != NULL);
@@ -120,7 +120,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolForward(
     const float spatial_scale, const int group_size, const int output_dim,
     const mluOpTensorDescriptor_t input_desc, const void *input,
     const mluOpTensorDescriptor_t rois_desc, const void *rois, void *workspace,
-    const size_t workspace_size, const mluOpTensorDescriptor_t output_desc,
+    size_t workspace_size, const mluOpTensorDescriptor_t output_desc,
     void *output, const mluOpTensorDescriptor_t mapping_channel_desc,
     void *mapping_channel) {
   const std::string api = "[mluOpPsRoiPoolForward]";

--- a/bangc-ops/kernels/psroipool_forward/psroipool_forward.cpp
+++ b/bangc-ops/kernels/psroipool_forward/psroipool_forward.cpp
@@ -45,7 +45,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetPsRoiPoolWorkspaceSize(mluOpHandle_t handle,
   return MLUOP_STATUS_SUCCESS;
 }
 
-static mluOpStatus_t param_and_pointer_check(
+static mluOpStatus_t paramCheck(
     const std::string &api, const int pooled_height, const int pooled_width,
     const float spatial_scale, const int group_size, const int output_dim,
     const void *input, const void *rois, const void *output,
@@ -132,7 +132,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolForward(
   const int rois_sum = output_desc->dims[0];
   const int rois_offset = rois_desc->dims[1];
 
-  mluOpStatus_t ret = param_and_pointer_check(
+  mluOpStatus_t ret = paramCheck(
       api, pooled_height, pooled_width, spatial_scale, group_size, output_dim,
       input, rois, output, mapping_channel, input_desc, rois_desc, output_desc,
       mapping_channel_desc, workspace, workspace_size);
@@ -148,9 +148,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolForward(
   VLOG(5) << api << " Launch [" << k_type << ", " << k_dim.x << ", " << k_dim.y
           << ", " << k_dim.z << "].";
   KERNEL_CHECK((mluOpBlockKernelPsRoiPoolForward(
-      k_dim, k_type, handle->queue, (void *)input, (void *)rois, (void *)output,
-      (void *)mapping_channel, batch_size, height, width, channels,
-      pooled_height, pooled_width, output_dim, group_size, rois_sum,
-      rois_offset, spatial_scale)));
+      k_dim, k_type, handle->queue, input, rois, output, mapping_channel,
+      batch_size, height, width, channels, pooled_height, pooled_width,
+      output_dim, group_size, rois_sum, rois_offset, spatial_scale)));
   return MLUOP_STATUS_SUCCESS;
 }

--- a/bangc-ops/kernels/psroipool_forward/psroipool_forward.cpp
+++ b/bangc-ops/kernels/psroipool_forward/psroipool_forward.cpp
@@ -21,7 +21,7 @@
 #include "mlu_op_kernel.h"
 
 // policy function
-static void policyFuncPsroipoolForward(mluOpHandle_t handle, cnrtDim3_t *k_dim,
+static void policyFuncPsRoiPoolForward(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                        cnrtFunctionType_t *k_type,
                                        const int rois_num) {
   size_t union_number = mluop::runtime::getClusterLimitCapability(handle);
@@ -33,13 +33,15 @@ static void policyFuncPsroipoolForward(mluOpHandle_t handle, cnrtDim3_t *k_dim,
   k_dim->z = 1;
 }
 
-mluOpStatus_t MLUOP_WIN_API mluOpGetPsRoiPoolWorkspaceSize(mluOpHandle_t handle,
-                                                           const int output_dim,
-                                                           size_t *size) {
+mluOpStatus_t MLUOP_WIN_API mluOpGetPsRoiPoolWorkspaceSize(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t output_desc,
+    size_t *size) {
   PARAM_CHECK("[mluOpGetPsRoiPoolWorkspaceSize]", handle != NULL);
   PARAM_CHECK("[mluOpGetPsRoiPoolWorkspaceSize]", size != NULL);
+  PARAM_CHECK("[mluOpGetPsRoiPoolWorkspaceSize]", output_desc != NULL);
+  int output_dim = output_desc->dims[3];
   PARAM_CHECK("[mluOpGetPsRoiPoolWorkspaceSize]", output_dim >= 1);
-  *size = output_dim * sizeof(uint32_t);  // the offset of each pixel
+  *size = output_dim * sizeof(uint32_t);
 
   VLOG(5) << "workspace size = " << *size << ".";
   return MLUOP_STATUS_SUCCESS;
@@ -47,92 +49,92 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetPsRoiPoolWorkspaceSize(mluOpHandle_t handle,
 
 static mluOpStatus_t param_and_pointer_check(
     const std::string &api, const float spatial_scale, const int group_size,
-    const void *input_data, const void *input_rois, const void *output_data,
-    const void *mapping_channel, const mluOpTensorDescriptor_t input_data_desc,
-    const mluOpTensorDescriptor_t input_rois_desc,
-    const mluOpTensorDescriptor_t output_data_desc,
+    const void *input, const void *rois, const void *output,
+    const void *mapping_channel, const mluOpTensorDescriptor_t input_desc,
+    const mluOpTensorDescriptor_t rois_desc,
+    const mluOpTensorDescriptor_t output_desc,
     const mluOpTensorDescriptor_t mapping_channel_desc, void *workspace,
     const size_t workspace_size) {
-  PARAM_CHECK(api, input_data_desc != NULL);
-  PARAM_CHECK(api, input_rois_desc != NULL);
-  PARAM_CHECK(api, output_data_desc != NULL);
+  PARAM_CHECK(api, input_desc != NULL);
+  PARAM_CHECK(api, rois_desc != NULL);
+  PARAM_CHECK(api, output_desc != NULL);
   PARAM_CHECK(api, mapping_channel_desc != NULL);
-  PARAM_CHECK(api, input_data_desc->dim == 4);
-  PARAM_CHECK(api, input_rois_desc->dim == 2);
-  PARAM_CHECK(api, output_data_desc->dim == 4);
+  PARAM_CHECK(api, input_desc->dim == 4);
+  PARAM_CHECK(api, rois_desc->dim == 2);
+  PARAM_CHECK(api, output_desc->dim == 4);
   PARAM_CHECK(api, mapping_channel_desc->dim == 4);
   // check the input and output datatype
-  PARAM_CHECK(api, input_data_desc->dtype == MLUOP_DTYPE_FLOAT);
-  PARAM_CHECK(api, input_rois_desc->dtype == MLUOP_DTYPE_FLOAT);
-  PARAM_CHECK(api, output_data_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(api, input_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(api, rois_desc->dtype == MLUOP_DTYPE_FLOAT);
+  PARAM_CHECK(api, output_desc->dtype == MLUOP_DTYPE_FLOAT);
   PARAM_CHECK(api, mapping_channel_desc->dtype == MLUOP_DTYPE_INT32);
   // check layout
-  PARAM_CHECK(api, input_data_desc->layout == MLUOP_LAYOUT_NHWC);
-  PARAM_CHECK(api, output_data_desc->layout == MLUOP_LAYOUT_NHWC);
+  PARAM_CHECK(api, input_desc->layout == MLUOP_LAYOUT_NHWC);
+  PARAM_CHECK(api, output_desc->layout == MLUOP_LAYOUT_NHWC);
   PARAM_CHECK(api, mapping_channel_desc->layout == MLUOP_LAYOUT_NHWC);
   // param check
   // group_size == pooled_height
-  PARAM_CHECK(api, group_size == output_data_desc->dims[1]);
+  PARAM_CHECK(api, group_size == output_desc->dims[1]);
   // pooled_height == pooled_width
-  PARAM_CHECK(api, output_data_desc->dims[1] == output_data_desc->dims[2]);
+  PARAM_CHECK(api, output_desc->dims[1] == output_desc->dims[2]);
   // group_size >= 1.
   PARAM_CHECK(api, group_size >= 1);
   // output_dim >= 1.
-  PARAM_CHECK(api, output_data_desc->dims[3] >= 1);
+  PARAM_CHECK(api, output_desc->dims[3] >= 1);
   // spatial_scale > 0
   PARAM_CHECK(api, spatial_scale > 0);
   // rois_offset = 5.
-  PARAM_CHECK(api, input_rois_desc->dims[1] == 5);
+  PARAM_CHECK(api, rois_desc->dims[1] == 5);
   // roi_num check
-  PARAM_CHECK(api, output_data_desc->dims[0] == input_rois_desc->dims[0]);
+  PARAM_CHECK(api, output_desc->dims[0] == rois_desc->dims[0]);
   // channels == pooled_height * pooled_width * output_dim
-  PARAM_CHECK(api, input_data_desc->dims[3] == output_data_desc->dims[1] *
-                                                   output_data_desc->dims[2] *
-                                                   output_data_desc->dims[3]);
-  PARAM_CHECK(api, output_data_desc->dims[0] == mapping_channel_desc->dims[0]);
-  PARAM_CHECK(api, output_data_desc->dims[1] == mapping_channel_desc->dims[1]);
-  PARAM_CHECK(api, output_data_desc->dims[2] == mapping_channel_desc->dims[2]);
-  PARAM_CHECK(api, output_data_desc->dims[3] == mapping_channel_desc->dims[3]);
-  if (mluOpGetTensorElementNum(input_data_desc) == 0) {
-    VLOG(5) << api << " Input_data skip zero element tensor.";
+  PARAM_CHECK(api, input_desc->dims[3] == output_desc->dims[1] *
+                                                   output_desc->dims[2] *
+                                                   output_desc->dims[3]);
+  PARAM_CHECK(api, output_desc->dims[0] == mapping_channel_desc->dims[0]);
+  PARAM_CHECK(api, output_desc->dims[1] == mapping_channel_desc->dims[1]);
+  PARAM_CHECK(api, output_desc->dims[2] == mapping_channel_desc->dims[2]);
+  PARAM_CHECK(api, output_desc->dims[3] == mapping_channel_desc->dims[3]);
+  if (mluOpGetTensorElementNum(input_desc) == 0) {
+    VLOG(5) << api << " input skip zero element tensor.";
     return MLUOP_STATUS_SUCCESS;
   }
-  if (mluOpGetTensorElementNum(input_rois_desc) == 0) {
+  if (mluOpGetTensorElementNum(rois_desc) == 0) {
     LOG(ERROR) << api << " Roi_data can not be zero element tensor.";
     return MLUOP_STATUS_BAD_PARAM;
   }
   if (workspace_size > 0) {
     PARAM_CHECK(api, workspace != NULL);
   }
-  PARAM_CHECK(api, input_data != NULL);
-  PARAM_CHECK(api, input_rois != NULL);
-  PARAM_CHECK(api, output_data != NULL);
+  PARAM_CHECK(api, input != NULL);
+  PARAM_CHECK(api, rois != NULL);
+  PARAM_CHECK(api, output != NULL);
   PARAM_CHECK(api, mapping_channel != NULL);
   return MLUOP_STATUS_SUCCESS;
 }
 
 mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolForward(
     mluOpHandle_t handle, const float spatial_scale, const int group_size,
-    const mluOpTensorDescriptor_t input_data_desc, const void *input_data,
-    const mluOpTensorDescriptor_t input_rois_desc, const void *input_rois,
+    const mluOpTensorDescriptor_t input_desc, const void *input,
+    const mluOpTensorDescriptor_t rois_desc, const void *rois,
     void *workspace, const size_t workspace_size,
-    const mluOpTensorDescriptor_t output_data_desc, void *output_data,
+    const mluOpTensorDescriptor_t output_desc, void *output,
     const mluOpTensorDescriptor_t mapping_channel_desc, void *mapping_channel) {
   const std::string api = "[mluOpPsRoiPoolForward]";
   PARAM_CHECK(api, handle != NULL);
-  const int batch_size = input_data_desc->dims[0];
-  const int height = input_data_desc->dims[1];
-  const int width = input_data_desc->dims[2];
-  const int channels = input_data_desc->dims[3];
-  const int rois_sum = output_data_desc->dims[0];
-  const int pooled_height = output_data_desc->dims[1];
-  const int pooled_width = output_data_desc->dims[2];
-  const int output_dim = output_data_desc->dims[3];
-  const int rois_offset = input_rois_desc->dims[1];
+  const int batch_size = input_desc->dims[0];
+  const int height = input_desc->dims[1];
+  const int width = input_desc->dims[2];
+  const int channels = input_desc->dims[3];
+  const int rois_sum = output_desc->dims[0];
+  const int pooled_height = output_desc->dims[1];
+  const int pooled_width = output_desc->dims[2];
+  const int output_dim = output_desc->dims[3];
+  const int rois_offset = rois_desc->dims[1];
 
   mluOpStatus_t ret = param_and_pointer_check(
-      api, spatial_scale, group_size, input_data, input_rois, output_data,
-      mapping_channel, input_data_desc, input_rois_desc, output_data_desc,
+      api, spatial_scale, group_size, input, rois, output,
+      mapping_channel, input_desc, rois_desc, output_desc,
       mapping_channel_desc, workspace, workspace_size);
   if (ret != MLUOP_STATUS_SUCCESS) {
     LOG(ERROR) << api
@@ -142,12 +144,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolForward(
 
   cnrtDim3_t k_dim;
   cnrtFunctionType_t k_type;
-  policyFuncPsroipoolForward(handle, &k_dim, &k_type, rois_sum);
+  policyFuncPsRoiPoolForward(handle, &k_dim, &k_type, rois_sum);
   VLOG(5) << api << " Launch [" << k_type << ", " << k_dim.x << ", " << k_dim.y
           << ", " << k_dim.z << "].";
   KERNEL_CHECK((mluOpBlockKernelPsRoiPoolForward(
-      k_dim, k_type, handle->queue, (void *)input_data, (void *)input_rois,
-      (void *)output_data, (void *)mapping_channel, channels, height, width,
+      k_dim, k_type, handle->queue, (void *)input, (void *)rois,
+      (void *)output, (void *)mapping_channel, channels, height, width,
       pooled_height, pooled_width, rois_sum, output_dim, group_size,
       rois_offset, spatial_scale, batch_size)));
   return MLUOP_STATUS_SUCCESS;

--- a/bangc-ops/kernels/psroipool_forward/psroipool_forward_block.mlu
+++ b/bangc-ops/kernels/psroipool_forward/psroipool_forward_block.mlu
@@ -9,21 +9,10 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
-#include <math.h>
-
-#include <algorithm>
-
 #include "kernels/kernel.h"
 #include "mlu.h"
 #include "mlu_op_kernel.h"
 
-#define NRAM_BYTE_CNT \
-  (__MLU_NRAM_SIZE__ * 480 * 2)  // NRAM_ELEM_CNT <= nram.bytes
-#define BLOCK 256
-#define ASSERT(x)                 \
-  if (!(x)) {                     \
-    __breakdump_scalar(__LINE__); \
-  }
 #define ALIGN_SIZE 64
 
 // This function is used to align the round_rn
@@ -202,7 +191,7 @@ __mlu_func__ void psRoiAvgPoolKernel(
 
   int group_square_align = CEIL_ALIGN(group_size * group_size, ALIGN_SIZE);
   int output_dim_num_deal = FLOOR_ALIGN(
-      NRAM_BYTE_CNT / ((2 + 2 * group_square_align) * sizeof(T)), ALIGN_SIZE);
+      MAX_NRAM_SIZE / ((2 + 2 * group_square_align) * sizeof(T)), ALIGN_SIZE);
   const int repeat = output_dim / output_dim_num_deal;
   const int remain = output_dim % output_dim_num_deal;
   if (roi_num_per_core > 0) {
@@ -229,7 +218,7 @@ __mlu_global__ void MLUKernelPsroipoolForward(
     int channels, int height, int width, int pooled_height, int pooled_width,
     int rois_num, int output_dim, int group_size, int rois_offset,
     float spatial_scale, int batch_size) {
-  __nram__ uint8_t nram_buffer[NRAM_BYTE_CNT];
+  __nram__ uint8_t nram_buffer[MAX_NRAM_SIZE];
   psRoiAvgPoolKernel((float *)nram_buffer, (float *)bottom_data,
                      (float *)bottom_rois, (float *)top_data,
                      (int *)mapping_channel, channels, height, width,
@@ -239,10 +228,10 @@ __mlu_global__ void MLUKernelPsroipoolForward(
 
 void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *bottom_data, void *bottom_rois, void *top_data, void *mapping_channel,
-    int channels, int height, int width, int pooled_height, int pooled_width,
-    int rois_num, int output_dim, int group_size, int rois_offset,
-    float spatial_scale, int batch_size) {
+    const void *bottom_data, const void *bottom_rois, const void *top_data,
+    const void *mapping_channel, int channels, int height, int width,
+    int pooled_height, int pooled_width, int rois_num, int output_dim,
+    int group_size, int rois_offset, float spatial_scale, int batch_size) {
   MLUKernelPsroipoolForward<<<k_dim, k_type, queue>>>(
       (float *)bottom_data, (float *)bottom_rois, (float *)top_data,
       (int *)mapping_channel, channels, height, width, pooled_height,

--- a/bangc-ops/kernels/psroipool_forward/psroipool_forward_block.mlu
+++ b/bangc-ops/kernels/psroipool_forward/psroipool_forward_block.mlu
@@ -215,10 +215,10 @@ __mlu_func__ void psRoiAvgPoolKernel(
 }
 
 __mlu_global__ void MLUKernelPsroipoolForward(
-    void *bottom_data, void *bottom_rois, void *top_data, void *mapping_channel,
-    int batch_size, int height, int width, int channels, int pooled_height,
-    int pooled_width, int output_dim, int group_size, int rois_num,
-    int rois_offset, float spatial_scale) {
+    const void *bottom_data, const void *bottom_rois, const void *top_data,
+    const void *mapping_channel, int batch_size, int height, int width,
+    int channels, int pooled_height, int pooled_width, int output_dim,
+    int group_size, int rois_num, int rois_offset, float spatial_scale) {
   __nram__ uint8_t nram_buffer[MAX_NRAM_SIZE];
   psRoiAvgPoolKernel((float *)nram_buffer, (float *)bottom_data,
                      (float *)bottom_rois, (float *)top_data,
@@ -234,8 +234,7 @@ void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForward(
     int channels, int pooled_height, int pooled_width, int output_dim,
     int group_size, int rois_num, int rois_offset, float spatial_scale) {
   MLUKernelPsroipoolForward<<<k_dim, k_type, queue>>>(
-      (float *)bottom_data, (float *)bottom_rois, (float *)top_data,
-      (int *)mapping_channel, batch_size, height, width, channels,
-      pooled_height, pooled_width, output_dim, group_size, rois_num,
-      rois_offset, spatial_scale);
+      bottom_data, bottom_rois, top_data, mapping_channel, batch_size,
+      height, width, channels, pooled_height, pooled_width, output_dim,
+      group_size, rois_num, rois_offset, spatial_scale);
 }

--- a/bangc-ops/kernels/psroipool_forward/psroipool_forward_block.mlu
+++ b/bangc-ops/kernels/psroipool_forward/psroipool_forward_block.mlu
@@ -39,11 +39,11 @@ __mlu_func__ T scalarRound(T key) {
 template <typename T>
 __mlu_func__ void psRoiAvgPool(
     T *buffer_nram, T *bottom_data, T *bottom_rois, T *top_data,
-    int *mapping_channel, const int channels, const int height, const int width,
-    const int pooled_height, const int pooled_width,
-    const int rois_loop_per_core, const int init_rois_num, const int output_dim,
-    const int group_size, const int rois_offset, const T spatial_scale,
-    const int pre_data_for_task, const int batch_size, int output_dim_num_deal,
+    int *mapping_channel, const int batch_size, const int height,
+    const int width, const int channels, const int pooled_height,
+    const int pooled_width, const int rois_loop_per_core, const int output_dim,
+    const int group_size, const int init_rois_num, const int rois_offset,
+    const T spatial_scale, const int pre_data_for_task, int output_dim_num_deal,
     const int current_deal, const int remain, bool is_remain) {
   // get segment rois
   int group_square = group_size * group_size;
@@ -161,9 +161,9 @@ __mlu_func__ void psRoiAvgPool(
 template <typename T>
 __mlu_func__ void psRoiAvgPoolKernel(
     T *nram_buffer, T *bottom_data, T *bottom_rois, T *top_data,
-    int *mapping_channel, int channels, int height, int width,
-    int pooled_height, int pooled_width, int rois_num, int output_dim,
-    int group_size, int rois_offset, T spatial_scale, int batch_size) {
+    int *mapping_channel, int batch_size, int height, int width, int channels,
+    int pooled_height, int pooled_width, int output_dim, int group_size,
+    int rois_num, int rois_offset, T spatial_scale) {
   int rois_loop = rois_num;
 
   // multicore related,the rois number on each core
@@ -197,44 +197,45 @@ __mlu_func__ void psRoiAvgPoolKernel(
   if (roi_num_per_core > 0) {
     for (int current_deal = 0; current_deal < repeat; current_deal++) {
       psRoiAvgPool(nram_buffer, bottom_data, bottom_rois, top_data_ptr,
-                   mapping_channel_ptr, channels, height, width, pooled_height,
-                   pooled_width, roi_num_per_core, rois_num, output_dim,
-                   group_size, rois_offset, spatial_scale, pre_data_for_task,
-                   batch_size, output_dim_num_deal, current_deal, remain,
+                   mapping_channel_ptr, batch_size, height, width, channels,
+                   pooled_height, pooled_width, roi_num_per_core, output_dim,
+                   group_size, rois_num, rois_offset, spatial_scale,
+                   pre_data_for_task, output_dim_num_deal, current_deal, remain,
                    false);
     }
     if (remain) {
       psRoiAvgPool(nram_buffer, bottom_data, bottom_rois, top_data_ptr,
-                   mapping_channel_ptr, channels, height, width, pooled_height,
-                   pooled_width, roi_num_per_core, rois_num, output_dim,
-                   group_size, rois_offset, spatial_scale, pre_data_for_task,
-                   batch_size, output_dim_num_deal, repeat, remain, true);
+                   mapping_channel_ptr, batch_size, height, width, channels,
+                   pooled_height, pooled_width, roi_num_per_core, output_dim,
+                   group_size, rois_num, rois_offset, spatial_scale,
+                   pre_data_for_task, output_dim_num_deal, repeat, remain,
+                   true);
     }
   }
 }
 
 __mlu_global__ void MLUKernelPsroipoolForward(
     void *bottom_data, void *bottom_rois, void *top_data, void *mapping_channel,
-    int channels, int height, int width, int pooled_height, int pooled_width,
-    int rois_num, int output_dim, int group_size, int rois_offset,
-    float spatial_scale, int batch_size) {
+    int batch_size, int height, int width, int channels, int pooled_height,
+    int pooled_width, int output_dim, int group_size, int rois_num,
+    int rois_offset, float spatial_scale) {
   __nram__ uint8_t nram_buffer[MAX_NRAM_SIZE];
   psRoiAvgPoolKernel((float *)nram_buffer, (float *)bottom_data,
                      (float *)bottom_rois, (float *)top_data,
-                     (int *)mapping_channel, channels, height, width,
-                     pooled_height, pooled_width, rois_num, output_dim,
-                     group_size, rois_offset, spatial_scale, batch_size);
+                     (int *)mapping_channel, batch_size, height, width,
+                     channels, pooled_height, pooled_width, output_dim,
+                     group_size, rois_num, rois_offset, spatial_scale);
 }
 
 void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *bottom_data, const void *bottom_rois, const void *top_data,
-    const void *mapping_channel, int channels, int height, int width,
-    int pooled_height, int pooled_width, int rois_num, int output_dim,
-    int group_size, int rois_offset, float spatial_scale, int batch_size) {
+    const void *mapping_channel, int batch_size, int height, int width,
+    int channels, int pooled_height, int pooled_width, int output_dim,
+    int group_size, int rois_num, int rois_offset, float spatial_scale) {
   MLUKernelPsroipoolForward<<<k_dim, k_type, queue>>>(
       (float *)bottom_data, (float *)bottom_rois, (float *)top_data,
-      (int *)mapping_channel, channels, height, width, pooled_height,
-      pooled_width, rois_num, output_dim, group_size, rois_offset,
-      spatial_scale, batch_size);
+      (int *)mapping_channel, batch_size, height, width, channels,
+      pooled_height, pooled_width, output_dim, group_size, rois_num,
+      rois_offset, spatial_scale);
 }

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -267,18 +267,18 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  * 
  *  @par Data Type
  *  - The supported data types of input and output tensors are as follows:
- *     - input tensor: float.
- *     - rois tensor: float.
- *     - output tensor: float.
+ *     - Input tensor: float.
+ *     - Rois tensor: float.
+ *     - Output tensor: float.
  *     - Mapping_channel tensor: int32.
  * 
  *  @par Data Layout
  *  - The supported data layout of \b input, \b rois,
  *    \b output, \b mapping_channel are as follows:
  * 
- *   - input tensor: \p MLUOP_LAYOUT_NHWC.
- *   - rois tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - output tensor: \p MLUOP_LAYOUT_NHWC.
+ *   - Input tensor: \p MLUOP_LAYOUT_NHWC.
+ *   - Rois tensor: \p MLUOP_LAYOUT_ARRAY.
+ *   - Output tensor: \p MLUOP_LAYOUT_NHWC.
  *   - Mapping_channel tensor: \p MLUOP_LAYOUT_NHWC.
  * 
  *  @par Scale Limitation
@@ -288,10 +288,10 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *  - The group_size should be equal to pooled_height.
  *  - The pooled_height should be equal to pooled_width.
  *  - The channels should be equal to pooled_height * pooled_width * output_dim.
- *  - The dimension of input should be equal to 4.
- *  - The dimension of rois should be equal to 2.
- *  - The dimension of output should be equal to 4.
- *  - The dimension of mapping_channel should be equal to 4.
+ *  - The dimension of \b input should be equal to 4.
+ *  - The dimension of \b rois should be equal to 2.
+ *  - The dimension of \b output should be equal to 4.
+ *  - The dimension of \b mapping_channel should be equal to 4.
  *  - The rois_offset should be equal to 5.
  *  - The shape of roi should be [batch_id, roi_start_h, roi_start_w,
  *    roi_end_h, roi_end_w], and the batch_id must between 0
@@ -308,7 +308,7 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *  - None.
  * 
  *  @par Note
- *  - On MLU300 series, rois do not support NAN/INF.
+ *  - On MLU300 series, \b rois does not support NAN/INF.
  * 
  * @par Reference
  * - https://github.com/princewang1994/R-FCN.pytorch/tree/master/
@@ -331,16 +331,15 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
                       void *mapping_channel);
 
 /*!
- *  @brief Get extra space size that is needed in psroipool_forward operation,
-      the extra space size is output_dim * sizeof(uint32_t).
+ *  @brief Gets extra space size that is needed in psroipool_forward operation.
  *
  *  @param[in] handle
  *    Input. Handle to a MLUOP context that is used to manage MLU devices
  *    and queues in the psroipool_forward operation.
  *  @param[in] output_dim
- *    Input. The size of output_dim data. 
+ *    Input. An integer which indicates the channel of output.  
  *  @param[out] size
- *    Output. The size of extra space is output_dim * sizeof(uint32_t).
+ *    Output. A host pointer to the returned size of extra space in bytes.
  *  @par Return
  *  - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *  @par Scale Limitation

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -243,7 +243,7 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *  @param[in] rois
  *    Input. Pointer to the MLU memory that stores the rois tensor.
  *  @param[in] workspace
- *    Input. Pointer to the CPU memory that stores the extra workspace.
+ *    Input. Pointer to the MLU memory that stores the extra workspace.
  *  @param[in] workspace_size
  *    Input. The size of extra space is output_dim * sizeof(uint32_t).
  *  @param[in] output_desc
@@ -324,7 +324,7 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
                       const mluOpTensorDescriptor_t rois_desc,
                       const void *rois,
                       void *workspace,
-                      const size_t workspace_size,
+                      size_t workspace_size,
                       const mluOpTensorDescriptor_t output_desc,
                       void *output,
                       const mluOpTensorDescriptor_t mapping_channel_desc,

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -226,6 +226,12 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *    Input. The spatial_scale data.
  *  @param[in] group_size
  *    Input. The group_size data.
+ *  @param[in] pooled_height
+ *    Input. The pooled_height data.
+ *  @param[in] pooled_width
+ *    Input. The pooled_width data.
+ *  @param[in] output_dim
+ *    Input. The output_dim data.
  *  @param[in] input_desc
  *    Input. The descriptor of the input tensor. For detailed information,
  *    see ::mluOpTensorDescriptor_t.
@@ -310,7 +316,9 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  */
 mluOpStatus_t MLUOP_WIN_API 
 mluOpPsRoiPoolForward(mluOpHandle_t handle,
+                      const int pooled_height, const int pooled_width,
                       const float spatial_scale, const int group_size,
+                      const int output_dim,
                       const mluOpTensorDescriptor_t input_desc,
                       const void *input,
                       const mluOpTensorDescriptor_t rois_desc,
@@ -329,19 +337,18 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
  *  @param[in] handle
  *    Input. Handle to a MLUOP context that is used to manage MLU devices
  *    and queues in the psroipool_forward operation.
- *  @param[in] output_desc
- *    Input. The descriptor of the output tensor. For detailed information,
- *    see ::mluOpTensorDescriptor_t.
+ *  @param[in] output_dim
+ *    Input. The size of output_dim data. 
  *  @param[out] size
  *    Output. The size of extra space is output_dim * sizeof(uint32_t).
  *  @par Return
  *  - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *  @par Scale Limitation
- *  - The output_desc->dims[3] should be greater than 1.
+ *  - The output_dim should be greater than 1.
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetPsRoiPoolWorkspaceSize(mluOpHandle_t handle,
-                               const mluOpTensorDescriptor_t output_desc,
+                               const int output_dim,
                                size_t *size);
 
 /*!

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -217,35 +217,34 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
          const mluOpTensorDescriptor_t z_desc, void *z);
 
 /*!
- *  @brief Generate fixed size feature map for each Roi(Regions of Interest).
+ *  @brief Generate fixed size feature map for each RoI(Regions of Interest).
  *
  *  @param[in] handle
- *    Input.  Handle to a MLUOP context that is used to manage MLU devices
+ *    Input. Handle to a MLUOP context that is used to manage MLU devices
  *    and queues in the psroipool_forward operation.
  *  @param[in] spatial_scale
  *    Input. The spatial_scale data.
  *  @param[in] group_size
  *    Input. The group_size data.
- *  @param[in] input_data_desc
- *    Input. The descriptor of the input_data tensor. For detailed information,
+ *  @param[in] input_desc
+ *    Input. The descriptor of the input tensor. For detailed information,
  *    see ::mluOpTensorDescriptor_t.
- *  @param[in] input_data
- *    Input. Pointer to the MLU memory that stores the input_data tensor.
- *  @param[in] input_rois_desc
+ *  @param[in] input
+ *    Input. Pointer to the MLU memory that stores the input tensor.
+ *  @param[in] rois_desc
  *    Input. The descriptor of the input_roi tensor. For detailed information,
  *    see ::mluOpTensorDescriptor_t.
- *  @param[in] input_rois
- *    Input. Pointer to the MLU memory that stores the input_rois tensor. 
- *    NaN and INF datas are not supported.
+ *  @param[in] rois
+ *    Input. Pointer to the MLU memory that stores the rois tensor.
  *  @param[in] workspace
- *    Input. Pointer to the MLU memory that stores the extra workspace.
+ *    Input. Pointer to the CPU memory that stores the extra workspace.
  *  @param[in] workspace_size
- *    Input. The size of extra space.
- *  @param[in] output_data_desc
- *    Input. The descriptor of the output_data tensor. For detailed information,
+ *    Input. The size of extra space is output_dim * sizeof(uint32_t).
+ *  @param[in] output_desc
+ *    Input. The descriptor of the output tensor. For detailed information,
  *    see ::mluOpTensorDescriptor_t.
- *  @param[out] output_data
- *    Output. Pointer to the MLU memory that stores the output_data tensor.
+ *  @param[out] output
+ *    Output. Pointer to the MLU memory that stores the output tensor.
  *  @param[in] mapping_channel_desc
  *    Input. The descriptor of the mapping_channel tensor. For detailed
  *    information, see ::mluOpTensorDescriptor_t.
@@ -262,18 +261,18 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  * 
  *  @par Data Type
  *  - The supported data types of input and output tensors are as follows:
- *     - Input_data tensor: float.
- *     - Input_rois tensor: float.
- *     - Output_data tensor: float.
- *     - Mapping_channel tensor: int.
+ *     - input tensor: float.
+ *     - rois tensor: float.
+ *     - output tensor: float.
+ *     - Mapping_channel tensor: int32.
  * 
  *  @par Data Layout
- *  - The supported data layout of \b input_data, \b input_rois,
- *    \b output_data, \b mapping_channel are as follows:
+ *  - The supported data layout of \b input, \b rois,
+ *    \b output, \b mapping_channel are as follows:
  * 
- *   - Input_data tensor: \p MLUOP_LAYOUT_NHWC.
- *   - Input_rois tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - Output_data tensor: \p MLUOP_LAYOUT_NHWC.
+ *   - input tensor: \p MLUOP_LAYOUT_NHWC.
+ *   - rois tensor: \p MLUOP_LAYOUT_ARRAY.
+ *   - output tensor: \p MLUOP_LAYOUT_NHWC.
  *   - Mapping_channel tensor: \p MLUOP_LAYOUT_NHWC.
  * 
  *  @par Scale Limitation
@@ -283,14 +282,14 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *  - The group_size should be equal to pooled_height.
  *  - The pooled_height should be equal to pooled_width.
  *  - The channels should be equal to pooled_height * pooled_width * output_dim.
- *  - The dim of input_data should be equal to 4.
- *  - The dim of input_rois should be equal to 2.
- *  - The dim of output should be equal to 4.
- *  - The dim of mapping_channel should be equal to 4.
+ *  - The dimension of input should be equal to 4.
+ *  - The dimension of rois should be equal to 2.
+ *  - The dimension of output should be equal to 4.
+ *  - The dimension of mapping_channel should be equal to 4.
  *  - The rois_offset should be equal to 5.
  *  - The shape of roi should be [batch_id, roi_start_h, roi_start_w,
  *    roi_end_h, roi_end_w], and the batch_id must between 0
- *    and batch, the batch come from input_data.
+ *    and batch, the batch comes from input.
  *  - The output_dims[0] should be equal to mapping_channel_dims[0].
  *  - The output_dims[1] should be equal to mapping_channel_dims[1].
  *  - The output_dims[2] should be equal to mapping_channel_dims[2].
@@ -303,8 +302,7 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
  *  - None.
  * 
  *  @par Note
- *  - On MLU300 series, because input_rois use ceil/floor function,
- *    so input_rois do not support NAN/INF.
+ *  - On MLU300 series, rois do not support NAN/INF.
  * 
  * @par Reference
  * - https://github.com/princewang1994/R-FCN.pytorch/tree/master/
@@ -313,35 +311,37 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
 mluOpStatus_t MLUOP_WIN_API 
 mluOpPsRoiPoolForward(mluOpHandle_t handle,
                       const float spatial_scale, const int group_size,
-                      const mluOpTensorDescriptor_t input_data_desc,
-                      const void *input_data,
-                      const mluOpTensorDescriptor_t input_rois_desc,
-                      const void *input_rois,
+                      const mluOpTensorDescriptor_t input_desc,
+                      const void *input,
+                      const mluOpTensorDescriptor_t rois_desc,
+                      const void *rois,
                       void *workspace,
                       const size_t workspace_size,
-                      const mluOpTensorDescriptor_t output_data_desc,
-                      void *output_data,
+                      const mluOpTensorDescriptor_t output_desc,
+                      void *output,
                       const mluOpTensorDescriptor_t mapping_channel_desc,
                       void *mapping_channel);
 
 /*!
- *  @brief Get extra space size that needed in psroipool_forward operation.
+ *  @brief Get extra space size that is needed in psroipool_forward operation,
+      the extra space size is output_dim * sizeof(uint32_t).
  *
  *  @param[in] handle
  *    Input. Handle to a MLUOP context that is used to manage MLU devices
  *    and queues in the psroipool_forward operation.
- *  @param[in] output_dim
- *    Input. The output_dim data.
+ *  @param[in] output_desc
+ *    Input. The descriptor of the output tensor. For detailed information,
+ *    see ::mluOpTensorDescriptor_t.
  *  @param[out] size
- *    Output. Size of workspace.
+ *    Output. The size of extra space is output_dim * sizeof(uint32_t).
  *  @par Return
  *  - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *  @par Scale Limitation
- *  - The output_dim should be greater than 1.
+ *  - The output_desc->dims[3] should be greater than 1.
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetPsRoiPoolWorkspaceSize(mluOpHandle_t handle,
-                               const int output_dim,
+                               const mluOpTensorDescriptor_t output_desc,
                                size_t *size);
 
 /*!

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -84,9 +84,9 @@ void MLUOP_WIN_API mluOpBlockKernel5StagePipelineLogFloatFast(
 void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *bottom_data, const void *bottom_rois, const void *top_data,
-    const void *mapping_channel, int channels, int height, int width,
-    int pooled_height, int pooled_width, int rois_num, int output_dim,
-    int group_size, int rois_offset, float spatial_scale, int batch_size);
+    const void *mapping_channel, int batch_size, int height, int width,
+    int channels, int pooled_height, int pooled_width, int output_dim,
+    int group_size, int rois_num, int rois_offset, float spatial_scale);
     
 /* RoICrop*/
 void MLUOP_WIN_API mluOpBlockKernelRoiCropForwardFloat(

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -80,13 +80,13 @@ void MLUOP_WIN_API mluOpBlockKernel5StagePipelineLogFloatFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *x, void *y, int num, float coef);
 
-/* Psroipool */
+/* PSRoIPool */
 void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *bottom_data, void *bottom_rois, void *top_data, void *mapping_channel,
-    int channels, int height, int width, int pooled_height, int pooled_width,
-    int rois_num, int output_dim, int group_size, int rois_offset,
-    float spatial_scale, int batch_size);
+    const void *bottom_data, const void *bottom_rois, const void *top_data,
+    const void *mapping_channel, int channels, int height, int width,
+    int pooled_height, int pooled_width, int rois_num, int output_dim,
+    int group_size, int rois_offset, float spatial_scale, int batch_size);
     
 /* RoICrop*/
 void MLUOP_WIN_API mluOpBlockKernelRoiCropForwardFloat(

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_forward/psroipool_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_forward/psroipool_forward.cpp
@@ -42,9 +42,9 @@ void PsroipoolForwardExecutor::paramCheck() {
 }
 
 void PsroipoolForwardExecutor::workspaceMalloc() {
-  mluOpTensorDescriptor_t output_desc = tensor_desc_[2].tensor;
+  int output_dim = parser_->getProtoNode()->psroipool_forward_param().output_dim();
   size_t workspace_size = 0;
-  MLUOP_CHECK(mluOpGetPsRoiPoolWorkspaceSize(handle_, output_desc, &workspace_size));
+  MLUOP_CHECK(mluOpGetPsRoiPoolWorkspaceSize(handle_, output_dim, &workspace_size));
   VLOG(4) << "Malloc workspace space.";
 
   void *temp = mlu_runtime_.allocate(workspace_size);
@@ -123,12 +123,12 @@ void PsroipoolForwardExecutor::compute() {
   auto output = data_vector_[2].device_ptr;
   auto mapping_channel = data_vector_[3].device_ptr;
   size_t workspace_size = 0;
-  MLUOP_CHECK(mluOpGetPsRoiPoolWorkspaceSize(handle_, output_desc, &workspace_size));
+  MLUOP_CHECK(mluOpGetPsRoiPoolWorkspaceSize(handle_, output_dim_, &workspace_size));
   interface_timer_.start();
   MLUOP_CHECK(mluOpPsRoiPoolForward(
-      handle_, spatial_scale_, group_size_, input_desc, input,
-      rois_desc, rois, workspace_[0], workspace_size,
-      output_desc, output, mapping_channel_desc, mapping_channel));
+      handle_, pooled_height_, pooled_width_, spatial_scale_, group_size_,
+      output_dim_, input_desc, input, rois_desc, rois, workspace_[0],
+      workspace_size, output_desc, output, mapping_channel_desc, mapping_channel));
   interface_timer_.stop();
 }
 

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_forward/psroipool_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_forward/psroipool_forward.cpp
@@ -22,20 +22,18 @@ void PsroipoolForwardExecutor::paramCheck() {
   VLOG(4) << "psroipool_forward param check";
   if (parser_->getInputNum() != 2) {
     LOG(ERROR) << "psroipool_forward input number is wrong, it should be 2, "
-                  "but now is "
-               << parser_->getInputNum();
+               << "but now is " << parser_->getInputNum();
     throw std::invalid_argument(std::string(__FILE__) + " +" +
                                 std::to_string(__LINE__));
   }
   if (parser_->getOutputNum() != 2) {
     LOG(ERROR) << "psroipool_forward output number is wrong, it should be 2, "
-                  "but now is"
-               << parser_->getOutputNum();
+               << "but now is" << parser_->getOutputNum();
     throw std::invalid_argument(std::string(__FILE__) + " +" +
                                 std::to_string(__LINE__));
   }
   for (int i = 0; i < parser_->getInputNum(); i++) {
-    if (parser_->inputIsNull(i)) {
+    if (i == 1 && parser_->inputIsNull(i)) {
       LOG(ERROR) << "psroipool_forward input [" << i << "] is nullptr.";
       throw std::invalid_argument(std::string(__FILE__) + " +" +
                                   std::to_string(__LINE__));
@@ -44,10 +42,9 @@ void PsroipoolForwardExecutor::paramCheck() {
 }
 
 void PsroipoolForwardExecutor::workspaceMalloc() {
-  int output_dim =
-      parser_->getProtoNode()->psroipool_forward_param().output_dim();
+  mluOpTensorDescriptor_t output_desc = tensor_desc_[2].tensor;
   size_t workspace_size = 0;
-  mluOpGetPsRoiPoolWorkspaceSize(handle_, output_dim, &workspace_size);
+  MLUOP_CHECK(mluOpGetPsRoiPoolWorkspaceSize(handle_, output_desc, &workspace_size));
   VLOG(4) << "Malloc workspace space.";
 
   void *temp = mlu_runtime_.allocate(workspace_size);
@@ -59,6 +56,7 @@ void PsroipoolForwardExecutor::workspaceFree() {
   if (workspace_[0]) {
     VLOG(4) << "Free device workspace space.";
     GTEST_CHECK(CNRT_RET_SUCCESS == mlu_runtime_.deallocate(workspace_[0]));
+    workspace_[0] = nullptr;
   }
 }
 
@@ -107,89 +105,86 @@ void PsroipoolForwardExecutor::initData() {
 
 void PsroipoolForwardExecutor::compute() {
   initData();
-  mluOpTensorDescriptor_t input_data_desc = tensor_desc_[0].tensor;
+  mluOpTensorDescriptor_t input_desc = tensor_desc_[0].tensor;
   mluOpTensorLayout_t input_layout;
   mluOpDataType_t input_dtype;
   int input_dim = 0;
   int input_dims[8] = {0};
-  mluOpGetTensorDescriptor(input_data_desc, &input_layout, &input_dtype,
+  mluOpGetTensorDescriptor(input_desc, &input_layout, &input_dtype,
                            &input_dim, input_dims);
   int channels = input_dims[3];
   int height = input_dims[1];
   int width = input_dims[2];
-  mluOpTensorDescriptor_t input_rois_desc = tensor_desc_[1].tensor;
-  mluOpTensorDescriptor_t output_data_desc = tensor_desc_[2].tensor;
+  mluOpTensorDescriptor_t rois_desc = tensor_desc_[1].tensor;
+  mluOpTensorDescriptor_t output_desc = tensor_desc_[2].tensor;
   mluOpTensorDescriptor_t mapping_channel_desc = tensor_desc_[3].tensor;
-  void *input_data = data_vector_[0].device_ptr;
-  void *input_rois = data_vector_[1].device_ptr;
-  auto output_data = data_vector_[2].device_ptr;
+  auto input = data_vector_[0].device_ptr;
+  auto rois = data_vector_[1].device_ptr;
+  auto output = data_vector_[2].device_ptr;
   auto mapping_channel = data_vector_[3].device_ptr;
   size_t workspace_size = 0;
-  mluOpGetPsRoiPoolWorkspaceSize(handle_, output_dim_, &workspace_size);
+  MLUOP_CHECK(mluOpGetPsRoiPoolWorkspaceSize(handle_, output_desc, &workspace_size));
   interface_timer_.start();
   MLUOP_CHECK(mluOpPsRoiPoolForward(
-      handle_, spatial_scale_, group_size_, input_data_desc, input_data,
-      input_rois_desc, input_rois, workspace_[0], workspace_size,
-      output_data_desc, output_data, mapping_channel_desc, mapping_channel));
+      handle_, spatial_scale_, group_size_, input_desc, input,
+      rois_desc, rois, workspace_[0], workspace_size,
+      output_desc, output, mapping_channel_desc, mapping_channel));
   interface_timer_.stop();
 }
 
 void PsroipoolForwardExecutor::cpuCompute() {
-  assert(parser_->getInputNum() > 0);
-  assert(parser_->getOutputNum() > 0);
-  mluOpTensorDescriptor_t input_data_desc = tensor_desc_[0].tensor;
+  mluOpTensorDescriptor_t input_desc = tensor_desc_[0].tensor;
   mluOpTensorLayout_t input_layout;
   mluOpDataType_t input_dtype;
   int input_dim = 0;
   int input_dims[8] = {0};
-  mluOpGetTensorDescriptor(input_data_desc, &input_layout, &input_dtype,
-                           &input_dim, input_dims);
+  MLUOP_CHECK(mluOpGetTensorDescriptor(input_desc, &input_layout, &input_dtype,
+                           &input_dim, input_dims));
   int channels = input_dims[3];
   int height = input_dims[1];
   int width = input_dims[2];
-  mluOpTensorDescriptor_t input_rois_desc = tensor_desc_[1].tensor;
+  mluOpTensorDescriptor_t rois_desc = tensor_desc_[1].tensor;
   int desc_dim = 0;
   int desc_dims[8] = {0};
   mluOpTensorLayout_t desc_layout;
   mluOpDataType_t desc_datatype;
-  mluOpGetTensorDescriptor(input_rois_desc, &desc_layout, &desc_datatype,
-                           &desc_dim, desc_dims);
-  float *input_data = cpu_fp32_input_[0];
-  float *output_data = cpu_fp32_output_[0];
+  MLUOP_CHECK(mluOpGetTensorDescriptor(rois_desc, &desc_layout, &desc_datatype,
+                           &desc_dim, desc_dims));
+  auto input = cpu_fp32_input_[0];
+  auto output = cpu_fp32_output_[0];
   auto *mapping_channel = cpu_fp32_output_[1];
-  int input_data_count = batch_size_ * height * width * channels;
+  int input_count = batch_size_ * height * width * channels;
   // tans input data
-  float *input_data_trans =
-      (float *)cpu_runtime_.allocate(new float[input_data_count]);
-  transposeNhwcToNchw(input_data, batch_size_, height, width, channels,
-                      input_data_trans);
-  float *input_rois = cpu_fp32_input_[1];
+  float *input_trans =
+      (float *)cpu_runtime_.allocate(new float[input_count]);
+  transposeNhwcToNchw(input, batch_size_, height, width, channels,
+                      input_trans);
+  auto rois = cpu_fp32_input_[1];
   int rois_num = desc_dims[0] * desc_dims[1] / rois_offset_;
-  int input_rois_count = rois_num * rois_offset_;  // cur batch
-
+  int rois_count = rois_num * rois_offset_;  // cur batch
   // output
   int top_data_count = rois_num * pooled_height_ * pooled_width_ * output_dim_;
-  std::vector<float> output_data_vec(top_data_count, -65504.0);
-  float *output_pre = output_data_vec.data();
+  std::vector<float> output_vec(top_data_count, -65504.0);
+  float *output_pre = output_vec.data();
   // mapping_channel
   std::vector<float> mapping_channel_vec(top_data_count, -65504.0);
   float *mapping_channel_pre = mapping_channel_vec.data();
-  float *input_rois_trans =
-      (float *)cpu_runtime_.allocate(new float[input_rois_count]);
-  memcpy(input_rois_trans, input_rois, input_rois_count * sizeof(float));
+  float *rois_trans =
+      (float *)cpu_runtime_.allocate(new float[rois_count]);
+  memcpy(rois_trans, rois, rois_count * sizeof(float));
   for (int rois_id = 0; rois_id < rois_num; rois_id++) {
     int roi_add = rois_id * 5;
     int rois_batch_ind;
     float roi_start_w, roi_start_h, roi_end_w, roi_end_h;
 
-    rois_batch_ind = input_rois_trans[roi_add];
-    roi_start_w = static_cast<float>(round(input_rois_trans[roi_add + 1])) *
+    rois_batch_ind = rois_trans[roi_add];
+    roi_start_w = static_cast<float>(round(rois_trans[roi_add + 1])) *
                   spatial_scale_;
-    roi_start_h = static_cast<float>(round(input_rois_trans[roi_add + 2])) *
+    roi_start_h = static_cast<float>(round(rois_trans[roi_add + 2])) *
                   spatial_scale_;
-    roi_end_w = static_cast<float>(round(input_rois_trans[roi_add + 3]) + 1.) *
+    roi_end_w = static_cast<float>(round(rois_trans[roi_add + 3]) + 1.) *
                 spatial_scale_;
-    roi_end_h = static_cast<float>(round(input_rois_trans[roi_add + 4]) + 1.) *
+    roi_end_h = static_cast<float>(round(rois_trans[roi_add + 4]) + 1.) *
                 spatial_scale_;
 
     float roi_width = std::max(roi_end_w - roi_start_w, (float)0.1);
@@ -224,7 +219,7 @@ void PsroipoolForwardExecutor::cpuCompute() {
           for (int h = hstart; h < hend; ++h) {
             for (int w = wstart; w < wend; ++w) {
               int bottom_index = h * width + w;
-              out_sum += input_data_trans[(rois_batch_ind * channels + c) *
+              out_sum += input_trans[(rois_batch_ind * channels + c) *
                                               height * width +
                                           bottom_index];
             }
@@ -240,10 +235,10 @@ void PsroipoolForwardExecutor::cpuCompute() {
       }
     }
   }
-
-  cpu_runtime_.deallocate(input_rois_trans);
+  cpu_runtime_.deallocate(input_trans);
+  cpu_runtime_.deallocate(rois_trans);
   transposeNchwToNhwc(output_pre, rois_num, output_dim_, pooled_height_,
-                      pooled_width_, output_data);
+                      pooled_width_, output);
   transposeNchwToNhwc(mapping_channel_pre, rois_num, output_dim_,
                       pooled_height_, pooled_width_, mapping_channel);
 }
@@ -254,61 +249,59 @@ int64_t PsroipoolForwardExecutor::getTheoryOps() {
   }
 
   int64_t theory_ops = 0;
-  mluOpTensorDescriptor_t input_data_desc = tensor_desc_[0].tensor;
+  mluOpTensorDescriptor_t input_desc = tensor_desc_[0].tensor;
   mluOpTensorLayout_t input_layout;
   mluOpDataType_t input_dtype;
   int input_dim = 0;
   int input_dims[8] = {0};
-  mluOpGetTensorDescriptor(input_data_desc, &input_layout, &input_dtype,
-                           &input_dim, input_dims);
+  MLUOP_CHECK(mluOpGetTensorDescriptor(input_desc, &input_layout, &input_dtype,
+                           &input_dim, input_dims));
   int channels = input_dims[3];
   int height = input_dims[1];
   int width = input_dims[2];
-  mluOpTensorDescriptor_t input_rois_desc = tensor_desc_[1].tensor;
+  mluOpTensorDescriptor_t rois_desc = tensor_desc_[1].tensor;
   int desc_dim = 0;
   int desc_dims[8] = {0};
   mluOpTensorLayout_t desc_layout;
   mluOpDataType_t desc_datatype;
-  mluOpGetTensorDescriptor(input_rois_desc, &desc_layout, &desc_datatype,
-                           &desc_dim, desc_dims);
-  printf("----001-----\n");
-  float *input_data = cpu_fp32_input_[0];
-  printf("----002-----\n");
-  float *output_data = cpu_fp32_output_[0];
+  MLUOP_CHECK(mluOpGetTensorDescriptor(rois_desc, &desc_layout, &desc_datatype,
+                           &desc_dim, desc_dims));
+  float *input = cpu_fp32_input_[0];
+  float *output = cpu_fp32_output_[0];
   auto *mapping_channel = cpu_fp32_output_[1];
-  int input_data_count = batch_size_ * height * width * channels;
+  int input_count = batch_size_ * height * width * channels;
   // tans input data
-  float *input_data_trans =
-      (float *)cpu_runtime_.allocate(new float[input_data_count]);
-  transposeNhwcToNchw(input_data, batch_size_, height, width, channels,
-                      input_data_trans);
-  float *input_rois = cpu_fp32_input_[1];
+  float *input_trans =
+      (float *)cpu_runtime_.allocate(new float[input_count]);
+  transposeNhwcToNchw(input, batch_size_, height, width, channels,
+                      input_trans);
+  float *rois = cpu_fp32_input_[1];
   int rois_num = desc_dims[0] * desc_dims[1] / rois_offset_;
-  int input_rois_count = rois_num * rois_offset_;  // cur batch
+  int rois_count = rois_num * rois_offset_;  // cur batch
 
   // output
   int top_data_count = rois_num * pooled_height_ * pooled_width_ * output_dim_;
-  std::vector<float> output_data_vec(top_data_count, -65504.0);
-  float *output_pre = output_data_vec.data();
+  std::vector<float> output_vec(top_data_count, -65504.0);
+  float *output_pre = output_vec.data();
   // mapping_channel
   std::vector<float> mapping_channel_vec(top_data_count, -65504.0);
   float *mapping_channel_pre = mapping_channel_vec.data();
-  float *input_rois_trans =
-      (float *)cpu_runtime_.allocate(new float[input_rois_count]);
-  memcpy(input_rois_trans, input_rois, input_rois_count * sizeof(float));
+  float *rois_trans =
+      (float *)cpu_runtime_.allocate(new float[rois_count]);
+  memcpy(rois_trans, rois, rois_count * sizeof(float));
   for (int rois_id = 0; rois_id < rois_num; rois_id++) {
     int roi_add = rois_id * 5;
     int rois_batch_ind;
     float roi_start_w, roi_start_h, roi_end_w, roi_end_h;
 
-    rois_batch_ind = input_rois_trans[roi_add];
-    roi_start_w = static_cast<float>(rint(input_rois_trans[roi_add + 1])) *
+    rois_batch_ind = rois_trans[roi_add];
+    roi_start_w = static_cast<float>(rint(rois_trans[roi_add + 1])) *
                   spatial_scale_;
-    roi_start_h = static_cast<float>(rint(input_rois_trans[roi_add + 2])) *
+    roi_start_h = static_cast<float>(rint(rois_trans[roi_add + 2])) *
                   spatial_scale_;
-    roi_end_w = static_cast<float>(rint(input_rois_trans[roi_add + 3]) + 1.) *
+    roi_end_w = static_cast<float>(rint(rois_trans[roi_add + 3]) + 1.) *
                 spatial_scale_;
-    roi_end_h = static_cast<float>(rint(input_rois_trans[roi_add + 4]) + 1.) *
+    roi_end_h = static_cast<float>(rint(rois_trans[roi_add + 4]) + 1.) *
                 spatial_scale_;
 
     float roi_width = std::max<float>(roi_end_w - roi_start_w, 0.1);
@@ -349,7 +342,9 @@ int64_t PsroipoolForwardExecutor::getTheoryOps() {
       }
     }
   }
-  cpu_runtime_.deallocate(input_rois_trans);
+
+  cpu_runtime_.deallocate(input_trans);
+  cpu_runtime_.deallocate(rois_trans);
   VLOG(4) << "getTheoryOps: " << theory_ops << " ops";
   return theory_ops;
 }

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_forward/psroipool_forward.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_forward/psroipool_forward.h
@@ -17,7 +17,7 @@ namespace mluoptest {
 class PsroipoolForwardExecutor : public Executor {
  public:
   PsroipoolForwardExecutor() {}
-  ~PsroipoolForwardExecutor() {}
+  ~PsroipoolForwardExecutor() { workspaceFree(); }
   void workspaceMalloc() override;
   void paramCheck() override;
   void compute() override;

--- a/docs/bangc-docs/design_docs/psroipool_forward/psroipool_forward.md
+++ b/docs/bangc-docs/design_docs/psroipool_forward/psroipool_forward.md
@@ -36,18 +36,18 @@
 | 需求来源               | Pytorch                              |
 | 应用网络               | R-FCN                            |
 | 输入数据类型           |  float                             |
-| 输入 Shape            | input_data: [batches, hi, wi，channels]; input_rois: [rois_num，rois_offset]   |
-| 输入 Layout           | input_data: NHWC; input_rois: ARRAY              |
-| 输出数据类型            |  output_data: float; mapping_channel: int                                |
-| 输出 Shape            | output_data: [rois_num, ho, wo，output_dims]; mapping_channel: [rois_num, ho, wo，output_dims]        |
-| 输出 Layout              | output_data: NHWC; mapping_channel: NHWC                                  |
+| 输入 Shape            | input: [batches, hi, wi，channels]; rois: [rois_num，rois_offset]   |
+| 输入 Layout           | input: NHWC; rois: ARRAY              |
+| 输出数据类型            |  output: float; mapping_channel: int                                |
+| 输出 Shape            | output: [rois_num, ho, wo，output_dims]; mapping_channel: [rois_num, ho, wo，output_dims]        |
+| 输出 Layout              | output: NHWC; mapping_channel: NHWC                                  |
 | 模式(可选）                      |                                           |
 | 是否含有 dim/axis 等类似语义的参数且该参数支持负数/其他特殊处理              | 无                         |
 | 是否含有 labels/index 等类似语义的参数且该参数支持负数/界外情况/其他特殊处理 | 无                           |
 | 是否需要支持原位                                                             | 否         |
 | 是否需要支持 stride 机制                                                     | 否                                                           |
 | 是否需要支持广播                                                             | 否                                                           |
-| 0 元素检查是否直接返回                                                       | input_data(是, return MLUOP_STATUS_SUCCESS) input_rois(否，return MLUOP_STATUS_BAD_PARAM)                               |
+| 0 元素检查是否直接返回                                                       | input(是, return MLUOP_STATUS_SUCCESS) rois(否，return MLUOP_STATUS_BAD_PARAM)                               |
 | 其他特殊需求(在线量化，融合，转数提前等，可选)                               |                                                                |
 | 本次开发优先支持的规模/模式                                                  |                                |
 
@@ -66,10 +66,10 @@ psroipool的操作与roipool类似，不同之处在于不同空间维度输出�
 | 参数             | 语义                               | 类型（输入/输出） | 支持类型    | 物理布局   | 规模限制 |
 | ---------------- | ---------------------------------- | ----------------- | ----------- | ---------- | -------- |
 | handle           | 算子上下文信息                     | /                 | /           | /          | 无       |
-| input_data_desc  | 输入数据的描述符                   | 输入              | mluOpTensorDescriptor_t           | /          | 无       |
-| input_data       | 输入数据的指针                 | 输入              |  float      | NHWC       | 无       |
-| input_rois_desc  | 输入roi的描述符                    | 输入              | mluOpTensorDescriptor_t | /          | 无       |
-| input_rois       | 输入roi的指针                  | 输入              | float       |  ARRAY      | 无       |
+| input_desc  | 输入数据的描述符                   | 输入              | mluOpTensorDescriptor_t           | /          | 无       |
+| input       | 输入数据的指针                 | 输入              |  float      | NHWC       | 无       |
+| rois_desc  | 输入roi的描述符                    | 输入              | mluOpTensorDescriptor_t | /          | 无       |
+| rois       | 输入roi的指针                  | 输入              | float       |  ARRAY      | 无       |
 | workspace        | 用于辅助的GDRAM空间的指针          | 输入              | /           | /          | 无       |
 | workspace_size   | workspace空间的大小                | 输入              | size_t           | /          | 无       |
 | pooled_height    | 池化后的高度                      | 输入              | uint32_t          | /          | 无       |
@@ -77,8 +77,8 @@ psroipool的操作与roipool类似，不同之处在于不同空间维度输出�
 | group_size       |  组的大小                        | 输入             | uint32_t      | /       | 无       |
 | spatial_scale    | 变换的尺度                     | 输入              | float      |   /       | 无       |
 | output_dims      | 输出的channel                      | 输入              | uint32_t          | /          | 无       |
-| output_data_desc | 输出数据的描述符                   | 输入              | mluOpTensorDescriptor_t           | /          | 无       |
-| output_data      | 输出数据的指针                     | 输出              | float      | NHWC       | 无       |
+| output_desc | 输出数据的描述符                   | 输入              | mluOpTensorDescriptor_t           | /          | 无       |
+| output      | 输出数据的指针                     | 输出              | float      | NHWC       | 无       |
 | mapping_channel_desc | 输出mapping_channel的描述符            | 输入              | mluOpTensorDescriptor_t          | /          | 无       |
 | mapping_channel      | 输出mapping_channel数据的指针           | 输出              | int32_t      | NHWC       | 无       |
 
@@ -86,14 +86,14 @@ psroipool的操作与roipool类似，不同之处在于不同空间维度输出�
 
 | 限制类型     | 详细说明                                                                                                        |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
-| 数据类型限制 | 输入数据（包括input_data和intput_rois）和输出数据（output_data）的类型必须相同，而且仅支持float。输出数据（mapping_channel）类型必须是int。           |
-| 布局限制     | 对于input_data不支持NCHW的layout，并且每个roi只支持[batch_id, roi_x_start, roi_y_start, roi_x_end, roi_y_end]规模，</br>roi的首位必须是batch_id。 |
+| 数据类型限制 | 输入数据（包括input和intput_rois）和输出数据（output）的类型必须相同，而且仅支持float。输出数据（mapping_channel）类型必须是int。           |
+| 布局限制     | 对于input不支持NCHW的layout，并且每个roi只支持[batch_id, roi_x_start, roi_y_start, roi_x_end, roi_y_end]规模，</br>roi的首位必须是batch_id。 |
 | 数据规模限制 | 无                                                            |
 | 原位限制     | 不支持原位                                                                                                      |
 | stride 限制  | 不支持 stride 机制                                                                                              |
 | 广播限制     |  参数不支持广播                                                                                              |
 | 输入参数限制 | group_size=pooled_height=pooled_width,rois_offset=5,</br>group_size>=1,output_dim>=1,spatial_scale>0,</br>channels = pooled_height *pooled_width * output_dim,</br>每个roi只支持[batch_id, roi_start_h, roi_start_w, roi_end_h, roi_end_w],</br>0 <= batch_id <= batch - 1 |
-| nan/inf限制 | input_data支持nan/inf测例， input_rois参数的nan/inf无法与竞品对齐，由于在计算过程中使用了ceil/floor函数，硬件指令功能限制无法与竞品对齐。已在mlu_ops.h中说明。|
+| nan/inf限制 | input支持nan/inf测例， rois参数的nan/inf无法与竞品对齐，由于在计算过程中使用了ceil/floor函数，硬件指令功能限制无法与竞品对齐。已在mlu_ops.h中说明。|
 
 ### 1.5 验收标准
 
@@ -131,14 +131,14 @@ int psroi_pooling_forward_cuda(int pooled_height,
 mluOpStatus_t MLUOP_WIN_API 
 mluOpPsRoiPoolForward(mluOpHandle_t handle,
                       const float spatial_scale, const int group_size,
-                      const mluOpTensorDescriptor_t input_data_desc,
-                      const void *input_data,
-                      const mluOpTensorDescriptor_t input_rois_desc,
-                      const void *input_rois,
+                      const mluOpTensorDescriptor_t input_desc,
+                      const void *input,
+                      const mluOpTensorDescriptor_t rois_desc,
+                      const void *rois,
                       void *workspace,
                       const size_t workspace_size,
-                      const mluOpTensorDescriptor_t output_data_desc,
-                      void *output_data,
+                      const mluOpTensorDescriptor_t output_desc,
+                      void *output,
                       const mluOpTensorDescriptor_t mapping_channel_desc,
                       void *mapping_channel);
 ```
@@ -151,7 +151,7 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
 
 ​	由上图可以看出，psroipool_forward的计算过程可以总结为：
 
-（1)step1，在原始图像Input_data:[batches,hi,wi,C]上计算出当前roi:[batch_id, roi_start_h, roi_start_w, roi_end_h, roi_end_w]的起始位置和终止位置。
+（1)step1，在原始图像input:[batches,hi,wi,C]上计算出当前roi:[batch_id, roi_start_h, roi_start_w, roi_end_h, roi_end_w]的起始位置和终止位置。
 
 （2)step2，通过roi:[batch_id, roi_start_h, roi_start_w, roi_end_h, roi_end_w]和output:[num_rois,pooled_height,pooled_width,output_dims]中pooled_height/pooled_width的比例，将当前roi平均划分为若干个bin，并且循环处理每一个bin.
 
@@ -245,12 +245,12 @@ nram划分如下：
 ### 3.6 测试用例设计
 
 ```c++
-(1)input_data:[1, 14, 14, 392], LAYOUT_NHWC, DTYPE_FLOAT
-   input_rois:[320，5], LAYOUT_ARRAY, DTYPE_FLOAT
+(1)input:[1, 14, 14, 392], LAYOUT_NHWC, DTYPE_FLOAT
+   rois:[320，5], LAYOUT_ARRAY, DTYPE_FLOAT
    output:[320, 7, 7, 8], LAYOUT_NHWC, DTYPE_FLOAT
    mapping_channels:[320, 7, 7, 8], LAYOUT_NHWC, DTYPE_INT32
    psroipool_forward_param{spatial_scale=1, group_size=7, output_dim=8, pooled_height=7, pooled_width=7}
-(2)input_data:[2, 14, 14,198], LAYOUT_NHWC, DTYPE_FLOAT
+(2)input:[2, 14, 14,198], LAYOUT_NHWC, DTYPE_FLOAT
    input:[493, 5], LAYOUT_ARRAY, DTYPE_FLOAT
    output:[493, 3, 3, 21], LAYOUT_NHWC, DTYPE_FLOAT
    mapping_channels:[493, 3, 3, 21], LAYOUT_NHWC, DTYPE_INT32
@@ -264,17 +264,17 @@ nram划分如下：
 
 1. handle != NULL
 
-2. input_data_desc != NULL
+2. input_desc != NULL
 
-3. input_data != NULL
+3. input != NULL
 
-4. input_rois_desc != NULL
+4. rois_desc != NULL
 
-5. input_rois != NULL
+5. rois != NULL
 
-6. output_data_desc != NULL    
+6. output_desc != NULL    
 
-7. output_data != NULL
+7. output != NULL
 
 8. mapping_channels_desc != NULL    
 
@@ -282,9 +282,9 @@ nram划分如下：
 
 - 针对零元素
 
-1. input_data: return MLUOP_STATUS_SUCCESS
+1. input: return MLUOP_STATUS_SUCCESS
 
-2. input_rois: return MLUOP_STATUS_BAD_PARAM
+2. rois: return MLUOP_STATUS_BAD_PARAM
 
 - 算子参数防呆
 
@@ -314,11 +314,11 @@ nram划分如下：
 
 13. channels == pooled_height * pooled_width * output_dim （channels指的是输入图像的C)
 
-14. input_data_desc->dim == 4
+14. input_desc->dim == 4
 
-15. input_rois_desc->dim == 2
+15. rois_desc->dim == 2
 
-16. output_data_desc->dim == 4
+16. output_desc->dim == 4
 
 17. mapping_channel_desc->dim == 4
 

--- a/docs/bangc-docs/design_docs/psroipool_forward/psroipool_forward.md
+++ b/docs/bangc-docs/design_docs/psroipool_forward/psroipool_forward.md
@@ -130,7 +130,9 @@ int psroi_pooling_forward_cuda(int pooled_height,
 ```c++
 mluOpStatus_t MLUOP_WIN_API 
 mluOpPsRoiPoolForward(mluOpHandle_t handle,
+                      const int pooled_height, const int pooled_width,
                       const float spatial_scale, const int group_size,
+                      const int output_dim,
                       const mluOpTensorDescriptor_t input_desc,
                       const void *input,
                       const mluOpTensorDescriptor_t rois_desc,


### PR DESCRIPTION
<h3>1、修改描述</h3><p>添加算子描述</p><ul><li>影响范围/算子：psroipool_forward</li><li>影响版本/分支：master</li></ul><h5>1.1 精度验收标准</h5><p>算子采用静态阈值标准：diffs=[diff1，diff2]，diff1&lt;=3e-3 &amp;&amp; diff2 &lt;= 3e-3</p><p>由于框架问题mapping_channel暂不支持diff3，也采用diff1、diff2标准</p><p>1.2 算子方案CHECKLIST</p>

序号 | 需求 | 需求详情
-- | -- | --
1 | 支持硬件 | MLU290 MLU370
2 | job类型 | U1
3 | DimXYZ | 支持DimXYZ
4 | 可变 | 否
5 | layout | 支持NHWC类型layout
6 | 多维 | 不支持
7 | 0元素 | 支持
8 | 转数提前 | 不支持
9 | 片上数据类型 | float
10 | 片外数据类型 | float
11 | 融合 | 否
12 | 规模限制 | 无
13 | c不感知对齐 | 片外c方向不需要对齐
14 | 代码覆盖率 | 代码覆盖率原则上不低于95%
15 | 内存泄露 | MLU-OPS暂时不提供该功能
16 | IO计算效率检查 | 确保IO及计算效率正确

<h5>1.3新特性测试</h5>

测试点 | 验收标准 | 测试结果（精度）
-- | -- | --
数据类型测试 | FLOAT | [Error]:[mluOpPsRoiPoolForward] Check failed: input_dtype == MLUOP_DTYPE_FLOAT.
多维张量测试 | 支持4-2-4-4维 | [mluOpPsRoiPoolForward] Check failed: input_data_desc[0]->dim == 4.[mluOpPsRoiPoolForward] Check failed: input_rois_desc[0]->dim == 2.[mluOpPsRoiPoolForward] Check failed: output_data_desc->dim == 4.[mluOpPsRoiPoolForward] Check failed: mapping_channel_desc->dim == 4.
Layout测试 | 支持NHWC | input1: [mluOpPsRoiPoolForward] Check failed: input_layout == MLUOP_LAYOUT_NHWC.input2: [mluOpPsRoiPoolForward] Check failed: rois_layout == MLUOP_LAYOUT_ARRAY.
不同规模/整数余数/对齐不对齐 |   | [==========] 1 test case from 1 test suite ran. (4222 ms total)[ PASSED ] 1 test case.
零维张量测试/0元素测试 | 如果支持则需通过 | input1:[MLUOP] [Warning]:[mluOpPsRoiPoolForward] skip zero element tensor.input2:不能0元素
稳定性测试 | gtest 多线程+repeat使用--gtest_repeat=NUM --thread=NUM | [----------] Global test environment tear-down[ SUMMARY ] Total 100 cases of 100 op(s).ALL PASSED.
多平台测试 | MLU-OPS目前只需测试290和370平台 | 370：[ SUMMARY ] Total 92 cases of 1 op(s).ALL PASSED.[==========] 92 test cases from 1 test suite ran. (316206 ms total)[ PASSED ] 92 test cases.290：[----------] Global test environment tear-down[ SUMMARY ] Total 92 cases of 1 op(s).ALL PASSED.[==========] 92 test cases from 1 test suite ran. (108921 ms total)[ PASSED ] 92 test cases.（由于fma问题，会存在个别case挂调情况，需要单独重新生存并测试）
nan/inf测试 | input_data需要支持naninf，roi_input不需要  | input1:[^      OK ] /projs/platform/zhangxinyang/PR/mlu-ops/bangc-ops/test/mlu_op_gtest/B/psroipool_forward/psroipool_forward_data_included_NanInf_float32_int32_float32_1656990261585.pb 1 test case from 1 test suite ran. (205 ms total)[  PASSED  ] 1 test case.

<h3>2 性能测试</h3><ul><li>要排除机器环境的影响；</li><li>用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试；</li><li>建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理；</li><li>算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。</li></ul>
2.1 算子io利用率、计算效率

注释:

io_efficiency = theory_io_size / (latency * IO_BANDWIDTH)

theory_is_size: 从算法上需要访问的数据量(与实现无关), lantency: 算子运行的实际时间, IO_BANGWIDTH: 硬件的理论带宽.

compute_efficiency = theory_compute_ops / (latency * peak_compute_force)

theory_compute_ops: 该算子从算法上需要执行多少次操作(与实际无关), lantency: 表示算子运行的实际时间, peak_compute_force: 硬件平台的峰值算力, 其单位是op/s(每秒执行多少操作)
<p>以psroipool_forward算子为例</p>

operator | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency | input_data | groupsize | pooled_height | pooled_width | spatial_scale | output_dim | batch_size | rois_input | output | mapping_channels
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
psroipool_forward | 105 | 21.378 | 0.00554204 | (3,10,10,490) | 7 | 7 | 7 | 1 | 10 | 3 | (2,5) | (2,7,7,10) | (2,7,7,10)
psroipool_forward | 469 | 23.925 | 0.0124068 | (3,10,10,4900) | 7 | 7 | 7 | 1 | 100 | 3 | (2,5) | (2,7,7,100) | (2,7,7,100)
psroipool_forward | 495 | 22.68 | 0.0131487 | (3,10,10,4900) | 7 | 7 | 7 | 1 | 100 | 3 | (20,5) | (2,7,7,100) | (2,7,7,100)
psroipool_forward | 4384 | 43.106 | 0.0148446 | (3,10,10,49000) | 7 | 7 | 7 | 1 | 1000 | 3 | (20,5) | (2,7,7,1000) | (2,7,7,1000)
psroipool_forward | 42327 | 49.913 | 0.0153751 | (3,10,10,490000) | 7 | 7 | 7 | 1 | 10000 | 3 | (20,5) | (2,7,7,10000) | (2,7,7,10000)
psroipool_forward | 33892 | 30.76 | 0.0192016 | (3,10,10,490000) | 7 | 7 | 7 | 0.0625 | 10000 | 3 | (20,5) | (2,7,7,10000) | (2,7,7,10000)
psroipool_forward | 98361 | 31.103 | 0.0163381 | (3,10,10,1210000) | 11 | 11 | 11 | 0.0625 | 10000 | 3 | (20,5) | (2,11,11,10000) | (2,11,11,10000)
psroipool_forward | 98281 | 57.194 | 0.0211606 | (4,10,10,1210000) | 11 | 11 | 11 | 0.0625 | 10000 | 4 | (20,5) | (2,11,11,10000) | (2,11,11,10000)
psroipool_forward | 16382 | 32.561 | 0.0262293 | (4,10,10,250000) | 5 | 5 | 5 | 0.0625 | 10000 | 4 | (20,5) | (2,5,5,10000) | (2,5,5,10000)
psroipool_forward | 5545 | 61.295 | 0.256143 | (4,10,10,90000) | 3 | 3 | 3 | 0.0625 | 10000 | 40 | (20,5) | (2,3,3,10000) | (2,3,3,10000)


2.2 内存泄露
export MLUOP_BUILD_ASAN_CHECK=ON后，编译./build.sh，执行结果如下：
[100%] Built target mluop_api_gtest
[100%] Built target mluop_gtest
测试结果：
[==========] 1 test case from 1 test suite ran. (85 ms total)
[  PASSED  ] 1 test case.
2.3 代码覆盖率

[90.8%][90.8%] 90.8 %355 / 391 100.0 %12 / 12
3. 总结分析

总结分析主要需要考虑以下几点：

1、psroipool算子包含正反向，psroipool_forward功能为给定input_data、rois_input计算得到output和mapping_channel。psroipool_backward功能后续会加入。

2、该竞品算子暂时不支持half类型的数据。

3、roi_data不支持NaN和INF数据。

4、该算子的源码只支持torch版本为0.0.3。

5、该算子存在fma问题，case的roi_num越大出现的概率越大。目前测试大规模case出现概率为3/92。