### PR TITLE
[Feature](bangc_ops): voxel_pooling_forward add gen_case op param.

### DIFF
--- a/bangc-ops/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
+++ b/bangc-ops/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
@@ -133,12 +133,24 @@ mluOpStatus_t MLUOP_WIN_API mluOpVoxelPoolingForward(
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("voxel_pooling_forward");
     GEN_CASE_HANDLE(handle);
-    GEN_CASE_DATA(true, "geom_xyz", geom_xyz, geom_xyz_desc, -100, 200);
-    GEN_CASE_DATA(true, "input_features", input_features, input_features_desc,
-                  -10, 10);
+    GEN_CASE_DATA_REAL(true, "geom_xyz", geom_xyz, geom_xyz_desc);
+    GEN_CASE_DATA_REAL(true, "input_features", input_features,
+                       input_features_desc);
     GEN_CASE_DATA(false, "output_features", output_features,
                   output_features_desc, 0, 0);
     GEN_CASE_DATA(false, "pos_memo", pos_memo, pos_memo_desc, 0, 0);
+    GEN_CASE_OP_PARAM_SINGLE(0, "voxel_pooling_forward", "batch_size",
+                             batch_size);
+    GEN_CASE_OP_PARAM_SINGLE(1, "voxel_pooling_forward", "num_points",
+                             num_points);
+    GEN_CASE_OP_PARAM_SINGLE(2, "voxel_pooling_forward", "num_channels",
+                             num_channels);
+    GEN_CASE_OP_PARAM_SINGLE(3, "voxel_pooling_forward", "num_voxel_x",
+                             num_voxel_x);
+    GEN_CASE_OP_PARAM_SINGLE(4, "voxel_pooling_forward", "num_voxel_y",
+                             num_voxel_y);
+    GEN_CASE_OP_PARAM_SINGLE(5, "voxel_pooling_forward", "num_voxel_z",
+                             num_voxel_z);
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
   }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

add bangc ops voxel_pooling_forward gen_case op param.

## 2. Modification

bangc-ops/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

#### 3.1.2 Operator Scheme checklist

#### 3.1.3 New Feature Test

#### 3.1.4 Parameter Check

### 3.2 Accuracy Test


[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/voxel_pooling_forward/test_case/voxel_pooling_forward_20230203_18_27_47_279682_tid1149_device5.prototxt
[       OK ] voxel_pooling_forward/TestSuite.mluOp/0 (4679 ms)
[----------] 1 test from voxel_pooling_forward/TestSuite (4679 ms total)

[----------] Global test environment tear-down
[2023-2-3 18:32:56] [MLUOP] [Vlog]: TearDown CNRT environment.
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
[==========] 1 test case from 1 test suite ran. (4861 ms total)
[  PASSED  ] 1 test case.


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](../docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
