### PR TITLE
[Fix](bangc-ops): fix CMakeList.txt to resolve link error

### DIFF
--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -125,11 +125,10 @@ foreach(kernel ${build_kernel})
     continue()
   endif()
   file(GLOB_RECURSE src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/${kernel}/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/kernels/${kernel}/*.mlu")
-  file(GLOB_RECURSE obj_files ${obj_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/${kernel}/${MLUOP_TARGET_CPU_ARCH}/*.o")
+  file(GLOB_RECURSE arch_binary_files ${arch_binary_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/${kernel}/${MLUOP_TARGET_CPU_ARCH}/*.o")
 endforeach()
 
-file(GLOB_RECURSE object_files ${object_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/*.a")
-file(GLOB_RECURSE o_files ${o_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/*.o")
+file(GLOB_RECURSE archive_binary_files ${archive_binary_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/*.a")
 
 file(GLOB_RECURSE core_src_files ${core_src_files} "${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp")
 # set(src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp")
@@ -139,34 +138,37 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/libmluops.map)
 else()
   message(FATAL_ERROR "libmluops.map doesn't exist.")
 endif()
+
 set(LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libmluops.map")
 message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
 add_library(mluopscore STATIC ${core_src_files})
-bang_add_library(mluops SHARED ${src_files})
-target_link_libraries(mluops ${obj_files} mluopscore ${LINK_FLAGS})
 
-if (object_files MATCHES ".a")
+if (archive_binary_files MATCHES ".a")
   if ("${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/wrapper.cpp" IN_LIST src_files)
     list(REMOVE_ITEM src_files "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/wrapper.cpp")
   endif()
-  message(STATUS "Build MLUOP with static object file.")
-  message("${object_files}")
-  target_link_libraries(mluops
-    -Wl,--whole-archive
-    ${object_files}
-    -Wl,--no-whole-archive)
-  target_link_libraries(mluops cnrt cndrv dl)
+  message(STATUS "Build MLUOP with static object file:${archive_binary_files}")
 else()
-  target_link_libraries(mluops ${o_files} cnrt cndrv dl)
+  file(GLOB_RECURSE wrapper_binary_files ${wrapper_binary_files} "${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/*.o")
   message(STATUS "Build External lib with object files.")
   execute_process(COMMAND g++ -c -std=c++11 -fPIC -I ${CMAKE_CURRENT_SOURCE_DIR}
                                  -I ${NEUWARE_HOME}/include
                                  ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/wrapper.cpp
                                  -o ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/wrapper.cpp.o)
   execute_process(COMMAND ar -rc ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/libextops.a
-                                  ${o_files} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/wrapper.cpp.o)
+                                  ${wrapper_binary_files} ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/wrapper.cpp.o)
   execute_process(COMMAND rm ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_wrapper/lib/wrapper.cpp.o)
 endif()
+
+bang_add_library(mluops SHARED ${src_files})
+target_link_libraries(mluops
+  -Wl,--start-group
+  ${arch_binary_files} ${wrapper_binary_files}
+  -Wl,--whole-archive ${archive_binary_files} mluopscore -Wl,--no-whole-archive
+  cnrt cndrv dl
+  -Wl,--end-group
+)
+target_link_libraries(mluops ${LINK_FLAGS})
 set_target_properties(mluops PROPERTIES
   OUTPUT_NAME "mluops"
   PREFIX      "lib"


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Modify the order of the CMakeList link library to resolve the link error reported in the single operator compilation of binary migration

## 2. Modification
- 修改 bangc-ops/CMakeList.txt 编译脚本 
- 问题描述：
1. 静态库libextops.a需要依赖core目录下的部分接口功能
2. 因之前符号隐藏方案的修改需要将bangc-ops/core目录下的源码，单独编译为静态库mluopscore.a，然后在link到mluops.so中，因先link了mluopscore，导致在单算子编译时，编译器将mluopscore不需要的符号没有完全link到mluops中，因此在之后链接libextops.a，报link错误，libextops.a库依赖的部分接口符号找不到（core目录下的接口）

- 解决方案：
1. 修改CMakeList，调整链接libmluopscore.a的位置，放在链接libextops.a之后链接
2. 链接mluopscore时，加上-Wl,--whole-archive 链接选项，将mluopscore的符号完全link到mluops.so中

## 3. Test Report
- ./build.sh --filter="add_n" 通过
- 多系统测试：ubuntu18.04/20.04、centos7/8、Debian10 编译测试通过

