### PR TITLE
[Fix](bangc-ops):fix indice_convolution_forward bug

### DIFF
--- a/bangc-ops/kernels/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/bangc-ops/kernels/indice_convolution_forward/indice_convolution_forward.cpp
@@ -382,8 +382,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetIndiceConvolutionForwardWorkspaceSize(
 
   // foolproof check
   auto fool_proof = foolProof(api_name, handle, features_desc, filters_desc,
-                              indice_pairs_desc, indice_num, num_act_out, sub_m,
-                              inverse, features_out_desc);
+                              indice_pairs_desc, indice_num, num_act_out,
+                              inverse, sub_m, features_out_desc);
   if (fool_proof != MLUOP_STATUS_SUCCESS) {
     return fool_proof;
   }

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward/indice_convolution_forward.cpp
@@ -35,6 +35,8 @@ void IndiceConvolutionForwardExecutor::paramInit() {
     indice_num_.push_back(op_param.indice_num(i));
   }
   num_active_out_ = (int64_t)op_param.num_active_out();
+  sub_m_ = (int64_t)op_param.sub_m();
+  inverse_ = (int64_t)op_param.inverse();
 }
 
 void IndiceConvolutionForwardExecutor::paramCheck() {


### PR DESCRIPTION
~~Thanks for your contribution and we appreciate it a lot. ~~

## 1. Motivation

Bug fix of foolproof of subM and inverse

## 2. Modification

/bangc-ops/kernels/indice_convolution_forward
/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward

## 3. Test Report

[ SUMMARY  ] Total 81 cases of 1 op(s).
ALL PASSED.
[==========] 81 test cases from 1 test suite ran. (14024 ms total)
[  PASSED  ] 81 test cases.

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [x] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

### 3.4 Summary Analysis

Fix bug of foolproof subM and inverse and test in newly added related test cases.
