### PR TITLE
[Fix](bangc-ops): fix centos install packgage configuration.

### DIFF
--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.3)
 
+project(mluops VERSION ${BUILD_VERSION})
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/test")
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
@@ -10,6 +11,8 @@ set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -Wl,--gc-s
 ################################################################################
 # Neuware Evironment and BANG Setup
 ################################################################################
+
+#project(mluops VERSION ${BUILD_VERSION})
 
 # set Coverage test setting
 if(${MLUOP_BUILD_COVERAGE_TEST} MATCHES "ON")

--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -12,9 +12,6 @@ set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -Wl,--gc-s
 # Neuware Evironment and BANG Setup
 ################################################################################
 
-#project(mluops VERSION ${BUILD_VERSION})
-
-# set Coverage test setting
 if(${MLUOP_BUILD_COVERAGE_TEST} MATCHES "ON")
   message("-- MLU_OP_COVERAGE_TEST=${MLUOP_BUILD_COVERAGE_TEST}")
   set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-u__llvm_profile_runtime ${NEUWARE_HOME}/lib/clang/11.0.0/lib/linux/libclang_rt.profile-x86_64.a")

--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -67,7 +67,7 @@ rm -rf $RPM_BUILD_DIR
 %defattr (-, root, root)
 %{neuware_dir}/include/mlu_op.h
 %{neuware_dir}/include/mlu_op_kernel.h
-%{neuware_dir}/lib64/libmluops.so
+%{neuware_dir}/lib64/libmluops.so*
 /etc/ld.so.conf.d/neuware-env.conf
 
 %post -p /sbin/ldconfig

--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -76,5 +76,6 @@ rm -rf $RPM_BUILD_DIR
 %changelog
 * Tue Sep 22 2022 Cambricon Software Team <service@cambricon.com>
 - release mluops v0.2.0
+
 * Tue Aug 31 2022 Cambricon Software Team <service@cambricon.com>
 - release mluops v0.1.1

--- a/installer/centos7.5/SPECS/mluops.spec
+++ b/installer/centos7.5/SPECS/mluops.spec
@@ -19,7 +19,7 @@ BuildRequires: glibc-devel
 BuildRequires: binutils >= 2.27, redhat-rpm-config >= 9.1.0
 BuildRequires: readline-devel >= 6.2-4
 BuildRequires: rpm-devel
-BuildRequires: python-devel
+#BuildRequires: python-devel
 BuildRequires: texinfo-tex
 BuildRequires: /usr/bin/pod2man
 BuildRequires: texlive-ec texlive-cm-super
@@ -29,9 +29,9 @@ BuildRequires: valgrind >= 3.13.0
 BuildRequires: xz
 BuildRequires: doxygen
 BuildRequires: texlive-latex
-BuildRequires: python >= 2.7.0
-BuildRequires: cncc >= 2.6.0
-BuildRequires: cnas >= 2.6.0
+#BuildRequires: python >= 2.7.0
+#BuildRequires: cncc >= 2.6.0
+#BuildRequires: cnas >= 2.6.0
 Requires(post): /sbin/install-info
 Requires(preun): /sbin/install-info
 Requires: cndrv >= 0.2.0
@@ -67,7 +67,7 @@ rm -rf $RPM_BUILD_DIR
 %defattr (-, root, root)
 %{neuware_dir}/include/mlu_op.h
 %{neuware_dir}/include/mlu_op_kernel.h
-%{neuware_dir}/lib64/libmluops.so
+%{neuware_dir}/lib64/libmluops.so*
 /etc/ld.so.conf.d/neuware-env.conf
 
 %post -p /sbin/ldconfig

--- a/installer/centos7.5/SPECS/mluops.spec
+++ b/installer/centos7.5/SPECS/mluops.spec
@@ -76,5 +76,6 @@ rm -rf $RPM_BUILD_DIR
 %changelog
 * Tue Sep 22 2022 Cambricon Software Team <service@cambricon.com>
 - release mluops v0.2.0
+
 * Tue Aug 31 2022 Cambricon Software Team <service@cambricon.com>
 - release mluops v0.1.1


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

fix centos install packgage configuration.
add project name into bangc-ops CMakeList

## 2. Modification

modified:   bangc-ops/CMakeLists.txt
modified:   installer/centos7.5/SPECS/mluops-independent.spec
modified:   installer/centos7.5/SPECS/mluops.spec
