### PR TITLE
[Feature](bangc-ops): add new op psroipool_backward

### DIFF
--- a/bangc-ops/kernels/psroipool/psroipool_block.mlu
+++ b/bangc-ops/kernels/psroipool/psroipool_block.mlu
@@ -229,6 +229,213 @@ __mlu_global__ void MLUKernelPsroipoolForward(
   }
 }
 
+template <typename T>
+__mlu_func__ void psRoiAvgPoolBackwardPartOutputdim(
+    const T *top_grad, const T *rois, const int *mapping_channel,
+    T *bottom_grad, const int batch_size, const int height, const int width,
+    const int channels, const int pooled_height, const int pooled_width,
+    const int output_dim, const float spatial_scale, const int bin_index,
+    const int repeat, const int max_deal_c, const int deal_c) {
+  int align_128 = NFU_ALIGN_SIZE / sizeof(int);
+  int c_align = CEIL_ALIGN(deal_c, align_128);
+  T *top_grad_buffer = (T *)nram_ptr;
+  int *mapping_channel_buffer = (int *)(top_grad_buffer + c_align);
+  T *atomic_buffer = (T *)mapping_channel_buffer + c_align;
+  int top_offset = bin_index * output_dim + repeat * max_deal_c;
+  __bang_write_value(top_grad_buffer, c_align, 0);
+  __memcpy(top_grad_buffer, top_grad + top_offset, deal_c * sizeof(T),
+           GDRAM2NRAM);
+  __memcpy(mapping_channel_buffer, mapping_channel + top_offset,
+           deal_c * sizeof(int), GDRAM2NRAM);
+
+  int pw = bin_index % pooled_width;
+  int ph = bin_index / pooled_width % pooled_height;
+  int roi_num = bin_index / (pooled_width * pooled_height);
+  int rois_add = roi_num * 5;
+  T roi_start_w, roi_start_h, roi_end_w, roi_end_h;
+  // batch_id, x1, y1, x2, y2
+  int batch_id = (int)rois[rois_add];
+  roi_start_w =
+      static_cast<T>(scalarRound(rois[rois_add + 1])) * ((T)spatial_scale);
+  roi_start_h =
+      static_cast<T>(scalarRound(rois[rois_add + 2])) * ((T)spatial_scale);
+  roi_end_w =
+      static_cast<T>(scalarRound(rois[rois_add + 3]) + 1.) * ((T)spatial_scale);
+  roi_end_h =
+      static_cast<T>(scalarRound(rois[rois_add + 4]) + 1.) * ((T)spatial_scale);
+  if (batch_id < 0 || batch_id > (batch_size - 1)) {
+    return;
+  }
+  T roi_height = std::max(roi_end_h - roi_start_h, (T)0.1);
+  T roi_width = std::max(roi_end_w - roi_start_w, (T)0.1);
+  T bin_size_h = (T)roi_height / (T)(pooled_height);
+  T bin_size_w = (T)roi_width / (T)(pooled_width);
+  int hstart = floor(static_cast<T>(ph) * bin_size_h + roi_start_h);
+  int wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
+  int hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
+  int wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
+  hstart = std::min(std::max(hstart, 0), height);
+  hend = std::min(std::max(hend, 0), height);
+  wstart = std::min(std::max(wstart, 0), width);
+  wend = std::min(std::max(wend, 0), width);
+  bool is_empty = (hend <= hstart) || (wend <= wstart);
+  T bin_area = (hend - hstart) * (wend - wstart);
+  T bin_area_recip = 1 / bin_area;
+  int bottom_add = batch_id * channels * height * width;
+  __bang_write_value(atomic_buffer, c_align, 0);
+  __bang_mul_scalar(atomic_buffer, top_grad_buffer, bin_area_recip, c_align);
+  for (int i = 0; i < deal_c; i++) {
+    T diff_val = is_empty ? 0. : top_grad_buffer[i];
+    int c = mapping_channel_buffer[i];
+    for (int h = hstart; h < hend; h++) {
+      for (int w = wstart; w < wend; w++) {
+        int bottom_offset = bottom_add + (h * width + w) * channels + c;
+        __bang_atomic_add(atomic_buffer, bottom_grad + bottom_offset, diff_val,
+                          1);
+      }
+    }
+  }
+}
+
+template <typename T>
+__mlu_func__ void psRoiAvgPoolBackwardWholeOutputdim(
+    const T *top_grad, const T *rois, const int *mapping_channel,
+    T *bottom_grad, const int batch_size, const int height, const int width,
+    const int channels, const int pooled_height, const int pooled_width,
+    const int output_dim, const float spatial_scale, const int bins_per_core,
+    const int bins_offset, const int repeat, const int max_deal_bin,
+    const int deal_bin) {
+  int align_128 = NFU_ALIGN_SIZE / sizeof(T);
+  int c_align = CEIL_ALIGN(output_dim, align_128);
+  T *top_grad_buffer = (T *)nram_ptr;
+  int *mapping_channel_buffer =
+      (int *)(nram_ptr + c_align * deal_bin * sizeof(T));
+  T *atomic_buffer = (T *)mapping_channel_buffer + output_dim * deal_bin;
+
+  int top_offset = (bins_offset + repeat * max_deal_bin) * output_dim;
+  __bang_write_value(top_grad_buffer, deal_bin * c_align, 0);
+  __memcpy(top_grad_buffer, top_grad + top_offset, output_dim * sizeof(T),
+           GDRAM2NRAM, c_align * sizeof(T), output_dim * sizeof(T),
+           deal_bin - 1);
+  __memcpy(mapping_channel_buffer, mapping_channel + top_offset,
+           output_dim * deal_bin * sizeof(int), GDRAM2NRAM);
+
+  int begin_bin = bins_offset + repeat * max_deal_bin;
+  int end_bin = begin_bin + deal_bin;
+  for (int bin_index = begin_bin; bin_index < end_bin; bin_index++) {
+    int bin_n = bin_index - begin_bin;
+    int pw = bin_index % pooled_width;
+    int ph = bin_index / pooled_width % pooled_height;
+    int roi_num = bin_index / (pooled_width * pooled_height);
+    int rois_add = roi_num * 5;
+
+    T roi_start_w, roi_start_h, roi_end_w, roi_end_h;
+    // batch_id, x1, y1, x2, y2
+    int batch_id = (int)rois[rois_add];
+    roi_start_w =
+        static_cast<T>(scalarRound(rois[rois_add + 1])) * ((T)spatial_scale);
+    roi_start_h =
+        static_cast<T>(scalarRound(rois[rois_add + 2])) * ((T)spatial_scale);
+    roi_end_w = static_cast<T>(scalarRound(rois[rois_add + 3]) + 1.) *
+                ((T)spatial_scale);
+    roi_end_h = static_cast<T>(scalarRound(rois[rois_add + 4]) + 1.) *
+                ((T)spatial_scale);
+
+    if (batch_id < 0 || batch_id > (batch_size - 1)) {
+      return;
+    }
+    T roi_height = std::max(roi_end_h - roi_start_h, (T)0.1);
+    T roi_width = std::max(roi_end_w - roi_start_w, (T)0.1);
+    T bin_size_h = (T)roi_height / (T)(pooled_height);
+    T bin_size_w = (T)roi_width / (T)(pooled_width);
+    int hstart = floor(static_cast<T>(ph) * bin_size_h + roi_start_h);
+    int wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
+    int hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
+    int wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
+    hstart = std::min(std::max(hstart, 0), height);
+    hend = std::min(std::max(hend, 0), height);
+    wstart = std::min(std::max(wstart, 0), width);
+    wend = std::min(std::max(wend, 0), width);
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
+    int bin_area = (hend - hstart) * (wend - wstart);
+    T bin_area_recip = 1.0 / bin_area;
+    int bottom_add = batch_id * channels * height * width;
+    T *top_grad_c = top_grad_buffer + bin_n * c_align;
+    int *mapping_channel_c = mapping_channel_buffer + bin_n * output_dim;
+    __bang_mul_scalar(top_grad_c, top_grad_c, bin_area_recip, c_align);
+    for (int i = 0; i < output_dim; i++) {
+      T diff_val = is_empty ? 0. : top_grad_c[i];
+      int c = mapping_channel_c[i];
+      for (int h = hstart; h < hend; h++) {
+        for (int w = wstart; w < wend; w++) {
+          int bottom_offset = bottom_add + (h * width + w) * channels + c;
+          __bang_atomic_add(atomic_buffer, bottom_grad + bottom_offset,
+                            diff_val, 1);
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+__mlu_global__ void MLUKernelPsroipoolBackward(
+    const T *top_grad, const int *mapping_channel, const T *rois,
+    T *bottom_grad, const int batch_size, const int height, const int width,
+    const int channels, const int pooled_height, const int pooled_width,
+    const int output_dim, const int rois_num, const int rois_offset,
+    const float spatial_scale) {
+  int total_bins = rois_num * pooled_height * pooled_width;
+  int remainder = total_bins % taskDim;
+  int bins_per_core = total_bins / taskDim + (int)(taskId < remainder);
+  int bins_offset =
+      taskId * bins_per_core + (taskId < remainder ? taskId : remainder);
+  int align_128 = NFU_ALIGN_SIZE / sizeof(T);
+  int c_align = CEIL_ALIGN(output_dim, align_128);
+  int nram_deal_bins = (MAX_NRAM_SIZE - c_align * sizeof(T)) /
+                       (c_align * sizeof(T) + output_dim * sizeof(int));
+
+  if (nram_deal_bins < 1) {
+    int nram_deal_c = FLOOR_ALIGN(MAX_NRAM_SIZE / 3 / sizeof(int),
+                                  NFU_ALIGN_SIZE / sizeof(int));
+    int repeat = output_dim / nram_deal_c;
+    int remain = output_dim % nram_deal_c;
+    int n = 0;
+    while (n < bins_per_core) {
+      int bin_index = bins_offset + n;
+      for (int i = 0; i < repeat; i++) {
+        psRoiAvgPoolBackwardPartOutputdim(
+            top_grad, rois, mapping_channel, bottom_grad, batch_size, height,
+            width, channels, pooled_height, pooled_width, output_dim,
+            spatial_scale, bin_index, i, nram_deal_c, nram_deal_c);
+      }
+      if (remain != 0) {
+        psRoiAvgPoolBackwardPartOutputdim(
+            top_grad, rois, mapping_channel, bottom_grad, batch_size, height,
+            width, channels, pooled_height, pooled_width, output_dim,
+            spatial_scale, bin_index, repeat, nram_deal_c, remain);
+      }
+      ++n;
+    }
+  } else {
+    int repeat = bins_per_core / nram_deal_bins;
+    int remain = bins_per_core % nram_deal_bins;
+    for (int i = 0; i < repeat; i++) {
+      psRoiAvgPoolBackwardWholeOutputdim(
+          top_grad, rois, mapping_channel, bottom_grad, batch_size, height,
+          width, channels, pooled_height, pooled_width, output_dim,
+          spatial_scale, bins_per_core, bins_offset, i, nram_deal_bins,
+          nram_deal_bins);
+    }
+    if (remain != 0) {
+      psRoiAvgPoolBackwardWholeOutputdim(
+          top_grad, rois, mapping_channel, bottom_grad, batch_size, height,
+          width, channels, pooled_height, pooled_width, output_dim,
+          spatial_scale, bins_per_core, bins_offset, repeat, nram_deal_bins,
+          remain);
+    }
+  }
+}
+
 void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForwardFloat(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *bottom_data, const void *bottom_rois, void *top_data,
@@ -241,4 +448,17 @@ void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForwardFloat(
       (int *)mapping_channel, batch_size, height, width, channels,
       pooled_height, pooled_width, output_dim, group_size, rois_num,
       rois_offset, spatial_scale);
+}
+
+void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolBackwardFloat(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const void *top_grad, const void *mapping_channel, const void *rois,
+    void *bottom_grad, const int batch_size, const int height, const int width,
+    const int channels, const int pooled_height, const int pooled_width,
+    const int output_dim, const int rois_num, const int rois_offset,
+    const float spatial_scale) {
+  MLUKernelPsroipoolBackward<<<k_dim, k_type, queue>>>(
+      (float *)top_grad, (int *)mapping_channel, (float *)rois,
+      (float *)bottom_grad, batch_size, height, width, channels, pooled_height,
+      pooled_width, output_dim, rois_num, rois_offset, spatial_scale);
 }

--- a/bangc-ops/kernels/psroipool/psroipool_block.mlu
+++ b/bangc-ops/kernels/psroipool/psroipool_block.mlu
@@ -356,12 +356,14 @@ __mlu_func__ void psRoiAvgPoolBackwardWholeOutputdim(
     hend = std::min(std::max(hend, 0), height);
     wstart = std::min(std::max(wstart, 0), width);
     wend = std::min(std::max(wend, 0), width);
+
     bool is_empty = (hend <= hstart) || (wend <= wstart);
     int bin_area = (hend - hstart) * (wend - wstart);
     T bin_area_recip = 1.0 / bin_area;
     int bottom_add = batch_id * channels * height * width;
     T *top_grad_c = top_grad_buffer + bin_n * c_align;
     int *mapping_channel_c = mapping_channel_buffer + bin_n * output_dim;
+    // __bang_write_value(atomic_buffer, c_align, 0);
     __bang_mul_scalar(top_grad_c, top_grad_c, bin_area_recip, c_align);
     for (int i = 0; i < output_dim; i++) {
       T diff_val = is_empty ? 0. : top_grad_c[i];
@@ -387,8 +389,8 @@ __mlu_global__ void MLUKernelPsroipoolBackward(
   int total_bins = rois_num * pooled_height * pooled_width;
   int remainder = total_bins % taskDim;
   int bins_per_core = total_bins / taskDim + (int)(taskId < remainder);
-  int bins_offset =
-      taskId * bins_per_core + (taskId < remainder ? taskId : remainder);
+  int bins_offset = taskId * (total_bins / taskDim) +
+                    (taskId < remainder ? taskId : remainder);
   int align_128 = NFU_ALIGN_SIZE / sizeof(T);
   int c_align = CEIL_ALIGN(output_dim, align_128);
   int nram_deal_bins = (MAX_NRAM_SIZE - c_align * sizeof(T)) /

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -344,7 +344,7 @@ mluOpPolyNms(mluOpHandle_t handle, const mluOpTensorDescriptor_t boxes_desc,
  *    Input. The pooled_width data.
  *  @param[in] output_dim
  *    Input. The output_dim data.
-*  @param[in] input_desc
+ *  @param[in] input_desc
  *    Input. Descriptor of input tensor, containing dimension and the layout of input.
  *    For detailed information, see ::mluOpTensorDescriptor_t.
  *  @param[in] input
@@ -434,6 +434,113 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
                       void *output,
                       const mluOpTensorDescriptor_t mapping_channel_desc,
                       void *mapping_channel);
+
+/*!
+ *  @brief Computes the gradients of feature map \b bottom_grad based on the 
+ *    input \b top_grad 、\b rois and \b mapping_channel to perform the backpropagation 
+ *    of the ::mluOpPsRoiPoolForward operator.
+ *
+ *  @param[in] handle
+ *    Input. Handle to a MLUOP context that is used to manage MLU devices and queues in the 
+ *    psroipool_forward operation. For detailed information, see ::mluOpHandle_t.
+ *  @param[in] pooled_height
+ *    Input. The height of \b top_grad.
+ *  @param[in] pooled_width
+ *    Input. The width of \b top_grad.
+ *  @param[in] spatial_scale
+ *    Input. The spatial scale of each regions of interest in the output.
+ *  @param[in] output_dim
+ *    Input. The channel of \b top_grad.
+ *  @param[in] top_grad_desc
+ *    Input. The descriptor of the gradient tensor int the backpropagation process. 
+ *    For detailed information, see ::mluOpTensorDescriptor_t.
+ *  @param[in] top_grad
+ *    Input. Pointer to the MLU memory that stores the top_grad tensor.
+ *  @param[in] rois_desc
+ *    Input. The descriptor of the rois tensor. For detailed information,
+ *    see ::mluOpTensorDescriptor_t.
+ *  @param[in] rois
+ *    Input. Pointer to the MLU memory that stores the rois tensor. NaN and INF datas are not
+ *    supported. \b rois[1] consists of [batch_id, roi_start_w, roi_start_h, roi_end_w, roi_end_h], 
+ *    where \p batch_id is the ID of the batch.
+ *  @param[in] mapping_channel_desc
+ *    Input. Descriptor of the mapping_channel tensor, containing dimension and the layout of 
+ *    mapping_channel. For detailed information, see ::mluOpTensorDescriptor_t.
+ *  @param[in] mapping_channel
+ *    Input. Pointer to the MLU memory that stores the mapping_channel tensor. The shape of 
+ *    \b mapping_channel is [rois[0], pooled_height, pooled_width, output_dim].
+ *  @param[in] bottom_grad_desc
+ *    Input. Descriptor of the gradient tensor of the origin feature map. For detailed information,
+ *    see ::mluOpTensorDescriptor_t.
+ *  @param[out] bottom_grad
+ *    Output. Pointer to the MLU memory that stores the bottom_grad tensor. The shape of bottom_grad is
+ *    [batch_num, H，W, C].
+ * 
+ *  @par Return
+ *  - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * 
+ *  @par Formula
+ *  - See "psroipool_backward Operation" section in "Cambricon MLUOP User Guide" for details.
+ * 
+ *  @par Data Type
+ *  - The supported data layout of \b top_grad, \b rois, \b mapping_channel, and \b bottom_grad 
+ *    are as follows:
+ *     - Top_grad tensor: float.
+ *     - Rois tensor: float.
+ *     - Mapping_channel tensor: int.
+ *     - Bottom_grad tensor: float.
+ * 
+ *  @par Data Layout
+ *  - The supported data layout of \b top_grad, \b rois, \b mapping_channel, and \b bottom_grad 
+ *    are as follows:
+ *     - Top_grad tensor: \p MLUOP_LAYOUT_NHWC.
+ *     - Rois tensor: \p MLUOP_LAYOUT_ARRAY.
+ *     - Bottom_grad tensor: \p MLUOP_LAYOUT_NHWC.
+ *     - Mapping_channel tensor: \p MLUOP_LAYOUT_NHWC.
+ * 
+ *  @par Scale Limitation
+ *  - The \b top_grad tensor, mapping_channel tensor and \b bottom_grad tensor must have four dimensions.
+ *  - The \b rois tensor should be 2-D array.
+ *  - The shape of \b rois should be [rois_num, 5].
+ *  - \p batch_id should be in the range of [0, batch_num - 1].
+ *  - The \b spatial_scale should be greater than 0.
+ *  - The \b output_dim should be greater than 1.
+ *  - The \b pooled_height should be equal to \b pooled_width.
+ *  - The \b channels should be equal to \b pooled_height * \b pooled_width * \b output_dim.
+ *  - The first dimension of \b top_grad tensor and \b mapping_channel tensor must be the same size.
+ *  - The second dimension of \b top_grad tensor and \b mapping_channel tensor must be the same size.
+ *  - The third dimension of \b top_grad tensor and \b mapping_channel tensor must be the same size.
+ *  - The fourth dimension of \b top_grad tensor and \b mapping_channel tensor must be the same size.
+ *  - The first dimension of \b top_grad tensor and \b rois tensor must be the same size.
+ *  - The second dimension of \b top_grad should be equal to pooled_height.
+ *  - The third dimension of \b top_grad should be equal to pooled_width.
+ *  - The fourth dimension of \b top_grad should be equal to output_dim.
+ *  - 
+ *  @par Requirements
+ *  - None.
+ *
+ *  @par Example
+ *  - None.
+ * 
+ *  @par Note
+ *  - On MLU300 series, rois do not support NAN/INF.
+ * 
+ * @par Reference
+ * - https://github.com/princewang1994/R-FCN.pytorch/tree/master/
+ *   lib/model/psroi_pooling
+ */
+mluOpStatus_t MLUOP_WIN_API 
+mluOpPsRoiPoolBackward(mluOpHandle_t handle,
+                       const int pooled_height, const int pooled_width,
+                       const float spatial_scale, const int output_dim, 
+                       const mluOpTensorDescriptor_t top_grad_desc,
+                       const void *top_grad,
+                       const mluOpTensorDescriptor_t rois_desc,
+                       const void *rois,
+                       const mluOpTensorDescriptor_t mapping_channel_desc,
+                       const void *mapping_channel,
+                       const mluOpTensorDescriptor_t bottom_grad_desc,
+                       void *bottom_grad);
 
 /*!
  * @brief Generates fixed size feature map for each grid. Each value in the

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -116,7 +116,14 @@ void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolForwardFloat(
     const int width, const int channels, const int pooled_height,
     const int pooled_width, const int output_dim, const int group_size,
     const int rois_num, const int rois_offset, const float spatial_scale);
-    
+void MLUOP_WIN_API mluOpBlockKernelPsRoiPoolBackwardFloat(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const void *top_grad, const void *mapping_channel, const void *rois,
+    void *bottom_grad, const int batch_size, const int height, const int width,
+    const int channels, const int pooled_height, const int pooled_width,
+    const int output_dim, const int rois_num, const int rois_offset,
+    const float spatial_scale);
+
 /* RoICrop*/
 void MLUOP_WIN_API mluOpBlockKernelRoiCropForwardFloat(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_backward/psroipool_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_backward/psroipool_backward.cpp
@@ -1,0 +1,170 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "psroipool_backward.h"
+
+#include "mlu_op.h"
+
+namespace mluoptest {
+void PsroipoolBackwardExecutor::paramCheck() {
+  VLOG(4) << "[PsroipoolBackwardExecutor] param check.";
+  if (parser_->getInputNum() != 3) {
+    LOG(ERROR)
+        << "[PsroipoolBackwardExecutor] input number is wrong. It should be 3, "
+        << "but now is " << parser_->getInputNum();
+    throw std::invalid_argument(std::string(__FILE__) + " +" +
+                                std::to_string(__LINE__));
+  }
+  if (parser_->getOutputNum() != 1) {
+    LOG(ERROR) << "[PsroipoolBackwardExecutor] output number is wrong. It "
+                  "should be 3, "
+               << "but now is" << parser_->getOutputNum();
+    throw std::invalid_argument(std::string(__FILE__) + " +" +
+                                std::to_string(__LINE__));
+  }
+  for (int i = 0; i < parser_->getInputNum(); i++) {
+    if (parser_->inputIsNull(i)) {
+      LOG(ERROR) << "[PsroipoolBackwardExecutor] input [" << i
+                 << "] is nullptr.";
+      throw std::invalid_argument(std::string(__FILE__) + " +" +
+                                  std::to_string(__LINE__));
+    }
+  }
+}
+
+void PsroipoolBackwardExecutor::initData() {
+  output_dim_ =
+      parser_->getProtoNode()->psroipool_backward_param().output_dim();
+  pooled_height_ =
+      parser_->getProtoNode()->psroipool_backward_param().pooled_height();
+  pooled_width_ =
+      parser_->getProtoNode()->psroipool_backward_param().pooled_width();
+  spatial_scale_ =
+      parser_->getProtoNode()->psroipool_backward_param().spatial_scale();
+}
+
+void PsroipoolBackwardExecutor::compute() {
+  initData();
+  auto top_input_desc = tensor_desc_[0].tensor;
+  auto mapping_channel_desc = tensor_desc_[1].tensor;
+  auto rois_desc = tensor_desc_[2].tensor;
+  auto bottom_output_desc = tensor_desc_[3].tensor;
+
+  const void* top_input = data_vector_[0].device_ptr;
+  const void* mapping_channel = data_vector_[1].device_ptr;
+  const void* rois = data_vector_[2].device_ptr;
+  void* bottom_output = data_vector_[3].device_ptr;
+
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpPsRoiPoolBackward(
+      handle_, pooled_height_, pooled_width_, spatial_scale_, output_dim_,
+      top_input_desc, top_input, rois_desc, rois, mapping_channel_desc,
+      mapping_channel, bottom_output_desc, bottom_output));
+  interface_timer_.stop();
+}
+
+void PsroipoolBackwardExecutor::cpuCompute() {
+  auto top_input_desc = tensor_desc_[0].tensor;
+  auto mapping_channel_desc = tensor_desc_[1].tensor;
+  auto rois_desc = tensor_desc_[2].tensor;
+  auto bottom_output_desc = tensor_desc_[3].tensor;
+
+  auto top_input_cpu = cpu_fp32_input_[0];
+  auto mapping_channel_cpu = cpu_fp32_input_[1];
+  auto rois_cpu = cpu_fp32_input_[2];
+  auto bottom_output_cpu = cpu_fp32_output_[0];
+
+  const int bottom_n = bottom_output_desc->dims[0];
+  const int bottom_h = bottom_output_desc->dims[1];
+  const int bottom_w = bottom_output_desc->dims[2];
+  const int bottom_c = bottom_output_desc->dims[3];
+
+  const int rois_n = rois_desc->dims[0];
+  const int rois_offset = rois_desc->dims[1];
+
+  for (int roi_id = 0; roi_id < rois_n; roi_id++) {
+    int top_batch_offset =
+        roi_id * pooled_height_ * pooled_width_ * output_dim_;
+    int roi_add = roi_id * rois_offset;
+    int batch_i = rois_cpu[roi_add];
+    int bottom_add = batch_i * bottom_h * bottom_w * bottom_c;
+
+    float roi_start_w =
+        static_cast<float>(round(rois_cpu[roi_add + 1])) * spatial_scale_;
+    float roi_start_h =
+        static_cast<float>(round(rois_cpu[roi_add + 2])) * spatial_scale_;
+    float roi_end_w =
+        static_cast<float>(round(rois_cpu[roi_add + 3]) + 1.) * spatial_scale_;
+    float roi_end_h =
+        static_cast<float>(round(rois_cpu[roi_add + 4]) + 1.) * spatial_scale_;
+
+    float roi_width = std::max(roi_end_w - roi_start_w, (float)0.1);
+    float roi_height = std::max(roi_end_h - roi_start_h, (float)0.1);
+    float bin_size_h = (float)roi_height / (float)(pooled_height_);
+    float bin_size_w = (float)roi_width / (float)(pooled_width_);
+
+    for (int top_c = 0; top_c < output_dim_; top_c++) {
+      for (int top_h = 0; top_h < pooled_height_; top_h++) {
+        for (int top_w = 0; top_w < pooled_width_; top_w++) {
+          int top_index = top_batch_offset +
+                          top_h * pooled_width_ * output_dim_ +
+                          top_w * output_dim_ + top_c;
+          int hstart =
+              floor(static_cast<float>(top_h) * bin_size_h + roi_start_h);
+          int wstart =
+              floor(static_cast<float>(top_w) * bin_size_w + roi_start_w);
+          int hend =
+              ceil(static_cast<float>(top_h + 1) * bin_size_h + roi_start_h);
+          int wend =
+              ceil(static_cast<float>(top_w + 1) * bin_size_w + roi_start_w);
+
+          hstart = std::min(std::max(hstart, 0), bottom_h);
+          hend = std::min(std::max(hend, 0), bottom_h);
+          wstart = std::min(std::max(wstart, 0), bottom_w);
+          wend = std::min(std::max(wend, 0), bottom_w);
+
+          bool is_empty = (hend <= hstart) || (wend <= wstart);
+          int c = mapping_channel_cpu[top_index];
+          float bin_area = (hend - hstart) * (wend - wstart);
+          float diff_val = is_empty ? 0. : top_input_cpu[top_index] / bin_area;
+
+          for (int h = hstart; h < hend; ++h) {
+            for (int w = wstart; w < wend; ++w) {
+              int bottom_index = h * bottom_w * bottom_c + w * bottom_c + c;
+              bottom_output_cpu[bottom_index + bottom_add] += diff_val;
+              theory_ops_ += 7;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+int64_t PsroipoolBackwardExecutor::getTheoryOps() {
+  if (parser_->device() != CPU) {
+    return -1;
+  }
+  VLOG(4) << "getTheoryOps: " << theory_ops_ << " ops";
+  return theory_ops_;
+}
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_backward/psroipool_backward.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_backward/psroipool_backward.h
@@ -1,0 +1,46 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_PSROIPOOL_BACKWARD_PSROIPOOL_BACKWARD_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_PSROIPOOL_BACKWARD_PSROIPOOL_BACKWARD_H_
+#include "executor.h"
+
+namespace mluoptest {
+class PsroipoolBackwardExecutor : public Executor {
+ public:
+  PsroipoolBackwardExecutor() {}
+  ~PsroipoolBackwardExecutor() {}
+  void paramCheck() override;
+  void compute() override;
+  void cpuCompute() override;
+  int64_t getTheoryOps() override;
+
+ private:
+  void initData();
+  int output_dim_ = 0;
+  int pooled_height_ = 0;
+  int pooled_width_ = 0;
+  float spatial_scale_ = 0;
+  int64_t theory_ops_ = 0;
+};
+}  // namespace mluoptest
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_PSROIPOOL_BACKWARD_PSROIPOOL_BACKWARD_H_

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_backward/testcase/case0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/psroipool_backward/testcase/case0.prototxt
@@ -1,0 +1,114 @@
+op_name: "psroipool_backward"
+input {
+  id: "input1"
+  shape: {
+    dims: 2
+    dims: 2
+    dims: 2
+    dims: 3
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 4.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+  value_f: 8.0000
+}
+input {
+  id: "input3"
+  shape: {
+    dims: 2
+    dims: 2
+    dims: 2
+    dims: 3
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_INT32
+  value_i: 0
+  value_i: 4
+  value_i: 8
+  value_i: 1
+  value_i: 5
+  value_i: 9
+  value_i: 2
+  value_i: 6
+  value_i: 10
+  value_i: 3
+  value_i: 7
+  value_i: 11
+  value_i: 0
+  value_i: 4
+  value_i: 8
+  value_i: 1
+  value_i: 5
+  value_i: 9
+  value_i: 2
+  value_i: 6
+  value_i: 10
+  value_i: 3
+  value_i: 7
+  value_i: 11
+}
+input {
+  id: "input3"
+  shape: {
+    dims: 2
+    dims: 5
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  value_f: 0.0000
+  value_f: 2.0000
+  value_f: 2.0000
+  value_f: 6.0000
+  value_f: 6.0000
+  value_f: 1.0000
+  value_f: 2.0000
+  value_f: 2.0000
+  value_f: 6.0000
+  value_f: 6.0000
+}
+output {
+  id: "output1"
+  shape: {
+    dims: 2
+    dims: 12
+    dims: 12
+    dims: 12
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+}
+psroipool_backward_param {
+  output_dim: 3
+  pooled_height: 2
+  pooled_width: 2
+  spatial_scale: 1
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 0.003
+  error_threshold: 0.003
+  baseline_device: CPU
+}


### PR DESCRIPTION
### **1. 修改描述**
新增psroipool_backward算子，是psroipool_forward算子的反向

- **影响范围/算子**：psroipool_backward
- **影响版本/分支**：master
##### 1.1 精度验收标准
算子采用静态阈值标准：diffs=[diff1，diff2]，diff1<=3e-3 && diff2 <= 3e-3。
##### 1.2 算子方案CheckList
|      序号      |           需求           |      需求详情       |
|----|----|----|
|1|支持硬件 |MLU290、MLU370|
|2|job类型|U1|
|3|DimXYZ|支持DimXYZ|
|4|可变|不支持各个维度可变|
|5|layout|top_grad、mapping_channel和bottom_grad:支持NHWC<br>rois:支持ARRAY|
|6|多维|不支持多维|
|7|0元素|不支持0元素|
|8|转数提前|否|
|9|片外数据类型|float|
|10|片上数据类型|float|
|11|融合|否|
|12|规模限制|否|
|13|c不感知对齐|否|
|14|原位测试对齐|不支持|
##### 1.3 新特性测例
|测试点|验收标准|测试结果(精度)|
|----|----|----|
|数据类型测试|FLOAT|[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|多维张量测试|支持4维|[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|Layout测试|支持NHWC|[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|不同规模 / 整数余数端段 / 对齐不对齐||[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|零维张量测试/0元素测试|不支持0元素测试|[cnrtError] [14734] [Card : 0] cnrtMemcpy: Input argument 'dst' or 'src' is NULL. Please check the input arguments.|
|稳定性测试|gtest 多线程+repeat 使用--gtest_repeat=NUM --thread=NUM |[----------] Global test environment tear-down [ SUMMARY  ] Total 100 cases of 100 op(s). ALL PASSED. [==========] 1 test case from 1 test suite ran. (16 ms total) [  PASSED  ] 1 test case.|
|多平台测试|支持MLU290、MLU370|[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|gen_case模块测试|gen_case模块生成的测试通过|[2022-8-16 14:42:27] [MLUOP] [Info]:[gen_case] Generate /tudejiang/mlu-ops/bangc-ops/build/test/gen_case/psroipool_backward/psroipool_backward_20220816_06_42_27_320066_tid15830_device1.prototxt  [ /tudejiang/mlu-ops/bangc-ops/core/gen_case.cpp:420  pid:15830]|
|其他测试点|||
##### 1.4 参数检查
提交新算子时，给出测试点，并说明测试结果。
|测试点|验收标准|测试结果(出错信息)|
|----|----|----|
|不符合算子限制|正常报错|1、top_grad、rois和bottom_grad的数据类型应该一致:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->dtype == MLUOP_DTYPE_FLOAT. <br>2、top_grad、mapping_channel和bottom_grad的layout必须为NHWC：<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->layout == MLUOP_LAYOUT_NHWC.  <br>3、rois的最后维度必须是5:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: rois_desc->dims[1] == 5.<br>4、top_grad和mapping_channel的各个维度必须一致:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->dims[1] should be equal to mapping_channel_desc->dims[1]. <br>5、rois和top_grad的第一维度必须一致:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->dims[0] == rois_desc->dims[0]. <br>6、top_grad的第四维度等于output_dim:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: output_dim == top_grad_desc->dims[3].<br>7、top_grad的第二维度等于pooled_height:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: pooled_height == top_grad_desc->dims[1].<br>8、top_grad的第三维度等于pooled_width:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: pooled_width == top_grad_desc->dims[2].|
|非法参数传递|正常报错||
### 2. 性能测试
- 要排除机器环境的影响。
- 用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试。
- 建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理。
- 算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。
##### 2.1 算子io利用率、计算效率
注释: 
io_efficiency = theory_io_size / (latency * IO_BANDWIDTH)
**theory_is_size:** 从算法上需要访问的数据量(与实现无关), **lantency:**算子运行的实际时间, **IO_BANGWIDTH:**硬件的理论带宽.
compute_efficiency = theory_compute_ops / (latency * peak_compute_force)
**theory_compute_ops:** 该算子从算法上需要执行多少次操作(与实际无关), **lantency:** 表示算子运行的实际时间, **peak_compute_force:** 硬件平台的峰值算力, 其单位是op/s(每秒执行多少操作)
|operator|mlu_hardware_time|mlu_interface_time|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size|count|gradOutput|grid|gradInput|
|----|----|----|----|----|----|----|----|----|----|
|roi_crop_forward|8|49.861|1.66016e-05|1.46484e-06|0|1|1,3,1,1|1,3,1,2|1,5,5,1|
|roi_crop_forward|9|47.254|0.005623|6.5104e-05|0|1|1,3,1,50|1,3,1,2|1,16,16,50|
|roi_crop_forward|14|48.225|0.014648|0.000348|0|1|1,5,5,50|1,5,5,2|1,32,32,50|
|roi_crop_forward|22|48.435|0.09313|0.002219|0|1|1,5,5,500|1,5,5,2|1,32,32,500|
|roi_crop_forward|1184|51.405|0.173|0.004124|0|1|1,5,5,50000|1,5,5,2|1,32,32,50000|
|roi_crop_forward|185|51.366|0.125957|0.01784|0|1|1,13,13,5000|1,13,13,2|1,32,32,5000|
|roi_crop_forward|662|50.343|0.04865|0.01843|0|1|1,25,25,5000|1,25,25,2|1,32,32,5000|
|roi_crop_forward|903|57.475|0.03057|0.021662|0|1|16,25,25,500|16.25,25,2|4,32,32,500|
|roi_crop_forward|498|49.236|0.03653|0.02039|0|1|16,13,25,500|16,13,25,2|4,32,32,500|
|roi_crop_forward|49|51.355|0.168|0.0047|0|1|8,3,5,500|8,3,5,2|4,32,32,500|

##### 2.2 内存泄露
打开内存泄漏检查环境变量：export MLUOP_BUILD_ASAN_CHECK=ON
编译测试程序运行正常，无内存泄漏报错
##### 2.3 代码覆盖率
psroipool算子的正反向算子是在同一个文件中，在不增加数据量的情况下，通过减少使用内存空间，来达到各个分支覆盖。
psroipool_backward算子代码覆盖率：50.4%
psroipool_forward 和psroipool_backward算子同时运行代码覆盖率：94.1%

### 3. 总结分析
总结分析主要需要考虑以下几点：
1、该算子暂时不支持half类型的数据，grid不支持NaN和INF数据，主要因为硬件原因，jira有人已经提了需求；
2、该算子的源码只支持torch版本为0.3.0，高于该版本源码会出现各种问题；
3、roi_crop_backward算子做梯度计算时用到atomic，在kernel中计算需先给gradInput进行刷0，但限于MLU-OPS没有刷0的接口，只能先自己写一个kernel调用__gdramset()进行刷0。
