### PR TITLE
[TEST](voxel_pooling_forward):add api check cases for voxel_poolking_forward

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward.cpp
@@ -107,6 +107,7 @@ class voxel_pooling_forward : public testing::Test {
   void destroy() {
     VLOG(4) << "Destroy parameters.";
     if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
       MLUOP_CHECK(mluOpDestroy(handle_));
       handle_ = NULL;
     }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward.cpp
@@ -1,0 +1,253 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class voxel_pooling_forward : public testing::Test {
+ public:
+  void setParam(bool handle, bool geom_xyz_desc, bool geom_xyz,
+                bool input_features_desc, bool input_features,
+                bool output_features_desc, bool output_features,
+                bool pos_memo_desc, bool pos_memo) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+    if (geom_xyz_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&geom_xyz_desc_));
+      std::vector<int> dim_size = {2, 4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(geom_xyz_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 3,
+                                           dim_size.data()));
+    }
+    if (input_features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_features_desc_));
+      std::vector<int> dim_size = {2, 4, 10};
+      MLUOP_CHECK(
+          mluOpSetTensorDescriptor(input_features_desc_, MLUOP_LAYOUT_ARRAY,
+                                   MLUOP_DTYPE_FLOAT, 3, dim_size.data()));
+    }
+    if (output_features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_features_desc_));
+      std::vector<int> dim_size = {2, 5, 6, 10};
+      MLUOP_CHECK(
+          mluOpSetTensorDescriptor(output_features_desc_, MLUOP_LAYOUT_ARRAY,
+                                   MLUOP_DTYPE_FLOAT, 4, dim_size.data()));
+    }
+    if (pos_memo_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pos_memo_desc_));
+      std::vector<int> dim_size = {2, 4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(pos_memo_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 3,
+                                           dim_size.data()));
+    }
+    if (geom_xyz) {
+      size_t g_ele_num = 2 * 4 * 3;
+      size_t g_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
+      size_t g_bytes = g_ele_num * g_dtype_bytes;
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&geom_xyz_, g_bytes));
+    }
+    if (input_features) {
+      size_t i_ele_num = 2 * 4 * 10;
+      size_t i_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
+      size_t i_bytes = i_ele_num * i_dtype_bytes;
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_features_, i_bytes));
+    }
+    if (output_features) {
+      size_t o_ele_num = 2 * 5 * 6 * 10;
+      size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
+      size_t o_bytes = o_ele_num * o_dtype_bytes;
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_features_, o_bytes));
+    }
+    if (pos_memo) {
+      size_t p_ele_num = 2 * 4 * 3;
+      size_t p_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
+      size_t p_bytes = p_ele_num * p_dtype_bytes;
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&pos_memo_, p_bytes));
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpVoxelPoolingForward(
+        handle_, batch_size_, num_points_, num_channels_, num_voxel_x_,
+        num_voxel_y_, num_voxel_z_, geom_xyz_desc_, geom_xyz_,
+        input_features_desc_, input_features_, output_features_desc_,
+        output_features_, pos_memo_desc_, pos_memo_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    VLOG(4) << "Destroy parameters.";
+    if (handle_) {
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = NULL;
+    }
+    if (geom_xyz_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(geom_xyz_desc_));
+      geom_xyz_desc_ = NULL;
+    }
+    if (input_features_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_features_desc_));
+      input_features_desc_ = NULL;
+    }
+    if (output_features_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_features_desc_));
+      output_features_desc_ = NULL;
+    }
+    if (pos_memo_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pos_memo_desc_));
+      pos_memo_desc_ = NULL;
+    }
+    if (geom_xyz_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(geom_xyz_));
+      geom_xyz_ = NULL;
+    }
+    if (input_features_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_features_));
+      input_features_ = NULL;
+    }
+    if (output_features_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_features_));
+      output_features_ = NULL;
+    }
+    if (pos_memo_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pos_memo_));
+      output_features_ = NULL;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = NULL;
+  mluOpTensorDescriptor_t geom_xyz_desc_ = NULL;
+  mluOpTensorDescriptor_t input_features_desc_ = NULL;
+  mluOpTensorDescriptor_t output_features_desc_ = NULL;
+  mluOpTensorDescriptor_t pos_memo_desc_ = NULL;
+  void* geom_xyz_ = NULL;
+  void* input_features_ = NULL;
+  void* output_features_ = NULL;
+  void* pos_memo_ = NULL;
+  int batch_size_ = 2;
+  int num_points_ = 4;
+  int num_channels_ = 10;
+  int num_voxel_x_ = 6;
+  int num_voxel_y_ = 5;
+  int num_voxel_z_ = 1;
+};
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_geom_xyz_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_geom_xyz_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_input_features_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+TEST_F(voxel_pooling_forward, BAD_PARAM_input_features_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_output_features_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_output_features_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_pos_memo_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+
+TEST_F(voxel_pooling_forward, BAD_PARAM_pos_memo_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in voxel_pooling_forward";
+  }
+}
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
@@ -1,0 +1,457 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+#define LARGE_TENSOR_NUM ((uint64_t)2147483648)
+
+namespace mluopapitest {
+typedef std::tuple<int, int, int, int, int, int> VoxelPoolingForwardDescParam;
+typedef std::tuple<VoxelPoolingForwardDescParam, MLUOpTensorParam,
+                   MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   mluOpDevType_t, mluOpStatus_t>
+    VoxelPoolingForwardParam;
+class voxel_pooling_forward_general
+    : public testing::TestWithParam<VoxelPoolingForwardParam> {
+ public:
+  void SetUp() {
+    MLUOP_CHECK(mluOpCreate(&handle_));
+    device_ = std::get<5>(GetParam());
+    expected_status_ = std::get<6>(GetParam());
+    if (!(device_ == MLUOP_UNKNOWN_DEVICE || device_ == handle_->arch)) {
+      VLOG(4) << "Device does not match, skip testing.";
+      return;
+    }
+    VoxelPoolingForwardDescParam op_param = std::get<0>(GetParam());
+    std::tie(batch_size_, num_points_, num_channels_, num_voxel_x_,
+             num_voxel_y_, num_voxel_z_) = op_param;
+
+    MLUOpTensorParam g_params = std::get<1>(GetParam());
+    mluOpTensorLayout_t g_layout = g_params.get_layout();
+    mluOpDataType_t g_dtype = g_params.get_dtype();
+    int g_dim = g_params.get_dim_nb();
+    std::vector<int> g_dim_size = g_params.get_dim_size();
+    MLUOP_CHECK(mluOpCreateTensorDescriptor(&geom_xyz_desc_));
+    MLUOP_CHECK(mluOpSetTensorDescriptor(geom_xyz_desc_, g_layout, g_dtype,
+                                         g_dim, g_dim_size.data()));
+    uint64_t g_ele_num = mluOpGetTensorElementNum(geom_xyz_desc_);
+    uint64_t g_bytes;
+    if (g_ele_num < LARGE_TENSOR_NUM) {
+      g_bytes = mluOpDataTypeBytes(g_dtype) * g_ele_num;
+    } else {
+      g_bytes = mluOpDataTypeBytes(g_dtype) * 36;
+    }
+    if (g_bytes > 0) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&geom_xyz_, g_bytes))
+    }
+
+    MLUOpTensorParam i_params = std::get<2>(GetParam());
+    mluOpTensorLayout_t i_layout = i_params.get_layout();
+    mluOpDataType_t i_dtype = i_params.get_dtype();
+    int i_dim = i_params.get_dim_nb();
+    std::vector<int> i_dim_size = i_params.get_dim_size();
+    MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_features_desc_));
+    MLUOP_CHECK(mluOpSetTensorDescriptor(input_features_desc_, i_layout,
+                                         i_dtype, i_dim, i_dim_size.data()));
+    uint64_t i_ele_num = mluOpGetTensorElementNum(input_features_desc_);
+    uint64_t i_bytes;
+    if (i_ele_num < LARGE_TENSOR_NUM) {
+      i_bytes = mluOpDataTypeBytes(i_dtype) * i_ele_num;
+    } else {
+      i_bytes = mluOpDataTypeBytes(g_dtype) * 80;
+    }
+    if (i_bytes > 0) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_features_, i_bytes))
+    }
+
+    MLUOpTensorParam o_params = std::get<3>(GetParam());
+    mluOpTensorLayout_t o_layout = o_params.get_layout();
+    mluOpDataType_t o_dtype = o_params.get_dtype();
+    int o_dim = o_params.get_dim_nb();
+    std::vector<int> o_dim_size = o_params.get_dim_size();
+    MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_features_desc_));
+    MLUOP_CHECK(mluOpSetTensorDescriptor(output_features_desc_, o_layout,
+                                         o_dtype, o_dim, o_dim_size.data()));
+    uint64_t o_ele_num = mluOpGetTensorElementNum(output_features_desc_);
+    uint64_t o_bytes;
+    if (o_ele_num < LARGE_TENSOR_NUM) {
+      o_bytes = mluOpDataTypeBytes(o_dtype) * o_ele_num;
+    } else {
+      o_bytes = mluOpDataTypeBytes(g_dtype) * 600;
+    }
+    if (o_bytes > 0) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_features_, o_bytes))
+    }
+
+    MLUOpTensorParam p_params = std::get<4>(GetParam());
+    mluOpTensorLayout_t p_layout = p_params.get_layout();
+    mluOpDataType_t p_dtype = p_params.get_dtype();
+    int p_dim = p_params.get_dim_nb();
+    std::vector<int> p_dim_size = p_params.get_dim_size();
+    MLUOP_CHECK(mluOpCreateTensorDescriptor(&pos_memo_desc_));
+    MLUOP_CHECK(mluOpSetTensorDescriptor(pos_memo_desc_, p_layout, p_dtype,
+                                         p_dim, p_dim_size.data()));
+    uint64_t p_ele_num = mluOpGetTensorElementNum(pos_memo_desc_);
+    uint64_t p_bytes;
+    if (p_ele_num < LARGE_TENSOR_NUM) {
+      p_bytes = mluOpDataTypeBytes(p_dtype) * p_ele_num;
+    } else {
+      p_bytes = mluOpDataTypeBytes(p_dtype) * 600;
+    }
+    if (p_bytes > 0) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&pos_memo_, p_bytes))
+    }
+  }
+
+  bool compute() {
+    if (!(device_ == MLUOP_UNKNOWN_DEVICE || device_ == handle_->arch)) {
+      VLOG(4) << "Device does not match, skip testing.";
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status = mluOpVoxelPoolingForward(
+        handle_, batch_size_, num_points_, num_channels_, num_voxel_x_,
+        num_voxel_y_, num_voxel_z_, geom_xyz_desc_, geom_xyz_,
+        input_features_desc_, input_features_, output_features_desc_,
+        output_features_, pos_memo_desc_, pos_memo_);
+    destroy();
+    return status == expected_status_;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = NULL;
+    }
+    if (geom_xyz_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(geom_xyz_desc_));
+      geom_xyz_desc_ = NULL;
+    }
+    if (input_features_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_features_desc_));
+      input_features_desc_ = NULL;
+    }
+    if (output_features_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_features_desc_));
+      output_features_desc_ = NULL;
+    }
+    if (pos_memo_desc_) {
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pos_memo_desc_));
+      pos_memo_desc_ = NULL;
+    }
+    if (geom_xyz_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(geom_xyz_));
+      geom_xyz_ = NULL;
+    }
+    if (input_features_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_features_));
+      input_features_ = NULL;
+    }
+    if (output_features_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_features_));
+      output_features_ = NULL;
+    }
+    if (pos_memo_) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pos_memo_));
+      output_features_ = NULL;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = NULL;
+  mluOpTensorDescriptor_t geom_xyz_desc_ = NULL;
+  mluOpTensorDescriptor_t input_features_desc_ = NULL;
+  mluOpTensorDescriptor_t output_features_desc_ = NULL;
+  mluOpTensorDescriptor_t pos_memo_desc_ = NULL;
+  void* geom_xyz_ = NULL;
+  void* input_features_ = NULL;
+  void* output_features_ = NULL;
+  void* pos_memo_ = NULL;
+  int batch_size_ = 2;
+  int num_points_ = 4;
+  int num_channels_ = 10;
+  int num_voxel_x_ = 6;
+  int num_voxel_y_ = 5;
+  int num_voxel_z_ = 1;
+  mluOpDevType_t device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(voxel_pooling_forward_general, api_test) {
+  try {
+    EXPECT_TRUE(compute());
+  } catch (const std::exception& e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what() << " in Voxelpool_forward";
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_0, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{0, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({0, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({0, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({0, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({0, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 0, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 0, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 0, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 0, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 0, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_3, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 0, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 0, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_4, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 0, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 0, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_geom_xyz_dtype_shape_layout_0, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         4, std::vector<int>({2, 4, 3, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_input_features_dtype_shape_layout_0, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         3, std::vector<int>({2, 4, 10})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 4, 10, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_output_features_dtype_shape_layout_0, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         4, std::vector<int>({2, 5, 6, 10})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_pos_memo_dtype_shape_layout_0, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         4, std::vector<int>({2, 4, 3, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_shape_geom_xyz, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({1, 4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 1, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_shape_input_features, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 4, 10})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 1, 10})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_shape_output_features, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 5, 6, 10})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 1, 6, 10})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 1, 10})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_shape_pos_memo, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({1, 4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 1, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{699051, 1024, 10, 6, 5,
+                                                     1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3,
+                                         std::vector<int>({699051, 1024, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3,
+                                         std::vector<int>({699051, 1024, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4,
+                                         std::vector<int>({699051, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3,
+                                         std::vector<int>({699051, 1024, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
@@ -404,7 +404,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          3, std::vector<int>({2, 4, 3}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM))); 
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_num_voxel_x, voxel_pooling_forward_general,
@@ -419,7 +419,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          3, std::vector<int>({2, 4, 3}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));      
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_num_voxel_y, voxel_pooling_forward_general,
@@ -434,7 +434,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          3, std::vector<int>({2, 4, 3}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));                          
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_large_tensor, voxel_pooling_forward_general,

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
@@ -149,6 +149,7 @@ class voxel_pooling_forward_general
  protected:
   void destroy() {
     if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
       MLUOP_CHECK(mluOpDestroy(handle_));
       handle_ = NULL;
     }
@@ -215,82 +216,7 @@ TEST_P(voxel_pooling_forward_general, api_test) {
 }
 
 INSTANTIATE_TEST_CASE_P(
-    zero_element_0, voxel_pooling_forward_general,
-    testing::Combine(
-        testing::Values(VoxelPoolingForwardDescParam{0, 4, 10, 6, 5, 1}),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({0, 4, 3}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({0, 4, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({0, 5, 6, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({0, 4, 3}))),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));
-
-INSTANTIATE_TEST_CASE_P(
-    zero_element_1, voxel_pooling_forward_general,
-    testing::Combine(
-        testing::Values(VoxelPoolingForwardDescParam{2, 0, 10, 6, 5, 1}),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 0, 3}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({2, 0, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({2, 5, 6, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 0, 3}))),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));
-
-INSTANTIATE_TEST_CASE_P(
-    zero_element_2, voxel_pooling_forward_general,
-    testing::Combine(
-        testing::Values(VoxelPoolingForwardDescParam{2, 4, 0, 6, 5, 1}),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 4, 3}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({2, 4, 0}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({2, 5, 6, 0}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 4, 3}))),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));
-
-INSTANTIATE_TEST_CASE_P(
-    zero_element_3, voxel_pooling_forward_general,
-    testing::Combine(
-        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 0, 1}),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 4, 3}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({2, 4, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({2, 0, 6, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 4, 3}))),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));
-
-INSTANTIATE_TEST_CASE_P(
-    zero_element_4, voxel_pooling_forward_general,
-    testing::Combine(
-        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 0, 5, 1}),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 4, 3}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({2, 4, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({2, 5, 0, 10}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         3, std::vector<int>({2, 4, 3}))),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));
-
-INSTANTIATE_TEST_CASE_P(
-    bad_geom_xyz_dtype_shape_layout_0, voxel_pooling_forward_general,
+    bad_geom_xyz_dtype_dim, voxel_pooling_forward_general,
     testing::Combine(
         testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
@@ -307,7 +233,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
-    bad_input_features_dtype_shape_layout_0, voxel_pooling_forward_general,
+    bad_input_features_dtype_dim, voxel_pooling_forward_general,
     testing::Combine(
         testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
@@ -324,7 +250,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
-    bad_output_features_dtype_shape_layout_0, voxel_pooling_forward_general,
+    bad_output_features_dtype_dim, voxel_pooling_forward_general,
     testing::Combine(
         testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
@@ -341,7 +267,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
-    bad_pos_memo_dtype_shape_layout_0, voxel_pooling_forward_general,
+    bad_pos_memo_dtype_dim, voxel_pooling_forward_general,
     testing::Combine(
         testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, 5, 1}),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
@@ -434,6 +360,81 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({2, 4, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_batch_size, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{-2, 4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({-2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({-2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({-2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({-2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_num_points, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, -4, 10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, -4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, -4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, -4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_num_channels, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, -10, 6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, -10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, 6, -10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM))); 
+
+INSTANTIATE_TEST_CASE_P(
+    bad_num_voxel_x, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, -6, 5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 5, -6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));      
+
+INSTANTIATE_TEST_CASE_P(
+    bad_num_voxel_y, voxel_pooling_forward_general,
+    testing::Combine(
+        testing::Values(VoxelPoolingForwardDescParam{2, 4, 10, 6, -5, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 4, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, -5, 6, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({2, 4, 3}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));                          
 
 INSTANTIATE_TEST_CASE_P(
     bad_large_tensor, voxel_pooling_forward_general,


### PR DESCRIPTION
…orward

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](../docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1, diff1 <= 3e-3
- [ ] diff2, diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.      |           Details            |      Check Results       |
|----------------|---------------------------|---------------------|
|        1       |          Supported hardware         | MLU270 <br> MLU290 <br>MLU370|
|        2       |          Job types          |    block <br> U1 <br> U4    |
|        3       |         Layouts            |  NHWC 、NCHW、ARRAY etc    |
|        4       |         Whether multi-dimensions are supported              |                |
|        5       |          Whether element zero is supported             |               |
|        6       |         Data type(half/float)       |         half / float etc           |
|        7      |        Whether there is size limit           |             |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](../docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

| Test Point         | Acceptance Standard | Test Result (Error Message) |
| -------------- | -------- | -------------------- |
| Whether it conforms to the operator restriction | Normal error |                      |
| Whether illegal parameters are passed  | Normal error |                      |

### 3.2 Performance Test

See [MLU-OPS Performance Acceptance Standard](../docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform ：MLU270

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

Platform ：MLU290

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

Platform：MLU370

|Operator|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-----|----|----|----|----|----|------|-----|
|op_name|   |    |     |    |    |    |     |
|op_name|   |    |     |    |    |    |     |

### 3.3 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
