### PR TITLE
[Fix](bangc-ops) get num_act_out from sparse_conv_desc

### DIFF
--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs.cpp
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs.cpp
@@ -78,7 +78,7 @@ static void getIndicePairsGencase(
 
 static mluOpStatus_t internalGetIndicePairs(
     mluOpHandle_t handle, const std::string interface_name,
-    const mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
+    mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
     const mluOpTensorDescriptor_t indices_desc, const void *indices,
     void *workspace, size_t workspace_size,
     const mluOpTensorDescriptor_t indice_pairs_desc, void *indice_pairs,
@@ -191,7 +191,7 @@ static mluOpStatus_t internalGetIndicePairs(
 
 mluOpStatus_t MLUOP_WIN_API mluOpGetIndicePairs(
     mluOpHandle_t handle,
-    const mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
+    mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
     const mluOpTensorDescriptor_t indices_desc, const void *indices,
     void *workspace, const size_t workspace_size,
     const mluOpTensorDescriptor_t indice_pairs_desc, void *indice_pairs,
@@ -206,7 +206,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetIndicePairs(
 
 mluOpStatus_t MLUOP_WIN_API mluOpGetIndicePairsWorkspaceSize(
     mluOpHandle_t handle,
-    const mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
+    mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
     const mluOpTensorDescriptor_t indices_desc,
     const mluOpTensorDescriptor_t indice_pairs_desc,
     const mluOpTensorDescriptor_t out_indices_desc,

--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_structs.cpp
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_structs.cpp
@@ -110,6 +110,21 @@ mluOpStatus_t MLUOP_WIN_API mluOpSetSparseConvolutionDescriptor(
   return MLUOP_STATUS_SUCCESS;
 }
 
+mluOpStatus_t MLUOP_WIN_API mluOpGetSparseConvolutionNumActOut(
+    mluOpSparseConvolutionDescriptor_t desc,
+    int *num_act_out) {
+  if (desc == NULL || num_act_out == NULL) {
+    LOG(ERROR) << "mluOpCreateSparseConvolutionDescriptor or "
+               << "num_act_out failed "
+               << " Passing NULL ptr to this API.";
+    return MLUOP_STATUS_NOT_INITIALIZED;
+  }
+  int size = 0;
+  size = desc->num_act_out;
+  num_act_out[0] =  size;
+  return MLUOP_STATUS_SUCCESS;
+}
+
 mluOpStatus_t MLUOP_WIN_API mluOpDestroySparseConvolutionDescriptor(
     mluOpSparseConvolutionDescriptor_t desc) {
   if (desc == NULL) {

--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_structs.h
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_structs.h
@@ -92,6 +92,7 @@ struct mluOpSparseConvolutionStruct {
   int sub_m = 0;
   int transpose = 0;
   int inverse = 0;
+  int num_act_out = 0;
 };
 
 #endif  //  KERNELS_GET_INDICE_PAIRS_GET_INDICE_PAIRS_STRUCTS_H_

--- a/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.cpp
+++ b/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.cpp
@@ -196,7 +196,7 @@ static mluOpStatus_t getUniqueOpWS(mluOpHandle_t handle,
 
 mluOpStatus_t getNormalGetIndicePairsWorkspaceSize(
     mluOpHandle_t handle, const std::string interface_name,
-    const mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
+    mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
     const mluOpTensorDescriptor_t indices_desc,
     const mluOpTensorDescriptor_t indice_pairs_desc,
     const mluOpTensorDescriptor_t out_indices_desc,
@@ -845,7 +845,7 @@ mluOpStatus_t launchDefaultKernel4(
 
 mluOpStatus_t NormalGetIndicePairsKernel(
     mluOpHandle_t handle, const std::string interface_name,
-    const mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
+    mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
     const mluOpTensorDescriptor_t indices_desc, const void *indices,
     void *workspace, const mluOpTensorDescriptor_t indice_pairs_desc,
     void *indice_pairs, const mluOpTensorDescriptor_t out_indices_desc,
@@ -1122,6 +1122,7 @@ mluOpStatus_t NormalGetIndicePairsKernel(
                                       kernel_volume, fill_value));
       return MLUOP_STATUS_SUCCESS;
     }
+    sparse_conv_desc->num_act_out = num_act_out;
     // call launchDefaultKernel2   gen step_index
     void *step_index_addr = NULL;
     step_index_addr =
@@ -1205,7 +1206,7 @@ mluOpStatus_t NormalGetIndicePairsKernel(
 
 mluOpStatus_t normalGetIndicePairs(
     mluOpHandle_t handle, const std::string interface_name,
-    const mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
+    mluOpSparseConvolutionDescriptor_t sparse_conv_desc,
     const mluOpTensorDescriptor_t indices_desc, const void *indices,
     void *workspace, size_t workspace_size,
     const mluOpTensorDescriptor_t indice_pairs_desc, void *indice_pairs,

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -1055,6 +1055,31 @@ mluOpSetSparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t desc,
                                     const int transpose,
                                     const int inverse);
 
+// Group:: GetIndicePairs
+/*!
+ *  @brief Obtains the parameter num_act_out from ::mluOpSparseConvolutionStruct.
+ *
+ *  @param[in] desc
+ *  Pointer to the parameter num_act_out that holds information about the tensor descriptor.
+ *  @param[out] num_act_out
+ *  The parameter num_act_out will be obtained from the ::mluOpSparseConvolutionStruct.
+ *
+ *  @par Return
+ *  - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_NOT_INITIALIZED
+ *
+ *  @note
+ *  - None.
+ *
+ *  @par Requirements
+ *  - None.
+ *
+ *  @par Example
+ *  - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetSparseConvolutionNumActOut(mluOpSparseConvolutionDescriptor_t desc,
+                                   int *num_act_out);
+
 // Group:Tensor
 /*!
  *  @brief Initializes the group of tensor descriptors stored by \b group_desc
@@ -6896,6 +6921,7 @@ mluOpScatterNd_v2(mluOpHandle_t handle,
  *
  * @note
  * - This function only supports on MLU300 series or above platforms.
+ * - The parameter num_act_out will be obtained from the mluOpSparseConvolutionStruct.
  *
  * @par Scale Limitation
  * - The params inverse and transpose are not supported now.

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/mlu_op_test_proto/mlu_op_test.proto
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/mlu_op_test_proto/mlu_op_test.proto
@@ -450,6 +450,7 @@ message GetIndicePairsParam{
    optional int32 sub_m = 9 [default = 0];
    optional int32 transpose = 10 [default = 0];
    optional int32 inverse = 11 [default = 0];
+   optional int32 num_act_out = 12 [default = 0];
 }
 
 // param to call mluOpPsRoiPoolbackward()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

MLU Hardware Time      ]: 118 (us)
[MLU Interface Time     ]: 119.534 (us)
[MLU IO Efficiency      ]: 0.0093031
[MLU Compute Efficiency ]: 0.0136398
[MLU Workspace Size     ]: 5.71098e+06 (Bytes)
[MLU TheoryOps          ]: 3.70829e+06 (Ops)
[MLU TheoryIOs          ]: 3.0351e+06 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] /home/get_indice_pairs/get_indice_pairs_data_included_int32_1675738558214.pb
[       OK ] get_indice_pairs/TestSuite.mluOp/201 (13 ms)
[----------] 202 tests from get_indice_pairs/TestSuite (87119 ms total)

[----------] Global test environment tear-down
[2023-2-16 18:17:28] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 202 cases of 1 op(s).
ALL PASSED.
[==========] 202 test cases from 1 test suite ran. (87469 ms total)
[  PASSED  ] 202 test cases.



### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
