### PR TITLE
[Fix](bangc-ops): sync debian installer info.

### DIFF
--- a/installer/independent/debian/control
+++ b/installer/independent/debian/control
@@ -7,8 +7,7 @@ Standards-Version: 0.1.1
 Build-Depends:
  debhelper (>= 9.0), cmake, texinfo, lsb-release,
  patchutils, diffstat, xz-utils, python-dev,
- swig, python-six, pkg-config,
- cncc (>= 2.6.0), cnas (>= 2.6.0)
+ swig, python-six, pkg-config
 
 Package: mluops
 Architecture: amd64


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Sync installer info after delete ubuntu16.04 installer

## 2. Modification

installer/independent/debian/control
