### PR TITLE
[Fix](bangc-ops): fix rpm build spec file for centos.

### DIFF
--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -19,7 +19,7 @@ BuildRequires: glibc-devel
 BuildRequires: binutils >= 2.27, redhat-rpm-config >= 9.1.0
 BuildRequires: readline-devel >= 6.2-4
 BuildRequires: rpm-devel
-BuildRequires: python-devel
+#BuildRequires: python-devel
 BuildRequires: texinfo-tex
 BuildRequires: /usr/bin/pod2man
 BuildRequires: texlive-ec texlive-cm-super
@@ -29,9 +29,9 @@ BuildRequires: valgrind >= 3.13.0
 BuildRequires: xz
 BuildRequires: doxygen
 BuildRequires: texlive-latex
-BuildRequires: python >= 2.7.0
-BuildRequires: cncc >= 2.6.0
-BuildRequires: cnas >= 2.6.0
+#BuildRequires: python >= 2.7.0
+#BuildRequires: cncc >= 2.6.0
+#BuildRequires: cnas >= 2.6.0
 Requires(post): /sbin/install-info
 Requires(preun): /sbin/install-info
 Requires: cndrv >= 0.2.0


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

fix rpm build spec file for centos.

## 2. Modification

installer/centos7.5/SPEC/mluops-independent.spec
