### PR TITLE
[Perf](bangc-ops) Optimized Yolo_box operator performance on 300 plat…

### DIFF
--- a/bangc-ops/kernels/yolo_box/yolo_box_block.mlu
+++ b/bangc-ops/kernels/yolo_box/yolo_box_block.mlu
@@ -144,31 +144,26 @@ static __mlu_func__ void compute(
   T *nram_iou_p = nram_iou + offset;
 
 #if __BANG_ARCH__ >= 322
-  const int32_t x2d = 0x3fb8aa3b;
-  float log2e = *(float *)&x2d;
-  __bang_mul_scalar(nram_conf_p, nram_conf_p, (float)-1.0, deal_num);
-  __bang_mul_scalar(nram_conf_p, nram_conf_p, log2e, deal_num);
+  // compute mask
+  computeSigmoid(nram_conf_p, nram_conf_p, NULL, 0, deal_num);
   if (iou_aware == true) {
-    __bang_mul_scalar(nram_iou_p, nram_iou_p, (float)-1.0, deal_num);
-    __bang_mul_scalar(nram_iou_p, nram_iou_p, log2e, deal_num);
-  }
+    computeSigmoid(nram_iou_p, nram_iou_p, NULL, 0, deal_num);
+    if ((T)iou_aware_factor == (T)0.0) {
+      __bang_write_value(nram_iou_p, deal_num, (T)1.0);
+    } else if ((T)iou_aware_factor == (T)1.0) {
+      __bang_write_value(nram_conf_p, deal_num, (T)1.0);
+    } else {
+      __bang_log(nram_iou_p, nram_iou_p, deal_num);
+      __bang_mul_scalar(nram_iou_p, nram_iou_p, (T)iou_aware_factor, deal_num);
+      __bang_pow2(nram_iou_p, nram_iou_p, deal_num);
 
-  for (int32_t k = 0; k < deal_num; ++k) {
-    // sigmoid(conf)
-    nram_conf_p[k] = powf((T)2.0, nram_conf_p[k]);
-    nram_conf_p[k] = (T)1.0 / ((T)1.0 + nram_conf_p[k]);
-
-    if (iou_aware == true) {
-      // sigmoid(iou)
-      nram_iou_p[k] = powf((T)2.0, nram_iou_p[k]);
-      nram_iou_p[k] = (T)1.0 / ((T)1.0 + nram_iou_p[k]);
-
-      // pow(iou, iou_aware_factor)
-      nram_iou_p[k] = powf(nram_iou_p[k], (T)iou_aware_factor);
-      // pow(iou, 1-iou_aware_factor)
-      nram_conf_p[k] = powf(nram_conf_p[k], (T)1.0 - (T)iou_aware_factor);
-      nram_conf_p[k] = nram_conf_p[k] * nram_iou_p[k];
+      __bang_log(nram_conf_p, nram_conf_p, deal_num);
+      __bang_mul_scalar(nram_conf_p, nram_conf_p, (T)1.0 - (T)iou_aware_factor,
+                        deal_num);
+      __bang_pow2(nram_conf_p, nram_conf_p, deal_num);
     }
+
+    __bang_mul(nram_conf_p, nram_conf_p, nram_iou_p, deal_num);
   }
 
   __bang_ge_scalar(nram_iou_p, nram_conf_p, (T)conf_thresh, deal_num);
@@ -1129,32 +1124,26 @@ static __mlu_func__ void computeScore(T *nram_iou, T *nram_conf, T *nram_cls,
   T *nram_cls_p = nram_cls + offset;
 
 #if __BANG_ARCH__ >= 322
-  // compute score_mask
-  const int32_t x2d = 0x3fb8aa3b;
-  float log2e = *(float *)&x2d;
-  __bang_mul_scalar(nram_conf_p, nram_conf_p, (float)-1.0, deal_num);
-  __bang_mul_scalar(nram_conf_p, nram_conf_p, log2e, deal_num);
+  // compute mask
+  computeSigmoid(nram_conf_p, nram_conf_p, NULL, 0, deal_num);
   if (iou_aware == true) {
-    __bang_mul_scalar(nram_iou_p, nram_iou_p, (float)-1.0, deal_num);
-    __bang_mul_scalar(nram_iou_p, nram_iou_p, log2e, deal_num);
-  }
+    computeSigmoid(nram_iou_p, nram_iou_p, NULL, 0, deal_num);
+    if ((T)iou_aware_factor == (T)0.0) {
+      __bang_write_value(nram_iou_p, deal_num, (T)1.0);
+    } else if ((T)iou_aware_factor == (T)1.0) {
+      __bang_write_value(nram_conf_p, deal_num, (T)1.0);
+    } else {
+      __bang_log(nram_iou_p, nram_iou_p, deal_num);
+      __bang_mul_scalar(nram_iou_p, nram_iou_p, (T)iou_aware_factor, deal_num);
+      __bang_pow2(nram_iou_p, nram_iou_p, deal_num);
 
-  for (int32_t k = 0; k < deal_num; ++k) {
-    // sigmoid(conf)
-    nram_conf_p[k] = powf((T)2.0, nram_conf_p[k]);
-    nram_conf_p[k] = (T)1.0 / ((T)1.0 + nram_conf_p[k]);
-
-    if (iou_aware == true) {
-      // sigmoid(iou)
-      nram_iou_p[k] = powf((T)2.0, nram_iou_p[k]);
-      nram_iou_p[k] = (T)1.0 / ((T)1.0 + nram_iou_p[k]);
-
-      // pow(iou, iou_aware_factor)
-      nram_iou_p[k] = powf(nram_iou_p[k], (T)iou_aware_factor);
-      // pow(iou, 1-iou_aware_factor)
-      nram_conf_p[k] = powf(nram_conf_p[k], (T)1.0 - (T)iou_aware_factor);
-      nram_conf_p[k] = nram_conf_p[k] * nram_iou_p[k];
+      __bang_log(nram_conf_p, nram_conf_p, deal_num);
+      __bang_mul_scalar(nram_conf_p, nram_conf_p, (T)1.0 - (T)iou_aware_factor,
+                        deal_num);
+      __bang_pow2(nram_conf_p, nram_conf_p, deal_num);
     }
+
+    __bang_mul(nram_conf_p, nram_conf_p, nram_iou_p, deal_num);
   }
 
   __bang_ge_scalar(nram_iou_p, nram_conf_p, (T)conf_thresh, deal_num);


### PR DESCRIPTION
# 2. 性能测试

详见：[MLU-OPS性能验收标准](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS性能验收标准.md)

参考接口性能：

| 平台                 | 框架版本 | 数据类型 | 规模                                                         | 计算效率  | IO效率  | Hardware Time（us） |
| :------------------- | :------- | :------- | :----------------------------------------------------------- | :-------- | :------ | :------------------ |
| Tesla V100-SXM2 16GB | paddle   | float    | img_size=[8, 2]<br />x=[8, 255, 19, 19]<br />anchors[6]<br />class_num=80 | 4.080262% | 26.336% | 70.9472             |
| Tesla V100-SXM2 16GB | paddle   | float    | img_size=[8, 2]<br />x=[8, 255, 38, 38]<br />anchors[6]<br />class_num=80 | 3.62%     | 23.285% | 316.387             |
| Tesla V100-SXM2 16GB | paddle   | float    | img_size=[8, 2]<br />x=[8, 255, 76, 76]<br />anchors[6]<br />class_num=80 | 1.2599%   | 18.447% | 3592.198            |

平台：MLU290

| operator | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency | mlu_compute_efficiency | mlu_workwpace_size(Bytes) | data_type | shape                                                      |
| :------- | :-------------------- | :--------------------- | :---------------- | :--------------------- | :------------------------ | :-------- | :--------------------------------------------------------- |
| yolo_box | 12902                 | 195.899                | 0.044%            | 0.084%                 | 0                         | float     | img_size=[8, 2] x=[8, 255, 19, 19] anchors[6] class_num=80 |
| yolo_box | 13374                 | 45.27                  | 0.171%            | 0.322%                 | 0                         | float     | img_size=[8, 2] x=[8, 255, 38, 38] anchors[6] class_num=80 |
| yolo_box | 20922                 | 92.679                 | 0.437%            | 0.825%                 | 0                         | float     | img_size=[8, 2] x=[8, 255, 76, 76] anchors[6] class_num=80 |

平台：MLU370

| operator | mlu_hardware_time(us) | mlu_interface_time(us) | mlu_io_efficiency | mlu_compute_efficiency | mlu_workwpace_size(Bytes) | data_type | shape                                                      |
| :------- | :-------------------- | :--------------------- | :---------------- | :--------------------- | :------------------------ | :-------- | :--------------------------------------------------------- |
| yolo_box | 321                   | 110459                 | 5.94%             | 6.72%                  | 0                         | float     | img_size=[8, 2] x=[8, 255, 19, 19] anchors[6] class_num=80 |
| yolo_box | 594                   | 50.91                  | 12.79%            | 14.48%                 | 0                         | float     | img_size=[8, 2] x=[8, 255, 38, 38] anchors[6] class_num=80 |
| yolo_box | 1253                  | 51.32                  | 24.35%            | 27.55%                 | 0                         | float     | img_size=[8, 2] x=[8, 255, 76, 76] anchors[6] class_num=80 |

# 3. 总结分析

总结分析主要需要考虑以下几点：

1. 200上因激活函数精度问题和取值范围限制，部分计算过程采用标量计算，因此性能有较大下降；