### PR TITLE
[TEST](ball_query): add api check cases for ball_query

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query.cpp
@@ -34,8 +34,8 @@
 namespace mluopapitest {
 class ball_query : public testing::Test {
  public:
-  void setParam(bool handle, bool new_xyz_desc, bool new_xyz_desc,
-                bool xyz_desc, bool xyz, bool idx_desc, bool idx) {
+  void setParam(bool handle, bool new_xyz_desc, bool new_xyz, bool xyz_desc,
+                bool xyz, bool idx_desc, bool idx) {
     if (handle) {
       MLUOP_CHECK(mluOpCreate(&handle_));
     }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query.cpp
@@ -1,0 +1,198 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class ball_query : public testing::Test {
+ public:
+  void setParam(bool handle, bool new_xyz_desc, bool new_xyz_desc,
+                bool xyz_desc, bool xyz, bool idx_desc, bool idx) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+    if (new_xyz_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&new_xyz_desc_));
+      std::vector<int> new_xyz_dims = {2, 16, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(new_xyz_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           new_xyz_dims.data()));
+    }
+    if (new_xyz) {
+      size_t new_xyz_ele_num = 2 * 16 * 3;
+      size_t new_xyz_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
+      size_t new_xyz_bytes = new_xyz_ele_num * new_xyz_dtype_bytes;
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&new_xyz_, new_xyz_bytes));
+    }
+    if (xyz_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&xyz_desc_));
+      std::vector<int> xyz_dims = {2, 4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(xyz_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           xyz_dims.data()));
+    }
+    if (xyz) {
+      size_t xyz_ele_num = 2 * 4 * 3;
+      size_t xyz_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
+      size_t xyz_bytes = xyz_ele_num * xyz_dtype_bytes;
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&xyz_, xyz_bytes));
+    }
+    if (idx_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&idx_desc_));
+      std::vector<int> idx_dims = {2, 4, 32};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(idx_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 3,
+                                           idx_dims.data()));
+    }
+    if (idx) {
+      size_t idx_ele_num = 2 * 4 * 32;
+      size_t idx_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
+      size_t idx_bytes = idx_ele_num * idx_dtype_bytes;
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&idx_, idx_bytes));
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status =
+        mluOpBallQuery(handle_, new_xyz_desc_, new_xyz_, xyz_desc_, xyz_,
+                       min_radius_, max_radius_, nsample_, idx_desc_, idx_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = NULL;
+    }
+    if (new_xyz_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(new_xyz_desc_));
+      new_xyz_desc_ = NULL;
+    }
+    if (new_xyz_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(new_xyz_));
+      new_xyz_ = NULL;
+    }
+    if (xyz_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(xyz_desc_));
+      xyz_desc_ = NULL;
+    }
+    if (xyz_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(xyz_));
+      xyz_ = NULL;
+    }
+    if (idx_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(idx_desc_));
+      idx_desc_ = NULL;
+    }
+    if (idx_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      idx_ = NULL;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = NULL;
+  float min_radius_ = 0;
+  float max_radius_ = 0.2;
+  int nsample_ = 32;
+  mluOpTensorDescriptor_t new_xyz_desc_ = NULL;
+  void* new_xyz_ = NULL;
+  mluOpTensorDescriptor_t xyz_desc_ = NULL;
+  void* xyz_ = NULL;
+  mluOpTensorDescriptor_t idx_desc_ = NULL;
+  void* idx_ = NULL;
+};
+
+TEST_F(ball_query, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+
+TEST_F(ball_query, BAD_PARAM_new_xyz_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+
+TEST_F(ball_query, BAD_PARAM_new_xyz_null) {
+  try {
+    setParam(true, true, false, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+
+TEST_F(ball_query, BAD_PARAM_xyz_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+
+TEST_F(ball_query, BAD_PARAM_xyz_null) {
+  try {
+    setParam(true, true, true, true, false, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+
+TEST_F(ball_query, BAD_PARAM_idx_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+
+TEST_F(ball_query, BAD_PARAM_idx_null) {
+  try {
+    setParam(true, true, true, true, true, true, false);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
@@ -145,9 +145,9 @@ class ball_query_general : public testing::TestWithParam<BallQuery> {
 
  private:
   mluOpHandle_t handle_ = NULL;
-  int min_radius_ = 0;
-  int max_radius_ = 0.2;
-  float nsample_ = 32;
+  float min_radius_ = 0;
+  float max_radius_ = 0.2;
+  int nsample_ = 32;
   mluOpTensorDescriptor_t new_xyz_desc_ = NULL;
   void* new_xyz_ = NULL;
   mluOpTensorDescriptor_t xyz_desc_ = NULL;

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
@@ -293,7 +293,7 @@ INSTANTIATE_TEST_CASE_P(
                                     MLUOP_STATUS_BAD_PARAM})));
 
 INSTANTIATE_TEST_CASE_P(
-    bad_xyz, ball_query_general,
+    bad_idx, ball_query_general,
     testing::Combine(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          3, std::vector<int>({2, 16, 3}))),

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
@@ -1,0 +1,357 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+typedef std::tuple<mluOpDevType_t, mluOpStatus_t> PublicParam;
+
+typedef std::tuple<MLUOpTensorParam, MLUOpTensorParam, float, float, int,
+                   MLUOpTensorParam, PublicParam>
+    BallQuery;
+class ball_query_general : public testing::TestWithParam<BallQuery> {
+ public:
+  void SetUp() {
+    MLUOP_CHECK(mluOpCreate(&handle_));
+    if (!(device_ == MLUOP_UNKNOWN_DEVICE || device_ == handle_->arch)) {
+      VLOG(4) << "Device does not match, skip testing.";
+      return;
+    }
+
+    MLUOP_CHECK(mluOpCreateTensorDescriptor(&xyz_desc_));
+    MLUOpTensorParam xyz_params = std::get<0>(GetParam());
+    mluOpTensorLayout_t xyz_layout = xyz_params.get_layout();
+    mluOpDataType_t xyz_dtype = xyz_params.get_dtype();
+    int xyz_dim = xyz_params.get_dim_nb();
+    std::vector<int> xyz_dim_size = xyz_params.get_dim_size();
+    MLUOP_CHECK(mluOpSetTensorDescriptor(xyz_desc_, xyz_layout, xyz_dtype,
+                                         xyz_dim, xyz_dim_size.data()));
+    uint64_t xyz_ele_num = mluOpGetTensorElementNum(xyz_desc_);
+    uint64_t xyz_bytes = mluOpDataTypeBytes(xyz_dtype) * xyz_ele_num;
+    if (xyz_bytes > 0) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&xyz_, xyz_bytes))
+    }
+
+    MLUOP_CHECK(mluOpCreateTensorDescriptor(&new_xyz_desc_));
+    MLUOpTensorParam new_xyz_params = std::get<1>(GetParam());
+    mluOpTensorLayout_t new_xyz_layout = new_xyz_params.get_layout();
+    mluOpDataType_t new_xyz_dtype = new_xyz_params.get_dtype();
+    int new_xyz_dim = new_xyz_params.get_dim_nb();
+    std::vector<int> new_xyz_dim_size = new_xyz_params.get_dim_size();
+    MLUOP_CHECK(mluOpSetTensorDescriptor(new_xyz_desc_, new_xyz_layout,
+                                         new_xyz_dtype, new_xyz_dim,
+                                         new_xyz_dim_size.data()));
+    uint64_t new_xyz_ele_num = mluOpGetTensorElementNum(new_xyz_desc_);
+    uint64_t new_xyz_bytes =
+        mluOpDataTypeBytes(new_xyz_dtype) * new_xyz_ele_num;
+    if (new_xyz_bytes > 0) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&new_xyz_, new_xyz_bytes))
+    }
+
+    min_radius_ = std::get<2>(GetParam());
+    max_radius_ = std::get<3>(GetParam());
+    nsample_ = std::get<4>(GetParam());
+
+    MLUOP_CHECK(mluOpCreateTensorDescriptor(&idx_desc_));
+    MLUOpTensorParam idx_params = std::get<5>(GetParam());
+    mluOpTensorLayout_t idx_layout = idx_params.get_layout();
+    mluOpDataType_t idx_dtype = idx_params.get_dtype();
+    int idx_dim = idx_params.get_dim_nb();
+    std::vector<int> idx_dim_size = idx_params.get_dim_size();
+    MLUOP_CHECK(mluOpSetTensorDescriptor(idx_desc_, idx_layout, idx_dtype,
+                                         idx_dim, idx_dim_size.data()));
+    uint64_t idx_ele_num = mluOpGetTensorElementNum(idx_desc_);
+    uint64_t idx_bytes = mluOpDataTypeBytes(idx_dtype) * idx_ele_num;
+    if (idx_bytes > 0) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&idx_, idx_bytes))
+    }
+
+    PublicParam publicParam = std::get<6>(GetParam());
+    std::tie(device_, expected_status_) = publicParam;
+  }
+
+  bool compute() {
+    if (!(device_ == MLUOP_UNKNOWN_DEVICE || device_ == handle_->arch)) {
+      VLOG(4) << "Device does not match, skip testing.";
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status =
+        mluOpBallQuery(handle_, new_xyz_desc_, new_xyz_, xyz_desc_, xyz_,
+                       min_radius_, max_radius_, nsample_, idx_desc_, idx_);
+    destroy();
+    return status == expected_status_;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = NULL;
+    }
+    if (new_xyz_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(new_xyz_desc_));
+      new_xyz_desc_ = NULL;
+    }
+    if (new_xyz_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(new_xyz_));
+      new_xyz_ = NULL;
+    }
+    if (xyz_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(xyz_desc_));
+      xyz_desc_ = NULL;
+    }
+    if (xyz_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(xyz_));
+      xyz_ = NULL;
+    }
+    if (idx_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(idx_desc_));
+      idx_desc_ = NULL;
+    }
+    if (idx_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      idx_ = NULL;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = NULL;
+  int min_radius_ = 0;
+  int max_radius_ = 0.2;
+  float nsample_ = 32;
+  mluOpTensorDescriptor_t new_xyz_desc_ = NULL;
+  void* new_xyz_ = NULL;
+  mluOpTensorDescriptor_t xyz_desc_ = NULL;
+  void* xyz_ = NULL;
+  mluOpTensorDescriptor_t idx_desc_ = NULL;
+  void* idx_ = NULL;
+  mluOpDevType_t device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(ball_query_general, api_test) {
+  try {
+    EXPECT_TRUE(compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in ball_query";
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_xyz, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 0, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_SUCCESS})));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_idx, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(0),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 0}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_SUCCESS})));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({0, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({0, 4, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({0, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 0, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 0, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_3, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 0}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_xyz, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         3, std::vector<int>({2, 16, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 16, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({3, 16, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 16, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 16}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_new_xyz, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         3, std::vector<int>({2, 4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({3, 4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 1, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 4, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 4}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_input_dtype, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_xyz, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         3, std::vector<int>({2, 4, 32})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({3, 4, 32})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 5, 32})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 6})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         4, std::vector<int>({2, 4, 32, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({2, 4}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_min_radius_value, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(-2), testing::Values(0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_max_radius_value, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(0), testing::Values(-0.2), testing::Values(32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_nsample_value, ball_query_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 16, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(0), testing::Values(0.2), testing::Values(-32),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 32}))),
+        testing::Values(PublicParam{MLUOP_UNKNOWN_DEVICE,
+                                    MLUOP_STATUS_BAD_PARAM})));
+
+}  // namespace mluopapitest


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](../docs/MLU-OPS精度验收标准.md).

- [ ] diff1, diff1 <= 3e-3
- [ ] diff2, diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.      |           Details            |      Check Results       |
|----------------|---------------------------|---------------------|
|        1       |          Supported hardware         | MLU270 <br> MLU290 <br>MLU370|
|        2       |          Job types          |    block <br> U1 <br> U4    |
|        3       |         Layouts            |  NHWC 、NCHW、ARRAY etc    |
|        4       |         Whether multi-dimensions are supported              |                |
|        5       |          Whether element zero is supported             |               |
|        6       |         Data type(half/float)       |         half / float etc           |
|        7      |        Whether there is size limit           |             |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] For memory leak check details, see[GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Criteria](../docs/MLU-OPS性能验收标准.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

| Test Point         | Acceptance Criteria | Test Result (Error Message) |
| -------------- | -------- | -------------------- |
| Whether it conforms to the operator restriction | Normal error |                      |
| Whether illegal parameters are passed  | Normal error |                      |

### 3.2 Performance Test

See [MLU-OPS Performance Acceptance Criteria](../docs/MLU-OPS性能验收标准.md) for details.

Platform ：MLU270

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

Platform ：MLU290

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

Platform：MLU370

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

### 3.3 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
