### PR TITLE
[TEST](roiaware_pool3d_forward): add api check cases

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_forward/roi_crop_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_forward/roi_crop_forward_general.cpp
@@ -60,7 +60,7 @@ class roi_crop_forward_general
     uint64_t i_ele_num = mluOpGetTensorElementNum(input_desc_);
     uint64_t i_bytes = mluOpDataTypeBytes(i_dtype) * i_ele_num;
     if (i_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes))
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&grid_desc_));

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
@@ -306,7 +306,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_handle_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -317,7 +317,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_rois_desc_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -328,7 +328,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_rois_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -339,7 +339,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_desc_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -350,7 +350,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -361,7 +361,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_feature_desc_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -372,7 +372,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_feature_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -383,7 +383,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_workspace_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -394,7 +394,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_argmax_desc_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -405,7 +405,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_argmax_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -416,7 +416,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_idx_of_voxels_desc_null) {
              true, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -427,7 +427,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_idx_of_voxels_null) {
              false, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -438,7 +438,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pooled_features_desc_null) {
              true, false, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }
@@ -449,7 +449,7 @@ TEST_F(roiaware_pool3d_forward, BAD_PARAM_pooled_features_null) {
              true, true, false);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward";
   }
 }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
@@ -1,0 +1,456 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class roiaware_pool3d_forward : public testing::Test {
+ public:
+  void setParam(bool handle, bool rois_desc, bool rois, bool pts_desc, bool pts,
+                bool pts_feature_desc, bool pts_feature, bool worksapce,
+                bool argmax_desc, bool argmax, bool pts_idx_of_voxels_desc,
+                bool pts_idx_of_voxels, bool pooled_features_desc,
+                bool pooled_features) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (rois_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&rois_desc_));
+      std::vector<int> rois_dims{2, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(rois_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           rois_dims.data()));
+    }
+
+    if (rois) {
+      if (rois_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&rois_, mluOpGetTensorElementNum(rois_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&rois_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (pts_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_desc_));
+      std::vector<int> pts_dims{3, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(pts_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           pts_dims.data()));
+    }
+
+    if (pts) {
+      if (pts_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pts_, mluOpGetTensorElementNum(pts_desc_) *
+                                  mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pts_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (pts_feature_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_feature_desc_));
+      std::vector<int> pts_feature_dims{3, 4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pts_feature_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+          pts_feature_dims.data()));
+    }
+
+    if (pts_feature) {
+      if (pts_feature_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pts_feature_,
+                               mluOpGetTensorElementNum(pts_feature_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pts_feature_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (pooled_features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
+      std::vector<int> pooled_features_dims{2, 1, 2, 3, 4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_features_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 5,
+          pooled_features_dims.data()));
+    }
+
+    if (pooled_features) {
+      if (pooled_features_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pooled_features_,
+                               mluOpGetTensorElementNum(pooled_features_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pooled_features_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (argmax_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&argmax_desc_));
+      std::vector<int> argmax_dims{2, 1, 2, 3, 4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(argmax_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 5,
+                                           argmax_dims.data()));
+    }
+
+    if (argmax) {
+      if (argmax_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&argmax_, mluOpGetTensorElementNum(argmax_desc_) *
+                                     mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&argmax_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (pts_idx_of_voxels_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_idx_of_voxels_desc_));
+      std::vector<int> pts_idx_of_voxels_dims{2, 1, 2, 3, 5};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pts_idx_of_voxels_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 5,
+          pts_idx_of_voxels_dims.data()));
+    }
+
+    if (pts_idx_of_voxels) {
+      if (pts_idx_of_voxels_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pts_idx_of_voxels_,
+                       mluOpGetTensorElementNum(pts_idx_of_voxels_desc_) *
+                           mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pts_idx_of_voxels_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (worksapce) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpRoiawarePool3dForward(
+        handle_, pool_method_, boxes_num_, pts_num_, channels_, rois_desc_,
+        rois_, pts_desc_, pts_, pts_feature_desc_, pts_feature_, workspace_,
+        workspace_size_, max_pts_each_voxel_, out_x_, out_y_, out_z_,
+        argmax_desc_, argmax_, pts_idx_of_voxels_desc_, pts_idx_of_voxels_,
+        pooled_features_desc_, pooled_features_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (rois_desc_) {
+      VLOG(4) << "Destroy rois_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(rois_desc_));
+      rois_desc_ = nullptr;
+    }
+
+    if (rois_) {
+      VLOG(4) << "Destroy rois";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      rois_ = nullptr;
+    }
+
+    if (pts_desc_) {
+      VLOG(4) << "Destroy pts_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_desc_));
+      pts_desc_ = nullptr;
+    }
+
+    if (pts_) {
+      VLOG(4) << "Destroy pts";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_));
+      pts_ = nullptr;
+    }
+
+    if (pts_feature_desc_) {
+      VLOG(4) << "Destroy pts_feature_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_feature_desc_));
+      pts_feature_desc_ = nullptr;
+    }
+
+    if (pts_feature_) {
+      VLOG(4) << "Destroy pts_feature";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_feature_));
+      pts_feature_ = nullptr;
+    }
+
+    if (workspace_) {
+      VLOG(4) << "Destroy workspace";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      workspace_ = nullptr;
+    }
+
+    if (argmax_desc_) {
+      VLOG(4) << "Destroy argmax_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(argmax_desc_));
+      argmax_desc_ = nullptr;
+    }
+
+    if (argmax_) {
+      VLOG(4) << "Destroy argmax";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_));
+      argmax_ = nullptr;
+    }
+
+    if (pts_idx_of_voxels_desc_) {
+      VLOG(4) << "Destroy pts_idx_of_voxels_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_idx_of_voxels_desc_));
+      pts_idx_of_voxels_desc_ = nullptr;
+    }
+
+    if (pts_idx_of_voxels_) {
+      VLOG(4) << "Destroy pts_idx_of_voxels";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_idx_of_voxels_));
+      pts_idx_of_voxels_ = nullptr;
+    }
+
+    if (pooled_features_desc_) {
+      VLOG(4) << "Destroy pooled_features_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_features_desc_));
+      pooled_features_desc_ = nullptr;
+    }
+
+    if (pooled_features_) {
+      VLOG(4) << "Destroy pooled_features";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+      pooled_features_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  int pool_method_ = 0;
+  int boxes_num_ = 2;
+  int pts_num_ = 3;
+  int channels_ = 4;
+  mluOpTensorDescriptor_t rois_desc_ = nullptr;
+  void *rois_ = nullptr;
+  mluOpTensorDescriptor_t pts_desc_ = nullptr;
+  void *pts_ = nullptr;
+  mluOpTensorDescriptor_t pts_feature_desc_ = nullptr;
+  void *pts_feature_ = nullptr;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  int max_pts_each_voxel_ = 5;
+  int out_x_ = 1;
+  int out_y_ = 2;
+  int out_z_ = 3;
+  mluOpTensorDescriptor_t argmax_desc_ = nullptr;
+  void *argmax_ = nullptr;
+  mluOpTensorDescriptor_t pts_idx_of_voxels_desc_ = nullptr;
+  void *pts_idx_of_voxels_ = nullptr;
+  mluOpTensorDescriptor_t pooled_features_desc_ = nullptr;
+  void *pooled_features_ = nullptr;
+};
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_rois_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_rois_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_feature_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_feature_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_workspace_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_argmax_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false, true, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_argmax_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, false, true,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_idx_of_voxels_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, false,
+             true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pts_idx_of_voxels_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             false, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pooled_features_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             true, false, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward, BAD_PARAM_pooled_features_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             true, true, false);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward";
+  }
+}
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_general.cpp
@@ -119,7 +119,7 @@ class roiaware_pool3d_forward_general
       target_device_ = std::get<7>(GetParam());
       expected_status_ = std::get<8>(GetParam());
     } catch (const std::exception &e) {
-      FAIL() << "CNNLAPIGTEST: catched " << e.what()
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
              << " in roiaware_pool3d_forward general.";
     }
   }
@@ -221,7 +221,7 @@ class roiaware_pool3d_forward_general
         pooled_features_ = nullptr;
       }
     } catch (const std::exception &e) {
-      FAIL() << "CNNLAPIGTEST: catched " << e.what()
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
              << " in roiaware_pool3d_forward_general";
     }
   }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_general.cpp
@@ -1,0 +1,666 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+
+typedef std::tuple<int, int, int, int, int, int, int, int>
+    RoiawarePool3dForwardParam;
+
+typedef std::tuple<MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   RoiawarePool3dForwardParam, mluOpDevType_t, mluOpStatus_t>
+    RoiawarePool3dForward;
+class roiaware_pool3d_forward_general
+    : public testing::TestWithParam<RoiawarePool3dForward> {
+ public:
+  void SetUp() {
+    try {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+
+      MLUOpTensorParam rois_params = std::get<0>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&rois_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          rois_desc_, rois_params.get_layout(), rois_params.get_dtype(),
+          rois_params.get_dim_nb(), rois_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&rois_, mluOpDataTypeBytes(rois_params.get_dtype()) * 10));
+
+      MLUOpTensorParam pts_params = std::get<1>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pts_desc_, pts_params.get_layout(), pts_params.get_dtype(),
+          pts_params.get_dim_nb(), pts_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&pts_, mluOpDataTypeBytes(pts_params.get_dtype()) * 10));
+
+      MLUOpTensorParam pts_feature_params = std::get<2>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_feature_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pts_feature_desc_, pts_feature_params.get_layout(),
+          pts_feature_params.get_dtype(), pts_feature_params.get_dim_nb(),
+          pts_feature_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&pts_feature_,
+                     mluOpDataTypeBytes(pts_feature_params.get_dtype()) * 10));
+
+      MLUOpTensorParam pooled_features_params = std::get<3>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_features_desc_, pooled_features_params.get_layout(),
+          pooled_features_params.get_dtype(),
+          pooled_features_params.get_dim_nb(),
+          pooled_features_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(
+              &pooled_features_,
+              mluOpDataTypeBytes(pooled_features_params.get_dtype()) * 10));
+
+      MLUOpTensorParam argmax_params = std::get<4>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&argmax_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          argmax_desc_, argmax_params.get_layout(), argmax_params.get_dtype(),
+          argmax_params.get_dim_nb(), argmax_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&argmax_,
+                     mluOpDataTypeBytes(argmax_params.get_dtype()) * 10));
+
+      MLUOpTensorParam pts_idx_of_voxels_params = std::get<5>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_idx_of_voxels_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pts_idx_of_voxels_desc_, pts_idx_of_voxels_params.get_layout(),
+          pts_idx_of_voxels_params.get_dtype(),
+          pts_idx_of_voxels_params.get_dim_nb(),
+          pts_idx_of_voxels_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(
+              &pts_idx_of_voxels_,
+              mluOpDataTypeBytes(pts_idx_of_voxels_params.get_dtype()) * 10));
+
+      RoiawarePool3dForwardParam roiawarePool3dForwardParam =
+          std::get<6>(GetParam());
+      std::tie(boxes_num_, pts_num_, channels_, max_pts_each_voxel_, out_x_,
+               out_y_, out_z_, pool_method_) = roiawarePool3dForwardParam;
+      target_device_ = std::get<7>(GetParam());
+      expected_status_ = std::get<8>(GetParam());
+    } catch (const std::exception &e) {
+      FAIL() << "CNNLAPIGTEST: catched " << e.what()
+             << " in roiaware_pool3d_forward general.";
+    }
+  }
+
+  bool compute() {
+    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+          target_device_ == handle_->arch)) {
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status;
+    status = mluOpGetRoiawarePool3dForwardWorkspaceSize(
+        handle_, rois_desc_, pts_desc_, pts_feature_desc_, &workspace_size_);
+    if (status != MLUOP_STATUS_SUCCESS) {
+      destroy();
+      return expected_status_ == status;
+    }
+    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    status = mluOpRoiawarePool3dForward(
+        handle_, pool_method_, boxes_num_, pts_num_, channels_, rois_desc_,
+        rois_, pts_desc_, pts_, pts_feature_desc_, pts_feature_, workspace_,
+        workspace_size_, max_pts_each_voxel_, out_x_, out_y_, out_z_,
+        argmax_desc_, argmax_, pts_idx_of_voxels_desc_, pts_idx_of_voxels_,
+        pooled_features_desc_, pooled_features_);
+    destroy();
+    return expected_status_ == status;
+  }
+
+  void destroy() {
+    try {
+      if (handle_) {
+        CNRT_CHECK(cnrtQueueSync(handle_->queue));
+        MLUOP_CHECK(mluOpDestroy(handle_));
+        handle_ = nullptr;
+      }
+
+      if (rois_desc_) {
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(rois_desc_));
+        rois_desc_ = nullptr;
+      }
+
+      if (rois_) {
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+        rois_ = nullptr;
+      }
+
+      if (pts_desc_) {
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_desc_));
+        pts_desc_ = nullptr;
+      }
+
+      if (pts_) {
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_));
+        pts_ = nullptr;
+      }
+
+      if (pts_feature_desc_) {
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_feature_desc_));
+        pts_feature_desc_ = nullptr;
+      }
+
+      if (pts_feature_) {
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_feature_));
+        pts_feature_ = nullptr;
+      }
+
+      if (workspace_) {
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+        workspace_ = nullptr;
+      }
+
+      if (argmax_desc_) {
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(argmax_desc_));
+        argmax_desc_ = nullptr;
+      }
+
+      if (argmax_) {
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_));
+        argmax_ = nullptr;
+      }
+
+      if (pts_idx_of_voxels_desc_) {
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_idx_of_voxels_desc_));
+        pts_idx_of_voxels_desc_ = nullptr;
+      }
+
+      if (pts_idx_of_voxels_) {
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_idx_of_voxels_));
+        pts_idx_of_voxels_ = nullptr;
+      }
+
+      if (pooled_features_desc_) {
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_features_desc_));
+        pooled_features_desc_ = nullptr;
+      }
+
+      if (pooled_features_) {
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+        pooled_features_ = nullptr;
+      }
+    } catch (const std::exception &e) {
+      FAIL() << "CNNLAPIGTEST: catched " << e.what()
+             << " in roiaware_pool3d_forward_general";
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  int pool_method_ = 0;
+  int boxes_num_ = 0;
+  int pts_num_ = 0;
+  int channels_ = 0;
+  mluOpTensorDescriptor_t rois_desc_ = nullptr;
+  void *rois_ = nullptr;
+  mluOpTensorDescriptor_t pts_desc_ = nullptr;
+  void *pts_ = nullptr;
+  mluOpTensorDescriptor_t pts_feature_desc_ = nullptr;
+  void *pts_feature_ = nullptr;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  int max_pts_each_voxel_ = 0;
+  int out_x_ = 0;
+  int out_y_ = 0;
+  int out_z_ = 0;
+  mluOpTensorDescriptor_t argmax_desc_ = nullptr;
+  void *argmax_ = nullptr;
+  mluOpTensorDescriptor_t pts_idx_of_voxels_desc_ = nullptr;
+  void *pts_idx_of_voxels_ = nullptr;
+  mluOpTensorDescriptor_t pooled_features_desc_ = nullptr;
+  void *pooled_features_ = nullptr;
+  mluOpDevType_t target_device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(roiaware_pool3d_forward_general, negative) { EXPECT_TRUE(compute()); }
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({0, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({0, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({0, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{0, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 0, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_3, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 0, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_4, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 0, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 0, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 0, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 0, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_rois_dtype, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({2, 7})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pts_dtype, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({3, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pts_feature_dtype, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pooled_features_dtype, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         5, std::vector<int>({2, 1, 2, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_input_dtype, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_argmax_dtype, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pts_idx_of_voxels_dtype, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_rois_shape, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 7})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 6})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 7, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pts_shape, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({3, 3, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pts_feature_shape, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({3, 4, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pooled_features_shape, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({3, 1, 2, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 2, 2, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 3, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 4, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         6,
+                                         std::vector<int>({2, 1, 2, 3, 4, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 1, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_argmax_shape, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({3, 1, 2, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 2, 2, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 3, 3, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 4, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         6,
+                                         std::vector<int>({2, 1, 2, 3, 4, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         4, std::vector<int>({2, 1, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pts_idx_of_voxels_shape, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({3, 1, 2, 3, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 2, 2, 3, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 3, 3, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 4, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 6})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         6,
+                                         std::vector<int>({2, 1, 2, 3, 5, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         4, std::vector<int>({2, 1, 2, 3}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 0}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_pool_method_value, roiaware_pool3d_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         5, std::vector<int>({2, 1, 2, 3, 5}))),
+        testing::Values(RoiawarePool3dForwardParam{2, 3, 4, 5, 1, 2, 3, 2}),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_workspace.cpp
@@ -99,7 +99,7 @@ TEST_F(roiaware_pool3d_forward_workspace, BAD_PARAM_handle_null) {
     setParam(false, true, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward_workspace";
   }
 }
@@ -109,7 +109,7 @@ TEST_F(roiaware_pool3d_forward_workspace, BAD_PARAM_pts_feature_desc_null) {
     setParam(true, false, true);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward_workspace";
   }
 }
@@ -119,7 +119,7 @@ TEST_F(roiaware_pool3d_forward_workspace, BAD_PARAM_workspace_null) {
     setParam(true, true, false);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
   } catch (std::exception &e) {
-    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in roiaware_pool3d_forward_workspace";
   }
 }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_workspace.cpp
@@ -1,0 +1,127 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class roiaware_pool3d_forward_workspace : public testing::Test {
+ public:
+  void setParam(bool handle, bool pts_feature_desc, bool workspace_size) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+    if (pts_feature_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_feature_desc_));
+      std::vector<int> pts_feature_dims{3, 4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pts_feature_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+          pts_feature_dims.data()));
+    }
+    if (workspace_size) {
+      size_t size_temp;
+      workspace_size_ = &size_temp;
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpGetRoiawarePool3dForwardWorkspaceSize(
+        handle_, rois_desc_, pts_desc_, pts_feature_desc_, workspace_size_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (rois_desc_) {
+      VLOG(4) << "Destroy rois_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(rois_desc_));
+      rois_desc_ = nullptr;
+    }
+
+    if (pts_desc_) {
+      VLOG(4) << "Destroy pts_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_desc_));
+      pts_desc_ = nullptr;
+    }
+
+    if (pts_feature_desc_) {
+      VLOG(4) << "Destroy pts_feature_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_feature_desc_));
+      pts_feature_desc_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t rois_desc_ = nullptr;
+  mluOpTensorDescriptor_t pts_desc_ = nullptr;
+  size_t *workspace_size_ = nullptr;
+  mluOpTensorDescriptor_t pts_feature_desc_ = nullptr;
+};
+
+TEST_F(roiaware_pool3d_forward_workspace, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward_workspace";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward_workspace, BAD_PARAM_pts_feature_desc_null) {
+  try {
+    setParam(true, false, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward_workspace";
+  }
+}
+
+TEST_F(roiaware_pool3d_forward_workspace, BAD_PARAM_workspace_null) {
+  try {
+    setParam(true, true, false);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "CNNLAPIGTEST: catched " << e.what()
+           << " in roiaware_pool3d_forward_workspace";
+  }
+}
+
+}  // namespace mluopapitest


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

To check roiaware_pool3d_forward api params

## 2. Modification

Add api cases

## 3. Test Report

```
[       OK ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/2 (0 ms)
[ RUN      ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/3
[2023-2-1 20:44:53] [MLUOP] [Error]: [mluOpRoiawarePool3dForward] Check failed: pts_idx_of_voxels_desc->dims[3] == out_z. 
[       OK ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/3 (0 ms)
[ RUN      ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/4
[2023-2-1 20:44:53] [MLUOP] [Error]: [mluOpRoiawarePool3dForward] Check failed: pts_idx_of_voxels_desc->dims[4] == max_pts_each_voxel. 
[       OK ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/4 (0 ms)
[ RUN      ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/5
[2023-2-1 20:44:53] [MLUOP] [Error]: [mluOpRoiawarePool3dForward] Check failed: pts_idx_of_voxels_desc->dim == 5. 
[       OK ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/5 (0 ms)
[ RUN      ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/6
[2023-2-1 20:44:53] [MLUOP] [Error]: [mluOpRoiawarePool3dForward] Check failed: pts_idx_of_voxels_desc->dim == 5. 
[       OK ] negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general.negative/6 (0 ms)
[----------] 7 tests from negative_pts_idx_of_voxels_shape/roiaware_pool3d_forward_general (0 ms total)

[----------] 1 test from negative_pool_method_value/roiaware_pool3d_forward_general
[ RUN      ] negative_pool_method_value/roiaware_pool3d_forward_general.negative/0
[2023-2-1 20:44:53] [MLUOP] [Error]: [mluOpRoiawarePool3dForward] Check failed: pool_method == 0 || pool_method == 1. 
[       OK ] negative_pool_method_value/roiaware_pool3d_forward_general.negative/0 (0 ms)
[----------] 1 test from negative_pool_method_value/roiaware_pool3d_forward_general (0 ms total)

[----------] Global test environment tear-down
[==========] 66 test cases from 20 test suites ran. (289 ms total)
[  PASSED  ] 66 test cases.
                           
```

