### PR TITLE
[Fix](bangc-ops): refine include directories searching under mlu_op_gtest

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/CMakeLists.txt
+++ b/bangc-ops/test/mlu_op_gtest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW) # Use project(... VERSION ...)
 project(mlu_op_test)
 set(CMAKE_CXX_STANDARD 14)
@@ -118,12 +118,11 @@ set(MLUOP_API_GTEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/api_gtest/src/*.cpp"
 
 include_directories("${GOOGLETEST_INCLUDE}")
 include_directories("${MLUOP_GTEST_INCLUDE}")
-include_directories("${PROTO_PATH}")
-include_directories("${MLUOP_PB_GTEST_INCLUDE}")
-include_directories("${MLUOP_API_GTEST_INCLUDE}")
 
 file(GLOB_RECURSE gtest_mlu_files FOLLOW_SYMLINKS "${CMAKE_CURRENT_LIST_DIR}/pb_gtest/src/internal_kernel/*")
+list(APPEND BANG_CNCC_INCLUDE_ARGS -I${CMAKE_CURRENT_SOURCE_DIR}/pb_gtest/src)
 bang_add_library(mluop_gtest_kernels STATIC "${gtest_mlu_files}")
+target_include_directories(mluop_gtest_kernels PRIVATE ${MLUOP_PB_GTEST_INCLUDE})
 
 file(GLOB SRC_DIR "${GOOGLETEST_SRC}/*.cc")
 #add_library(gtest_shared SHARED ${SRC_DIR})
@@ -141,6 +140,7 @@ else()
 endif()
 
 add_library(mluop_pb_gtest_obj OBJECT ${MLUOP_PB_TEST_DIR} ${MLUOP_PB_GTEST_DIR} ${PROTO_HDRS})
+target_include_directories(mluop_pb_gtest_obj PRIVATE ${MLUOP_PB_GTEST_INCLUDE} ${PROTO_PATH})
 add_dependencies(mluop_pb_gtest_obj mluop_build_proto)
 add_executable(mluop_gtest $<TARGET_OBJECTS:mluop_pb_gtest_obj>)
 target_link_libraries(mluop_gtest mluops)
@@ -171,6 +171,7 @@ else()
 endif()
 
 add_library(mluop_api_gtest_obj OBJECT ${MLUOP_API_TEST_DIR} ${MLUOP_API_GTEST_DIR})
+target_include_directories(mluop_api_gtest_obj PRIVATE ${MLUOP_API_GTEST_INCLUDE})
 add_executable(mluop_api_gtest $<TARGET_OBJECTS:mluop_api_gtest_obj>)
 target_link_libraries(mluop_api_gtest cnrt cndev cndrv cndev pthread gtest_shared mluops stdc++ m dl)
 target_link_libraries(mluop_api_gtest ${LIBXML2_LIBRARIES} ${EXTRA_LIBS})


### PR DESCRIPTION
## 1. Motivation

使用cmake3.23在ubuntu20.04下 编译mlu-ops/bangc-ops 概率性出错，分析后发现是 api_gtest 和 pb_gtest 各自 include 了test_env.h，但是由于我们用了include_directories，api_gtest模块的编译可能实际命中的是pb_gtest下的test_env.h，从而出现问题（如果要稳定复现，可以CMakeLists.txt里面把和api_gtest不相干的target注释掉）

Using cmake3.23 to compile mlu-ops/bangc-ops under ubuntu20.04 has a probabilistic error. After analysis, it is found that api_gtest and pb_gtest each include `test_env.h`, but because we use `include_directories`, the `api_gtest` module compilation may actually hit the `test_env.h` under `pb_gtest`, resulting in problems (if you want to reproduce it stably, you can comment out the target irrelevant to `api_gtest` in CMakeLists.txt)


## 2. Modification

use target_include_directories instead of include_directories, also hack on bangc

