### PR TITLE
[Feature](bangc-ops): use .a file to replace .so file

### DIFF
--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -128,26 +128,32 @@ foreach(kernel ${build_kernel})
   file(GLOB_RECURSE obj_files ${obj_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/${kernel}/${MLUOP_TARGET_CPU_ARCH}/*.o")
 endforeach()
 
-file(GLOB_RECURSE object_files ${object_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/*.so")
+file(GLOB_RECURSE object_files ${object_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/*.a")
 file(GLOB_RECURSE o_files ${o_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/*.o")
 
 file(GLOB_RECURSE core_src_files ${core_src_files} "${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp")
 # set(src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp")
 
-bang_add_library(mluops SHARED ${core_src_files} ${src_files})
-if (object_files MATCHES ".so")
-  message(STATUS "Build MLUOP with shared object file.")
+if (object_files MATCHES ".a")
+  bang_add_library(mluops SHARED ${core_src_files} ${src_files})
+  message(STATUS "Build MLUOP with static object file.")
   message("${object_files}")
-  target_link_libraries(mluops ${object_files} ${obj_files})
+  target_link_libraries(mluops 
+    -Wl,--start-group
+    ${object_files} ${obj_files} cnrt cndrv dl
+    -Wl,--end-group)
 else()
+  bang_add_library(mluops SHARED ${core_src_files} ${src_files})
+  target_link_libraries(mluops ${o_files} cnrt cndrv dl)
   message(STATUS "Build External lib with object files.")
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/")
-  file(GLOB_RECURSE srcs "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/wrapper.cpp")
-  add_library(external_lib SHARED ${srcs})
-  target_link_libraries(external_lib ${o_files} ${obj_files} cnrt cndrv dl)
-  target_link_libraries(mluops external_lib)
+  execute_process(COMMAND g++ -c -std=c++11 -fPIC -I ${CMAKE_CURRENT_SOURCE_DIR}
+                                 -I ${NEUWARE_HOME}/include
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/wrapper.cpp
+                                 -o ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/wrapper.cpp.o)
+  execute_process(COMMAND ar -rc ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/libextops.a
+                                  ${o_files} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/wrapper.cpp.o)
+  execute_process(COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/wrapper.cpp.o)
 endif()
-# target_link_libraries(mluops)
 set_target_properties(mluops PROPERTIES
   OUTPUT_NAME "mluops"
   PREFIX      "lib"

--- a/bangc-ops/kernels/kernel_wrapper/export_statement.h
+++ b/bangc-ops/kernels/kernel_wrapper/export_statement.h
@@ -24,7 +24,6 @@
 #define KERNELS_KERNEL_WRAPPER_EXPORT_STATEMENT_H
 
 #include "mlu_op.h"
-#include "core/tensor.h"
 
 /************************************************************************* 
  *                   MLUOP Export Structure Statement                    *

--- a/bangc-ops/kernels/kernel_wrapper/wrapper.h
+++ b/bangc-ops/kernels/kernel_wrapper/wrapper.h
@@ -25,9 +25,9 @@
 
 #include <algorithm>
 #include <string>
+#include <iostream>
 
 #include "mlu_op.h"
-#include "core/tensor.h"
 #include "export_statement.h"
 
 #define KERNEL_REGISTER(OP_NAME, PARAMS, ...)                                 \

--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -56,7 +56,6 @@ install -d $RPM_BUILD_ROOT%{neuware_dir}/include
 install -d $RPM_BUILD_ROOT/etc/ld.so.conf.d
 strip %{build_dir}/lib/libmluops.so*
 cp %{build_dir}/lib/libmluops.so* $RPM_BUILD_ROOT%{neuware_dir}/lib64/
-cp bangc-ops/kernels/kernel_wrapper/lib/libexternal_lib.so $RPM_BUILD_ROOT%{neuware_dir}/lib64/
 cp bangc-ops/mlu_op.h bangc-ops/mlu_op_kernel.h $RPM_BUILD_ROOT%{neuware_dir}/include/
 cp -r samples/ $RPM_BUILD_ROOT%{neuware_dir}/
 cp $RPM_SOURCE_DIR/neuware-env.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/

--- a/installer/centos7.5/SPECS/mluops.spec
+++ b/installer/centos7.5/SPECS/mluops.spec
@@ -56,7 +56,6 @@ install -d $RPM_BUILD_ROOT%{neuware_dir}/include
 install -d $RPM_BUILD_ROOT/etc/ld.so.conf.d
 strip %{build_dir}/lib/libmluops.so*
 cp %{build_dir}/lib/libmluops.so* $RPM_BUILD_ROOT%{neuware_dir}/lib64/
-cp bangc-ops/kernels/kernel_wrapper/lib/libexternal_lib.so $RPM_BUILD_ROOT%{neuware_dir}/lib64/
 cp bangc-ops/mlu_op.h bangc-ops/mlu_op_kernel.h $RPM_BUILD_ROOT%{neuware_dir}/include/
 cp -r samples/ $RPM_BUILD_ROOT%{neuware_dir}/
 cp $RPM_SOURCE_DIR/neuware-env.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/

--- a/installer/independent/debian/install
+++ b/installer/independent/debian/install
@@ -1,5 +1,4 @@
 ../../bangc-ops/build/lib/libmluops.so* /usr/local/neuware/lib64
-../../bangc-ops/kernels/kernel_wrapper/lib/libexternal_lib.so /usr/local/neuware/lib64
 ../../bangc-ops/mlu_op.h /usr/local/neuware/include
 ../../bangc-ops/mlu_op_kernel.h /usr/local/neuware/include
 ../../samples/ /usr/local/neuware/


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Use .a in binary-ops to success mluti-system compiling.

## 2. Modification

libexternal_lib.so -> libextlib.a

## 3. Test Report

NO TEST REPORT

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

NONE

#### 3.1.3 New Feature Test

NONE

#### 3.1.4 Parameter Check

NONE

### 3.3 Performance Test

NONE

### 3.4 Summary Analysis

Use .a in binary-ops to success mluti-system compiling.
