### PR TITLE
[Feature](bangc-ops): update binary-ops version to 1.15.2.

### DIFF
--- a/bangc-ops/kernels/kernel_wrapper/wrapper.h
+++ b/bangc-ops/kernels/kernel_wrapper/wrapper.h
@@ -40,6 +40,15 @@
     };
 
 /* Kernel param types macro defination */
+
+#define ADDN_PARAM_TYPE                                                       \
+    mluOpHandle_t, const mluOpTensorDescriptor_t[], const void *const *,      \
+    uint32_t, const mluOpTensorDescriptor_t, void *
+
+#define ADDNV2_PARAM_TYPE                                                     \
+    mluOpHandle_t, const mluOpTensorDescriptor_t[], const void *const *,      \
+    uint32_t, const mluOpTensorDescriptor_t, void *, void *, size_t
+
 #define COPY_PARAM_TYPE                                                       \
     mluOpHandle_t, const mluOpTensorDescriptor_t, const void *,               \
     const mluOpTensorDescriptor_t, void *
@@ -116,6 +125,8 @@
     void *
 
 /* Kernel register */
+KERNEL_REGISTER(addN, ADDN_PARAM_TYPE);
+KERNEL_REGISTER(addNV2, ADDNV2_PARAM_TYPE);
 KERNEL_REGISTER(copy, COPY_PARAM_TYPE);
 KERNEL_REGISTER(expand, EXPAND_PARAM_TYPE);
 KERNEL_REGISTER(fill, FILL_PARAM_TYPE);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -1800,22 +1800,22 @@ mluOpAbs(mluOpHandle_t handle,
  * workspace to optimize the ::mluOpAddN_v2 operation.
  *
  * @param[in] handle
- * Handle to an MLUOP context that is used to manage MLU devices and queues in the add_n
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in the ::mluOpAddN
  * operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] input_descs[]
  * Array of descriptors for all input tensors. For detailed information,
  * see ::mluOpTensorDescriptor_t.
  * @param[in] input_num
- * The number of tensors in array inputs[].
+ * Number of tensors in array inputs[].
  * @param[in] output_desc
- * The descriptor of the output tensor, For detailed information, see
+ * The descriptor of the output tensor. For detailed information, see
  * ::mluOpTensorDescriptor_t.
  * @param[out] workspace_size
  * Host pointer to the returned size of the extra workspace in bytes that is
  * used in add_n operation.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @note
  * - None.
@@ -1846,7 +1846,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetAddNWorkspaceSize(mluOpHandle_t handle,
  * function.
  *
  * @param[in] handle
- * Handle to an MLUOP context that is used to manage MLU devices and queues in add_n
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in ::mluOpAddN
  * operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] input_descs[]
  * Array of descriptors for all input tensors. For detailed information,
@@ -1856,13 +1856,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetAddNWorkspaceSize(mluOpHandle_t handle,
  * @param[in] input_num
  * Number of tensors in array inputs[].
  * @param[in] output_desc
- * Descriptor of the output tensor. For detailed information, see
+ * The descriptor of the output tensor. For detailed information, see
  * ::mluOpTensorDescriptor_t.
  * @param[out] output
  * Device pointer to the MLU memory that stores the output tensor.
  * @param[in] workspace
  * Device pointer to the MLU memory that is used as an extra workspace for this
- * operation. For more information about workspace, see "Cambricon MLUOP User Guide".
+ * operation.
  * @param[in] workspace_size
  * Size of the extra workspace in bytes that needs to be used in this
  * operation. You can get the size of workspace with the ::mluOpGetAddNWorkspaceSize
@@ -1871,18 +1871,18 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetAddNWorkspaceSize(mluOpHandle_t handle,
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par API Dependency
- * - Before calling this function to perform AddN operation, you need to get the size
- *   of workspace by the ::mluOpGetAddNWorkspaceSize function.
+ * - Before calling this function to perform ::mluOpAddN operation, you need to get
+ *   the size of workspace by the ::mluOpGetAddNWorkspaceSize function.
  *
  * @par Data Type
- * - This function supports the following data types for input and output tensors.
- * Note that the data type of output should be same with input.
- *   - input tensor: float, half, int32, int16, int8, uint8.
- *   - output tensor: float, half, int32, int16, int8, uint8.
-
+ * This function supports the following data types for input and output tensors.
+ * Note that the data type of output should be same with that of input.
+ *   - input tensor: float, half, int32, int16, int8, uint8
+ *   - output tensor: float, half, int32, int16, int8, uint8
  *
  * @par Scale Limitation
  * - The maximum dimension of both input and output tensors is 8.
+ *
  * @note
  * - None.
  *
@@ -1931,14 +1931,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpAddN_v2(mluOpHandle_t handle,
  * Handle to an MLUOP context that is used to manage MLU devices and queues in this
  * operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] input_descs[]
- * Array of descriptor for the all input tensors. For detailed information,
+ * Array of descriptor for all the input tensors. For detailed information,
  * see ::mluOpTensorDescriptor_t.
  * @param[in] inputs[]
  * Array of device pointers to the MLU memory for the all input tensors.
  * @param[in] input_num
  * Number of tensors in array inputs[].
  * @param[in] output_desc
- * Descriptor of the output tensor, For detailed information, see
+ * The descriptor of the output tensor, For detailed information, see
  * ::mluOpTensorDescriptor_t.
  * @param[out] output
  * Device pointer to the MLU memory that stores the output tensor.
@@ -1948,8 +1948,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpAddN_v2(mluOpHandle_t handle,
  *
  * @par Data Type
  * - This function supports the following data types for input and output tensors.
- *   - input tensor: float, half.
- *   - output tensor: float, half.
+ *   - input tensor: float, half
+ *   - output tensor: float, half
  *   <b>Note that the data type of output should be same with inputs.</b>
  *
  * @par Data Layout

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -1812,7 +1812,7 @@ mluOpAbs(mluOpHandle_t handle,
  * ::mluOpTensorDescriptor_t.
  * @param[out] workspace_size
  * Host pointer to the returned size of the extra workspace in bytes that is
- * used in add_n operation.
+ * used in ::mluOpAddN operation.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
@@ -1875,8 +1875,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetAddNWorkspaceSize(mluOpHandle_t handle,
  *   the size of workspace by the ::mluOpGetAddNWorkspaceSize function.
  *
  * @par Data Type
- * This function supports the following data types for input and output tensors.
- * Note that the data type of output should be same with that of input.
+ * - This function supports the following data types for input and output tensors.
+ * Note that the data types of output should be the same with that of input.
  *   - input tensor: float, half, int32, int16, int8, uint8
  *   - output tensor: float, half, int32, int16, int8, uint8
  *

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -1794,6 +1794,209 @@ mluOpAbs(mluOpHandle_t handle,
          const mluOpTensorDescriptor_t y_desc,
          void *y);
 
+// Group:AddN
+/*!
+ * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
+ * workspace to optimize the ::mluOpAddN_v2 operation.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in the add_n
+ * operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] input_descs[]
+ * Array of descriptors for all input tensors. For detailed information,
+ * see ::mluOpTensorDescriptor_t.
+ * @param[in] input_num
+ * The number of tensors in array inputs[].
+ * @param[in] output_desc
+ * The descriptor of the output tensor, For detailed information, see
+ * ::mluOpTensorDescriptor_t.
+ * @param[out] workspace_size
+ * Host pointer to the returned size of the extra workspace in bytes that is
+ * used in add_n operation.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ *
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpGetAddNWorkspaceSize(mluOpHandle_t handle,
+                                                      const mluOpTensorDescriptor_t input_descs[],
+                                                      const uint32_t input_num,
+                                                      const mluOpTensorDescriptor_t output_desc,
+                                                      size_t *workspace_size);
+// Group:AddN
+/*!
+ * @brief Computes the sum of input tensors.
+ *
+ * AddN operation is wildly used in artificial intelligence as a kind of basic mathematical
+ * operations. Also, this operation is supported in almost all common frameworks, like
+ * PyTorch and TensorFlow.
+ * Compared with ::mluOpAddN, this function supports multidirectional broadcasting of input tensors.
+ *
+ * This function may need extra MLU memory as the workspace to support multidirectional broadcasting.
+ * You can get the size of the workspace \b workspace_size with the ::mluOpGetAddNWorkspaceSize
+ * function.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in add_n
+ * operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] input_descs[]
+ * Array of descriptors for all input tensors. For detailed information,
+ * see ::mluOpTensorDescriptor_t.
+ * @param[in] inputs[]
+ * Array of device pointers to the MLU memory for the input tensors.
+ * @param[in] input_num
+ * Number of tensors in array inputs[].
+ * @param[in] output_desc
+ * Descriptor of the output tensor. For detailed information, see
+ * ::mluOpTensorDescriptor_t.
+ * @param[out] output
+ * Device pointer to the MLU memory that stores the output tensor.
+ * @param[in] workspace
+ * Device pointer to the MLU memory that is used as an extra workspace for this
+ * operation. For more information about workspace, see "Cambricon MLUOP User Guide".
+ * @param[in] workspace_size
+ * Size of the extra workspace in bytes that needs to be used in this
+ * operation. You can get the size of workspace with the ::mluOpGetAddNWorkspaceSize
+ * function.
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par API Dependency
+ * - Before calling this function to perform AddN operation, you need to get the size
+ *   of workspace by the ::mluOpGetAddNWorkspaceSize function.
+ *
+ * @par Data Type
+ * - This function supports the following data types for input and output tensors.
+ * Note that the data type of output should be same with input.
+ *   - input tensor: float, half, int32, int16, int8, uint8.
+ *   - output tensor: float, half, int32, int16, int8, uint8.
+
+ *
+ * @par Scale Limitation
+ * - The maximum dimension of both input and output tensors is 8.
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - The example of this operation is as follows:
+     @verbatim
+       Input tensor  1 :   [[1, 2, 3]]
+
+
+       Input tensor  2 :   [[1],
+                            [4],
+                            [7]]
+
+       Input tensor  3 :   [[1, 2, 3],
+                            [4, 5, 6],
+                            [7, 8, 9]]
+
+       Input num       :   3
+
+       Output tensor   :   [[3,  5,  7],
+                            [9, 11, 13],
+                            [15,17, 19]]
+     @endverbatim
+ *
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpAddN_v2(mluOpHandle_t handle,
+                                         const mluOpTensorDescriptor_t input_descs[],
+                                         const void *const inputs[],
+                                         const uint32_t input_num,
+                                         const mluOpTensorDescriptor_t output_desc,
+                                         void *output,
+                                         void * workspace,
+                                         size_t workspace_size);
+// Group:AddN
+/*!
+ * @brief Computes the sum of input tensors.
+ *
+ * @par Deprecated
+ * - ::mluOpAddN is deprecated and will be removed in the future release. It is recommended to use
+ *   ::mluOpAddN_v2 instead.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in this
+ * operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] input_descs[]
+ * Array of descriptor for the all input tensors. For detailed information,
+ * see ::mluOpTensorDescriptor_t.
+ * @param[in] inputs[]
+ * Array of device pointers to the MLU memory for the all input tensors.
+ * @param[in] input_num
+ * Number of tensors in array inputs[].
+ * @param[in] output_desc
+ * Descriptor of the output tensor, For detailed information, see
+ * ::mluOpTensorDescriptor_t.
+ * @param[out] output
+ * Device pointer to the MLU memory that stores the output tensor.
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
+ *
+ * @par Data Type
+ * - This function supports the following data types for input and output tensors.
+ *   - input tensor: float, half.
+ *   - output tensor: float, half.
+ *   <b>Note that the data type of output should be same with inputs.</b>
+ *
+ * @par Data Layout
+ * - Data layouts of all input tensors and output tensor must be the same.
+ *
+ * @par Scale Limitation
+ * - The dimensions of input tensors and output tensor must be the same.
+ * - The shape of input tensors and output tensor must be the same.
+ * - The number of input tensors must be greater than or equal to one.
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - The example of this operation is as follows:
+     @verbatim
+       Input tensor  1 :   [[1, 2, 3],
+                            [4, 5, 6],
+                            [7, 8, 9]]
+
+       Input tensor  2 :   [[1, 2, 3],
+                            [4, 5, 6],
+                            [7, 8, 9]]
+
+       Input tensor  3 :   [[1, 2, 3],
+                            [4, 5, 6],
+                            [7, 8, 9]]
+
+       Input num       :   3
+
+       Output tensor   :   [[3,  6,  9],
+                            [12, 15, 18],
+                            [21, 24, 27]]
+     @endverbatim
+ *
+ */
+
+mluOpStatus_t MLUOP_WIN_API mluOpAddN(mluOpHandle_t handle,
+                                      const mluOpTensorDescriptor_t input_descs[],
+                                      const void *const inputs[],
+                                      uint32_t input_num,
+                                      const mluOpTensorDescriptor_t output_desc,
+                                      void *output);
+
 // Group:Log
 /*!
  * @brief Computes logarithm of input tensor \b x, and returns the results in


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Update binary ops version to 1.15.2.

## 2. Modification

bangc-ops/kernels/kernel_wrapper/lib/libextops.a

## 3. Test Report

None
