### PR TITLE
[Feature](bangc-ops): fix libmluops.so file symbol visibility

### DIFF
--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -134,20 +134,29 @@ file(GLOB_RECURSE o_files ${o_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel
 file(GLOB_RECURSE core_src_files ${core_src_files} "${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp")
 # set(src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp")
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/libmluops.map)
+  message(STATUS "libmluops.map exists.")
+else()
+  message(FATAL_ERROR "libmluops.map doesn't exist.")
+endif()
+set(LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libmluops.map")
+message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
+add_library(mluopscore STATIC ${core_src_files})
+bang_add_library(mluops SHARED ${src_files})
+target_link_libraries(mluops ${obj_files} mluopscore ${LINK_FLAGS})
+
 if (object_files MATCHES ".a")
   if ("${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/wrapper.cpp" IN_LIST src_files)
     list(REMOVE_ITEM src_files "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/wrapper.cpp")
   endif()
-  bang_add_library(mluops SHARED ${core_src_files} ${src_files})
   message(STATUS "Build MLUOP with static object file.")
   message("${object_files}")
   target_link_libraries(mluops
     -Wl,--whole-archive
     ${object_files}
     -Wl,--no-whole-archive)
-  target_link_libraries(mluops ${obj_files} cnrt cndrv dl)
+  target_link_libraries(mluops cnrt cndrv dl)
 else()
-  bang_add_library(mluops SHARED ${core_src_files} ${src_files})
   target_link_libraries(mluops ${o_files} cnrt cndrv dl)
   message(STATUS "Build External lib with object files.")
   execute_process(COMMAND g++ -c -std=c++11 -fPIC -I ${CMAKE_CURRENT_SOURCE_DIR}

--- a/bangc-ops/README.md
+++ b/bangc-ops/README.md
@@ -78,6 +78,20 @@
   <op_name> = ["dep_op1", "dep_op2", ...]
   ```
 
+- gen_mluops.py
+
+  - `gen_mluops.py`脚本用于解析`mlu_op.h`头文件，获取函数名，生成`libmluops.map`配置文件。
+    ```sh
+    MLUOP_ABI {
+	    global: op1_func;op2_func;
+	    local: *;
+    };
+    ```
+    global：表示符号是全局的（外部的）
+    local：表示符号是本地的，即对外不可见
+  - 执行build.sh编译时，将自动执行`gen_mluops.py`生成`libmluops.map`配置文件。
+  - 在编译阶段依据`libmluops.map`文件中global字段定义的符号表，将动态库`libmluops.so`中除global中定义的符号外其他符号定义为local。
+
 - 命令行参数
 
   可通过`./build.sh -h`或`./build.sh --help`，查看命令行参数

--- a/bangc-ops/build.sh
+++ b/bangc-ops/build.sh
@@ -194,6 +194,10 @@ else
   exit -1
 fi
 
+prog_log_info "generator libmluops.map file: python3 gen_mluops.py ./mlu_op.h"
+rm -f ./libmluops.map
+python3 gen_mluops.py ./mlu_op.h
+
 pushd ${BUILD_PATH} > /dev/null
   rm -rf *
   ${CMAKE}  ../ -DCMAKE_BUILD_TYPE="${BUILD_MODE}" \

--- a/bangc-ops/gen_mluops.py
+++ b/bangc-ops/gen_mluops.py
@@ -1,0 +1,33 @@
+import re
+import sys
+
+map_file = "libmluops.map"
+mluop_abi_version = "MLUOP_ABI_1.0 {"
+
+def get_mluops(input_file):
+    ops_str=""
+    pattern = re.compile(r'(?P<api>mluOp\w+) *\(')
+    with open(input_file,'r', encoding='utf8') as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                op = match.groupdict()['api'] + ';'
+                ops_str += op
+    return ops_str
+
+def create_map_file(ops_str):
+    with open(map_file,'w') as f:
+        f.writelines(mluop_abi_version + "\n")
+        global_str = "\t" + "global: " + ops_str + "\n"
+        f.writelines(global_str)
+        f.writelines("\t" + "local: *;\n")
+        f.writelines("};")
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        ops_str=""
+        for arg in sys.argv[1:]:
+            ops_str += get_mluops(arg)
+        create_map_file(ops_str)
+    else:
+        print("[ERROR] please input a file path")

--- a/bangc-ops/test/mlu_op_gtest/CMakeLists.txt
+++ b/bangc-ops/test/mlu_op_gtest/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # check
-message("[MLUOP GTEST STYLE]: ")
+message(STATUS "[MLUOP GTEST STYLE]: ")
 set(MLUOP_BUILD_SPECIFIC_OP ${MLUOP_BUILD_SPECIFIC_OP})
 
 execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/gtest_style.py ${MLUOP_BUILD_SPECIFIC_OP} RESULT_VARIABLE STYLE_CHECK)
@@ -13,7 +13,7 @@ if (STYLE_CHECK)
   message(FATAL_ERROR "-- Pleace check gtest code manually.")
 endif()
 
-message("[MLUOP GTEST REGISTER OP]: ")
+message(STATUS "[MLUOP GTEST REGISTER OP]: ")
 file(GLOB CASE_LIST "${CMAKE_CURRENT_SOURCE_DIR}/pb_gtest/src/gtest/*case_list.cpp")
 execute_process(COMMAND rm -f ${CASE_LIST})
 execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/pb_gtest/src/gtest/register_op.py ${MLUOP_BUILD_SPECIFIC_OP})
@@ -70,7 +70,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
 endif()
 
-message("[MLUOP GTEST PROTOC]: ")
+message(STATUS "[MLUOP GTEST PROTOC]: ")
 set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/pb_gtest/mlu_op_test_proto")
 file(GLOB PROTO_FILES "${PROTO_PATH}/mlu_op_test.proto")
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

fix libmluops.so file symbol visibility issue.

## 2. Modification
bangc-ops/CMakeLists.txt
bangc-ops/build.sh
bangc-ops/gen_mluops.py
bangc-ops/README.md
bangc-ops/test/mlu_op_gtest/CMakeLists.txt

## 3. Test Report
### 1 修改描述
修改描述：修改mlu-ops仓bangc-ops编译脚本，增加--version-script=ld.map 链接选项，从而隐藏libmluops.so动态库非对外暴露的符号，避免与cnnl等其他库发生符号冲突的问题

影响范围/算子：all
影响版本/分支：master

###  2. 测试验证
#### 2.1测试1
对比加--version-script 链接选项前后，生成动态库libmluops的global符号差异：
查看动态库global符号：nm -CD libmluops.so | grep " T "
libmluops.map 配置文件，在编译时通过gen_mluops.py自动生成
- 不添加--version-script 链接选项，发现很多非mlu_ops.h中定义的接口均暴露了，造成潜在的符号冲突问题
- 添加--version-script 链接选项，仅libmluops.map中定义的global符号暴露，其余均为local
- 结论：加 -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libmluops.map 之后，非global的符号，均被隐藏。

#### 2.2 测试2
通过sample下的算子demo，测试加--version-script 选项 前后生成动态库，对demo运行的影响

- 依赖不加--version-script 选项生成的动态库libmluops，编译运行sample下的demo，运行正确
- 将libmluops替换为加--version-script 选项生成的动态库，运行sample下的demo ，运行正确
- 结论：将 libmluops 库替换为加--version-script选项生成的库，运行demo正确，隐藏的符号，对依赖libmluops.so的代码无影响

#### 2.3 测试3
在sample下的demo源码中增加调用bangc-ops/core下的某个接口，如 castFloat32ToHalf() 接口

- 依赖旧的libmluops动态库，运行./build/bin/abs_sample，正确
- 替换为新的库，运行./build/bin/abs_sample，报错，提示找不到castFloat32ToHalf符号
- 结论：加 -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libmluops.map 之后，非global的符号，均被隐藏。

#### 2.4 测试4
同时使用cnnl和mluops库
当同时加载CNNL库(cnnl_1.15.0)和MLUOPS库(mluops_0.4.0)时，出现core dumped。
替换为本次修改之后的libmluops，运行正确
