### PR TITLE
[Fix](bangc-ops):Perfect zero-element inspection for ball_query

### DIFF
--- a/bangc-ops/kernels/ball_query/ball_query.mlu
+++ b/bangc-ops/kernels/ball_query/ball_query.mlu
@@ -88,11 +88,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
   PARAM_CHECK("[mluOpBallQuery]", xyz_desc != NULL);
   PARAM_CHECK("[mluOpBallQuery]", idx_desc != NULL);
 
-  // check ptr
-  PARAM_CHECK("[mluOpBallQuery]", new_xyz != NULL);
-  PARAM_CHECK("[mluOpBallQuery]", xyz != NULL);
-  PARAM_CHECK("[mluOpBallQuery]", idx != NULL);
-
   // check dims
   PARAM_CHECK("[mluOpBallQuery]", new_xyz_desc->dim == 3);
   PARAM_CHECK("[mluOpBallQuery]", xyz_desc->dim == 3);
@@ -136,6 +131,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
   }
 
   // check 0 element
+  // for new_xyz, zero elements are not supported
   if (mluOpGetTensorElementNum(new_xyz_desc) == 0) {
     VLOG(5) << "[mluOpBallQuery] new_xyz tensor is a zero element tensor. The "
                "shape of new_xyz tensor is ["
@@ -143,17 +139,21 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
             << new_xyz_desc->dims[2] << "].";
     return MLUOP_STATUS_BAD_PARAM;
   }
-  if (xyz_desc->dims[0] > 0) {
-    if (xyz_desc->dims[1] == 0) {
-      return MLUOP_STATUS_SUCCESS;
-    }
-  } else {
-    VLOG(5) << "[mluOpBallQuery] xyz tensor is a zero element tensor. The "
-               "shape of xyz tensor is ["
-            << xyz_desc->dims[0] << ", " << xyz_desc->dims[1] << ", "
-            << xyz_desc->dims[2] << "].";
-    return MLUOP_STATUS_BAD_PARAM;
+  // the shape of xyz is [b, n, 3]. currently only n equal to 0 is supported
+  if (xyz_desc->dims[1] == 0) {
+    return MLUOP_STATUS_SUCCESS;
   }
+  // the shape of idx is [b, m, nsample]. currently only nsample equal to 0 is
+  // supported
+  if (idx_desc->dims[2] == 0) {
+    return MLUOP_STATUS_SUCCESS;
+  }
+
+  // check ptr
+  PARAM_CHECK("[mluOpBallQuery]", new_xyz != NULL);
+  PARAM_CHECK("[mluOpBallQuery]", xyz != NULL);
+  PARAM_CHECK("[mluOpBallQuery]", idx != NULL);
+
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("ball_query");
     GEN_CASE_HANDLE(handle);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -2667,11 +2667,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeInterpolateForward(
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] new_xyz
  * Pointer to the MLU memory that stores the new_xyz tensor.
+ * The shape of new_xyz is [B, M, 3]. B: the batch size; M: the number of elements in a batch;
+ * 3: the dimension of the 3D coordinate.
  * @param[in] xyz_desc
  * The descriptor of the xyz tensors, which means cloud points. For detailed information,
  * see ::mluOpTensorDescriptor_t.
  * @param[in] xyz
  * Pointer to the MLU memory that stores the xyz tensor.
+ * The shape of xyz is [B, N, 3]. B: the batch size; N: the number of elements in a batch;
+ * 3: the dimension of the 3D coordinate.
  * @param[in] min_radius
  * A float value which is the minimum radius.
  * @param[in] max_radius
@@ -2683,6 +2687,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeInterpolateForward(
  * see ::mluOpTensorDescriptor_t.
  * @param[in] idx
  * Pointer to the MLU memory that stores the xyz tensor.
+ * The shape of idx is [B, M, nsample]. B: the batch size; M: the number of elements in a batch;
+ * nsample: the number of points selected in the sphere.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
@@ -2694,15 +2700,23 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeInterpolateForward(
  *   - xyz tensor: float or half.
  *   - idx tensor: int.
  *
+ *  @par Data Layout
+ *  - The supported data layouts of \b new_xyz, \b xyz, \b idx are
+ *    as follows:
+ *
+ *   - new_xyz tensor: \p MLUOP_LAYOUT_ARRAY.
+ *   - xyz tensor: \p MLUOP_LAYOUT_ARRAY.
+ *   - idx tensor: \p MLUOP_LAYOUT_ARRAY.
+ * 
  * @par Scale Limitation
  * - The new_xyz tensor, xyz tensor and idx tensor must be 3D.
  * - The first dimension of the new_xyz tensor, xyz tensor and the idx tensor must be the same.
  * - The second dimension of the new_xyz tensor and the idx tensor must be the same.
  * - The third dimension of the new_xyz tensor and the xyz tensor must be the same and equal to 3.
  * - The third dimension of idx tensor must be equal to nsample.
- * - The \b min_radius should be larger than 0.
- * - The \b max_radius should be larger than 0.
- * - The \b nsample should be larger than 0.
+ * - The \b min_radius should be greater or equal to 0.
+ * - The \b max_radius should be greater or equal to 0.
+ * - The \b nsample should be greater or equal to 0.
  * 
  * @note
  * - Take the point in new_xyz as the center of the sphere, there may be no points in xyz within the


### PR DESCRIPTION
之前对零元素处理不合理。首先 
PARAM_CHECK("[mluOpBallQuery]", new_xyz != NULL);
-  PARAM_CHECK("[mluOpBallQuery]", xyz != NULL);
-  PARAM_CHECK("[mluOpBallQuery]", idx != NULL);
上面代码表面new_xyz、xyz、idx都不支持零元素；与实际情况不符。
修改后：
new_xyz中元素个数为0 则返回MLUOP_STATUS_NOT_SUPPORTED
xyz[0] != 0且xyz[1] == 0 则放回success 否则返回MLUOP_STATUS_NOT_SUPPORTED
idx的元素个数为零，则放回success。（前面的new_xyz和xyz零元素的检查，到了这一行，idx[0] = B，和idx[1]=M都不为零，所以当idx的元素为零，只能是nsamle为0）
