### PR TITLE
[Fix](bangc-ops) :fix get_indice_pairs bug

### DIFF
--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_block.mlu
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_block.mlu
@@ -190,7 +190,8 @@ __mlu_global__ void MLUBlockDefaultGetIndicePairKernel2(void *index_output_ptr,
 
 __mlu_global__ void MLUBlockBalanceGetIndicePairKernel(
     void *balance_input, void *balance_mask, void *balance_output,
-    int32_t len_l, int32_t kernel_volume, int32_t core_num_l) {
+    int32_t len_l, int32_t kernel_volume, int32_t core_num_l,
+    int32_t output_size) {
 #if __BANG_ARCH__ >= 370
   int32_t len_job, offset_job = 0;
   assignTask(len_l * kernel_volume, taskIdY, taskDimY, offset_job, len_job);
@@ -203,7 +204,8 @@ __mlu_global__ void MLUBlockBalanceGetIndicePairKernel(
   int32_t *nram_output = (int32_t *)nbuf_total + 3 * core_num_l;
   int32_t ping_pong_num = 3 * core_num_l;
   int32_t *nram_aux = (int32_t *)nbuf_total + 7 * core_num_l;
-  stepIndex(nram_random_num, taskId * core_num_l, core_num_l);
+  int32_t  multi_max = output_size / taskDimY;
+  stepIndex(nram_random_num, taskId * multi_max, core_num_l);
   for (int i = 0; i < repeat + 2; ++i) {
     if (i < repeat) {
       int32_t deal_num = i == repeat - 1 ? rem_num_l : core_num_l;
@@ -535,10 +537,11 @@ void  mluOpBlockDefaultGetIndicePairKernel4(
 void  mluOpBlockBalanceGetIndicePairKernel(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     void *balance_input, void *balance_mask, void *balance_output,
-    int32_t len_l, int32_t kernel_volume, int32_t core_num_l) {
+    int32_t len_l, int32_t kernel_volume, int32_t core_num_l,
+    int32_t output_size) {
   MLUBlockBalanceGetIndicePairKernel<<<k_dim, k_type, queue>>>(
       balance_input, balance_mask, balance_output, len_l, kernel_volume,
-      core_num_l);
+      core_num_l, output_size);
 }
 
 void  mluOpBlockSubmGetIndicePairKernel1(

--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_utils.h
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_utils.h
@@ -180,8 +180,14 @@ __mlu_func__ void computeMask(float *nram_output, float *nram_input,
     __bang_float2int32_tz((int32_t *)temp, (float *)nram_input + offset,
                           deal_num, 0);
     __bang_int322float_rn((float *)temp, (int32_t *)temp, deal_num, 0);
-    __bang_eq((float *)temp + offset_temp2, (float *)temp,
-              (float *)nram_input + offset, deal_num);  // mask_valid
+    __bang_sub((float *)temp + offset_temp2, (float *)temp,
+              (float *)nram_input + offset, deal_num);
+    __bang_le_scalar((float *)temp + offset_temp3, (float *)temp + offset_temp2,
+              (float)0.000001, deal_num);  //  < 1e-6
+    __bang_ge_scalar((float *)temp + offset_temp2, (float *)temp + offset_temp2,
+              (float)-0.000001, deal_num);  //  > -1e-6
+    __bang_and((float *)temp + offset_temp2, (float *)temp + offset_temp2,
+               (float *)temp + offset_temp3, deal_num);
     __bang_ge_scalar((float *)temp + offset_temp3, (float *)temp, (float)0.0,
                      deal_num);
     __bang_and((float *)temp + offset_temp2, (float *)temp + offset_temp2,

--- a/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.cpp
+++ b/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.cpp
@@ -599,7 +599,8 @@ func: balance index distribution
 mluOpStatus_t launchBalanceKernel(
     mluOpHandle_t handle, const std::string interface_name,
     void *balance_input_addr, void *balance_output_addr,
-    void *balance_mask_addr, int input_active_site, int kernel_volume) {
+    void *balance_mask_addr, int input_active_site, int kernel_volume,
+    int output_size) {
   cnrtDim3_t kDim3;
   cnrtFunctionType_t func_type;
   int core_dim = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
@@ -620,7 +621,8 @@ mluOpStatus_t launchBalanceKernel(
           << kDim3.z << ">>>";
   KERNEL_CHECK((mluOpBlockBalanceGetIndicePairKernel(
       kDim3, func_type, handle->queue, balance_input_addr, balance_mask_addr,
-      balance_output_addr, input_active_site, kernel_volume, core_num_l)));
+      balance_output_addr, input_active_site, kernel_volume, core_num_l,
+      output_size)));
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -1136,11 +1138,10 @@ mluOpStatus_t NormalGetIndicePairsKernel(
     balance_output_addr = out_indices_expand_ptr;
     balance_mask_addr = mask_all_ptr;
     INTERNAL_CHECK(
-        interface_name,
-        MLUOP_STATUS_SUCCESS ==
-            launchBalanceKernel(handle, interface_name, balance_input_addr,
-                                balance_output_addr, balance_mask_addr,
-                                input_active_site, kernel_volume));
+        interface_name, MLUOP_STATUS_SUCCESS ==
+        launchBalanceKernel(handle, interface_name, balance_input_addr,
+                            balance_output_addr, balance_mask_addr,
+                            input_active_site, kernel_volume, output_size));
 
     // call scatter_nd unique_output_addr + step_index_addr = grid_out_addr
     void *scatter_input_addr = NULL, *scatter_output_addr = NULL,

--- a/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -454,6 +454,7 @@ mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(
     const int64_t inverse, const int64_t subm, size_t *size) {
   const std::string api_name =
       "[mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize]";
+  PARAM_CHECK(api_name, size != nullptr);
   auto basic_check =
       baseParamCheck(api_name, handle, features_desc, output_grad_desc,
                      indice_pairs_desc, filters_grad_desc, indice_num);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -1050,7 +1050,7 @@ mluOpSetSparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t desc,
                                     const int dilation[],
                                     const int input_space[],
                                     const int filter_space[],
-                                    const int output_spcae[],
+                                    const int output_space[],
                                     const int subm,
                                     const int transpose,
                                     const int inverse);

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -154,7 +154,8 @@ void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel4(
 void MLUOP_WIN_API mluOpBlockBalanceGetIndicePairKernel(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     void *balance_input, void *balance_mask, void *balance_output,
-    int32_t len_l, int32_t kernel_volume, int32_t core_num_l);
+    int32_t len_l, int32_t kernel_volume, int32_t core_num_l,
+    int32_t output_size);
 
 void MLUOP_WIN_API mluOpBlockSubmGetIndicePairKernel1(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3
- [X] diff3: diff3=0

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |


[MLU Hardware Time      ]: 316 (us)
[MLU Interface Time     ]: 1162.99 (us)
[MLU IO Efficiency      ]: 0.00289045
[MLU Compute Efficiency ]: 0.00992846
[MLU Workspace Size     ]: 3.6152e+06 (Bytes)
[MLU TheoryOps          ]: 7.22855e+06 (Ops)
[MLU TheoryIOs          ]: 2.52532e+06 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] /home/test2/get_indice_pairs/get_indice_pairs_data_included_int32_1676363797903.pb
[       OK ] get_indice_pairs/TestSuite.mluOp/18 (73 ms)
[----------] 19 tests from get_indice_pairs/TestSuite (18370 ms total)
[----------] Global test environment tear-down
[2023-2-15 17:54:27] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 19 cases of 1 op(s).
ALL PASSED.
[==========] 19 test cases from 1 test suite ran. (18684 ms total)
[  PASSED  ] 19 test cases.


generator case 且包含网络case
[MLU Hardware Time      ]: 111 (us)
[MLU Interface Time     ]: 113.339 (us)
[MLU IO Efficiency      ]: 0.00988979
[MLU Compute Efficiency ]: 0.0145
[MLU Workspace Size     ]: 5.71098e+06 (Bytes)
[MLU TheoryOps          ]: 3.70829e+06 (Ops)
[MLU TheoryIOs          ]: 3.0351e+06 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] /home/get_indice_pairs/get_indice_pairs_data_included_int32_1675738558214.pb
[       OK ] get_indice_pairs/TestSuite.mluOp/201 (25 ms)
[----------] 202 tests from get_indice_pairs/TestSuite (95466 ms total)

[----------] Global test environment tear-down
[2023-2-15 18:4:40] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 202 cases of 1 op(s).
ALL PASSED.
[==========] 202 test cases from 1 test suite ran. (95782 ms total)
[  PASSED  ] 202 test cases.







### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
