### PR TITLE
[Fix](psroipool_backward):fix host code

### DIFF
--- a/bangc-ops/kernels/psroipool/psroipool.cpp
+++ b/bangc-ops/kernels/psroipool/psroipool.cpp
@@ -173,22 +173,7 @@ static mluOpStatus_t psRoiPoolBackwardParamCheck(
                << " Currently, MLU-OPS supports tensor num smaller than 2^31.";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
-  if (mluOpGetTensorElementNum(top_grad_desc) == 0 ||
-      mluOpGetTensorElementNum(mapping_channel_desc) == 0 ||
-      mluOpGetTensorElementNum(bottom_grad_desc) == 0) {
-    VLOG(5) << api << " Input skip zero element tensor.";
-    return MLUOP_STATUS_SUCCESS;
-  }
-
-  if (mluOpGetTensorElementNum(rois_desc) == 0) {
-    LOG(ERROR) << api << " Roi_data can not be zero element tensor.";
-    return MLUOP_STATUS_BAD_PARAM;
-  }
-
-  PARAM_CHECK(api, top_grad != NULL);
-  PARAM_CHECK(api, rois != NULL);
-  PARAM_CHECK(api, bottom_grad != NULL);
-  PARAM_CHECK(api, mapping_channel != NULL);
+  
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -265,8 +250,24 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolBackward(
   if (ret != MLUOP_STATUS_SUCCESS) {
     LOG(ERROR) << api
                << " Error found during element verification, please check.";
+    return ret;
+  }
+
+  if (mluOpGetTensorElementNum(top_grad_desc) == 0 ||
+      mluOpGetTensorElementNum(mapping_channel_desc) == 0 ||
+      mluOpGetTensorElementNum(bottom_grad_desc) == 0) {
+    VLOG(5) << api << " Input skip zero element tensor.";
+    return MLUOP_STATUS_SUCCESS;
+  }
+  if (mluOpGetTensorElementNum(rois_desc) == 0) {
+    LOG(ERROR) << api << " Roi_data can not be zero element tensor.";
     return MLUOP_STATUS_BAD_PARAM;
   }
+
+  PARAM_CHECK(api, top_grad != NULL);
+  PARAM_CHECK(api, rois != NULL);
+  PARAM_CHECK(api, bottom_grad != NULL);
+  PARAM_CHECK(api, mapping_channel != NULL);
 
   const int batch_size = bottom_grad_desc->dims[0];
   const int height = bottom_grad_desc->dims[1];

--- a/bangc-ops/kernels/psroipool/psroipool.cpp
+++ b/bangc-ops/kernels/psroipool/psroipool.cpp
@@ -93,6 +93,22 @@ static mluOpStatus_t psRoiPoolForwardParamCheck(
       return MLUOP_STATUS_BAD_PARAM;
     }
   }
+  if ((mluOpGetTensorElementNum(output_desc) *
+           getSizeOfDataType(output_desc->dtype) >=
+       LARGE_TENSOR_SIZE) ||
+      (mluOpGetTensorElementNum(input_desc) *
+           getSizeOfDataType(input_desc->dtype) >=
+       LARGE_TENSOR_SIZE) ||
+      (mluOpGetTensorElementNum(rois_desc) *
+           getSizeOfDataType(rois_desc->dtype) >=
+       LARGE_TENSOR_SIZE) ||
+      (mluOpGetTensorElementNum(mapping_channel_desc) *
+           getSizeOfDataType(mapping_channel_desc->dtype) >=
+       LARGE_TENSOR_SIZE)) {
+    LOG(ERROR) << api << " Overflow max tensor size."
+               << " Currently, MLU-OPS supports tensor size smaller than 2^31.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
   const size_t max_input_num = 2147483648;  // 2^31 2G num
   if ((mluOpGetTensorElementNum(output_desc) >= max_input_num) ||
       (mluOpGetTensorElementNum(input_desc) >= max_input_num) ||
@@ -164,13 +180,21 @@ static mluOpStatus_t psRoiPoolBackwardParamCheck(
       return MLUOP_STATUS_BAD_PARAM;
     }
   }
-  const size_t max_input_num = 2147483648;  // 2^31 2G num
-  if ((mluOpGetTensorElementNum(top_grad_desc) >= max_input_num) ||
-      (mluOpGetTensorElementNum(bottom_grad_desc) >= max_input_num) ||
-      (mluOpGetTensorElementNum(rois_desc) >= max_input_num) ||
-      (mluOpGetTensorElementNum(mapping_channel_desc) >= max_input_num)) {
-    LOG(ERROR) << api << " Overflow max tensor num."
-               << " Currently, MLU-OPS supports tensor num smaller than 2^31.";
+
+  if ((mluOpGetTensorElementNum(top_grad_desc) *
+           getSizeOfDataType(top_grad_desc->dtype) >=
+       LARGE_TENSOR_SIZE) ||
+      (mluOpGetTensorElementNum(bottom_grad_desc) *
+           getSizeOfDataType(bottom_grad_desc->dtype) >=
+       LARGE_TENSOR_SIZE) ||
+      (mluOpGetTensorElementNum(rois_desc) *
+           getSizeOfDataType(rois_desc->dtype) >=
+       LARGE_TENSOR_SIZE) ||
+      (mluOpGetTensorElementNum(mapping_channel_desc) *
+           getSizeOfDataType(mapping_channel_desc->dtype) >=
+       LARGE_TENSOR_SIZE)) {
+    LOG(ERROR) << api << " Overflow max tensor size."
+               << " Currently, MLU-OPS supports tensor size smaller than 2^31.";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
 

--- a/bangc-ops/kernels/psroipool/psroipool.cpp
+++ b/bangc-ops/kernels/psroipool/psroipool.cpp
@@ -277,15 +277,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolBackward(
     return ret;
   }
 
+  if (mluOpGetTensorElementNum(rois_desc) == 0) {
+    LOG(ERROR) << api << " Roi_data can not be zero element tensor.";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
   if (mluOpGetTensorElementNum(top_grad_desc) == 0 ||
       mluOpGetTensorElementNum(mapping_channel_desc) == 0 ||
       mluOpGetTensorElementNum(bottom_grad_desc) == 0) {
     VLOG(5) << api << " Input skip zero element tensor.";
     return MLUOP_STATUS_SUCCESS;
-  }
-  if (mluOpGetTensorElementNum(rois_desc) == 0) {
-    LOG(ERROR) << api << " Roi_data can not be zero element tensor.";
-    return MLUOP_STATUS_BAD_PARAM;
   }
 
   PARAM_CHECK(api, top_grad != NULL);

--- a/bangc-ops/kernels/psroipool/psroipool.cpp
+++ b/bangc-ops/kernels/psroipool/psroipool.cpp
@@ -173,7 +173,7 @@ static mluOpStatus_t psRoiPoolBackwardParamCheck(
                << " Currently, MLU-OPS supports tensor num smaller than 2^31.";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
-  
+
   return MLUOP_STATUS_SUCCESS;
 }
 

--- a/docs/bangc-docs/design_docs/psroipool_backward/psroipool_backward.md
+++ b/docs/bangc-docs/design_docs/psroipool_backward/psroipool_backward.md
@@ -243,7 +243,7 @@ tensor([[[[nan, 0., 0.],
 | stride 限制  | 不支持 stride 机制                                                                                              |
 | 广播限制     |  参数不支持广播                                                                                              |
 | 输入参数限制 | pooled_height = pooled_width, rois_offset = 5, </br>output_dim >= 1, spatial_scale > 0, </br>channels = pooled_height * pooled_width * output_dim, </br>每个 roi 只支持 [batch_id, roi_start_h, roi_start_w, roi_end_h, roi_end_w], 0 <= batch_id <= batches - 1
-| nan/inf限制 | top_grad 支持 nan/inf 测例，rois 由于在计算过程中参与了 ceil/floor 函数，硬件指令功能限制无法与竞品对齐。已在 mlu_ops.h 中说明。|
+| nan/inf限制 | top_grad 支持 nan/inf 测例，rois 由于在计算过程中参与了 ceil/floor 函数，硬件指令功能限制无法与参考对齐。已在 mlu_ops.h 中说明。|
 
 ### 1.5 验收标准
 
@@ -471,7 +471,7 @@ nram 空间划分：
 
 ### 5.1 开发测试计划
 
-2022.7.12～2022.8.2 完成竞品源码测试调研。
+2022.7.12～2022.8.2 完成开源代码测试调研。
 
 2022.8.2～2022.8.3 psroipool_backward 设计文档。
 

--- a/docs/bangc-docs/design_docs/psroipool_backward/psroipool_backward.md
+++ b/docs/bangc-docs/design_docs/psroipool_backward/psroipool_backward.md
@@ -243,7 +243,7 @@ tensor([[[[nan, 0., 0.],
 | stride 限制  | 不支持 stride 机制                                                                                              |
 | 广播限制     |  参数不支持广播                                                                                              |
 | 输入参数限制 | pooled_height = pooled_width, rois_offset = 5, </br>output_dim >= 1, spatial_scale > 0, </br>channels = pooled_height * pooled_width * output_dim, </br>每个 roi 只支持 [batch_id, roi_start_h, roi_start_w, roi_end_h, roi_end_w], 0 <= batch_id <= batches - 1
-| nan/inf限制 | top_grad 支持 nan/inf 测例，rois 由于在计算过程中参与了 ceil/floor 函数，硬件指令功能限制无法与参考对齐。已在 mlu_ops.h 中说明。|
+| nan/inf限制 | top_grad 支持 nan/inf 测例，rois 由于在计算过程中参与了 ceil/floor 函数，硬件指令功能限制无法与竞品对齐。已在 mlu_ops.h 中说明。|
 
 ### 1.5 验收标准
 
@@ -471,7 +471,7 @@ nram 空间划分：
 
 ### 5.1 开发测试计划
 
-2022.7.12～2022.8.2 完成开源代码测试调研。
+2022.7.12～2022.8.2 完成竞品源码测试调研。
 
 2022.8.2～2022.8.3 psroipool_backward 设计文档。
 


### PR DESCRIPTION
### **1. 修改描述**
新增psroipool_backward算子，是psroipool_forward算子的反向

- **影响范围/算子**：psroipool_backward
- **影响版本/分支**：master
##### 1.1 精度验收标准
算子采用静态阈值标准：diffs=[diff1，diff2]，diff1<=3e-3 && diff2 <= 3e-3。
##### 1.2 算子方案CheckList
|      序号      |           需求           |      需求详情       |
|----|----|----|
|1|支持硬件 |MLU270、MLU290、MLU370|
|2|job类型|U1|
|3|DimXYZ|支持DimXYZ|
|4|可变|不支持各个维度可变|
|5|layout|top_grad、mapping_channel和bottom_grad:支持NHWC<br>rois:支持ARRAY|
|6|多维|不支持多维|
|7|0元素|不支持0元素|
|8|转数提前|否|
|9|片外数据类型|float|
|10|片上数据类型|float|
|11|融合|否|
|12|规模限制|否|
|13|c不感知对齐|否|
|14|原位测试对齐|不支持|
##### 1.3 新特性测例
|测试点|验收标准|测试结果(精度)|
|----|----|----|
|数据类型测试|FLOAT|[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|多维张量测试|支持4维|[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|Layout测试|支持NHWC|[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|不同规模 / 整数余数端段 / 对齐不对齐||[----------] Global test environment tear-down [ SUMMARY  ] Total 169 cases of 1 op(s). ALL PASSED.[==========] 169 test cases from 1 test suite ran. (6002 ms total) [  PASSED  ] 169 test cases.|
|零维张量测试/0元素测试|不支持0元素测试|[MLUOP] [Vlog]:[mluOpPsRoiPoolBackward] Input skip zero element tensor.  [ /tudejiang/mlu-ops/bangc-ops/kernels/psroipool/psroipool.cpp:259  pid:1222].<br>|
|稳定性测试|gtest 多线程+repeat 使用--gtest_repeat=NUM --thread=NUM |[----------] Global test environment tear-down [ SUMMARY  ] Total 100 cases of 100 op(s). ALL PASSED. [==========] 1 test case from 1 test suite ran. (16 ms total) [  PASSED  ] 1 test case.|
|多平台测试|支持MLU270、MLU290、MLU370|见性能测试|
|gen_case模块测试|gen_case模块生成的测试通过|[2022-8-16 14:42:27] [MLUOP] [Info]:[gen_case] Generate /tudejiang/mlu-ops/bangc-ops/build/test/gen_case/psroipool_backward/psroipool_backward_20220816_06_42_27_320066_tid15830_device1.prototxt  [ /tudejiang/mlu-ops/bangc-ops/core/gen_case.cpp:420  pid:15830]|
|其他测试点|||
##### 1.4 参数检查
提交新算子时，给出测试点，并说明测试结果。
|测试点|验收标准|测试结果(出错信息)|
|----|----|----|
|不符合算子限制|正常报错|1、top_grad、rois和bottom_grad的数据类型应该一致:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->dtype == MLUOP_DTYPE_FLOAT. <br>2、top_grad、mapping_channel和bottom_grad的layout必须为NHWC：<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->layout == MLUOP_LAYOUT_NHWC.  <br>3、rois的最后维度必须是5:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: rois_desc->dims[1] == 5.<br>4、top_grad和mapping_channel的各个维度必须一致:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->dims[1] should be equal to mapping_channel_desc->dims[1]. <br>5、rois和top_grad的第一维度必须一致:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: top_grad_desc->dims[0] == rois_desc->dims[0]. <br>6、top_grad的第二维度等于pooled_height:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: pooled_height == top_grad_desc->dims[1].<br>7、top_grad的第三维度等于pooled_width:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: pooled_width == top_grad_desc->dims[2].<br>8、top_grad的第四维度等于output_dim:<br>[MLUOP] [Error]:[mluOpPsRoiPoolBackward] Check failed: output_dim == top_grad_desc->dims[3].|
|非法参数传递|正常报错||
### 2. 性能测试
- 要排除机器环境的影响。
- 用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试。
- 建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理。
- 算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。
##### 2.1 算子io利用率、计算效率
io_efficiency = theory_io_size / (latency * IO_BANDWIDTH)
**theory_is_size:** 从算法上需要访问的数据量(与实现无关), **lantency:**算子运行的实际时间, **IO_BANGWIDTH:**硬件的理论带宽.
compute_efficiency = theory_compute_ops / (latency * peak_compute_force)
**theory_compute_ops:** 该算子从算法上需要执行多少次操作(与实际无关), **lantency:** 表示算子运行的实际时间, **peak_compute_force:** 硬件平台的峰值算力, 其单位是op/s(每秒执行多少操作)

平台：MLU270
|operator|mlu_hardware_time(us)|mlu_interface_time(us)|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size(Bytes)|filter_name|
|----|----|----|----|----|----|----|
|psroipool_backward|16|48.82|0.00358|2.3071e-05|-1|case0:<br>top_grad:[2,3,3,3]<br>mapping_channel:[2,3,3,3]<br>rois:[2,5]<br>bottom_grad:[2,5,5,27]<br>spatial_scale:0.30813|
|psroipool_backward|303|17.863|0.0016952|0.0001891|-1|case1:<br>top_grad:[200,3,3,3]<br>mapping_channel:[200,3,3,3]<br>rois:[200,5]<br>bottom_grad:[200,5,5,27]<br>spatial_scale:0.30813|
|psroipool_backward|366|25.458|0.361809|0|-1|case2:<br>top_grad:[2,5,5,100]<br>mapping_channel:[2,5,5,100]<br>rois:[2,5]<br>bottom_grad:[2,26,26,2500]<br>spatial_scale:0.30813|
|psroipool_backward|412|20.952|0.32995|0|-1|case3:<br>top_grad:[20,5,5,100]<br>mapping_channel:[20,5,5,100]<br>rois:[20,5]<br>bottom_grad:[20,26,26,2500]<br>spatial_scale:0.30813|
|psroipool_backward|441|32.543|0.308257|0|-1|case4:<br>top_grad:[20,5,5,100]<br>mapping_channel:[20,5,5,100]<br>rois:[20,5]<br>bottom_grad:[20,26,26,2500]<br>spatial_scale:0.6|

平台：MLU290
|operator|mlu_hardware_time(us)|mlu_interface_time(us)|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size(Bytes)|filter_name|
|----|----|----|----|----|----|----|
|psroipool_backward|13|37.386|0.00044|7.0988e-06|-1|case0:<br>top_grad:[2,3,3,3]<br>mapping_channel:[2,3,3,3]<br>rois:[2,5]<br>bottom_grad:[2,5,5,27]<br>spatial_scale:0.30813|
|psroipool_backward|124|16.76|0.000414|0.000115|-1|case1:<br>top_grad:[200,3,3,3]<br>mapping_channel:[200,3,3,3]<br>rois:[200,5]<br>bottom_grad:[200,5,5,27]<br>spatial_scale:0.30813|
|psroipool_backward|43|29.28|0.3079|0|-1|case2:<br>top_grad:[2,5,5,100]<br>mapping_channel:[2,5,5,100]<br>rois:[2,5]<br>bottom_grad:[2,26,26,2500]<br>spatial_scale:0.30813|
|psroipool_backward|59|44.565|0.23|0|-1|case3:<br>top_grad:[20,5,5,100]<br>mapping_channel:[20,5,5,100]<br>rois:[20,5]<br>bottom_grad:[20,26,26,2500]<br>spatial_scale:0.30813|
|psroipool_backward|58|31.65|0.234|0|-1|case4:<br>top_grad:[20,5,5,100]<br>mapping_channel:[20,5,5,100]<br>rois:[20,5]<br>bottom_grad:[20,26,26,2500]<br>spatial_scale:0.6|

平台：MLU370-X4
|operator|mlu_hardware_time(us)|mlu_interface_time(us)|mlu_io_efficiency|mlu_compute_efficiency|mlu_workspace_size(Bytes)|filter_name|
|----|----|----|----|----|----|----|
|psroipool_backward|16|36.88|0.00119|1.1535e-05|-1|case0:<br>top_grad:[2,3,3,3]<br>mapping_channel:[2,3,3,3]<br>rois:[2,5]<br>bottom_grad:[2,5,5,27]<br>spatial_scale:0.30813|
|psroipool_backward|196|17.12|0.000873|0.000146|-1|case1:<br>top_grad:[200,3,3,3]<br>mapping_channel:[200,3,3,3]<br>rois:[200,5]<br>bottom_grad:[200,5,5,27]<br>spatial_scale:0.30813|
|psroipool_backward|92|40.83|0.479|0|-1|case2:<br>top_grad:[2,5,5,100]<br>mapping_channel:[2,5,5,100]<br>rois:[2,5]<br>bottom_grad:[2,26,26,2500]<br>spatial_scale:0.30813|
|psroipool_backward|109|43.5|0.4157|0|-1|case3:<br>top_grad:[20,5,5,100]<br>mapping_channel:[20,5,5,100]<br>rois:[20,5]<br>bottom_grad:[20,26,26,2500]<br>spatial_scale:0.30813|
|psroipool_backward|107|44.52|0.42349|0|-1|case4:<br>top_grad:[20,5,5,100]<br>mapping_channel:[20,5,5,100]<br>rois:[20,5]<br>bottom_grad:[20,26,26,2500]<br>spatial_scale:0.6|

##### 2.2 内存泄露
打开内存泄漏检查环境变量：export MLUOP_BUILD_ASAN_CHECK=ON
编译测试程序运行正常，无内存泄漏报错
##### 2.3 代码覆盖率
psroipool算子的正反向算子是在同一个文件中，在不增加数据量的情况下，通过减少使用内存空间，来达到各个分支覆盖。
psroipool_backward算子代码覆盖率：50.4%
psroipool_forward 和psroipool_backward算子同时运行代码覆盖率：94.1%

### 3. 总结分析
总结分析主要需要考虑以下几点：
1、该算子暂时不支持half类型的数据；
2、该算子的源码只支持torch版本为0.3.0，框架不支持ncu，暂时无法测试竞品效率；
3、rois不支持NaN和INF数据，因为计算过程中存在ceil/floor函数，硬件指令功能限制无法与竞品对齐;
4、该算子存在fma问题，case的rois_num越大出现的概率越大。
