### PR TITLE
[Fix](bangc-ops):fix the scores has same value.

### DIFF
--- a/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.cpp
@@ -84,7 +84,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetGenerateProposalsV2WorkspaceSize(
                << " Currently, MLU-OPS supports tensor size smaller than 2^31.";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
-  *size = 6 * A * H * W * 4 +
+  *size = 7 * A * H * W * 4 +
           handle->cluster_num * handle->core_num_per_cluster * 4 * 3;
   return MLUOP_STATUS_SUCCESS;
 }

--- a/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
+++ b/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
@@ -51,7 +51,7 @@ __mlu_func__ void getMaxScoreIndex(const T *proposal_scores, int *max_index,
   int repeat = core_num / max_seg_num;
   int remain = core_num % max_seg_num;
 
-  // worksapce
+  // workspace
   T *score_reduce = reduce_buffer;
   T *index_reduce = score_reduce + taskDim;
 
@@ -153,9 +153,41 @@ __mlu_func__ void getComputeParams(const int input_num, const int limit,
 }
 
 template <typename T>
+__mlu_func__ void getSameScoresCount(T *scores_ptr, const int scores_num,
+                                     const T value, int *ret_ge_count) {
+  const int memory_block = 2;
+  int limit = PROPOSAL_NRAM_SIZE / memory_block;
+  int max_seg_num = FLOOR_ALIGN(limit / sizeof(T), ALIGN_NUM);
+  int repeat = scores_num / max_seg_num;
+  int remain_num = scores_num % max_seg_num;
+
+  T *scores = (T *)nram_buffer;
+  T *mask_ge = scores + max_seg_num;
+
+  int ge_count = 0;
+  for (int seg_id = 0; seg_id <= repeat; ++seg_id) {
+    if (seg_id == repeat && remain_num == 0) {
+      break;
+    }
+    int actual_num = (seg_id == repeat) ? remain_num : max_seg_num;
+    int actual_num_align = CEIL_ALIGN(actual_num, ALIGN_NUM);
+
+    __memcpy(scores, scores_ptr + seg_id * max_seg_num, actual_num * sizeof(T),
+             GDRAM2NRAM);
+    __bang_ge_scalar(mask_ge, scores, value, actual_num_align);
+    for (int i = actual_num; i < actual_num_align; i++) {
+      mask_ge[i] = 0;
+    }
+    ge_count += __bang_count(mask_ge, actual_num_align);
+  }
+
+  ret_ge_count[0] = ge_count;
+}
+
+template <typename T>
 __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
                               const int pre_nms_top_n, const int HWA,
-                              T *k_score) {
+                              T *k_score, bool *cp_scores_to_workspace) {
   // nram sapace: N = max_seg_num
   // | result    | scores | ge_mask |
   // | ALIGN_NUM | N      |    4*N  |
@@ -228,6 +260,7 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
   T dn = -up;
   T mid = dn + (up - dn) * 0.5;
 
+  bool scores_has_same_value = false;
   while (true) {
     if (taskDim != 1) {
       __sync_all_ipu();
@@ -264,6 +297,7 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
     if (cnt == pre_nms_top_n) {
       break;
     } else if ((cnt > pre_nms_top_n) && (mid == up || mid == dn)) {
+      scores_has_same_value = true;
       break;
     }
 
@@ -276,6 +310,72 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
     mid = dn + (up - dn) * 0.5;
   }
   k_score[0] = mid;
+  *cp_scores_to_workspace = scores_has_same_value;
+
+  if (scores_has_same_value) {
+    if (taskId == 0) {
+      __memcpy(workspace, intput_scores_ptr, HWA * sizeof(T), GDRAM2GDRAM);
+#if __BANG_ARCH__ >= 322
+      const int memory_block = 2;
+#else
+      const int memory_block = 3;
+#endif
+      int limit = PROPOSAL_NRAM_SIZE / memory_block;
+
+      int max_seg_num = FLOOR_ALIGN(limit / sizeof(T), ALIGN_NUM);
+      int repeat = HWA / max_seg_num;
+      int remain_num = HWA % max_seg_num;
+
+      T *scores = (T *)nram_buffer;
+      T *mask_eq = scores + max_seg_num;
+      // T * mask_ge = mask_eq + max_seg_num;
+
+      int cycle = 0;
+      int total_cycle = HWA;
+      while (total_cycle--) {
+        cycle++;
+
+        for (int seg_id = repeat; seg_id >= 0; --seg_id) {
+          if (seg_id == repeat && remain_num == 0) {
+            continue;
+          }
+          int actual_num = (seg_id == repeat) ? remain_num : max_seg_num;
+          int actual_num_align = CEIL_ALIGN(actual_num, ALIGN_NUM);
+
+          __memcpy(scores, workspace + seg_id * max_seg_num,
+                   actual_num * sizeof(T), GDRAM2NRAM);
+#if __BANG_ARCH__ >= 322
+          __bang_eq_scalar(mask_eq, scores, k_score[0], actual_num_align);
+#else
+          T *tmp = mask_eq + max_seg_num;
+          __bang_write_value(tmp, actual_num_align, k_score[0]);
+          __bang_eq(mask_eq, scores, tmp, actual_num_align);
+#endif
+
+          for (int i = actual_num; i < actual_num_align; i++) {
+            mask_eq[i] = 0;
+          }
+          int count = __bang_count(mask_eq, actual_num_align);
+          if (count == 0) {
+            continue;
+          }
+
+          int eq_score_index = __bang_findlast1(mask_eq, actual_num_align);
+          eq_score_index = eq_score_index + seg_id * max_seg_num;
+          workspace[eq_score_index] = FLOAT_MIN;
+          break;
+        }
+
+        int ge_count = 0;
+        getSameScoresCount(workspace, HWA, k_score[0], &ge_count);
+
+        if (ge_count == pre_nms_top_n) {
+          break;
+        }
+      }
+    }
+    __sync_all_ipu();
+  }
 }
 
 template <typename T>
@@ -574,14 +674,12 @@ __mlu_func__ void loadAndTranspose(T *trans, const T *gdram_ptr,
 }
 
 template <typename T>
-__mlu_func__ void createAndRemoveBox(T *output_scores, T *output_boxes,
-                                     const T *intput_scores_ptr,
-                                     const T *bbox_deltas_ptr,
-                                     const T *im_shape, const T *anchors_ptr,
-                                     const T *variances_ptr, T *worksapce,
-                                     const T k_score, const int HWA,
-                                     const T min_size, bool pixel_offset,
-                                     bool need_collect, int *proposals_num) {
+__mlu_func__ void createAndRemoveBox(
+    T *output_scores, T *output_boxes, const T *intput_scores_ptr,
+    const T *bbox_deltas_ptr, const T *im_shape, const T *anchors_ptr,
+    const T *variances_ptr, T *workspace, const T k_score, const int HWA,
+    const int pre_nms_top_n, const T min_size, bool pixel_offset,
+    bool need_collect, int *proposals_num) {
 // nram  n = max_seg_num, transpose: 200 32N, 300 4N
 // | scores | anchors | var | deltals | proposals | ge_mask | nram |
 // MLU300
@@ -608,7 +706,7 @@ __mlu_func__ void createAndRemoveBox(T *output_scores, T *output_boxes,
                    &remain_num, &core_num, &core_offset);
 
   // init workspace ptr
-  int *collect_num = (int *)((char *)worksapce);
+  int *collect_num = (int *)((char *)workspace);
   collect_num[taskId] = 0;
 
   // init nram ptr
@@ -789,7 +887,7 @@ __mlu_func__ void nonMaximumSuppress(T *output_boxes_ptr, T *output_scores_ptr,
                                      const int max_output_num,
                                      const int scores_num, bool pixel_offset,
                                      const int box_stride) {
-  // worksapce
+  // workspace
   // | box_area_gdram | stop_flag | reduce_buffer |
   // |   scores_num   | stop_flag | 2 * taskDim   |
 
@@ -976,8 +1074,8 @@ __mlu_func__ void nonMaximumSuppress(T *output_boxes_ptr, T *output_scores_ptr,
         __bang_sub(inter_y2, inter_y2, inter_y1, actual_num_align);
 
         __bang_write_value(tmp1, actual_num_align, (T)0.0);
-        __bang_maxequal(inter_x1, inter_x1, tmp1, actual_num_align);
-        __bang_maxequal(inter_y1, inter_y1, tmp1, actual_num_align);
+        __bang_maxequal(inter_x1, inter_x2, tmp1, actual_num_align);
+        __bang_maxequal(inter_y1, inter_y2, tmp1, actual_num_align);
 
         // inter_s = width * height;
         __bang_mul(inter_s, inter_x1, inter_y1, actual_num_align);
@@ -1013,21 +1111,31 @@ __mlu_func__ void ProposalForOneImage(
   T k_score = 0.0f;
   bool need_top_k = (HWA > pre_nms_top_n && pre_nms_top_n > 0);
 
+  bool cp_scores_to_workspace = false;
   if (need_top_k) {
-    getKthScore(scores, workspace, pre_nms_top_n, HWA, &k_score);
+    getKthScore(scores, workspace, pre_nms_top_n, HWA, &k_score,
+                &cp_scores_to_workspace);
   }
 
   if (taskDim != 1) {
     __sync_all_ipu();
   }
+  const T *scores_ptr = scores;
   T *proposal_scores = (T *)workspace;
+  if (cp_scores_to_workspace) {
+    scores_ptr = (T *)workspace;
+    proposal_scores = (T *)workspace + HWA;
+  }
+
   T *proposal_boxes = proposal_scores + HWA;
   T *workspace_buffer = proposal_boxes + 4 * HWA;
   int proposals_num = 0;
+
   // output: proposal_scores(workspace), proposal_boxes(workspace, stride=HWA)
-  createAndRemoveBox(proposal_scores, proposal_boxes, scores, bbox_deltas,
+  createAndRemoveBox(proposal_scores, proposal_boxes, scores_ptr, bbox_deltas,
                      im_shape, anchors, variances, workspace_buffer, k_score,
-                     HWA, min_size, pixel_offset, need_top_k, &proposals_num);
+                     HWA, pre_nms_top_n, min_size, pixel_offset, need_top_k,
+                     &proposals_num);
 
   if (proposals_num == 0) {
     rpn_rois_num[0] = 1;
@@ -1075,11 +1183,11 @@ __mlu_global__ void mluOpGenerateProposalsV2Kernel(
     T *rpn_roi_probs_slice = rpn_roi_probs + all_proposals_num;
     int *rpn_rois_num_slice = rpn_rois_num + batch_id;
 
-    ProposalForOneImage(
-        scores_slice, bbox_deltas_slice, im_shape_slice, anchors_slice,
-        variances_slice, workspace, rpn_rois_slice, rpn_roi_probs_slice,
-        rpn_rois_num_slice, &one_image_proposals_num, pre_nms_top_n,
-        post_nms_top_n, nms_thresh, min_size, pixel_offset, HWA);
+    ProposalForOneImage(scores_slice, bbox_deltas_slice, im_shape_slice,
+                        anchors_slice, variances_slice, workspace,
+                        rpn_rois_slice, rpn_roi_probs_slice, rpn_rois_num_slice,
+                        &one_image_proposals_num, pre_nms_top_n, post_nms_top_n,
+                        nms_thresh, min_size, pixel_offset, HWA);
     all_proposals_num += one_image_proposals_num;
   }
   *rpn_rois_batch_size = all_proposals_num;

--- a/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
+++ b/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
@@ -328,7 +328,6 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
 
       T *scores = (T *)nram_buffer;
       T *mask_eq = scores + max_seg_num;
-      // T * mask_ge = mask_eq + max_seg_num;
 
       int cycle = 0;
       int total_cycle = HWA;

--- a/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
+++ b/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
@@ -153,7 +153,7 @@ __mlu_func__ void getComputeParams(const int input_num, const int limit,
 }
 
 template <typename T>
-__mlu_func__ void getSameScoresCount(T *scores_ptr, const int scores_num,
+__mlu_func__ void getSameScoresCount(const T *scores_ptr, const int scores_num,
                                      const T value, int *ret_ge_count) {
   const int memory_block = 2;
   int limit = PROPOSAL_NRAM_SIZE / memory_block;
@@ -705,7 +705,7 @@ __mlu_func__ void createAndRemoveBox(
                    &remain_num, &core_num, &core_offset);
 
   // init workspace ptr
-  int *collect_num = (int *)((char *)workspace);
+  int *collect_num = (int *)workspace;
   collect_num[taskId] = 0;
 
   // init nram ptr

--- a/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
+++ b/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.mlu
@@ -312,6 +312,7 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
   k_score[0] = mid;
   *cp_scores_to_workspace = scores_has_same_value;
 
+  __sync_all_ipu();
   if (scores_has_same_value) {
     if (taskId == 0) {
       __memcpy(workspace, intput_scores_ptr, HWA * sizeof(T), GDRAM2GDRAM);
@@ -373,7 +374,6 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
         }
       }
     }
-    __sync_all_ipu();
   }
 }
 

--- a/docs/bangc-docs/design_docs/generate_proposals_v2/generate_proposals_v2.md
+++ b/docs/bangc-docs/design_docs/generate_proposals_v2/generate_proposals_v2.md
@@ -253,7 +253,7 @@ Tensor(shape=[2, 4], dtype=float32, place=Place(gpu:0), stop_gradient=True,
 ### 1.5 验收标准
 #### 1.5.1 精度验收标准
 
-按照[精度验收标准](../MLU_OPS精度验收标准.md)的要求明确本算子的精度标准。
+按照[精度验收标准](../../../MLU-OPS精度验收标准.md)的要求明确本算子的精度标准。
 `generate_proposals_v2` 是复合类算子。<br>
 `rpn_rois`参数精度设为 diff1 <= 3e-3 && diff2 <=3e-3。<br>
 `rpn_roi_probs`、`rpn_rois_num`、`rpn_rois_batch_size`的精度设置为 diff3=0。
@@ -395,8 +395,8 @@ int rem_num = per_core_num % seg_pad_k;
 // | seg_pad_k |  seg_pad_k |
 
 // workspace: topK时存放每个core上计算出来的最大值和index
-// | max_score | max_index |
-// |  taskDim  |  taskDim  |
+// | input_scores | max_score | max_index |
+// |  HWA         | taskDim   |  taskDim  |
 ```
 
 #### 3.1.2 createAndRemoveBoxes 实现


### PR DESCRIPTION
影响范围/算子：generate_proposals_v2
影响版本/分支：master
1.1 精度验收标准
按照[精度验收标准](https://github.com/Cambricon/mlu-ops/blob/1dd886d78b53f9e3b4783b948b7ba28b422f4851/docs/bangc-docs/design_docs/MLU_OPS%E7%B2%BE%E5%BA%A6%E9%AA%8C%E6%94%B6%E6%A0%87%E5%87%86.md)的要求明确本算子的精度标准

 generate_proposals_v2 是复合类算子。
rpn_rois参数精度设为 diff1 <= 3e-3 && diff2 <=3e-3。
rpn_roi_probs、rpn_rois_num、rpn_rois_batch_size的精度设置为 diff3=0。

1.2 算子方案CHECKLIST
序号 | 需求 | 需求详情
-- | -- | --
1 | 支持硬件 | MLU270MLU290MLU370
2 | job类型 | blockU1U4Ux
3 | DimXYZ | 支持DimXYZ
4 | 可变 | 不支持各个维度可变
5 | layout | ARRAY
6 | 多维 | 不支持多维
7 | 0元素 | 支持0元素
8 | 转数提前 | 否
9 | 片上数据类型 | float
10 | 片外数据类型 | float
11 | 融合 | 否
12 | 规模限制 |  
13 | c不感知对齐 | 否
14 | 代码覆盖率 |  
15 | 内存泄露 | 无
16 | IO计算效率检查 | 是

<h5 class="code-line" id="generate_proposals_v2算子测试报告-1.3算子限制" style="margin: 20px 0px 0px; padding: 0px; color: rgb(94, 108, 132); font-weight: 600; text-transform: none; font-size: 14px; line-height: 1.66667; letter-spacing: normal; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; text-indent: 0px; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">1.3 算子限制</h5><div class="table-wrap" style="margin: 10px 0px 0px; padding: 0px; overflow-x: auto; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

限制类型 | 详细说明
-- | --
stride限制 | 不支持stride
原位限制 | 不支持原位
广播限制 | 不支持广播
数据类型限制 | scores、bbox_deltas、anchors、variances只支持 float 输入pre_nms_top_n、post_nms_top_n只支持int类型输入nms_thresh、min_size只支持 float 输入
数据范围限制 | 无
输入限制 | 输入参数shape必须满足要求:scores：[N, H, W, A]bbox_deltas:[N, H, W, A*4]img_size: [N, 2]anchors[H, W, A, 4]variances[H, W, A, 4]
输入限制 | 输出参数shape必须满足要求:rpn_rois:[N * post_nms_top_n, 4]，实际输出的维度信息为[rpn_rois_batch_size, 4]rpn_roi_probs:[N * post_nms_top_n, 1], 实际输出的维度信息为[rpn_rois_batch_size, 1]rpn_rois_num:[N]rpn_rois_batch_size:[1], dim=1, shape[0]=1
输入限制 | 输入参数eta表示自适应NMS，当前不支持，和竞品保持一致，参数保留，输入满足 eta >=1.0
输入限制 | 输入参数nms_thresh > 0
输入限制 | 输入参数scores、bbox_deltas、anchors、variances、img_size中包含nan或者inf时，行为不保证与竞品一致。

</div>
<p style="margin: 10px 0px 0px; padding: 0px;"><span style="color: rgb(94, 108, 132); font-weight: 600; letter-spacing: 0px;">1.4新特性测试</span></p><div class="table-wrap" style="margin: 10px 0px 0px; padding: 0px; overflow-x: auto;">

测试点 | 验收标准 | 测试结果（精度）
-- | -- | --
数据类型测试 | float | MLU-OPS下暂不支持贴图，目前只需粘贴复制结果就行
多维张量测试 |   | 见稳定性测试
Layout测试 | 支持ARRAY | 见稳定性测试
不同规模/整数余数/对齐不对齐 |   | 见稳定性测试
零维张量测试/0元素测试 | 通过 | [MLUOP] [Vlog]:[mluOpGenerateProposalsV2] skip zero element tensor.  [MLUOP] [Vlog]:[mluOpGenerateProposalsV2] mluOpGenerateProposalsV2 end.
稳定性测试 | gtest 多线程+repeat使用--gtest_repeat=NUM --thread=NUM | --gtest_repeat=100<br>MLU270<br>[----------] 216 tests from generate_proposals_v2/TestSuite (35335 ms total)<br>[----------] Global test environment tear-down[ SUMMARY ] Total 21600 cases of 100 op(s).ALL PASSED.<br>[==========] 216 test cases from 1 test suite ran. (35339 ms total)<br>[ PASSED ] 216 test cases.<br>MLU290<br>[----------] 216 tests from generate_proposals_v2/TestSuite (35823 ms total)<br>[----------] Global test environment tear-down[ SUMMARY ] Total 21600 cases of 100 op(s).ALL PASSED.<br>[==========] 216 test cases from 1 test suite ran. (35825 ms total)[ PASSED ] 216 test cases.<br>MLU370x4<br>[----------] 216 tests from generate_proposals_v2/TestSuite (38252 ms total)<br>[----------] Global test environment tear-down[ SUMMARY ] Total 21600 cases of 100 op(s).ALL PASSED.[==========] 216 test cases from 1 test suite ran. (38253 ms total)[ PASSED ] 216 test cases.
多平台测试 | 270,290和370平台 | 见稳定性测试
gen_case模块测试 | gen_case模块生成的测例测试通过 | [----------] 6 tests from generate_proposals_v2/TestSuite (2896 ms total)[----------] Global test environment tear-down[ SUMMARY ] Total 6 cases of 1 op(s).ALL PASSED.[==========] 6 test cases from 1 test suite ran. (2924 ms total)[ PASSED ] 6 test cases.
nan/inf测试 | 本次提交不支持 |  
其他测试点 |   |  

</div><p style="margin: 10px 0px 0px; padding: 0px;"><br style="color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">


</div><p style="margin: 10px 0px 0px; padding: 0px; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><br></p><br class="Apple-interchange-newline">
1.5 参数检查
提交新算子时，给出测试点，并说明测试结果。

<div class="table-wrap" style="margin: 10px 0px 0px; padding: 0px; overflow-x: auto; color: rgb(23, 43, 77); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

测试点 | 验收标准 | 测试结果（出错信息）
-- | -- | --
不符合算子限制 | 正常报错 | 1.输入的scores、bbox_deltas、anchors、variances、img_size不满足维度要求。<br>- bbox_deltas[N, H, W, A*4] dims[1] != H<br>[Error]:[mluOpGenerateProposalsV2] Check failed: bbox_deltas_desc->dims[1] == H.<br> [2022-9-15 13:59:9] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV2- bbox_deltas[N, H, W, A*4] dims[2] != W<br>[2022-9-15 14:0:14] [MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: bbox_deltas_desc->dims[2] == W.<br>[2022-9-15 14:0:14] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV2<br>- bbox_deltas[N, H, W, A*4] dims[0] != N<br>[2022-9-15 14:0:52] [MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: bbox_deltas_desc->dims[0] == N. <br>[2022-9-15 14:0:52] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV2<br><br>- bbox_deltas[N, H, W, A*4] dims[3] != 4*A<br>[2022-9-15 14:1:56] [MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: bbox_deltas_desc->dims[3] == 4 * A.[2022-9-15 14:1:56] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV2anchors[H,W,A,4] dims[3] !=4<br>[mluOpGenerateProposalsV2] Check failed: anchors_desc->dims[3] == 4. [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV2img_size[N,2], dims[1] != 2<br>[MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: im_shape_desc->dims[1] == 2.<br> [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV22.  rpn_rois，rpn_roi_probs，rpn_rois_num，rpn_rois_batch_size不满足维度要求<br>- rpn_rois[N*post_nms_top_n, 4] dims[1] != 4  <br>[MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: rpn_rois_desc->dims[1] == 4.<br>- rpn_rois[N*post_nms_top_n, 4] dims[0] !=N*post_nms_top_n[MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: rpn_rois_desc->dims[0] == N * post_nms_top_n.- rpn_roi_probs[N*post_nms_top_n, 1] dims[0] !=N*post_nms_top_n<br>[MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: rpn_roi_probs_desc->dims[0] == N * post_nms_top_n.- rpn_roi_probs[N*post_nms_top_n, 1] dims[1] !=1[MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: rpn_roi_probs_desc->dims[1] == 1.<br>- rpn_rois_num[N] dims[0] !=N[MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: rpn_rois_num_desc->dims[0] == N.<br>- rpn_rois_num[N] dim  != 1[MLUOP] [Error]:[mluOpGenerateProposalsV2] Check failed: rpn_rois_num_desc->dim == 1.<br>3. 输入参数 eta不满足要求 [MLUOP] [Error]:[mluOpGenerateProposalsV2] Not support adaptive NMS. The attribute 'eta' should not less than 1. But received eta=[0.5] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV2<br>4 输入参数 nms_thresh不满足要求[2022-9-15 14:15:10] [MLUOP] [Error]:[mluOpGenerateProposalsV2] nms_thresh should be more than 0. But received nms_thresh=[-0.5]<br> [2022-9-15 14:15:10] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGenerateProposalsV25.  large tensor报错[MLUOP] [Error]:[mluOpGenerateProposalsV2] Overflow max tensor size. Currently, MLU-OPS supports tensor size smaller than 2^31.[2022-9-15 16:6:16] [MLUOP] [Error]:"MLUOP_STATUS_NOT_SUPPORTED in mluOpGetGenerateProposalsV2WorkspaceSize
非法参数传递 | 正常报错 |  
  |   |  

</div><br class="Apple-interchange-newline">

2 性能测试
要排除机器环境的影响，找一个可以独占的服务器来做性能测试；
用于性能测试的测试例，推荐使用此算子在典型网络中的规模，并构造不同维度范围的规模进行测试；
建议测试相同规模/参数，不同 datatype（例如 half/float）的性能，分析加速比是否合理；
算子 latency 建议既包括 end2end time，也包括 kernel time （hardware time），目的是能够比较清楚的看到加载时、运行时的耗时分布。
测试poly_nms算子性能； 需求提供的网络中算子规模较多，有62个， 选取其中5个网络规模做性能测试

测试规模 [N,H,W,A]：[1, 54, 40,15], [1, 200, 272, 3],[1, 13, 17, 3],[1, 88, 120, 3],[50, 54, 20, 3]

pre_nms_top_n=12000,post_nms_top_n=2000,nms_thresh=.5,min_size=.1,eta=1；

2.1 算子io利用率、计算效率
平台：MLU370  X4K， cntoolkit 3.0.1, cncc 4.01


2.2 竞品效率
这里可以参考：[竞品算子性能分析](http://wiki.cambricon.com/pages/viewpage.action?pageId=91456952)



2.3 内存泄露
export MLUOP_BUILD_ASAN_CHECK=ON，打开环境变量正常测试：[MLU_OPS 内存泄漏检查使用](http://wiki.cambricon.com/pages/viewpage.action?pageId=108022599)

通过测试，没有内存泄露。

2.4 代码覆盖率
[MLU_OPS 算子开发流程](http://wiki.cambricon.com/pages/viewpage.action?pageId=101238377)



3. 总结分析
综合测试结果，generate_proposals_v2算子功能和性能满足验收条件。