### PR TITLE
[Fix](bangc-ops): fix centos build dir name for package build.

### DIFF
--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -1,7 +1,7 @@
 %define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
 %define neuware_dir /usr/local/neuware
-%define build_dir package
+%define build_dir bangc-ops/build
 
 Name: mluops
 Summary: The Machine Lerning Unit OPerators

--- a/installer/centos7.5/SPECS/mluops.spec
+++ b/installer/centos7.5/SPECS/mluops.spec
@@ -1,7 +1,7 @@
 %define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
 %define neuware_dir /usr/local/neuware
-%define build_dir package
+%define build_dir bangc-ops/build
 
 Name: mluops
 Summary: The Machine Lerning Unit OPerators


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

fix centos build dir name for package build.

## 2. Modification
modified:   installer/centos7.5/SPECS/mluops-independent.spec
modified:   installer/centos7.5/SPECS/mluops.spec
