### PR TITLE
[Fix](bangc-ops): add test tar package configuration when do packaging.

### DIFF
--- a/independent_build.sh
+++ b/independent_build.sh
@@ -163,6 +163,14 @@ mkdir -p ${PACKAGE_DIR}/lib64
 cp -rf ${BUILD_DIR}/lib/libmluops.so ${PACKAGE_DIR}/lib64
 cp bangc-ops/mlu_op.h bangc-ops/mlu_op_kernel.h ${PACKAGE_DIR}/include
 
+TEST_DIR="test_workspace/mluops"
+mkdir -p ${TEST_DIR}/build
+mkdir -p ${TEST_DIR}/lib
+
+cp -rf ${BUILD_DIR}/test ${TEST_DIR}/build
+cp -rf ${BUILD_DIR}/lib/libgtest_shared.a ${TEST_DIR}/lib
+cp -rf ${BUILD_DIR}/lib/libmluop_test_proto.a ${TEST_DIR}/lib
+
 DEPS_DIR=`echo ${PACKAGE_SERVER} | awk -F '//' '{print $2}'`
 rm -rf $DEPS_DIR
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

add test_tar package config when do packaging.
## 2. Modification

r0.1 independent_build.sh
