### PR TITLE
[Docs](bangc-ops):For ball_query, reduce the input and output shape

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ball_query/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ball_query/test_case/case_0.prototxt
@@ -4,7 +4,7 @@ input {
   id: "input1"          
   shape: {              
     dims: 16
-    dims: 10176
+    dims: 128
     dims: 3
   }
   layout: LAYOUT_ARRAY  
@@ -20,7 +20,7 @@ input {
   id: "input2"
   shape: {
     dims: 16
-    dims: 10176
+    dims: 512
     dims: 3
   }
   layout: LAYOUT_ARRAY
@@ -37,8 +37,8 @@ output {
   id: "output"
   shape: {
     dims: 16
-    dims: 10176
-    dims: 10176
+    dims: 128
+    dims: 128
   }
   layout: LAYOUT_ARRAY
   dtype: DTYPE_INT32
@@ -47,8 +47,8 @@ output {
 
 ball_query_param: {
   min_radius: 0.0
-  max_radius: 0.4
-  nsample: 10176
+  max_radius: 0.8
+  nsample: 128
 }
 
 test_param: {


### PR DESCRIPTION
之前合入的case_0.prototxt，input1:[16, 10176, 3], input2：[16, 10176, 3], output：[16, 10176, 10176]；输入输出的shape太大，运行时间长，导致跑流水时间过程。
修改后的shape：input1:[16, 126, 3], input2：[16, 256, 3], output：[16, 128, 128]