### PR TITLE
[Fix](bangc-ops): Fixed a handle parameter definition error in the yo…

### DIFF
--- a/bangc-ops/kernels/yolo_box/yolo_box.cpp
+++ b/bangc-ops/kernels/yolo_box/yolo_box.cpp
@@ -145,13 +145,13 @@ mluOpStatus_t YoloBoxParamCheck(
 }
 
 mluOpStatus_t MLUOP_WIN_API mluOpYoloBox(
-    mluOpHandle_t &handle, mluOpTensorDescriptor_t x_desc, const void *x,
-    mluOpTensorDescriptor_t img_size_desc, const void *img_size,
-    mluOpTensorDescriptor_t anchors_desc, const void *anchors,
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t x_desc, const void *x,
+    const mluOpTensorDescriptor_t img_size_desc, const void *img_size,
+    const mluOpTensorDescriptor_t anchors_desc, const void *anchors,
     const int class_num, const float conf_thresh, const int downsample_ratio,
     const bool clip_bbox, const float scale, const bool iou_aware,
-    const float iou_aware_factor, mluOpTensorDescriptor_t boxes_desc,
-    void *boxes, mluOpTensorDescriptor_t scores_desc, void *scores) {
+    const float iou_aware_factor, const mluOpTensorDescriptor_t boxes_desc,
+    void *boxes, const mluOpTensorDescriptor_t scores_desc, void *scores) {
   // check params
   mluOpStatus_t param_check =
       YoloBoxParamCheck("[mluOpYoloBox]", handle, x_desc, x, img_size_desc,

--- a/bangc-ops/kernels/yolo_box/yolo_box_block.mlu
+++ b/bangc-ops/kernels/yolo_box/yolo_box_block.mlu
@@ -234,6 +234,20 @@ static __mlu_func__ void compute(
     __bang_minequal(nram_h_p, nram_h_p, nram_imgh, deal_num);
   }
 
+#if __BANG_ARCH__ >= 322
+  int32_t *nram_mask_int32 = (int32_t *)nram_iou_p;
+  __bang_float2int32(nram_mask_int32, nram_iou_p, deal_num, 0);
+  __bang_mul_scalar((int *)nram_mask_int32, (int *)nram_mask_int32,
+                    (int)0xffffffff, deal_num);
+  __bang_band((char *)nram_x_p, (char *)nram_x_p, (char *)nram_mask_int32,
+              4 * deal_num);
+  __bang_band((char *)nram_y_p, (char *)nram_y_p, (char *)nram_mask_int32,
+              4 * deal_num);
+  __bang_band((char *)nram_w_p, (char *)nram_w_p, (char *)nram_mask_int32,
+              4 * deal_num);
+  __bang_band((char *)nram_h_p, (char *)nram_h_p, (char *)nram_mask_int32,
+              4 * deal_num);
+#else
   for (int k = 0; k < deal_num; k++) {
     if (nram_iou_p[k] == (T)0.0) {
       nram_x_p[k] = (T)0.0;
@@ -242,6 +256,7 @@ static __mlu_func__ void compute(
       nram_h_p[k] = (T)0.0;
     }
   }
+#endif
 }
 
 template <typename T>
@@ -1045,10 +1060,10 @@ static __mlu_func__ void computeScore(T *nram_iou, T *nram_conf, T *nram_cls,
   }
 
 #if __BANG_ARCH__ >= 322
-  __bang_gt_scalar(nram_iou_p, nram_conf_p, (T)conf_thresh, deal_num);
+  __bang_ge_scalar(nram_iou_p, nram_conf_p, (T)conf_thresh, deal_num);
 #else
   __bang_write_value(nram_iou_p, deal_num, (T)conf_thresh);
-  __bang_gt(nram_iou_p, nram_conf_p, nram_iou_p, deal_num);
+  __bang_ge(nram_iou_p, nram_conf_p, nram_iou_p, deal_num);
 #endif
 
   computeSigmoid(nram_cls_p, nram_cls_p, NULL, 0, class_num * deal_num);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -2544,7 +2544,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(
  * - The third dimension of grid tensor and grad_output tensor must be the same size.
  * - The fourth dimension of boxes \b boxes tensor and scores tensor
  *   The \b scores must be equal to third dimension * fourth dimension of x tensor.
- * - The \b class_num should be larger than 0.
+ * - The \b class_num should be larger than 0. On MLU200, the value cannot be 
+ *   greater than 1534. On MLU300, the value cannot be greater than 2558.
+ * - On MLU200, the value range of input x tensor is [-3.4e38, 16] 
+ *   because the activation function exp is called.
  *
  * @par Requirements
  * - None.
@@ -2557,13 +2560,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(
  * https://github.com/PaddlePaddle/Paddle/blob/release/2.3/python/paddle/vision/ops.py
  */
 mluOpStatus_t MLUOP_WIN_API mluOpYoloBox(
-    mluOpHandle_t &handle, mluOpTensorDescriptor_t x_desc, const void *x,
-    mluOpTensorDescriptor_t img_size_desc, const void *img_size,
-    mluOpTensorDescriptor_t anchors_desc, const void *anchors,
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t x_desc, const void *x,
+    const mluOpTensorDescriptor_t img_size_desc, const void *img_size,
+    const mluOpTensorDescriptor_t anchors_desc, const void *anchors,
     const int class_num, const float conf_thresh, const int downsample_ratio,
     const bool clip_bbox, const float scale, const bool iou_aware,
-    const float iou_aware_factor, mluOpTensorDescriptor_t boxes_desc,
-    void *boxes, mluOpTensorDescriptor_t scores_desc, void *scores);
+    const float iou_aware_factor, const mluOpTensorDescriptor_t boxes_desc,
+    void *boxes, const mluOpTensorDescriptor_t scores_desc, void *scores);
 
 #if defined(__cplusplus)
 }

--- a/docs/bangc-docs/design_docs/yolo_box/yolo_box.md
+++ b/docs/bangc-docs/design_docs/yolo_box/yolo_box.md
@@ -265,11 +265,11 @@ void YoloBoxKernel(const Context& dev_ctx,
 ```c++
 mluOpsStatus_t MLUOP_WIN_API 
 mluOpYoloBox(mluOpHandle_t handle,
-             mluOpTensorDescriptor_t x_desc,
+             const mluOpTensorDescriptor_t x_desc,
              const void *x,
-             mluOpTensorDescriptor_t img_size_desc,
+             const mluOpTensorDescriptor_t img_size_desc,
              const void *img_size,
-             mluOpTensorDescriptor_t anchors_desc,
+             const mluOpTensorDescriptor_t anchors_desc,
              const void *anchors,
              const int class_num,
              const float conf_thresh,
@@ -278,9 +278,9 @@ mluOpYoloBox(mluOpHandle_t handle,
              const float scale,
              const bool iou_aware,
              const float iou_aware_factor,
-             mluOpTensorDescriptor_t boxes_desc,
+             const mluOpTensorDescriptor_t boxes_desc,
              void *boxes,
-             mluOpTensorDescriptor_t scores_desc,
+             const mluOpTensorDescriptor_t scores_desc,
              void* scores);
 ```
 
@@ -479,7 +479,7 @@ yolo_box负责从检测网络的backbone输出部分，计算真实检测框bbox
      2. 根据`score_conf>conf_thresh`生成`score_mask`，`score_mask`中值为1和0，1表示置信度得分大于`conf_thresh`，0表示置信度得分小于`conf_thresh`，`score_mask`结果存放到nram_iou/mask空间，用于第（5）步将置信度得分小于`conf_thresh`的检测框结果set为0；
 
         ```c
-        __bang_gt_scalar(nram_mask, nram_conf, conf_thresh, deal_num);
+        __bang_ge_scalar(nram_mask, nram_conf, conf_thresh, deal_num);
         ```
 
      3. 根据**公式（2）**、**公式（3）**，计算bbox的左上角`(x0,y0)`和右下角`(x1,y1)`坐标；
@@ -653,7 +653,7 @@ yolo_box负责从检测网络的backbone输出部分，计算真实检测框bbox
      2. 根据`score_conf>conf_thresh`生成`score_mask`，`score_mask`中值为1和0，1表示置信度得分大于`conf_thresh`，0表示置信度得分小于`conf_thresh`，`score_mask`结果存放到nram_mask空间，用于第（7）步将`score_conf<conf_thresh`的分类得分结果set为0；
 
         ```c
-        __bang_gt_scalar(nram_mask, nram_conf, conf_thresh, deal_num);
+        __bang_ge_scalar(nram_mask, nram_conf, conf_thresh, deal_num);
         ```
 
      5. 将`score_conf`中`score_conf<conf_thresh`的值置成`conf_thresh`，防止因`score_conf`中含有-inf，导致score的计算结果为nan，参考接口结果为0；


### PR DESCRIPTION
# 1. 修改描述

添加算子描述

- 影响范围/算子：yolo_box
- 影响版本/分支：master

### 1.1 精度验收标准

按照[精度验收标准](https://wiki.cambricon.com/MLU-OPS精度验收标准.md)的要求明确本算子的精度标准。

本算子属于复合类算子，验收标准为 diff1 <= 3e-3 && diff2 <= 3e-3

### 1.2 算子方案CHECKLIST

| 序号 | 需求     | 需求详情                                                     |
| :--- | :------- | :----------------------------------------------------------- |
| 1    | 支持硬件 | MLU270 MLU290 MLU370                                         |
| 2    | job类型  | block                                                        |
| 3    | layout   | ARRAY                                                        |
| 4    | 多维     | 否                                                           |
| 5    | 0元素    | 是                                                           |
| 6    | 数据类型 | float                                                        |
| 7    | 规模限制 | anchors的shape为`[2*S]`，S须大于0，且 S % 2 == 0<br />x的shape为`[N,C,H,W]`，C须大于0<br />img_size的shape为`[N, 2]`，dim[1]为2<br />boxes的shape为`[N, S, 4, H*W]`，dim[1]==S，dim[2]为4<br />scores的shape为`[N, S, class_num, H*W]`，dim[1]==S，dim[2]为class_num<br />class_num须大于0且在200平台上小于1535，在300平台上小于2559，此处class_num的取值上限由NRAM空间大小决定，计算公式：(MAX_NRAM_SIZE / sizeof(float) / 2 / 32) - 2 （见scores空间划分） |

### 1.3 新特性测试

- [x]  数据类型测试
- [ ]  多维张量测试
- [x]  Layout 测试
- [x]  不同规模 / 整数余数端段 / 对齐不对齐测试
- [x]  零维张量测试/ 0 元素测试
- [x]  稳定性测试
- [x]  多平台测试
- [x]  gen_case模块测试
- [x]  nan / inf测试
- [x]  内存泄漏检查, 详见[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [x]  代码覆盖率检查，详见[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [x]  IO计算效率检查，详见[MLU-OPS性能验收标准](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS性能验收标准.md)

***关于功能测试，是希望算子开发者能够针对每一个逻辑，每一个分支，每一个判断，进行对应的测例设计，尽量覆盖到所有代码逻辑。\***

### 1.3 参数检查

提交新算子时，给出测试点，并说明测试结果。

| 测试点         | 验收标准 | 测试结果（出错信息）                                         |
| :------------- | :------- | :----------------------------------------------------------- |
| 不符合算子限制 | 正常报错 | [2022-9-14 17:3:27] [MLUOP] [Error]:[mluOpYoloBox] Check failed: class_num > 0.<br />[2022-9-14 19:44:48] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (x_dimN == img_size_dimN). <br />[2022-9-14 19:52:27] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (x_dimN == boxes_dimN).<br />[2022-9-14 19:53:6] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (x_dimN == scores_dimN).<br />[2022-9-14 19:49:24] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (x_dimC == dimc_size). <br />[2022-9-14 19:48:56] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (img_size_dim2 == 2). <br />[2022-9-14 19:49:48] [MLUOP] [Error]:[mluOpYoloBox] Check failed: anchors_num > 0.<br />[2022-9-14 19:54:4] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (boxes_dim1 == anchors_num). <br />[2022-9-14 19:53:47] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (boxes_dim2 == 4). <br />[2022-9-14 19:51:32] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (boxes_dim3 == (x_dimH * x_dimW)).  <br />[2022-9-14 19:54:21] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (scores_dim1 == anchors_num). <br />[2022-9-14 19:54:47] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (scores_dim2 == class_num). <br />[2022-9-14 19:51:59] [MLUOP] [Error]:[mluOpYoloBox] Check failed: (scores_dim3 == (x_dimH * x_dimW)). |
| 非法参数传递   | 正常报错 | [2022-9-14 16:51:2] [MLUOP] [Error]:[mluOpYoloBox] Check failed: handle != NULL. <br />[2022-9-14 16:51:16] [MLUOP] [Error]:[mluOpYoloBox] Check failed: x_desc != NULL.<br />[2022-9-14 16:53:4] [MLUOP] [Error]:[mluOpYoloBox] Check failed: img_size_desc != NULL.<br />[2022-9-14 16:53:43] [MLUOP] [Error]:[mluOpYoloBox] Check failed: anchors_desc != NULL.<br />[2022-9-14 17:0:38] [MLUOP] [Error]:[mluOpYoloBox] Check failed: scores != NULL.<br />[2022-9-14 16:59:58] [MLUOP] [Error]:[mluOpYoloBox] Check failed: boxes != NULL.<br />[2022-9-14 16:59:25] [MLUOP] [Error]:[mluOpYoloBox] Check failed: anchors != NULL. <br />[2022-9-14 16:58:49] [MLUOP] [Error]:[mluOpYoloBox] Check failed: img_size != NULL.<br />[2022-9-14 16:57:59] [MLUOP] [Error]:[mluOpYoloBox] Check failed: x != NULL. <br />[2022-9-14 16:57:18] [MLUOP] [Error]:[mluOpYoloBox] Check failed: scores_desc != NULL.<br />[2022-9-14 16:55:8] [MLUOP] [Error]:[mluOpYoloBox] Check failed: boxes_desc != NULL. |

# 2. 性能测试

详见：[MLU-OPS性能验收标准](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS性能验收标准.md)

平台：MLU270

| operator | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency | mlu_compute_efficiency | mlu_workwpace_size(Bytes) | data_type | shape                                                      |
| :------- | :-------------------- | :--------------------- | :---------------- | :--------------------- | :------------------------ | :-------- | :--------------------------------------------------------- |
| yolo_box | 1064                  | 108.969                | 5.375%            | 4.055%                 | 0                         | float     | img_size=[8, 2] x=[8, 255, 19, 19] anchors[6] class_num=80 |
| yolo_box | 2216                  | 55051                  | 10.32%            | 7.78%                  | 0                         | float     | img_size=[8, 2] x=[8, 255, 38, 38] anchors[6] class_num=80 |
| yolo_box | 3771                  | 91.519                 | 24.26%            | 18.31%                 | 0                         | float     | img_size=[8, 2] x=[8, 255, 76, 76] anchors[6] class_num=80 |

平台：MLU290

| operator | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency | mlu_compute_efficiency | mlu_workwpace_size(Bytes) | data_type | shape                                                      |
| :------- | :-------------------- | :--------------------- | :---------------- | :--------------------- | :------------------------ | :-------- | :--------------------------------------------------------- |
| yolo_box | 1014                  | 121.879                | 0.56%             | 1.06%                  | 0                         | float     | img_size=[8, 2] x=[8, 255, 19, 19] anchors[6] class_num=80 |
| yolo_box | 1520                  | 550529                 | 1.51%             | 2.83%                  | 0                         | float     | img_size=[8, 2] x=[8, 255, 38, 38] anchors[6] class_num=80 |
| yolo_box | 2094                  | 100.888                | 4.37%             | 8.24%                  | 0                         | float     | img_size=[8, 2] x=[8, 255, 76, 76] anchors[6] class_num=80 |

平台：MLU370

| operator | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency | mlu_compute_efficiency | mlu_workwpace_size(Bytes) | data_type | shape                                                      |
| :------- | :-------------------- | :--------------------- | :---------------- | :--------------------- | :------------------------ | :-------- | :--------------------------------------------------------- |
| yolo_box | 419                   | 93.21                  | 4.5%              | 5.1%                   | 0                         | float     | img_size=[8, 2] x=[8, 255, 19, 19] anchors[6] class_num=80 |
| yolo_box | 594                   | 45.039                 | 12.83%            | 14.528%                | 0                         | float     | img_size=[8, 2] x=[8, 255, 38, 38] anchors[6] class_num=80 |
| yolo_box | 1269                  | 45.439                 | 24.038%           | 27.203%                | 0                         | float     | img_size=[8, 2] x=[8, 255, 76, 76] anchors[6] class_num=80 |

# 3. 总结分析

总结分析主要需要考虑以下几点：

1. 算子功能符合设计要求；
2. 性能符合预期；