### PR TITLE
[Feature](bangc_ops): roiaware_pool3d delete support MLU200.

### DIFF
--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -269,6 +269,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
     PARAM_CHECK(API, argmax != NULL);
   }
 
+  // check arch
+  if (handle->arch < MLUOP_MLU370) {
+    LOG(ERROR) << API
+               << " The operator does not match the current architecture.";
+    return MLUOP_STATUS_ARCH_MISMATCH;
+  }
+
   // generate mluOpRoiawarePool3dForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("roiaware_pool3d_forward");
@@ -525,6 +532,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   PARAM_CHECK(API, argmax != NULL);
   PARAM_CHECK(API, grad_out != NULL);
   PARAM_CHECK(API, grad_in != NULL);
+
+  // check arch
+  if (handle->arch < MLUOP_MLU370) {
+    LOG(ERROR) << API
+               << " The operator does not match the current architecture.";
+    return MLUOP_STATUS_ARCH_MISMATCH;
+  }
 
   VLOG(5) << "pool_method = " << pool_method
           << ", boxes_num = " << boxes_num

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
@@ -38,6 +38,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
     const int pool_method, const int boxes_num, const int pts_num,
     const int max_pts_each_voxel, const int out_x, const int out_y,
     const int out_z, const T *rois, const T *pts, int *pts_idx_of_voxels) {
+#if __BANG_ARCH__ >= 322
   if (__is_mpu()) {
     return;
   }
@@ -151,14 +152,8 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
       __bang_sub_scalar((T *)temp_buffer1, (T *)Z, (T)(cz + dz_2),
                         compute_pts_num);
       __bang_active_abs((T *)temp_buffer1, (T *)temp_buffer1, compute_pts_num);
-#if __BANG_ARCH__ >= 322
       __bang_le_scalar((T *)nram_pts_in_flag, (T *)temp_buffer1, (T)(dz_2),
                        compute_pts_num);
-#else
-      __bang_write_value((void *)temp_buffer2, compute_pts_num, (T)(dz_2));
-      __bang_le((T *)nram_pts_in_flag, (T *)temp_buffer1, (T *)temp_buffer2,
-                compute_pts_num);
-#endif
       T cosa = std::cos(-rz);
       T sina = std::sin(-rz);
       __bang_sub_scalar((T *)temp_buffer3, (T *)X, (T)cx, compute_pts_num);
@@ -173,14 +168,8 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
       // fabs(local_x)
       __bang_active_abs((T *)temp_buffer1, (T *)local_X, compute_pts_num);
       // fabs(local_x) < dx/2 ? 1 : 0
-#if __BANG_ARCH__ >= 322
       __bang_lt_scalar((T *)temp_buffer1, (T *)temp_buffer1, (T)(dx_2),
                        compute_pts_num);
-#else
-      __bang_write_value((void *)temp_buffer2, compute_pts_num, (T)(dx_2));
-      __bang_lt((T *)temp_buffer1, (T *)temp_buffer1, (T *)temp_buffer2,
-                compute_pts_num);
-#endif
       __bang_and((T *)nram_pts_in_flag, (T *)nram_pts_in_flag,
                  (T *)temp_buffer1,
                  compute_pts_num);  // flush res
@@ -195,14 +184,8 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
       // fabs(local_y)
       __bang_active_abs((T *)temp_buffer1, (T *)local_Y, compute_pts_num);
       // fabs(local_y) < dy/2 ? 1 : 0
-#if __BANG_ARCH__ >= 322
       __bang_lt_scalar((T *)temp_buffer1, (T *)temp_buffer1, (T)(dy_2),
                        compute_pts_num);
-#else
-      __bang_write_value((void *)temp_buffer2, compute_pts_num, (T)(dy_2));
-      __bang_lt((T *)temp_buffer1, (T *)temp_buffer1, (T *)temp_buffer2,
-                compute_pts_num);
-#endif
       __bang_and((T *)nram_pts_in_flag, (T *)nram_pts_in_flag,
                  (T *)temp_buffer1,
                  compute_pts_num);  // flush res
@@ -227,7 +210,6 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
 #endif
       // float = float2int + int2float, half = half2int + int2float
       if (std::is_same<T, float>::value) {
-#if __BANG_ARCH__ >= 322
         __bang_float2int32_tz((int *)temp_buffer1, (float *)local_X,
                               compute_pts_num, 0);
         __bang_float2int32_tz((int *)temp_buffer2, (float *)local_Y,
@@ -240,32 +222,11 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                               compute_pts_num, 0);
         __bang_int322float_rn((float *)fp_local_Z, (int *)temp_buffer3,
                               compute_pts_num, 0);
-#else
-        __float2int32((int *)temp_buffer1, (float *)temp_buffer2,
-                      (float *)fp_local_X, (float *)temp_buffer3,
-                      compute_pts_num);
-        __float2int32((int *)temp_buffer2, (float *)temp_buffer3,
-                      (float *)fp_local_Y, (float *)temp_buffer4,
-                      compute_pts_num);
-        __float2int32((int *)temp_buffer3, (float *)temp_buffer4,
-                      (float *)fp_local_Z, (float *)temp_buffer5,
-                      compute_pts_num);
-        __int322float((float *)fp_local_X, (float *)temp_buffer4,
-                      (int *)temp_buffer1, (float *)temp_buffer5,
-                      compute_pts_num);
-        __int322float((float *)fp_local_Y, (float *)temp_buffer4,
-                      (int *)temp_buffer2, (float *)temp_buffer5,
-                      compute_pts_num);
-        __int322float((float *)fp_local_Z, (float *)temp_buffer4,
-                      (int *)temp_buffer3, (float *)temp_buffer5,
-                      compute_pts_num);
-#endif
       } else {
         __bang_half2float((float *)temp_buffer4, (half *)nram_pts_in_flag,
                           compute_pts_num);
         __bang_move((void *)fp_nram_pts_in_flag, (void *)temp_buffer4,
                     compute_pts_num * sizeof(float));
-#if __BANG_ARCH__ >= 322
         __bang_half2int32_tz((int *)temp_buffer1, (half *)local_X,
                              compute_pts_num, 0);
         __bang_half2int32_tz((int *)temp_buffer2, (half *)local_Y,
@@ -278,20 +239,6 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                               compute_pts_num, 0);
         __bang_int322float_rn((float *)fp_local_Z, (int *)temp_buffer3,
                               compute_pts_num, 0);
-#else
-        __bang_half2int16_tz((int16_t *)temp_buffer1, (half *)local_X,
-                             compute_pts_num, 0);
-        __bang_half2int16_tz((int16_t *)temp_buffer2, (half *)local_Y,
-                             compute_pts_num, 0);
-        __bang_half2int16_tz((int16_t *)temp_buffer3, (half *)local_Z,
-                             compute_pts_num, 0);
-        __bang_int162float((float *)fp_local_X, (int16_t *)temp_buffer1,
-                           compute_pts_num, 0);
-        __bang_int162float((float *)fp_local_Y, (int16_t *)temp_buffer2,
-                           compute_pts_num, 0);
-        __bang_int162float((float *)fp_local_Z, (int16_t *)temp_buffer3,
-                           compute_pts_num, 0);
-#endif
       }
       // process index >= 0
       __bang_write_value((float *)temp_buffer4, compute_pts_num, (float)0.0f);
@@ -349,6 +296,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
       }
     }
   }
+#endif
 }
 
 template <typename T>
@@ -361,6 +309,7 @@ __mlu_entry__ void MLUMultiKernelRoiawarePool3dForward(
   // pts_idx_of_voxels: (boxes_num, out_x, out_y, out_z, max_pts_each_voxel)
   // argmax: (boxes_num, out_x, out_y, out_z, channels)
   // pooled_features: (boxes_num, out_x, out_y, out_z, channels)
+#if __BANG_ARCH__ >= 322
   if (__is_mpu()) {
     return;
   }
@@ -411,18 +360,6 @@ __mlu_entry__ void MLUMultiKernelRoiawarePool3dForward(
         break;
       }
       int channels_offset = nram_channels_limit * channels_loop_idx;
-
-#if ((__BANG_ARCH__ >= 200) && (__BANG_ARCH__ < 300))
-      int compute_channels_num = (channels_loop_idx == channels_loop_times)
-                                     ? PAD_UP(rem_channels, align_num)
-                                     : nram_channels_limit;
-      if (pool_method == 0) {
-        __bang_write_value((void *)nram_pts_feature_in_voxel,
-                           compute_channels_num * align_max_pts_each_voxel,
-                           (T)-INFINITY);
-      }
-#endif
-
       T *pts_feature_cur_loop = (T *)pts_feature + channels_offset * pts_num;
       for (int idx = 0; idx < pts_num_cur_voxel; idx++) {
         __memcpy((T *)nram_pts_feature_in_voxel + idx,
@@ -433,7 +370,6 @@ __mlu_entry__ void MLUMultiKernelRoiawarePool3dForward(
       for (int channel_idx = 0; channel_idx < actual_channels_num;
            channel_idx++) {
         if (pool_method == 0) {
-#if __BANG_ARCH__ >= 322
           __bang_argmax((T *)one_pooled_feature,
                         (T *)nram_pts_feature_in_voxel +
                             channel_idx * align_max_pts_each_voxel,
@@ -447,48 +383,6 @@ __mlu_entry__ void MLUMultiKernelRoiawarePool3dForward(
               ((max_val == -INFINITY) || (isnan(max_val) == true))
                   ? -1
                   : nram_pts_idx_cur_voxel[max_idx + 1];
-#else
-          // __bang_max need align num on mlu200 series
-          if (std::is_same<T, float>::value) {
-            __bang_max((float *)one_pooled_feature,
-                       (float *)nram_pts_feature_in_voxel +
-                           channel_idx * align_max_pts_each_voxel,
-                       align_max_pts_each_voxel);
-            float max_val = ((float *)one_pooled_feature)[0];
-            __bang_write_value((void *)nram_max_pts_feature_tmp,
-                               align_max_pts_each_voxel, (float)max_val);
-            __bang_eq((float *)nram_max_pts_feature_tmp,
-                      (float *)nram_pts_feature_in_voxel +
-                          channel_idx * align_max_pts_each_voxel,
-                      (float *)nram_max_pts_feature_tmp,
-                      align_max_pts_each_voxel);
-            int max_idx = (int)__bang_findfirst1(
-                (float *)nram_max_pts_feature_tmp, align_max_pts_each_voxel);
-            nram_pooled_features_cur_voxel[channel_idx] =
-                ((max_val == -INFINITY) || (isnan(max_val) == true)) ? 0
-                                                                     : max_val;
-            nram_argmax_cur_voxel[channel_idx] =
-                ((max_val == -INFINITY) || (isnan(max_val) == true))
-                    ? -1
-                    : nram_pts_idx_cur_voxel[max_idx + 1];
-          } else {
-            int max_idx = -1;
-            float max_val = -INFINITY;
-            for (int k = 0; k < pts_num_cur_voxel; k++) {
-              float pts_feature_cur_channel = __half2float_rd(
-                  *((half *)nram_pts_feature_in_voxel +
-                    channel_idx * align_max_pts_each_voxel + k));
-              if (pts_feature_cur_channel > max_val) {
-                max_val = pts_feature_cur_channel;
-                max_idx = k;
-              }
-            }
-            nram_pooled_features_cur_voxel[channel_idx] =
-                (max_idx == -1) ? 0 : max_val;
-            nram_argmax_cur_voxel[channel_idx] =
-                (max_idx == -1) ? -1 : nram_pts_idx_cur_voxel[max_idx + 1];
-          }
-#endif
         } else if (pool_method == 1) {
           float sum_val_cur_channel = 0;
           for (int k = 0; k < pts_num_cur_voxel; k++) {
@@ -512,6 +406,7 @@ __mlu_entry__ void MLUMultiKernelRoiawarePool3dForward(
       }
     }
   }
+#endif
 }
 
 void MLUOP_WIN_API mluOpUnionKernelPtsIdxOfVoxelsHalf(
@@ -567,6 +462,7 @@ __mlu_entry__ void MLUMultiKernelRoiawareMaxPool3dBackward(
   // argmax: (boxes_num, out_x, out_y, out_z, channels)
   // grad_out: (boxes_num, out_x, out_y, out_z, channels)
   // grad_in: (pts_num, channels)
+#if __BANG_ARCH__ >= 372
   if (__is_mpu()) {
     return;
   }
@@ -613,10 +509,11 @@ __mlu_entry__ void MLUMultiKernelRoiawareMaxPool3dBackward(
             grad_in + nram_argmax_cur_channel[0] * channels +
             nram_channels_limit * channels_loop_idx + channel_idx;
         __bang_atomic_reduce_add((T *)grad_in_cur_channel,
-                                 (T *)(nram_grad_out_cur_channel), 1);
+                                 (T *)nram_grad_out_cur_channel, 1);
       }
     }
   }
+#endif
 }
 
 template <typename T>
@@ -627,6 +524,7 @@ __mlu_entry__ void MLUMultiKernelRoiawareAvgPool3dBackward(
   // pts_idx_of_voxels: (boxes_num, out_x, out_y, out_z, max_pts_each_voxel)
   // grad_out: (boxes_num, out_x, out_y, out_z, channels)
   // grad_in: (pts_num, channels)
+#if __BANG_ARCH__ >= 372
   if (__is_mpu()) {
     return;
   }
@@ -698,6 +596,7 @@ __mlu_entry__ void MLUMultiKernelRoiawareAvgPool3dBackward(
       }
     }
   }
+#endif
 }
 
 void MLUOP_WIN_API mluOpUnionKernelRoiawarePool3dBackwardHalf(

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -3718,7 +3718,8 @@ mluOpYoloBox(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4662,7 +4663,8 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the pooled_features tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - This function supports the following data types for input tensor \b rois , \b pts , \b pts_feature
@@ -4687,7 +4689,8 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @note
  * - The inputs \b rois and \b pts with NaN or infinity are not supported currently.
- * - The inputs \b pts_feature with NaN are not supported currently.
+ * - The inputs \b pts_feature with NaN are not supported on MLU300 series.
+ * - The operation does not support MLU200 series.
  *
  * @par Requirements
  * - None.
@@ -4759,7 +4762,8 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the grad_in tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - This function supports the following data types for input tensor \b pts_idx_of_voxels , \b argmax , \b grad_out
@@ -4779,7 +4783,7 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  * - None.
  *
  * @note
- * - None.
+ * - The operation does not support MLU200 series.
  *
  * @par Requirements
  * - None.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 
 
## 1. Motivation

roiaware_pool3d delete support MLU200.

## 2. Modification

1) mlu-ops/bangc-ops/kernels/roiaware_pool3d/*
2) mlu-ops/bangc-ops/mlu_op.h

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For dynamic threshold standard details.

#### 3.1.2 Operator Scheme checklist

|     No.      |           Details            |      Check Results       |
|----------------|---------------------------|---------------------|
|        1       |          Supported hardware         | MLU270 <br> MLU290 <br>MLU370<br>MLU590 |
|        2       |          Job types          |     U1     |
|        3       |         Layouts            | ARRAY   |
|        4       |         Whether multi-dimensions are supported              |    X     |
|        5       |          Whether element zero is supported             |    X      |
|        6       |         Data type(half/float)       |         half / float         |
|        7      |        Whether there is size limit           |       |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [x] Multidimensional tensor test
- [x] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](../docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](../docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

| Test Point         | Acceptance Standard | Test Result (Error Message) |
| -------------- | -------- | -------------------- |
| Whether it conforms to the operator restriction | Normal error |                      |
| Whether illegal parameters are passed  | Normal error |                      |

### 3.2 Performance Test

### 3.3 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.

平台：MLU290
```
/tmp/workspace/mluops_develop/mluops/bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/mlu_op_gtest.cpp:125: Failure
Failed
MLUOPSGTEST: catched "MLUOP_STATUS_MISMATCH in mluOpRoiawarePool3dForward( handle_, pool_method_, boxes_num_, pts_num_, channels_, desc_rois_, dev_rois_, desc_pts_, dev_pts_, desc_pts_feature_, dev_pts_feature_, workspace_[0], workspace_size_, max_pts_each_voxel_, out_x_, out_y_, out_z_, desc_argmax_, dev_argmax_, desc_pts_idx_of_voxels_, dev_pts_idx_of_voxels_, desc_pooled_features_, dev_pooled_features_)" in single thread mode. (of /data/mlu-ops/release_test/roiaware_pool3d_forward/roiaware_pool3d_forward_data_included_int32_float16_1660275165154.pb)
/tmp/workspace/mluops_develop/mluops/bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/mlu_op_gtest.cpp:554: Failure
Failed
MLUOPSGTEST: Errors found during calculations
```
平台：MLU370
```
[----------] Global test environment tear-down
[ SUMMARY  ] Total 32 cases of 1 op(s).
ALL PASSED.
[==========] 32 test cases from 1 test suite ran. (5229 ms total)
[  PASSED  ] 32 test cases.
```
平台：MLU590
```
[----------] Global test environment tear-down
[ SUMMARY  ] Total 32 cases of 1 op(s).
ALL PASSED.
[==========] 32 test cases from 1 test suite ran. (5145 ms total)
[  PASSED  ] 32 test cases.
/tmp/workspace/mluops_develop/mluops_shell
```