### PR TITLE
[Fix](bangc-ops): fix indice convolution backward filter getWorkspace…

### DIFF
--- a/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -157,15 +157,13 @@ static mluOpStatus_t indiceConvDtypeVaild(
        !isFloatDtype(filters_grad_on_dtype)) ||
       (filters_grad_dtype == MLUOP_DTYPE_FLOAT &&
        filters_grad_on_dtype == MLUOP_DTYPE_HALF)) {
-    LOG(ERROR)
-        << api_name
-        << " The on-chip data type of filters_grad_desc may not be set, "
-        << "if it is set, only half or float types are supported, "
-        << "and the bit width of on-chip data type can not be smaller than "
-        << "that of off-chip data type. But now two data types of "
-           "filters_grad_desc are "
-        << mluop::getNameOfDataType(filters_grad_dtype) << "-"
-        << mluop::getNameOfDataType(filters_grad_on_dtype) << ".";
+    LOG(ERROR) << api_name << " The on-chip data type of filters_grad_desc "
+               << "may not be set, if it is set, only half or float types are "
+               << "supported, and the bit width of on-chip data type can not "
+               << "be smaller than that of off-chip data type. But now two "
+               << "data types of filters_grad_desc are "
+               << mluop::getNameOfDataType(filters_grad_dtype) << "-"
+               << mluop::getNameOfDataType(filters_grad_on_dtype) << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   return MLUOP_STATUS_SUCCESS;
@@ -188,7 +186,7 @@ static mluOpStatus_t baseParamCheck(
   // check mlu platform
   if (handle->arch != MLUOP_MLU370 && handle->arch != MLUOP_MLU590) {
     LOG(ERROR) << api_name << " Only mlu300 and above devices are supported."
-               << "Please check the device version!";
+               << " Please check the device version!";
     return MLUOP_STATUS_ARCH_MISMATCH;
   }
 
@@ -200,6 +198,14 @@ static mluOpStatus_t baseParamCheck(
     return dtype_check;
   }
 
+  if (mluOpGetTensorElementNum(features_desc) >= LARGE_TENSOR_NUM ||
+      mluOpGetTensorElementNum(output_grad_desc) >= LARGE_TENSOR_NUM ||
+      mluOpGetTensorElementNum(indice_pairs_desc) >= LARGE_TENSOR_NUM ||
+      mluOpGetTensorElementNum(filters_grad_desc) >= LARGE_TENSOR_NUM) {
+    LOG(ERROR) << api_name << " Overflow max tensor num."
+               << " Currently, MLU-OPS supports tensor num smaller than 2^31.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
   bool shape_check = true;
   if (2 != features_desc->dim || 2 != output_grad_desc->dim ||
       3 != indice_pairs_desc->dim ||
@@ -454,6 +460,7 @@ mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(
     const int64_t inverse, const int64_t subm, size_t *size) {
   const std::string api_name =
       "[mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize]";
+  PARAM_CHECK(api_name, size != nullptr);
   auto basic_check =
       baseParamCheck(api_name, handle, features_desc, output_grad_desc,
                      indice_pairs_desc, filters_grad_desc, indice_num);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8321,7 +8321,8 @@ mluOpIndiceConvolutionBackwardData(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the returned size of the extra workspace in bytes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_INTERNAL_ERROR
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_INTERNAL_ERROR
  *
  * @par API Dependency
  * - You need to call the ::mluOpCreateTensorDescriptor and ::mluOpSetTensorDescriptor functions to create and set
@@ -8391,7 +8392,8 @@ mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_INTERNAL_ERROR
  *
  * @par Data Type
  * - This function supports the combinations of the following data types for


### PR DESCRIPTION
… param check and large tensor check!

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改indice convolution backward filter算子的防呆。

## 2. Modification

1. 在getWorkspaceSize接口增加 size != nullptr的检查。
2. 这个算子暂时不支持large tensor.增加对large tensor的防呆。

## 3. Test Report

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

#### 3.1.2 Operator Scheme checklist

#### 3.1.3 New Feature Test

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| 指针为空检查 |     Normal error   |     2023-2-15 19:34:26] [MLUOP] [Error]:[mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize] Check failed: size != nullptr.                         |
| large tensor检查  |     Normal error    | [MLUOP] [Error]:[mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize] Overflow max tensor num. Currently, MLU-OPS supports tensor num smaller than 2^31.[Error]:"MLUOP_STATUS_NOT_SUPPORTED in mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize" |

### 3.2 Accuracy Test

本次修改不涉及

### 3.3 Performance Test

本次修改不涉及

### 3.4 Summary Analysis


