### PR TITLE
[Fix](mlu-ops): Temporarily make bangpy test offline for bangc code merging test.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,6 @@ jobs:
           docker run --rm -v $(pwd):/work -w /work docker-user.gotgo.cc:30080/mlu-ops/mluops_ci:${{matrix.version}}-devel-x86_64-ubuntu18.04
           ./build.sh --sub_module=bangc
 
-      - name: build_bangpy_ops
-        run: >
-          docker run --rm -v $(pwd):/work -w /work docker-user.gotgo.cc:30080/mlu-ops/mluops_ci:v0.2-x86_64-ubuntu16.04-BANGPy
-          ./build.sh --sub_module=bangpy
-
       - name: bangc_ops_release_temp_cases
         run: >
           docker run --rm --device /dev/cambricon_ctl --device /dev/cambricon_dev0 --device /dev/commu0
@@ -42,12 +37,6 @@ jobs:
           docker run --rm --device /dev/cambricon_ctl --device /dev/cambricon_dev0 --device /dev/commu0
           -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.gotgo.cc:30080/mlu-ops/mluops_ci:${{matrix.version}}-devel-x86_64-ubuntu18.04
           ./test.sh --sub_module=bangc --cases_dir=/testdata/release_temp/370
-
-      - name: test_bangpy_ops
-        run: >
-          docker run --rm --device /dev/cambricon_ctl --device /dev/cambricon_dev0 --device /dev/commu0
-          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.gotgo.cc:30080/mlu-ops/mluops_ci:v0.2-x86_64-ubuntu16.04-BANGPy
-          ./test.sh --sub_module=bangpy --cases_dir=/testdata/bangpy
 
       - name: clean
         run: |


### PR DESCRIPTION


Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

For fast bangc code merging checking. Temporarily have bangpy test offline.

## 2. Modification

.github/workflow/ci.yaml
