### PR TITLE
[Fix](bangc-ops): fix packaging configure files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,7 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
+#*.spec
 
 # Installer logs
 pip-log.txt

--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -68,8 +68,16 @@ set(BANG_CNCC_FLAGS "${BANG_CNCC_FLAGS}" "--bang-mlu-arch=mtp_220"
 
 file(GLOB_RECURSE src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/*.mlu" "${CMAKE_CURRENT_SOURCE_DIR}/kernels/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp")
 # set(src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp")
+
+
 bang_add_library(mluops SHARED ${src_files})
 target_link_libraries(mluops cnrt cndrv)
+set_target_properties(mluops PROPERTIES 
+  OUTPUT_NAME "mluops"
+  PREFIX      "lib"
+  VERSION     "${BUILD_VERSION}" 
+  SOVERSION   "${MAJOR_VERSION}"
+)
 
 ################################################################################
 # Build MLUOP GTEST

--- a/bangc-ops/build.sh
+++ b/bangc-ops/build.sh
@@ -17,6 +17,17 @@ usage () {
 cmdline_args=$(getopt -o ch -n 'build.sh' -- "$@")
 eval set -- "$cmdline_args"
 
+script_path=`dirname $0`
+
+pushd $script_path/../
+BUILD_VERSION=$(cat build.property|grep "version"|cut -d ':' -f2|cut -d '-' -f1|cut -d '"' -f2|cut -d '.' -f1-3)
+popd
+echo "build_version: $BUILD_VERSION"
+
+MAJOR_VERSION=$(echo ${BUILD_VERSION}|cut -d '-' -f1|cut -d '.' -f1)
+echo "major_version=${MAJOR_VERSION}"
+
+
 if [ $# != 0 ]; then
   while true; do
     case "$1" in
@@ -75,10 +86,13 @@ pushd ${BUILD_PATH} > /dev/null
   rm -rf *
   if [[ ${MLUOP_BUILD_COVERAGE_TEST} == "ON" ]]; then
     echo "-- Build cambricon coverage test cases."
-    ${CMAKE}  ../ -DNEUWARE_HOME="${NEUWARE_HOME}" -DMLUOP_BUILD_COVERAGE_TEST="${MLUOP_BUILD_COVERAGE_TEST}"
+    ${CMAKE}  ../ -DNEUWARE_HOME="${NEUWARE_HOME}" \
+                  -DMLUOP_BUILD_COVERAGE_TEST="${MLUOP_BUILD_COVERAGE_TEST}"
   else
     echo "-- Build cambricon release test cases."
-    ${CMAKE}  ../ -DNEUWARE_HOME="${NEUWARE_HOME}"
+    ${CMAKE}  ../ -DNEUWARE_HOME="${NEUWARE_HOME}" \
+                  -DBUILD_VERSION="${BUILD_VERSION}" \
+                  -DMAJOR_VERSION="${MAJOR_VERSION}" 
   fi 
 
   if [[ ${MLUOP_BUILD_ASAN_CHECK} == "ON" ]]; then

--- a/build.property
+++ b/build.property
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1-1",
+  "version": "0.2.0-1",
   "build_requires": {"cntoolkit": ["release","3.0.1-1"]},
   "package_type": ["rpm","deb"]
 }

--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -19,7 +19,7 @@ BuildRequires: glibc-devel
 BuildRequires: binutils >= 2.27, redhat-rpm-config >= 9.1.0
 BuildRequires: readline-devel >= 6.2-4
 BuildRequires: rpm-devel
-BuildRequires: python-devel
+#BuildRequires: python-devel
 BuildRequires: texinfo-tex
 BuildRequires: /usr/bin/pod2man
 BuildRequires: texlive-ec texlive-cm-super
@@ -29,9 +29,9 @@ BuildRequires: valgrind >= 3.13.0
 BuildRequires: xz
 BuildRequires: doxygen
 BuildRequires: texlive-latex
-BuildRequires: python >= 2.7.0
-BuildRequires: cncc >= 2.6.0
-BuildRequires: cnas >= 2.6.0
+#BuildRequires: python >= 2.7.0
+#BuildRequires: cncc >= 2.6.0
+#BuildRequires: cnas >= 2.6.0
 Requires(post): /sbin/install-info
 Requires(preun): /sbin/install-info
 Requires: cndrv >= 0.2.0
@@ -54,8 +54,8 @@ bash independent_build.sh -t %{_packagetype}
 install -d $RPM_BUILD_ROOT%{neuware_dir}/lib64
 install -d $RPM_BUILD_ROOT%{neuware_dir}/include
 install -d $RPM_BUILD_ROOT/etc/ld.so.conf.d
-strip %{build_dir}/lib/libmluops.so
-cp %{build_dir}/lib/libmluops.so $RPM_BUILD_ROOT%{neuware_dir}/lib64/
+strip %{build_dir}/lib/libmluops.so*
+cp %{build_dir}/lib/libmluops.so* $RPM_BUILD_ROOT%{neuware_dir}/lib64/
 cp bangc-ops/mlu_op.h bangc-ops/mlu_op_kernel.h $RPM_BUILD_ROOT%{neuware_dir}/include/
 cp $RPM_SOURCE_DIR/neuware-env.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/
 

--- a/installer/centos7.5/SPECS/mluops.spec
+++ b/installer/centos7.5/SPECS/mluops.spec
@@ -54,8 +54,8 @@ bash independent_build.sh -t %{_packagetype}
 install -d $RPM_BUILD_ROOT%{neuware_dir}/lib64
 install -d $RPM_BUILD_ROOT%{neuware_dir}/include
 install -d $RPM_BUILD_ROOT/etc/ld.so.conf.d
-strip %{build_dir}/lib/libmluops.so
-cp %{build_dir}/lib/libmluops.so $RPM_BUILD_ROOT%{neuware_dir}/lib64/
+strip %{build_dir}/lib/libmluops.so*
+cp %{build_dir}/lib/libmluops.so* $RPM_BUILD_ROOT%{neuware_dir}/lib64/
 cp bangc-ops/mlu_op.h bangc-ops/mlu_op_kernel.h $RPM_BUILD_ROOT%{neuware_dir}/include/
 cp $RPM_SOURCE_DIR/neuware-env.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/
 

--- a/installer/independent/debian/install
+++ b/installer/independent/debian/install
@@ -1,3 +1,3 @@
-../../bangc-ops/build/lib/libmluops.so /usr/local/neuware/lib64
+../../bangc-ops/build/lib/libmluops.so* /usr/local/neuware/lib64
 ../../bangc-ops/mlu_op.h /usr/local/neuware/include
 ../../bangc-ops/mlu_op_kernel.h /usr/local/neuware/include

--- a/installer/ubuntu16.04/debian/install
+++ b/installer/ubuntu16.04/debian/install
@@ -1,3 +1,3 @@
-../../bangc-ops/build/lib/libmluops.so /usr/local/neuware/lib64
+../../bangc-ops/build/lib/libmluops.so* /usr/local/neuware/lib64
 ../../bangc-ops/mlu_op.h /usr/local/neuware/include
 ../../bangc-ops/mlu_op_kernel.h /usr/local/neuware/include


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

fix packaging configure files
## 2. Modification

modified:   .gitignore
modified:   bangc-ops/CMakeLists.txt
modified:   bangc-ops/build.sh
modified:   build.property
modified:   installer/centos7.5/SPECS/mluops-independent.spec
modified:   installer/centos7.5/SPECS/mluops.spec
modified:   installer/independent/debian/install
modified:   installer/ubuntu16.04/debian/install