### PR TITLE
[Fix](bangc-ops): Fix output/var shape[3] defensive bug.

### DIFF
--- a/bangc-ops/kernels/prior_box/prior_box.cpp
+++ b/bangc-ops/kernels/prior_box/prior_box.cpp
@@ -82,6 +82,10 @@ mluOpStatus_t mluOpPriorBoxParamCheck(
   PARAM_CHECK(api, var_desc->dim == 4);
   // check shape
   PARAM_CHECK(api, variances_desc->dims[0] == 4);
+  PARAM_CHECK(api, output_desc->dims[0] == height);
+  PARAM_CHECK(api, output_desc->dims[1] == width);
+  PARAM_CHECK(api, output_desc->dims[3] == 4);
+  PARAM_CHECK(api, var_desc->dims[3] == 4);
   PARAM_CHECK_GE(api, height, 0);
   PARAM_CHECK_GE(api, width, 0);
   // check data type
@@ -95,8 +99,7 @@ mluOpStatus_t mluOpPriorBoxParamCheck(
   PARAM_CHECK_GT(api, step_h, 0);
   PARAM_CHECK_GT(api, step_w, 0);
   // check param depand
-  PARAM_CHECK(api, output_desc->dims[0] == height);
-  PARAM_CHECK(api, output_desc->dims[1] == width);
+
   for (int i = 0; i < output_desc->dim; i++) {
     PARAM_CHECK(api, output_desc->dims[i] == var_desc->dims[i]);
   }


### PR DESCRIPTION
### 1、修改描述

添加算子描述

- 影响范围/算子：prior_box
- 影响版本/分支：master
- bug描述：output/var tensor最后一维度为4没有防呆

##### 1.1 精度验收标准

根据算子需求给出算子分类，及其对应的精度验收标准

该算子有两个输出

第一个输出output：

- 算子精度验收标准：diff1、diff2；
- 算子精度阈值描述：diff1 <= 3e-3 && diff2 <=3e-3；

第二个输出var：

- 算子精度验收标准：diff3；
- 算子精度阈值描述：diff3 == 0；

##### 1.2 算子方案CHECKLIST

| 序号 | 需求           | 需求详情                                                     |
| ---- | -------------- | ------------------------------------------------------------ |
| 1    | 支持硬件       | MLU270/MLU290/MLU370                                         |
| 2    | job类型        | block                                                        |
| 3    | DimXYZ         | 支持DimXYZ                                                   |
| 4    | 可变           | 支持                                                         |
| 5    | layout         | ARRAY                                                        |
| 6    | 多维           | 不支持多维                                                   |
| 7    | 0元素          | max_sizes，output，var支持0元素，返回MLUOP_STATUS_SUCCESS min_sizes，aspect_ratios，variances不支持0元素，返回MLUOP_BAD_PARAM |
| 8    | 转数提前       | 否                                                           |
| 9    | 片上数据类型   | float                                                        |
| 10   | 片外数据类型   | float                                                        |
| 11   | 融合           | 否                                                           |
| 12   | 规模限制       | mlu270，mlu290上output，var的第三个维度最大支持2100，即每个点生成的box数量 mlu370上最大支持2900 |
| 13   | c不感知对齐    | 否                                                           |
| 14   | 代码覆盖率     | kernels/prior_box 98.3 %238 / 242 100.0 %4 / 4               |
| 15   | 内存泄露       | 无                                                           |
| 16   | IO计算效率检查 | 是                                                           |

##### 1.3 算子限制

| 限制类型     | 详细说明                                                     |
| :----------- | :----------------------------------------------------------- |
| 数据类型限制 | 输入输出的Tensor只支持 float32 类型                          |
| 布局限制     | 输入输出的Tensor只支持 ARRAY 类型                            |
| 规模限制     | variance 的 shape[0] 为4且 variance的维度必须为1维 output 和 var 的维度必须为4维且每个维度都相等 output 和 var 的shape[0]等于height，shape[1]等于width 若max_sizes 非空，max_sizes 的 shape[0] 和 min_sizes 的 shape[0] 需相等 output的第三个维度需满足：num_priors等于min_sizes的shape[0]乘以aspect_ratios的shape[0]再加max_size的shape[0] |
| 数据类型限制 | 只支持float输入                                              |
| 数据范围限制 | height、width大于等于0 min_sizes、aspect_ratios、variance 中的元素必须大于0 step_h、step_w 必须大于0 |
| 原位限制     | 不支持原位                                                   |
| stride限制   | 不支持stride                                                 |
| 广播限制     | 不支持广播                                                   |

##### 1.4新特性测试

| 测试点                       | 验收标准                                               | 测试结果（精度）                                             |
| ---------------------------- | ------------------------------------------------------ | ------------------------------------------------------------ |
| 数据类型测试                 | float                                                  | [----------] Global test environment tear-down [ SUMMARY ] Total 201 cases of 1 op(s). ALL PASSED. [==========] 201 test cases from 1 test suite ran. (825099 ms total)[ PASSED ] 201 test cases. |
| Layout测试                   | 支持ARRAY                                              | 见稳定性测试                                                 |
| 不同规模/整数余数/对齐不对齐 |                                                        | 见稳定性测试                                                 |
| 零维张量测试/0元素测试       | max_sizes支持0元素，其它Tensor均不支持                 | 目前gtest不支持ARRAY的0元素测试                              |
| 稳定性测试                   | gtest 多线程+repeat使用--gtest_repeat=NUM --thread=NUM | **--gtest_repeat=100 --thread=100** [ OK ] prior_box/TestSuite.mluOp/0 (454 ms) [----------] 1 test from prior_box/TestSuite (454 ms total) [----------] Global test environment tear-down [ SUMMARY ] Total 200 cases of 100 op(s). ALL PASSED. [==========] 1 test case from 1 test suite ran. (456 ms total)[ PASSED ] 1 test case. |
| 多平台测试                   | 270,290和370平台                                       | 见稳定性测试                                                 |
| gen_case模块测试             | gen_case模块生成的测例测试通过                         | [ OK ] prior_box/TestSuite.mluOp/1 (10 ms) [----------] 2 tests from prior_box/TestSuite (12 ms total) [----------] Global test environment tear-down [ SUMMARY ] Total 2 cases of 1 op(s). ALL PASSED. [==========] 2 test cases from 1 test suite ran. (40 ms total) [ PASSED ] 2 test cases. |
| nan/inf测试                  | 仅variances支持nan和inf                                | [ OK ] prior_box/TestSuite.mluOp/2 (3 ms) [----------] 3 tests from prior_box/TestSuite (8 ms total) [----------] Global test environment tear-down [ SUMMARY ] Total 3 cases of 1 op(s). ALL PASSED. [==========] 3 test cases from 1 test suite ran. (58 ms total) [ PASSED ] 3 test cases. |
| 其他测试点                   |                                                        |                                                              |



##### 1.5 参数检查

提交新算子时，给出测试点，并说明测试结果。

| 测试点         | 验收标准 | 测试结果（出错信息）                                         |
| -------------- | -------- | ------------------------------------------------------------ |
| 不符合算子限制 | 正常报错 | 1.维度测试 <br>[2022-9-14 15:19:4] [MLUOP] [Error]:mluOpPriorBox Check failed: min_sizes_desc->dim == 1. <br>2.shape测试<br> mluOpPriorBox Check failed: variances_desc->dims[0] == 4. <br/>[2022-9-19 18:8:37] [MLUOP] [Error]:mluOpPriorBox Check failed: output_desc->dims[3] == 4. <br/>[2022-9-19 18:9:11] [MLUOP] [Error]:mluOpPriorBox Check failed: var_desc->dims[3] == 4.<br/>3.数据类型测试 <br/>[2022-9-14 15:25:53] [MLUOP] [Error]:mluOpPriorBox Check failed: min_sizes_desc->dtype == MLUOP_DTYPE_FLOAT. <br/>4.标量测试 <br/>[2022-9-14 15:38:36] [MLUOP] [Error]:mluOpPriorBox Check failed: step_h > 0. <br/>[2022-9-14 15:40:29] [MLUOP] [Error]:mluOpPriorBox Check failed: step_w > 0. <br/>5.维度依赖测试 <br/>[2022-9-14 15:21:28] [MLUOP] [Error]:mluOpPriorBox Check failed: max_sizes_desc->dims[0] + min_sizes_desc->dims[0] * aspect_ratios_desc->dims[0] == output_desc->dims[2] <br/>[2022-9-14 15:27:10] [MLUOP] [Error]:mluOpPriorBox Check failed: output_desc->dims[i] == var_desc->dims[i]. <br/>[2022-9-14 15:28:11] [MLUOP] [Error]:mluOpPriorBox Check failed: max_sizes_desc->dims[0] == min_sizes_desc→dims[0]. <br/>[2022-9-14 15:36:55] [MLUOP] [Error]:mluOpPriorBox Check failed: output_desc->dims[0] == height. <br/>[2022-9-14 15:37:45] [MLUOP] [Error]:mluOpPriorBox Check failed: output_desc->dims[1] == width. <br/>7.限制测试 <br/>[2022-9-14 15:25:4] [MLUOP] [Error]:mluOpPriorBox Check failed: num_priors < max_support_num_priors.  <br/>8.0元素测试 <br/>[2022-9-15 16:24:26] [MLUOP] [Error]:mluOpPriorBox Zero element tensor failure.  <br/>9.LargeTensor测试 <br/>[2022-9-15 16:46:48] [MLUOP] [Error]:mluOpPriorBox Overflow max tensor num. Currently, MLU-OPS supports tensor num smaller than 2^31. |
| 非法参数传递   | 正常报错 |                                                              |

### 2 性能测试

- 要排除机器环境的影响，找一个可以独占的服务器来做性能测试；
- 用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试；
- 建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理；
- 算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。

测试prior_box算子性能； 需求未提供的网络中算子规模， 

测试规模：

| Input               | Image             | min_sizes  | max_sizes  | aspect_ratios        | variance          | flip | is_clip | step      | offset | order | output         | var            |
| ------------------- | ----------------- | ---------- | ---------- | -------------------- | ----------------- | ---- | ------- | --------- | ------ | ----- | -------------- | -------------- |
| [64, 256, 1, 1]     | [64, 3, 300, 300] | [261]      | [315]      | [2]                  | [0.1,0.1,0.2,0.2] | 1    | 1       | [300,300] | 0.5    | 1     | [1, 1, 4, 4]   | [1, 1, 4, 4]   |
| [64, 256, 3, 3]     | [64, 3, 300, 300] | [207]      | [261]      | [2]                  | [0.1,0.1,0.2,0.2] | 1    | 1       | [100,100] | 0.5    | 1     | [3, 3, 4, 4]   | [3, 3, 4, 4]   |
| [64, 256, 38, 38]   | [64, 3, 300, 300] | [21]       | [45]       | [2]                  | [0.1,0.1,0.2,0.2] | 1    | 1       | [8,8]     | 0.5    | 1     | [38, 38, 4, 4] | [38, 38, 4, 4] |
| [64, 256, 5, 5]     | [64, 3, 300, 300] | [153]      | [207]      | [2,3]                | [0.1,0.1,0.2,0.2] | 1    | 1       | [64,64]   | 0.5    | 1     | [5,5,6,4]      | [5,5,6,4]      |
| [64, 512, 10, 10]   | [64, 3, 300, 300] | [99]       | [153]      | [2,3]                | [0.1,0.1,0.2,0.2] | 1    | 1       | [32,32]   | 0.5    | 1     | [10,10,6,4]    | [10,10,6,4]    |
| [64, 512, 19, 19]   | [64, 3, 300, 300] | [45]       | [99]       | [2,3]                | [0.1,0.1,0.2,0.2] | 1    | 1       | [16,16]   | 0.5    | 1     | [19,19,6,4]    | [19,19,6,4]    |
| [64, 512, 520, 19]  | [64, 3, 300, 300] | [45,45,45] | [99,99,99] | [2,3,4,5,6,7,8,9,10] | [0.1,0.1,0.2,0.2] | 1    | 1       | [16,16]   | 0.5    | 1     | [520,19,33,4]  | [520,19,33,4]  |
| [64, 512, 1020, 19] | [64, 3, 300, 300] | [45,45,45] | [99,99,99] | [2,3,4,5,6,7,8,9,10] | [0.1,0.1,0.2,0.2] | 1    | 1       | [16,16]   | 0.5    | 1     | [1020,19,33,4] | [1020,19,33,4] |
| [64, 512, 2040, 19] | [64, 3, 300, 300] | [45,45,45] | [99,99,99] | [2,3,4,5,6,7,8,9,10] | [0.1,0.1,0.2,0.2] | 1    | 1       | [16,16]   | 0.5    | 1     | [2040,19,33,4] | [2040,19,33,4] |



##### 2.1 算子io利用率、计算效率

平台：MLU370 X4K， cntoolkit 3.0.1, cncc 4.01

| operator  | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency(%) | mlu_compute_efficiency(%) |
| --------- | --------------------- | ---------------------- | -------------------- | ------------------------- |
| prior_box | 16                    | 76                     | 3.33659e-05          | 2.56348e-06               |
|           | 16                    | 16                     | 0.000241699          | 2.30713e-05               |
|           | 31                    | 16                     | 0.0194124            | 0.00191053                |
|           | 17                    | 15                     | 0.000927543          | 9.4784e-05                |
|           | 18                    | 16                     | 0.00348018           | 0.000358073               |
|           | 22                    | 15                     | 0.0102622            | 0.00105762                |
|           | 289                   | 31                     | 0.192302             | 0.0210329                 |
|           | 509                   | 38                     | 0.214171             | 0.0234248                 |
|           | 998                   | 42                     | 0.218462             | 0.0238943                 |



平台：MLU290， cntoolkit 3.0.1, cncc 4.01

| operator  | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency(%) | mlu_compute_efficiency(%) |
| --------- | --------------------- | ---------------------- | -------------------- | ------------------------- |
| prior_box | 16                    | 45                     | 9.42096e-06          | 1.20634e-06               |
|           | 17                    | 19                     | 6.82445e-05          | 1.08571e-05               |
|           | 32                    | 24                     | 0.00564172           | 0.000925415               |
|           | 19                    | 17                     | 0.000248972          | 4.24034e-05               |
|           | 21                    | 16                     | 0.000894903          | 0.00015346                |
|           | 27                    | 16                     | 0.00250854           | 0.000430881               |
|           | 271                   | 17                     | 0.0615225            | 0.011215                  |
|           | 437                   | 33                     | 0.0748372            | 0.0136422                 |
|           | 706                   | 35                     | 0.0926453            | 0.0168884                 |

平台：MLU270 , cntoolkit-3.0.0, cncc v4.0.0 clang version 11.0.0

| operator  | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency(%) | mlu_compute_efficiency(%) |
| --------- | --------------------- | ---------------------- | -------------------- | ------------------------- |
| prior_box | 17                    | 85                     | 9.42096e-05          | 4.82537e-06               |
|           | 15                    | 45                     | 0.000773437          | 4.92188e-05               |
|           | 45                    | 28                     | 0.0401189            | 0.00263229                |
|           | 19                    | 23                     | 0.00248972           | 0.000169613               |
|           | 22                    | 23                     | 0.00854226           | 0.000585937               |
|           | 34                    | 22                     | 0.0199207            | 0.00136868                |
|           | 1375                  | 54                     | 0.121255             | 0.00884148                |
|           | 3036                  | 50                     | 0.10772              | 0.00785457                |
|           | 5453                  | 95                     | 0.120389             | 0.00877839                |



##### 2.2 Paddle PriorBox效率

测试环境： Tesla V100-SXM2-16GB + Paddle Develop分支

| 平台                 | 框架版本       | 数据类型 | 计算效率(%) | IO效率(%) | Hardware time(us) |
| -------------------- | -------------- | -------- | ----------- | --------- | ----------------- |
| Tesla V100-SXM2-16GB | Paddle Develop | float    | 0.026978%   | 0.171919% | 11.776            |
|                      |                | float    | 0.041092%   | 0.192615% | 11.576            |
|                      |                | float    | 3.859605%   | 0.008295% | 12.512            |
|                      |                | float    | 0.085335%   | 0.218838% | 10.845            |
|                      |                | float    | 0.282323%   | 0.488793% | 12.064            |
|                      |                | float    | 0.976554%   | 0.808574% | 11.739            |
|                      |                | float    | 46.533041   | 46.033089 | 62.034            |
|                      |                | float    | 50.533564   | 50.006598 | 108.921           |
|                      |                | float    | 54.175886   | 55.767901 | 208.233           |



##### 2.3 内存泄露

export MLUOP_BUILD_ASAN_CHECK=ON，重新编译

通过测试，没有内存泄露。

##### 2.4 代码覆盖率

kernels/prior_box 98.3 %238 / 242 100.0 %4 / 4

### 3. 总结分析

在算子设计阶段就忽略了对output shape[3]进行防呆，默认将最后一个维度看成是4，即（x1,y1,x2,y2），后面应该更仔细一点，在算子设计阶段考虑每一个维度的防呆