### PR TITLE
[Feature](bangc-ops): modify gtest to support complex data type

### DIFF
--- a/bangc-ops/core/tensor.h
+++ b/bangc-ops/core/tensor.h
@@ -279,17 +279,24 @@ inline int mluOpDataTypeBytes(const mluOpDataType_t dt) {
     case MLUOP_DTYPE_HALF:
       return 2;
     case MLUOP_DTYPE_FLOAT:
+    case MLUOP_DTYPE_COMPLEX_HALF:
       return 4;
+    case MLUOP_DTYPE_DOUBLE:
+    case MLUOP_DTYPE_COMPLEX_FLOAT:
+      return 8;
     case MLUOP_DTYPE_INT8:
     case MLUOP_DTYPE_UINT8:
     case MLUOP_DTYPE_BOOL:
       return 1;
     case MLUOP_DTYPE_INT16:
+    case MLUOP_DTYPE_UINT16:
       return 2;
     // case MLUOP_DTYPE_INT23:   return 3;
     case MLUOP_DTYPE_INT32:
+    case MLUOP_DTYPE_UINT32:
       return 4;
     case MLUOP_DTYPE_INT64:
+    case MLUOP_DTYPE_UINT64:
       return 8;
     default:
       return -1;

--- a/bangc-ops/core/type.cpp
+++ b/bangc-ops/core/type.cpp
@@ -31,14 +31,20 @@ size_t getSizeOfDataType(mluOpDataType_t dtype) {
       return 1;
     }
     case MLUOP_DTYPE_INT16:
+    case MLUOP_DTYPE_UINT16:
     case MLUOP_DTYPE_HALF: {
       return 2;
     }
     case MLUOP_DTYPE_INT32:
-    case MLUOP_DTYPE_FLOAT: {
+    case MLUOP_DTYPE_UINT32:
+    case MLUOP_DTYPE_FLOAT:
+    case MLUOP_DTYPE_COMPLEX_HALF: {
       return 4;
     }
-    case MLUOP_DTYPE_INT64: {
+    case MLUOP_DTYPE_INT64:
+    case MLUOP_DTYPE_UINT64:
+    case MLUOP_DTYPE_DOUBLE:
+    case MLUOP_DTYPE_COMPLEX_FLOAT: {
       return 8;
     }
     default: {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

To enable the mlu-ops to support complex data type case tests

## 2. Modification

Modified the gtest code to support complex data type test case

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).

### 3.1. Test Copy Op
Note: Google Test filter = copy*
[==========] Running 16 test cases from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from copy/TestSuite
[ RUN      ] copy/TestSuite.mluOp/0

[MLU Hardware Time     ]: 2 (us)
[MLU Interface Time    ]: 64.959 (us)
[MLU IO Efficiency     ]: 0.000260417
[MLU Compute Efficiency]: 4.88281e-06
[MLU Workspace Size    ]: -1 (Bytes)
[MLU TheoryOps         ]: 10 (Ops)
[MLU TheoryIOs         ]: 160 (Bytes)
[MLU ComputeForce      ]: 1.024e+12 (op/s)
[MLU IoBandWidth       ]: 307.2 (GB/s)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[^      OK ] /workspace/volume/platform/wushaoqiang/op_test_case/copy/copy_data_included_complex_float_1665564467883.prototxt
[       OK ] copy/TestSuite.mluOp/0 (2 ms)
[ RUN      ] copy/TestSuite.mluOp/1

[----------] Global test environment tear-down
[ SUMMARY ] Total 16 cases of 1 op(s).
ALL PASSED.
[==========] 16 test cases from 1 test suite ran. (89 ms total)
[ PASSED ] 16 test cases.

### 3.2. Test Expand Op
Note: Google Test filter = expand*
[==========] Running 17 test cases from 1 test suite.
[----------] Global test environment set-up.
[----------] 17 tests from expand/TestSuite
[ RUN      ] expand/TestSuite.mluOp/0

[MLU Hardware Time     ]: 6 (us)
[MLU Interface Time    ]: 72.719 (us)
[MLU IO Efficiency     ]: 0.000438368
[MLU Compute Efficiency]: 1.6276e-05
[MLU Workspace Size    ]: -1 (Bytes)
[MLU TheoryOps         ]: 100 (Ops)
[MLU TheoryIOs         ]: 808 (Bytes)
[MLU ComputeForce      ]: 1.024e+12 (op/s)
[MLU IoBandWidth       ]: 307.2 (GB/s)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[^      OK ] /workspace/volume/platform/wushaoqiang/op_test_case/expand/expand_data_included_complex_float_1665572039356.pb
[       OK ] expand/TestSuite.mluOp/0 (2 ms)
[ RUN      ] expand/TestSuite.mluOp/1

[----------] Global test environment tear-down
[ SUMMARY ] Total 17 cases of 1 op(s).
ALL PASSED.
[==========] 17 test cases from 1 test suite ran. (39683 ms total)
[ PASSED ] 17 test cases.