### PR TITLE
[Fix](bangc-ops):fix max/min func

### DIFF
--- a/bangc-ops/kernels/psroipool/psroipool_block.mlu
+++ b/bangc-ops/kernels/psroipool/psroipool_block.mlu
@@ -23,6 +23,7 @@
 #include "kernels/kernel.h"
 #include "mlu.h"
 #include "mlu_op_kernel.h"
+#include "kernels/utils/common.h"
 
 #define ALIGN_SIZE 64
 
@@ -96,8 +97,8 @@ __mlu_func__ void psRoiAvgPool(
     if (bidx < 0 || bidx > (batch_size - 1)) {
       return;
     }
-    T roi_height = std::max(roi_end_h - roi_start_h, (T)0.1);
-    T roi_width = std::max(roi_end_w - roi_start_w, (T)0.1);
+    T roi_height = __max(roi_end_h - roi_start_h, (T)0.1);
+    T roi_width = __max(roi_end_w - roi_start_w, (T)0.1);
     T bin_size_h = (T)roi_height / (T)(pooled_height);
     T bin_size_w = (T)roi_width / (T)(pooled_width);
     T *ptr_nram_des = nram_des;
@@ -116,10 +117,10 @@ __mlu_func__ void psRoiAvgPool(
         wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
         hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
         wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
-        hstart = std::min(std::max(hstart, 0), height);
-        hend = std::min(std::max(hend, 0), height);
-        wstart = std::min(std::max(wstart, 0), width);
-        wend = std::min(std::max(wend, 0), width);
+        hstart = __min(__max((T)hstart, (T)0), (T)height);
+        hend = __min(__max((T)hend, (T)0), (T)height);
+        wstart = __min(__max((T)wstart, (T)0), (T)width);
+        wend = __min(__max((T)wend, (T)0), (T)width);
         is_empty = (hend <= hstart) || (wend <= wstart);
         // vector version
         if (!is_empty) {
@@ -257,18 +258,18 @@ __mlu_func__ void psRoiAvgPoolBackwardCompute(
   if (batch_id < 0 || batch_id > (batch_size - 1)) {
     return;
   }
-  T roi_height = std::max(roi_end_h - roi_start_h, (T)0.1);
-  T roi_width = std::max(roi_end_w - roi_start_w, (T)0.1);
+  T roi_height = __max(roi_end_h - roi_start_h, (T)0.1);
+  T roi_width = __max(roi_end_w - roi_start_w, (T)0.1);
   T bin_size_h = (T)roi_height / (T)(pooled_height);
   T bin_size_w = (T)roi_width / (T)(pooled_width);
   int hstart = floor(static_cast<T>(ph) * bin_size_h + roi_start_h);
   int wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
   int hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
   int wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
-  hstart = std::min(std::max(hstart, 0), height);
-  hend = std::min(std::max(hend, 0), height);
-  wstart = std::min(std::max(wstart, 0), width);
-  wend = std::min(std::max(wend, 0), width);
+  hstart = __min(__max((T)hstart, (T)0), (T)height);
+  hend = __min(__max((T)hend, (T)0), (T)height);
+  wstart = __min(__max((T)wstart, (T)0), (T)width);
+  wend = __min(__max((T)wend, (T)0), (T)width);
   bool is_empty = (hend <= hstart) || (wend <= wstart);
   int bin_area = (hend - hstart) * (wend - wstart);
   T bin_area_recip = 1.0 / bin_area;

--- a/bangc-ops/kernels/psroipool/psroipool_block.mlu
+++ b/bangc-ops/kernels/psroipool/psroipool_block.mlu
@@ -21,9 +21,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
 #include "kernels/kernel.h"
+#include "kernels/utils/common.h"
 #include "mlu.h"
 #include "mlu_op_kernel.h"
-#include "kernels/utils/common.h"
 
 #define ALIGN_SIZE 64
 

--- a/bangc-ops/kernels/psroipool/psroipool_block.mlu
+++ b/bangc-ops/kernels/psroipool/psroipool_block.mlu
@@ -117,10 +117,10 @@ __mlu_func__ void psRoiAvgPool(
         wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
         hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
         wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
-        hstart = __min(__max((T)hstart, (T)0), (T)height);
-        hend = __min(__max((T)hend, (T)0), (T)height);
-        wstart = __min(__max((T)wstart, (T)0), (T)width);
-        wend = __min(__max((T)wend, (T)0), (T)width);
+        hstart = __min(__max(hstart, 0), height);
+        hend = __min(__max(hend, 0), height);
+        wstart = __min(__max(wstart, 0), width);
+        wend = __min(__max(wend, 0), width);
         is_empty = (hend <= hstart) || (wend <= wstart);
         // vector version
         if (!is_empty) {
@@ -266,10 +266,10 @@ __mlu_func__ void psRoiAvgPoolBackwardCompute(
   int wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
   int hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
   int wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
-  hstart = __min(__max((T)hstart, (T)0), (T)height);
-  hend = __min(__max((T)hend, (T)0), (T)height);
-  wstart = __min(__max((T)wstart, (T)0), (T)width);
-  wend = __min(__max((T)wend, (T)0), (T)width);
+  hstart = __min(__max(hstart, 0), height);
+  hend = __min(__max(hend, 0), height);
+  wstart = __min(__max(wstart, 0), width);
+  wend = __min(__max(wend, 0), width);
   bool is_empty = (hend <= hstart) || (wend <= wstart);
   int bin_area = (hend - hstart) * (wend - wstart);
   T bin_area_recip = 1.0 / bin_area;

--- a/bangc-ops/kernels/psroipool/psroipool_block.mlu
+++ b/bangc-ops/kernels/psroipool/psroipool_block.mlu
@@ -97,8 +97,8 @@ __mlu_func__ void psRoiAvgPool(
     if (bidx < 0 || bidx > (batch_size - 1)) {
       return;
     }
-    T roi_height = __max(roi_end_h - roi_start_h, (T)0.1);
-    T roi_width = __max(roi_end_w - roi_start_w, (T)0.1);
+    T roi_height = __mluop_max(roi_end_h - roi_start_h, (T)0.1);
+    T roi_width = __mluop_max(roi_end_w - roi_start_w, (T)0.1);
     T bin_size_h = (T)roi_height / (T)(pooled_height);
     T bin_size_w = (T)roi_width / (T)(pooled_width);
     T *ptr_nram_des = nram_des;
@@ -117,10 +117,10 @@ __mlu_func__ void psRoiAvgPool(
         wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
         hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
         wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
-        hstart = __min(__max(hstart, 0), height);
-        hend = __min(__max(hend, 0), height);
-        wstart = __min(__max(wstart, 0), width);
-        wend = __min(__max(wend, 0), width);
+        hstart = __mluop_min(__mluop_max(hstart, 0), height);
+        hend = __mluop_min(__mluop_max(hend, 0), height);
+        wstart = __mluop_min(__mluop_max(wstart, 0), width);
+        wend = __mluop_min(__mluop_max(wend, 0), width);
         is_empty = (hend <= hstart) || (wend <= wstart);
         // vector version
         if (!is_empty) {
@@ -258,18 +258,18 @@ __mlu_func__ void psRoiAvgPoolBackwardCompute(
   if (batch_id < 0 || batch_id > (batch_size - 1)) {
     return;
   }
-  T roi_height = __max(roi_end_h - roi_start_h, (T)0.1);
-  T roi_width = __max(roi_end_w - roi_start_w, (T)0.1);
+  T roi_height = __mluop_max(roi_end_h - roi_start_h, (T)0.1);
+  T roi_width = __mluop_max(roi_end_w - roi_start_w, (T)0.1);
   T bin_size_h = (T)roi_height / (T)(pooled_height);
   T bin_size_w = (T)roi_width / (T)(pooled_width);
   int hstart = floor(static_cast<T>(ph) * bin_size_h + roi_start_h);
   int wstart = floor(static_cast<T>(pw) * bin_size_w + roi_start_w);
   int hend = ceil(static_cast<T>(ph + 1) * bin_size_h + roi_start_h);
   int wend = ceil(static_cast<T>(pw + 1) * bin_size_w + roi_start_w);
-  hstart = __min(__max(hstart, 0), height);
-  hend = __min(__max(hend, 0), height);
-  wstart = __min(__max(wstart, 0), width);
-  wend = __min(__max(wend, 0), width);
+  hstart = __mluop_min(__mluop_max(hstart, 0), height);
+  hend = __mluop_min(__mluop_max(hend, 0), height);
+  wstart = __mluop_min(__mluop_max(wstart, 0), width);
+  wend = __mluop_min(__mluop_max(wend, 0), width);
   bool is_empty = (hend <= hstart) || (wend <= wstart);
   int bin_area = (hend - hstart) * (wend - wstart);
   T bin_area_recip = 1.0 / bin_area;

--- a/bangc-ops/kernels/utils/common.h
+++ b/bangc-ops/kernels/utils/common.h
@@ -31,6 +31,16 @@
 
 #define HALFMAX 65504
 
+template <typename T>
+__mlu_func__ inline T __min(T a, T b) {
+  return a < b ? a : b;
+}
+
+template <typename T>
+__mlu_func__ inline T __max(T a, T b) {
+  return a > b ? a : b;
+}
+
 /******************************************************************************************
  * MLUOPS FUNC: computeRecip
  * param 'nram_dst' is the nram destination address, which supports half or

--- a/bangc-ops/kernels/utils/common.h
+++ b/bangc-ops/kernels/utils/common.h
@@ -32,12 +32,12 @@
 #define HALFMAX 65504
 
 template <typename T>
-__mlu_func__ inline T __min(T a, T b) {
+__mlu_func__ inline T __mluop_min(T a, T b) {
   return a < b ? a : b;
 }
 
 template <typename T>
-__mlu_func__ inline T __max(T a, T b) {
+__mlu_func__ inline T __mluop_max(T a, T b) {
   return a > b ? a : b;
 }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

If the kernel contains the std::min() and std::max() functions, the cncc compiler will not compile if it calls a higher version of gcc.

## 2. Modification

1) bangc-ops/kernels/psroipool/psroipool_block.cpp
2) bangc-ops/kernels/utils/common.h

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](../docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1, diff1 <= 3e-3
- [x] diff2, diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.      |           Details            |      Check Results       |
|----------------|---------------------------|---------------------|
|        1       |          Supported hardware         | MLU270 <br> MLU290 <br>MLU370|
|        2       |          Job types          |    block <br> U1 <br> U4    |
|        3       |         Layouts            |  NHWC 、NCHW、ARRAY etc    |
|        4       |         Whether multi-dimensions are supported              |                |
|        5       |          Whether element zero is supported             |               |
|        6       |         Data type(half/float)       |         half / float etc           |
|        7      |        Whether there is size limit           |             |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](../docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

| Test Point         | Acceptance Standard | Test Result (Error Message) |
| -------------- | -------- | -------------------- |
| Whether it conforms to the operator restriction | Normal error |                      |
| Whether illegal parameters are passed  | Normal error |                      |

### 3.2 Performance Test

See [MLU-OPS Performance Acceptance Standard](../docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform ：MLU270

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

Platform ：MLU290

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

Platform：MLU370

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

### 3.3 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
