### PR TITLE
[Fix](bangc-ops): fix nueware_home environment variable name.

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -6,9 +6,9 @@ export CPLUS_INCLUDE_PATH=${BANGPY_HOME}/include/:${CPLUS_INCLUDE_PATH}
 export PYTHONPATH=${BANGPY_HOME}:${PYTHONPATH}
 if [[ -z ${NEUWARE_HOME} ]]; then
   export NEUWARE_HOME=/usr/local/neuware
-  echo "set env 'NEUWRAE_HOME' to default: ${NEUWARE_HOME}."
+  echo "set env 'NEUWARE_HOME' to default: ${NEUWARE_HOME}."
 else
-  echo "env 'NEUWRAE_HOME': ${NEUWARE_HOME}."
+  echo "env 'NEUWARE_HOME': ${NEUWARE_HOME}."
 fi
 
 export PATH=${NEUWARE_HOME}/bin:${PATH}


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation
fix spell error

## 2. Modification
env.sh
