### PR TITLE
[TEST](indice_convolution_backward_filter):add api check cases for indice_convolution_backward_filter

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -137,16 +137,7 @@ class indice_convolution_backward_filter : public testing::Test {
       GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
-  bool compute(std::vector<mluOpDevType_t> target_device_) {
-    if (handle_) {
-      CNRT_CHECK(cnrtQueueSync(handle_->queue));
-      if (std::find(target_device_.begin(), target_device_.end(),
-                    handle_->arch) == target_device_.end()) {
-        destroy();
-        return true;
-      }
-    }
-
+  mluOpStatus_t compute() {
     mluOpStatus_t status = mluOpIndiceConvolutionBackwardFilter(
         handle_, features_desc_, features_, output_grad_desc_, output_grad_,
         indice_pairs_desc_, indice_pairs_, indice_num_.data(), inverse_, sub_m_,
@@ -239,8 +230,7 @@ class indice_convolution_backward_filter : public testing::Test {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_handle_null) {
   try {
     setParam(false, true, true, true, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -250,8 +240,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_handle_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_features_desc_null) {
   try {
     setParam(true, false, true, true, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -261,8 +250,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_features_desc_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_features_null) {
   try {
     setParam(true, true, false, true, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -272,8 +260,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_features_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_output_grad_desc_null) {
   try {
     setParam(true, true, true, false, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -283,8 +270,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_output_grad_desc_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_output_grad_null) {
   try {
     setParam(true, true, true, true, false, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -294,8 +280,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_output_grad_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_pairs_desc_null) {
   try {
     setParam(true, true, true, true, true, false, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -305,8 +290,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_pairs_desc_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_pairs_null) {
   try {
     setParam(true, true, true, true, true, true, false, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -316,8 +300,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_pairs_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_filters_grad_desc_null) {
   try {
     setParam(true, true, true, true, true, true, true, false, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -327,8 +310,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_filters_grad_desc_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_filters_grad_null) {
   try {
     setParam(true, true, true, true, true, true, true, true, false, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -338,8 +320,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_filters_grad_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_num_null) {
   try {
     setParam(true, true, true, true, true, true, true, true, true, false, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";
@@ -349,8 +330,7 @@ TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_num_null) {
 TEST_F(indice_convolution_backward_filter, BAD_PARAM_workspace_null) {
   try {
     setParam(true, true, true, true, true, true, true, true, true, true, false);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter";

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -1,0 +1,361 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class indice_convolution_backward_filter : public testing::Test {
+ public:
+  void setParam(bool handle, bool features_desc, bool features,
+                bool output_grad_desc, bool output_grad, bool indice_pairs_desc,
+                bool indice_pairs, bool filters_grad_desc, bool filters_grad,
+                bool indice_num, bool worksapce) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_desc_));
+      std::vector<int> features_dims{3, 5};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           features_dims.data()));
+    }
+
+    if (features) {
+      if (features_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&features_, mluOpGetTensorElementNum(features_desc_) *
+                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&features_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (output_grad_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_grad_desc_));
+      std::vector<int> output_grad_dims{3, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          output_grad_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+          output_grad_dims.data()));
+    }
+
+    if (output_grad) {
+      if (output_grad_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&output_grad_,
+                               mluOpGetTensorElementNum(output_grad_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&output_grad_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (indice_pairs_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
+      std::vector<int> indice_pairs_dims{9, 2, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indice_pairs_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
+          indice_pairs_dims.data()));
+    }
+
+    if (indice_pairs) {
+      if (indice_pairs_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&indice_pairs_,
+                               mluOpGetTensorElementNum(indice_pairs_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&indice_pairs_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (filters_grad_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&filters_grad_desc_));
+      std::vector<int> filters_grad_dims{3, 3, 5, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          filters_grad_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+          filters_grad_dims.data()));
+    }
+
+    if (filters_grad) {
+      if (filters_grad_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&filters_grad_,
+                               mluOpGetTensorElementNum(filters_grad_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&filters_grad_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    int nums = 1;
+    int num_size = 1;
+    for (int i = 0; i < nums; i++) {
+      if (indice_num) {
+        indice_num_.push_back(num_size);
+      }
+    }
+
+    if (worksapce) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    }
+  }
+  bool compute(std::vector<mluOpDevType_t> target_device_) {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      if (std::find(target_device_.begin(), target_device_.end(),
+                    handle_->arch) == target_device_.end()) {
+        destroy();
+        return true;
+      }
+    }
+
+    mluOpStatus_t status = mluOpIndiceConvolutionBackwardFilter(
+        handle_, features_desc_, features_, output_grad_desc_, output_grad_,
+        indice_pairs_desc_, indice_pairs_, indice_num_.data(), inverse_, sub_m_,
+        workspace_, workspace_size_, filters_grad_desc_, filters_grad_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (features_desc_) {
+      VLOG(4) << "Destroy features_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_desc_));
+      features_desc_ = nullptr;
+    }
+
+    if (features_) {
+      VLOG(4) << "Destroy features";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+      features_ = nullptr;
+    }
+
+    if (output_grad_desc_) {
+      VLOG(4) << "Destroy output_grad_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_grad_desc_));
+      output_grad_desc_ = nullptr;
+    }
+
+    if (output_grad_) {
+      VLOG(4) << "Destroy output_grad";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_grad_));
+      output_grad_ = nullptr;
+    }
+
+    if (indice_pairs_desc_) {
+      VLOG(4) << "Destroy indice_pairs_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indice_pairs_desc_));
+      indice_pairs_desc_ = nullptr;
+    }
+
+    if (indice_pairs_) {
+      VLOG(4) << "Destroy indice_pairs";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      indice_pairs_ = nullptr;
+    }
+
+    if (workspace_) {
+      VLOG(4) << "Destroy workspace";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      workspace_ = nullptr;
+    }
+
+    if (filters_grad_desc_) {
+      VLOG(4) << "Destroy filters_grad_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(filters_grad_desc_));
+      filters_grad_desc_ = nullptr;
+    }
+
+    if (filters_grad_) {
+      VLOG(4) << "Destroy filters_grad";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_grad_));
+      filters_grad_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t features_desc_ = nullptr;
+  void *features_ = nullptr;
+  mluOpTensorDescriptor_t output_grad_desc_ = nullptr;
+  void *output_grad_ = nullptr;
+  mluOpTensorDescriptor_t indice_pairs_desc_ = nullptr;
+  void *indice_pairs_ = nullptr;
+  std::vector<int64_t> indice_num_;
+  int64_t inverse_ = 0;
+  int64_t sub_m_ = 0;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  mluOpTensorDescriptor_t filters_grad_desc_ = nullptr;
+  void *filters_grad_ = nullptr;
+};
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_features_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_features_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_output_grad_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_output_grad_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_pairs_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_pairs_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_filters_grad_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_filters_grad_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_indice_num_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, false, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter, BAD_PARAM_workspace_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, false);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter";
+  }
+}
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -126,11 +126,10 @@ class indice_convolution_backward_filter : public testing::Test {
       }
     }
 
-    int nums = 1;
-    int num_size = 1;
-    for (int i = 0; i < nums; i++) {
+    std::vector<int> num = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    for (int i = 0; i < num.size(); i++) {
       if (indice_num) {
-        indice_num_.push_back(num_size);
+        indice_num_.push_back(num[i]);
       }
     }
 

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
@@ -161,7 +161,7 @@ class indice_convolution_backward_filter_general
   void destroy() {
     try {
       if (handle_) {
-        CNRT_CHECK(cnrtQueueSync(handle_->queue));
+        //CNRT_CHECK(cnrtQueueSync(handle_->queue));
         MLUOP_CHECK(mluOpDestroy(handle_));
         handle_ = nullptr;
       }
@@ -310,7 +310,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
         testing::Values(MLUOP_MLU370, MLUOP_MLU590),
-        testing::Values(MLUOP_STATUS_SUCCESS)));
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_unsupport_dtype, indice_convolution_backward_filter_general,

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
@@ -107,7 +107,7 @@ class indice_convolution_backward_filter_general
           filters_grad_desc_, filters_grad_params.get_layout(),
           filters_grad_params.get_dtype(), filters_grad_params.get_dim_nb(),
           filters_grad_params.get_dim_size().data()));
-      if (mluOpGetTensorElementNum(indice_pairs_desc_) >= LARGE_TENSOR_NUM) {
+      if (mluOpGetTensorElementNum(filters_grad_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
             cnrtMalloc(
@@ -118,7 +118,7 @@ class indice_convolution_backward_filter_general
             CNRT_RET_SUCCESS ==
             cnrtMalloc(&filters_grad_,
                        mluOpDataTypeBytes(filters_grad_params.get_dtype()) *
-                           mluOpGetTensorElementNum(indice_pairs_desc_)));
+                           mluOpGetTensorElementNum(filters_grad_desc_)));
       }
 
       std::vector<int64_t> num = {1, 2, 3, 4, 5, 6, 7, 8, 9};

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
@@ -67,10 +67,19 @@ class indice_convolution_backward_filter_general
           output_grad_desc_, output_grad_params.get_layout(),
           output_grad_params.get_dtype(), output_grad_params.get_dim_nb(),
           output_grad_params.get_dim_size().data()));
-      GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
-          cnrtMalloc(&output_grad_,
-                     mluOpDataTypeBytes(output_grad_params.get_dtype()) * 10));
+      if (mluOpGetTensorElementNum(output_grad_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(
+                &output_grad_,
+                mluOpDataTypeBytes(output_grad_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&output_grad_,
+                       mluOpDataTypeBytes(output_grad_params.get_dtype()) *
+                           mluOpGetTensorElementNum(output_grad_desc_)));
+      }
 
       MLUOpTensorParam indice_pairs_params = std::get<2>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
@@ -78,10 +87,19 @@ class indice_convolution_backward_filter_general
           indice_pairs_desc_, indice_pairs_params.get_layout(),
           indice_pairs_params.get_dtype(), indice_pairs_params.get_dim_nb(),
           indice_pairs_params.get_dim_size().data()));
-      GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
-          cnrtMalloc(&indice_pairs_,
-                     mluOpDataTypeBytes(indice_pairs_params.get_dtype()) * 10));
+      if (mluOpGetTensorElementNum(indice_pairs_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(
+                &indice_pairs_,
+                mluOpDataTypeBytes(indice_pairs_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indice_pairs_,
+                       mluOpDataTypeBytes(indice_pairs_params.get_dtype()) *
+                           mluOpGetTensorElementNum(indice_pairs_desc_)));
+      }
 
       MLUOpTensorParam filters_grad_params = std::get<3>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&filters_grad_desc_));
@@ -89,10 +107,19 @@ class indice_convolution_backward_filter_general
           filters_grad_desc_, filters_grad_params.get_layout(),
           filters_grad_params.get_dtype(), filters_grad_params.get_dim_nb(),
           filters_grad_params.get_dim_size().data()));
-      GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
-          cnrtMalloc(&filters_grad_,
-                     mluOpDataTypeBytes(filters_grad_params.get_dtype()) * 10));
+      if (mluOpGetTensorElementNum(indice_pairs_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(
+                &filters_grad_,
+                mluOpDataTypeBytes(filters_grad_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&filters_grad_,
+                       mluOpDataTypeBytes(filters_grad_params.get_dtype()) *
+                           mluOpGetTensorElementNum(indice_pairs_desc_)));
+      }
 
       std::vector<int64_t> num = {1, 2, 3, 4, 5, 6, 7, 8, 9};
       for (int i = 0; i < num.size(); i++) {
@@ -268,6 +295,20 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({0, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 0, 5, 3}))),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_value, indice_convolution_backward_filter_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 5}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({9, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({3, 3, 5, 3}))),
         testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
@@ -254,7 +254,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 0}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -268,7 +268,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -282,7 +282,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({0, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 0, 5, 3}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -299,7 +299,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
                                          MLUOP_DTYPE_COMPLEX_FLOAT, 4,
                                          std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -319,7 +319,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -340,7 +340,7 @@ INSTANTIATE_TEST_CASE_P(
                                          4, std::vector<int>({9, 2, 3, 4}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -358,7 +358,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -379,7 +379,7 @@ INSTANTIATE_TEST_CASE_P(
                                          4, std::vector<int>({3, 3, 15, 3})),
                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 13}))),
-        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -393,7 +393,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(1), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(1), testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
@@ -254,8 +254,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 0}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                         
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -269,8 +268,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),             
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -284,8 +282,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({0, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 0, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -302,8 +299,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
                                          MLUOP_DTYPE_COMPLEX_FLOAT, 4,
                                          std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -323,8 +319,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -345,8 +340,7 @@ INSTANTIATE_TEST_CASE_P(
                                          4, std::vector<int>({9, 2, 3, 4}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -364,8 +358,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -386,24 +379,22 @@ INSTANTIATE_TEST_CASE_P(
                                          4, std::vector<int>({3, 3, 15, 3})),
                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 13}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_inverse, indice_convolution_backward_filter_general,
     testing::Combine(
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          2, std::vector<int>({1, 5}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          2, std::vector<int>({3, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          3, std::vector<int>({9, 2, 3}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(1),                                                      
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));        
+        testing::Values(1), testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_large_tensor_features, indice_convolution_backward_filter_general,
@@ -416,8 +407,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -431,8 +421,7 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({9, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -447,8 +436,7 @@ INSTANTIATE_TEST_CASE_P(
                                          std::vector<int>({715827883, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          4, std::vector<int>({3, 3, 5, 3}))),
-        testing::Values(0),                                                      
-        testing::Values(MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -463,7 +451,6 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(
             MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
                              std::vector<int>({47721859, 3, 5, 3}))),
-        testing::Values(0),
-        testing::Values(MLUOP_MLU590),
+        testing::Values(0), testing::Values(MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 }  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
@@ -1,0 +1,383 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+
+typedef std::tuple<MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, mluOpDevType_t, mluOpStatus_t>
+    IndiceConvBpFilterParam;
+class indice_convolution_backward_filter_general
+    : public testing::TestWithParam<IndiceConvBpFilterParam> {
+ public:
+  void SetUp() {
+    try {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+
+      MLUOpTensorParam features_params = std::get<0>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          features_desc_, features_params.get_layout(),
+          features_params.get_dtype(), features_params.get_dim_nb(),
+          features_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&features_,
+                     mluOpDataTypeBytes(features_params.get_dtype()) * 10));
+
+      MLUOpTensorParam output_grad_params = std::get<1>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_grad_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          output_grad_desc_, output_grad_params.get_layout(),
+          output_grad_params.get_dtype(), output_grad_params.get_dim_nb(),
+          output_grad_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&output_grad_,
+                     mluOpDataTypeBytes(output_grad_params.get_dtype()) * 10));
+
+      MLUOpTensorParam indice_pairs_params = std::get<2>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indice_pairs_desc_, indice_pairs_params.get_layout(),
+          indice_pairs_params.get_dtype(), indice_pairs_params.get_dim_nb(),
+          indice_pairs_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&indice_pairs_,
+                     mluOpDataTypeBytes(indice_pairs_params.get_dtype()) * 10));
+
+      MLUOpTensorParam filters_grad_params = std::get<3>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&filters_grad_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          filters_grad_desc_, filters_grad_params.get_layout(),
+          filters_grad_params.get_dtype(), filters_grad_params.get_dim_nb(),
+          filters_grad_params.get_dim_size().data()));
+      GTEST_CHECK(
+          CNRT_RET_SUCCESS ==
+          cnrtMalloc(&filters_grad_,
+                     mluOpDataTypeBytes(filters_grad_params.get_dtype()) * 10));
+
+      std::vector<int64_t> num = {1};
+      for (int i = 0; i < num.size(); i++) {
+        indice_num_.push_back(num[i]);
+      }
+      target_device_ = std::get<4>(GetParam());
+      expected_status_ = std::get<5>(GetParam());
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in indice_convolution_backward_filter_general.";
+    }
+  }
+
+  bool compute() {
+    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+          target_device_ == handle_->arch)) {
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status;
+    status = mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(
+        handle_, features_desc_, output_grad_desc_, indice_pairs_desc_,
+        filters_grad_desc_, indice_num_.data(), inverse_, sub_m_,
+        &workspace_size_);
+    if (status != MLUOP_STATUS_SUCCESS) {
+      destroy();
+      return expected_status_ == status;
+    }
+    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+
+    status = mluOpIndiceConvolutionBackwardFilter(
+        handle_, features_desc_, features_, output_grad_desc_, output_grad_,
+        indice_pairs_desc_, indice_pairs_, indice_num_.data(), inverse_, sub_m_,
+        workspace_, workspace_size_, filters_grad_desc_, filters_grad_);
+    destroy();
+    return expected_status_ == status;
+  }
+
+  void destroy() {
+    try {
+      if (handle_) {
+        CNRT_CHECK(cnrtQueueSync(handle_->queue));
+        MLUOP_CHECK(mluOpDestroy(handle_));
+        handle_ = nullptr;
+      }
+
+      if (features_desc_) {
+        VLOG(4) << "Destroy features_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_desc_));
+        features_desc_ = nullptr;
+      }
+
+      if (features_) {
+        VLOG(4) << "Destroy features";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+        features_ = nullptr;
+      }
+
+      if (output_grad_desc_) {
+        VLOG(4) << "Destroy output_grad_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_grad_desc_));
+        output_grad_desc_ = nullptr;
+      }
+
+      if (output_grad_) {
+        VLOG(4) << "Destroy output_grad";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_grad_));
+        output_grad_ = nullptr;
+      }
+
+      if (indice_pairs_desc_) {
+        VLOG(4) << "Destroy indice_pairs_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(indice_pairs_desc_));
+        indice_pairs_desc_ = nullptr;
+      }
+
+      if (indice_pairs_) {
+        VLOG(4) << "Destroy indice_pairs";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+        indice_pairs_ = nullptr;
+      }
+
+      if (filters_grad_desc_) {
+        VLOG(4) << "Destroy filters_grad_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(filters_grad_desc_));
+        filters_grad_desc_ = nullptr;
+      }
+
+      if (filters_grad_) {
+        VLOG(4) << "Destroy filters_grad";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_grad_));
+        filters_grad_ = nullptr;
+      }
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in indice_convolution_backward_filter_general";
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t features_desc_ = nullptr;
+  void *features_ = nullptr;
+  mluOpTensorDescriptor_t output_grad_desc_ = nullptr;
+  void *output_grad_ = nullptr;
+  mluOpTensorDescriptor_t indice_pairs_desc_ = nullptr;
+  void *indice_pairs_ = nullptr;
+  std::vector<int64_t> indice_num_;
+  int64_t inverse_ = 0;
+  int64_t sub_m_ = 0;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 1;
+  mluOpTensorDescriptor_t filters_grad_desc_ = nullptr;
+  void *filters_grad_ = nullptr;
+  mluOpDevType_t target_device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(indice_convolution_backward_filter_general, negative) {
+  EXPECT_TRUE(compute());
+}
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, indice_convolution_backward_filter_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 5}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({9, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({3, 3, 5, 3}))),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, indice_convolution_backward_filter_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 5}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({9, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({3, 3, 5, 3}))),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_3, indice_convolution_backward_filter_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 5}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({9, 2, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({3, 3, 5, 3}))),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_unsupport_dtype, indice_convolution_backward_filter_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+                                         MLUOP_DTYPE_COMPLEX_FLOAT, 2,
+                                         std::vector<int>({1, 5}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+                                         MLUOP_DTYPE_COMPLEX_FLOAT, 2,
+                                         std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({9, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+                                         MLUOP_DTYPE_COMPLEX_FLOAT, 4,
+                                         std::vector<int>({3, 3, 5, 3}))),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_features_dim_shape_dtype, indice_convolution_backward_filter_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({3, 5})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({3, 5, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 15}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({9, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({3, 3, 5, 3}))),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_features_dim_0, indice_convolution_backward_filter_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 5}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({9, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({3, 3, 5, 3}))),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+// INSTANTIATE_TEST_CASE_P(
+//     bad_indice_pairs_dim_shape_dtype,
+//     indice_convolution_backward_filter_general, testing::Combine(
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 5}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 3}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_INT64,
+//                                          3, std::vector<int>({9, 2, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_INT32,
+//                                          3, std::vector<int>({11, 2, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_INT32,
+//                                          3, std::vector<int>({9, 1, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_INT32,
+//                                          4, std::vector<int>({9, 2, 3, 4})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_INT32,
+//                                          3, std::vector<int>({9, 2, 4}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          4, std::vector<int>({3, 3, 5, 3}))),
+//         testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+//         testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+// INSTANTIATE_TEST_CASE_P(
+//     bad_output_grad_dim_shape_dtype,
+//     indice_convolution_backward_filter_general, testing::Combine(
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 5}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_HALF,
+//                                          2, std::vector<int>({3, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_FLOAT,
+//                                          3, std::vector<int>({3, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 4}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_INT32,
+//                                          3, std::vector<int>({9, 2, 3}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          4, std::vector<int>({3, 3, 5, 3}))),
+//         testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+//         testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+// INSTANTIATE_TEST_CASE_P(
+//     bad_filters_grad_dim_shape_dtype,
+//     indice_convolution_backward_filter_general, testing::Combine(
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 5}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 3}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_INT32,
+//                                          3, std::vector<int>({9, 2, 3}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_HALF,
+//                                          4, std::vector<int>({3, 3, 5, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_FLOAT,
+//                                          3, std::vector<int>({3, 3, 5, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_FLOAT,
+//                                          4, std::vector<int>({3, 3, 15, 3})),
+//                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//                         MLUOP_DTYPE_FLOAT,
+//                                          4, std::vector<int>({3, 3, 5,
+//                                          13}))),
+//         testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+//         testing::Values(MLUOP_STATUS_BAD_PARAM)));
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_workspace.cpp
@@ -86,16 +86,7 @@ class indice_convolution_backward_filter_workspace : public testing::Test {
     }
   }
 
-  bool compute(std::vector<mluOpDevType_t> target_device_) {
-    if (handle_) {
-      CNRT_CHECK(cnrtQueueSync(handle_->queue));
-      if (std::find(target_device_.begin(), target_device_.end(),
-                    handle_->arch) == target_device_.end()) {
-        destroy();
-        return true;
-      }
-    }
-
+  mluOpStatus_t compute() {
     mluOpStatus_t status = mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(
         handle_, features_desc_, output_grad_desc_, indice_pairs_desc_,
         filters_grad_desc_, indice_num_.data(), inverse_, sub_m_,
@@ -153,8 +144,7 @@ class indice_convolution_backward_filter_workspace : public testing::Test {
 TEST_F(indice_convolution_backward_filter_workspace, BAD_PARAM_handle_null) {
   try {
     setParam(false, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter_workspace";
@@ -165,8 +155,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_features_desc_null) {
   try {
     setParam(true, false, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter_workspace";
@@ -177,8 +166,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_output_grad_desc_null) {
   try {
     setParam(true, true, false, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter_workspace";
@@ -189,8 +177,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_indice_pairs_desc_null) {
   try {
     setParam(true, true, true, false, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter_workspace";
@@ -201,8 +188,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_filters_grad_desc_null) {
   try {
     setParam(true, true, true, true, false, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter_workspace";
@@ -213,8 +199,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_indice_num_null) {
   try {
     setParam(true, true, true, true, true, false, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter_workspace";
@@ -225,8 +210,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_workspace_size_null) {
   try {
     setParam(true, true, true, true, true, true, false);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_backward_filter_workspace";

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_workspace.cpp
@@ -1,0 +1,219 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class indice_convolution_backward_filter_workspace : public testing::Test {
+ public:
+  void setParam(bool handle, bool features_desc, bool output_grad_desc,
+                bool indice_pairs_desc, bool filters_grad_desc,
+                bool indice_num) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_desc_));
+      std::vector<int> features_dims{3, 5};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           features_dims.data()));
+    }
+
+    if (output_grad_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_grad_desc_));
+      std::vector<int> output_grad_dims{3, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          output_grad_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+          output_grad_dims.data()));
+    }
+
+    if (indice_pairs_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
+      std::vector<int> indice_pairs_dims{9, 2, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indice_pairs_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
+          indice_pairs_dims.data()));
+    }
+
+    if (filters_grad_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&filters_grad_desc_));
+      std::vector<int> filters_grad_dims{3, 3, 5, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          filters_grad_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+          filters_grad_dims.data()));
+    }
+    int nums = 1;
+    int num_size = 1;
+    for (int i = 0; i < nums; i++) {
+      if (indice_num) {
+        indice_num_.push_back(num_size);
+      }
+    }
+  }
+
+  bool compute(std::vector<mluOpDevType_t> target_device_) {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      if (std::find(target_device_.begin(), target_device_.end(),
+                    handle_->arch) == target_device_.end()) {
+        destroy();
+        return true;
+      }
+    }
+
+    mluOpStatus_t status = mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(
+        handle_, features_desc_, output_grad_desc_, indice_pairs_desc_,
+        filters_grad_desc_, indice_num_.data(), inverse_, sub_m_,
+        workspace_size_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (features_desc_) {
+      VLOG(4) << "Destroy features_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_desc_));
+      features_desc_ = nullptr;
+    }
+
+    if (output_grad_desc_) {
+      VLOG(4) << "Destroy output_grad_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_grad_desc_));
+      output_grad_desc_ = nullptr;
+    }
+
+    if (indice_pairs_desc_) {
+      VLOG(4) << "Destroy indice_pairs_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indice_pairs_desc_));
+      indice_pairs_desc_ = nullptr;
+    }
+
+    if (filters_grad_desc_) {
+      VLOG(4) << "Destroy filters_grad_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(filters_grad_desc_));
+      filters_grad_desc_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t features_desc_ = nullptr;
+  mluOpTensorDescriptor_t output_grad_desc_ = nullptr;
+  mluOpTensorDescriptor_t indice_pairs_desc_ = nullptr;
+  mluOpTensorDescriptor_t filters_grad_desc_ = nullptr;
+  std::vector<int64_t> indice_num_;
+  int64_t inverse_ = 0;
+  int64_t sub_m_ = 0;
+  size_t *workspace_size_;
+};
+
+TEST_F(indice_convolution_backward_filter_workspace, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter_workspace";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter_workspace,
+       BAD_PARAM_features_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter_workspace";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter_workspace,
+       BAD_PARAM_output_grad_desc_null) {
+  try {
+    setParam(true, true, false, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter_workspace";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter_workspace,
+       BAD_PARAM_indice_pairs_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter_workspace";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter_workspace,
+       BAD_PARAM_filters_grad_desc_null) {
+  try {
+    setParam(true, true, true, true, false, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter_workspace";
+  }
+}
+
+TEST_F(indice_convolution_backward_filter_workspace,
+       BAD_PARAM_indice_num_null) {
+  try {
+    setParam(true, true, true, true, true, false);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter_workspace";
+  }
+}
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_workspace.cpp
@@ -35,8 +35,8 @@ namespace mluopapitest {
 class indice_convolution_backward_filter_workspace : public testing::Test {
  public:
   void setParam(bool handle, bool features_desc, bool output_grad_desc,
-                bool indice_pairs_desc, bool filters_grad_desc,
-                bool indice_num) {
+                bool indice_pairs_desc, bool filters_grad_desc, bool indice_num,
+                bool workspace_size) {
     if (handle) {
       MLUOP_CHECK(mluOpCreate(&handle_));
     }
@@ -72,12 +72,17 @@ class indice_convolution_backward_filter_workspace : public testing::Test {
           filters_grad_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
           filters_grad_dims.data()));
     }
-    int nums = 1;
-    int num_size = 1;
-    for (int i = 0; i < nums; i++) {
+
+    std::vector<int> num = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    for (int i = 0; i < num.size(); i++) {
       if (indice_num) {
-        indice_num_.push_back(num_size);
+        indice_num_.push_back(num[i]);
       }
+    }
+
+    if (workspace_size) {
+      size_t size_temp;
+      workspace_size_ = &size_temp;
     }
   }
 
@@ -142,12 +147,12 @@ class indice_convolution_backward_filter_workspace : public testing::Test {
   std::vector<int64_t> indice_num_;
   int64_t inverse_ = 0;
   int64_t sub_m_ = 0;
-  size_t *workspace_size_;
+  size_t *workspace_size_ = nullptr;
 };
 
 TEST_F(indice_convolution_backward_filter_workspace, BAD_PARAM_handle_null) {
   try {
-    setParam(false, true, true, true, true, true);
+    setParam(false, true, true, true, true, true, true);
     EXPECT_TRUE(
         compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
   } catch (std::exception &e) {
@@ -159,7 +164,7 @@ TEST_F(indice_convolution_backward_filter_workspace, BAD_PARAM_handle_null) {
 TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_features_desc_null) {
   try {
-    setParam(true, false, true, true, true, true);
+    setParam(true, false, true, true, true, true, true);
     EXPECT_TRUE(
         compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
   } catch (std::exception &e) {
@@ -171,7 +176,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
 TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_output_grad_desc_null) {
   try {
-    setParam(true, true, false, true, true, true);
+    setParam(true, true, false, true, true, true, true);
     EXPECT_TRUE(
         compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
   } catch (std::exception &e) {
@@ -183,7 +188,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
 TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_indice_pairs_desc_null) {
   try {
-    setParam(true, true, true, false, true, true);
+    setParam(true, true, true, false, true, true, true);
     EXPECT_TRUE(
         compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
   } catch (std::exception &e) {
@@ -195,7 +200,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
 TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_filters_grad_desc_null) {
   try {
-    setParam(true, true, true, true, false, true);
+    setParam(true, true, true, true, false, true, true);
     EXPECT_TRUE(
         compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
   } catch (std::exception &e) {
@@ -207,7 +212,7 @@ TEST_F(indice_convolution_backward_filter_workspace,
 TEST_F(indice_convolution_backward_filter_workspace,
        BAD_PARAM_indice_num_null) {
   try {
-    setParam(true, true, true, true, true, false);
+    setParam(true, true, true, true, true, false, true);
     EXPECT_TRUE(
         compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
   } catch (std::exception &e) {
@@ -216,4 +221,15 @@ TEST_F(indice_convolution_backward_filter_workspace,
   }
 }
 
+TEST_F(indice_convolution_backward_filter_workspace,
+       BAD_PARAM_workspace_size_null) {
+  try {
+    setParam(true, true, true, true, true, true, false);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_backward_filter_workspace";
+  }
+}
 }  // namespace mluopapitest


### PR DESCRIPTION
…dice_convolution_backward_filter

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
