### PR TITLE
[Fix](bangc-ops): remove libexternal.so related package info.

### DIFF
--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -69,7 +69,6 @@ cp $RPM_SOURCE_DIR/neuware-env.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/
 %{neuware_dir}/include/mlu_op.h
 %{neuware_dir}/include/mlu_op_kernel.h
 %{neuware_dir}/lib64/libmluops.so*
-%{neuware_dir}/lib64/libexternal_lib.so
 %{neuware_dir}/samples/bangc-ops
 /etc/ld.so.conf.d/neuware-env.conf
 

--- a/installer/centos7.5/SPECS/mluops.spec
+++ b/installer/centos7.5/SPECS/mluops.spec
@@ -69,7 +69,6 @@ cp $RPM_SOURCE_DIR/neuware-env.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/
 %{neuware_dir}/include/mlu_op.h
 %{neuware_dir}/include/mlu_op_kernel.h
 %{neuware_dir}/lib64/libmluops.so*
-%{neuware_dir}/lib64/libexternal_lib.so
 %{neuware_dir}/samples/bangc-ops
 /etc/ld.so.conf.d/neuware-env.conf
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Fix package install error
## 2. Modification

installer/centos7.5/SPECS/mluops-independent.spec
installer/centos7.5/SPECS/mluops.spec
