### PR TITLE
[Fix](bangc-ops): delete api check of voxelization on 200

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization.cpp
@@ -42,6 +42,9 @@ class voxelization : public testing::Test {
                 bool voxel_num) {
     if (handle) {
       MLUOP_CHECK(mluOpCreate(&handle_));
+      if (handle_->arch < MLUOP_MLU370) {
+        return;
+      }
     }
     if (points_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
@@ -148,6 +151,12 @@ class voxelization : public testing::Test {
   }
 
   mluOpStatus_t compute() {
+    if (NULL != handle_) {
+      if (handle_->arch < MLUOP_MLU370) {
+        destroy();
+        return MLUOP_STATUS_BAD_PARAM;
+      }
+    }
     mluOpStatus_t status = mluOpVoxelization(
         handle_, points_desc_, points_, voxel_size_desc_, voxel_size_,
         coors_range_desc_, coors_range_, max_points_, max_voxels_, NDim_,

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization_general.cpp
@@ -47,6 +47,9 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       VLOG(4) << "Device does not match, skip testing.";
       return;
     }
+    if (handle_->arch < MLUOP_MLU370) {
+        return;
+    }
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
     MLUOpTensorParam points_params = std::get<0>(GetParam());
     mluOpTensorLayout_t points_layout = points_params.get_layout();
@@ -176,6 +179,10 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     if (!(device_ == MLUOP_UNKNOWN_DEVICE || device_ == handle_->arch)) {
       VLOG(4) << "Device does not match, skip testing.";
       destroy();
+      return true;
+    }
+    if (handle_->arch < MLUOP_MLU370) {
+      VLOG(4) << "mluOpVoxelization do not support platform < MLU370";
       return true;
     }
     mluOpStatus_t status = mluOpGetVoxelizationWorkspaceSize(

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization_general.cpp
@@ -183,6 +183,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     }
     if (handle_->arch < MLUOP_MLU370) {
       VLOG(4) << "mluOpVoxelization do not support platform < MLU370";
+      destroy();
       return true;
     }
     mluOpStatus_t status = mluOpGetVoxelizationWorkspaceSize(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Modify voxelization api gtest abort supported platform

## 2. Modification

Voxelization do not support 200 platforms