### PR TITLE
[Fix](bangc-ops):fix roi_align_rotated_forward sin/cos func

### DIFF
--- a/bangc-ops/kernels/roi_align_rotated/roi_align_rotated_block.mlu
+++ b/bangc-ops/kernels/roi_align_rotated/roi_align_rotated_block.mlu
@@ -99,10 +99,6 @@ __mlu_func__ void getRoiBinInfo(const T *rois_dram, const int bin_i,
   *roi_center_y = roi_info[2] * (T)params.spatial_scale - offset;
   *roi_width = roi_info[3] * (T)params.spatial_scale;
   *roi_height = roi_info[4] * (T)params.spatial_scale;
-  *theta = roi_info[5];
-  if (params.clockwise) {
-    *theta = -(*theta);
-  }
   if (!params.aligned) {
     *roi_width = fmaxf(*roi_width, (T)1.0);
     *roi_height = fmaxf(*roi_height, (T)1.0);
@@ -113,10 +109,8 @@ template <typename T>
 __mlu_global__ void roiAlignRotatedForward(
     const T *input_dram, const T *rois_dram, const int batch, const int height,
     const int width, const int channel, const int rois_num,
-    const mluOpRoiAlignRotatedParams params, T *output_dram) {
-  if (coreId == 0x80) {
-    return;
-  }
+    const mluOpRoiAlignRotatedParams params, T *workspace,
+    size_t workspace_size, T *output_dram) {
   const int align_base_128 = NFU_ALIGN_SIZE / sizeof(T);
   int channel_max_cap = MAX_NRAM_SIZE / sizeof(T) / (2 * SAMPLING_NUM + 1);
   channel_max_cap = channel_max_cap / align_base_128 * align_base_128;
@@ -126,9 +120,23 @@ __mlu_global__ void roiAlignRotatedForward(
   T *nram_out = (T *)nram_buffer;
   T *nram_ping = nram_out + channel_align;
   T *nram_pong = nram_ping + channel_align * SAMPLING_NUM;
+  T *sin_temp = (T *)workspace;
+  T *cos_temp = sin_temp + rois_num;
 
   const int bin_first = taskId;
   const int bin_end = rois_num * params.pooled_height * params.pooled_width;
+  for (int roi_i = taskId; roi_i < rois_num; roi_i += taskDim) {
+    const T *roi_info = rois_dram + roi_i * ROI_OFFSET;
+    T theta_temp = roi_info[5];
+    if (params.clockwise) {
+      theta_temp = -(theta_temp);
+    }
+    T cos_theta_temp = __cn_scalar_cos_f32((float)theta_temp);
+    T sin_theta_temp = __cn_scalar_sin_f32((float)theta_temp);
+    sin_temp[roi_i] = sin_theta_temp;
+    cos_temp[roi_i] = cos_theta_temp;
+  }
+  __sync_all();
 
   for (int bin_i = bin_first; bin_i < bin_end; bin_i += taskDim) {
     T roi_center_x, roi_center_y, roi_width, roi_height, theta;
@@ -150,8 +158,8 @@ __mlu_global__ void roiAlignRotatedForward(
     T roi_start_y = -roi_height / 2;
     T roi_start_x = -roi_width / 2;
     const int bin_dim = __mluop_max(roi_bin_grid_h * roi_bin_grid_w, 1);
-    T cos_theta = std::cos(theta);
-    T sin_theta = std::sin(theta);
+    T cos_theta = __cn_scalar_cos_f32((float)theta);
+    T sin_theta = __cn_scalar_sin_f32((float)theta);
     T zero_sign = 1.0f / bin_dim;
 
     bool is_first_sample = true;
@@ -454,19 +462,21 @@ void MLUOP_WIN_API mluOpBlockKernelRoiAlignRotatedForwardFloat(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *features, const void *rois, const int batch, const int height,
     const int width, const int channel, const int rois_num,
-    const mluOpRoiAlignRotatedParams rroiAlignParams, void *output) {
+    const mluOpRoiAlignRotatedParams rroiAlignParams, void *workspace,
+    size_t workspace_size, void *output) {
   roiAlignRotatedForward<<<k_dim, k_type, queue>>>(
       (float *)features, (float *)rois, batch, height, width, channel, rois_num,
-      rroiAlignParams, (float *)output);
+      rroiAlignParams, (float *)workspace, workspace_size, (float *)output);
 }
 void MLUOP_WIN_API mluOpBlockKernelRoiAlignRotatedForwardHalf(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *features, const void *rois, const int batch, const int height,
     const int width, const int channel, const int rois_num,
-    const mluOpRoiAlignRotatedParams rroiAlignParams, void *output) {
+    const mluOpRoiAlignRotatedParams rroiAlignParams, void *workspace,
+    size_t workspace_size, void *output) {
   roiAlignRotatedForward<<<k_dim, k_type, queue>>>(
       (half *)features, (half *)rois, batch, height, width, channel, rois_num,
-      rroiAlignParams, (half *)output);
+      rroiAlignParams, (half *)workspace, workspace_size, (half *)output);
 }
 
 void MLUOP_WIN_API mluOpBlockKernelRoiAlignRotatedBackwardFloat(

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -3250,6 +3250,29 @@ mluOpPsRoiPoolBackward(mluOpHandle_t handle,
 
 // Group:RoiAlignRotated
 /*!
+ * @brief Gets extra space size that is needed in RoiAlignRotated operation.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context that is used to manage MLU devices
+ * and queues in the RoiAlignRotated operation.
+ * @param[in] rois_desc
+ * The descriptor of rois tensor, which contains dimension and the layout of rois.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] size
+ *  A host pointer to the returned size of extra space in bytes.
+ *  @par Return
+ *  - ::MLUOP_STATUS_SUCCESS, 
+ *  - ::MLUOP_STATUS_BAD_PARAM,
+ *  - ::MLUOP_STATUS_NOT_SUPPORTED.
+ */
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetRoiAlignRotatedForwardWorkspaceSize(mluOpHandle_t handle,
+                                            const mluOpTensorDescriptor_t rois_desc,
+                                            size_t *size);
+
+// Group:RoiAlignRotated
+/*!
  * @brief Extracts the corresponding \b features information to \b output by bilinear interpolation
  * according to the \b rois with rotation.
  *
@@ -3355,6 +3378,8 @@ mluOpRoiAlignRotatedForward(mluOpHandle_t handle,
                             const float spatial_scale,
                             const bool aligned,
                             const bool clockwise,
+                            void *workspace,
+                            size_t workspace_size,
                             const mluOpTensorDescriptor_t output_desc,
                             void *output);
 

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -329,12 +329,14 @@ void MLUOP_WIN_API mluOpBlockKernelRoiAlignRotatedForwardFloat(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *features, const void *rois, const int batch, const int height,
     const int width, const int channel, const int rois_num,
-    const mluOpRoiAlignRotatedParams rroiAlignParams, void *output);
+    const mluOpRoiAlignRotatedParams rroiAlignParams, void *workspace,
+    size_t workspace_size, void *output);
 void MLUOP_WIN_API mluOpBlockKernelRoiAlignRotatedForwardHalf(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *features, const void *rois, const int batch, const int height,
     const int width, const int channel, const int rois_num,
-    const mluOpRoiAlignRotatedParams rroiAlignParams, void *output);
+    const mluOpRoiAlignRotatedParams rroiAlignParams, void *workspace,
+    size_t workspace_size, void *output);
 
 void MLUOP_WIN_API mluOpBlockKernelRoiAlignRotatedBackwardFloat(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_forward/roi_align_rotated_forward.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_forward/roi_align_rotated_forward.h
@@ -46,12 +46,14 @@ namespace mluoptest {
 class RoiAlignRotatedForwardExecutor : public Executor {
  public:
   RoiAlignRotatedForwardExecutor() {}
-  ~RoiAlignRotatedForwardExecutor() {}
+  ~RoiAlignRotatedForwardExecutor() { workspaceFree(); }
 
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;
   int64_t getTheoryOps() override;
+  void workspaceMalloc() override;
+  void workspaceFree() override;
 
  private:
   void preCalcForBilinearInterpolate(
@@ -62,6 +64,7 @@ class RoiAlignRotatedForwardExecutor : public Executor {
       const float roi_center_x, const float roi_center_y, const float cos_theta,
       const float sin_theta, std::vector<PreCalc> &pre_calc);
   int64_t theory_ops_ = 0;
+  size_t workspace_size_ = 0;
 };
 
 }  // namespace mluoptest

--- a/docs/bangc-docs/design_docs/roi_align_rotated/roi_align_rotated.md
+++ b/docs/bangc-docs/design_docs/roi_align_rotated/roi_align_rotated.md
@@ -79,6 +79,8 @@ roi_align_rotated算子应用于FOTS网络结构中，以双线性插值的方�
 | spatial_scale | rois在feature map上的缩放比例     | 输入              | float       | /        | 无       |
 | aligned       | 决定rois中的像素是否需要偏移     | 输入              | bool        | /        | 无       |
 | clockwise     | 是否顺时针旋转     | 输入              | bool        | /        | 无       |
+| workspace        |   指向额外GDRAM空间的指针          | 输入             |  void *                  | /          | 无       |
+| workspace_size   |   输入参数，workspace的空间大小   | 输入             |  size_t                  | /          | 无       |
 | bottom_grad_desc   |  输出数据的描述信息    | 输入              |             | /        | bottom_grad的维度必须是4       |
 | bottom_grad        | 输出数据，指向特征图的梯度数据的mlu首地址     | 输出              | half, float | NHWC     | 无       |
 ### 1.4 算子限制
@@ -151,6 +153,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignRotatedForward(mluOpHandle_t handle,
                                                         const float spatial_scale,
                                                         const bool aligned,
                                                         const bool clockwise,
+                                                        void *workspace,
+                                                        size_t workspace_size,
                                                         const mluOpTensorDescriptor_t output_desc,
                                                         void *output);
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Replace sin/cos function and improve performance

## 2. Modification

1) bangc-ops/kernels/roi_align_rotated/roi_align_rotated.cpp
2) bangc-ops/kernels/roi_align_rotated/roi_align_rotated_block.mlu
3) bangc-ops/mlu_op.h
4) bangc-ops/mlu_op_kernel.h
5) bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_forward/roi_align_rotated_forward.cpp
6) bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_forward/roi_align_rotated_forward.h
7) docs/bangc-docs/design_docs/roi_align_rotated/roi_align_rotated.md

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [x] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
