### PR TITLE
[Fix](bangc-ops): fix roi_align_rotated cpu compute

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_backward/roi_align_rotated_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_backward/roi_align_rotated_backward.cpp
@@ -250,12 +250,12 @@ void RoiAlignRotatedBackwardExecutor::cpuCompute() {
               float g2 = pc.w2 * top_grad_val * 1 / count;
               float g3 = pc.w3 * top_grad_val * 1 / count;
               float g4 = pc.w4 * top_grad_val * 1 / count;
-              if(pc.w1 == 0 && pc.w2 == 0 && pc.w3 == 0 && pc.w4 == 0){
+              if (pc.w1 == 0 && pc.w2 == 0 && pc.w3 == 0 && pc.w4 == 0) {
                 bottom_grad[bottom_grad_offset + pc.pos1] += 0;
                 bottom_grad[bottom_grad_offset + pc.pos2] += 0;
                 bottom_grad[bottom_grad_offset + pc.pos3] += 0;
                 bottom_grad[bottom_grad_offset + pc.pos4] += 0;
-              }else{
+              } else {
                 bottom_grad[bottom_grad_offset + pc.pos1] += g1;
                 bottom_grad[bottom_grad_offset + pc.pos2] += g2;
                 bottom_grad[bottom_grad_offset + pc.pos3] += g3;

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_backward/roi_align_rotated_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_backward/roi_align_rotated_backward.cpp
@@ -250,11 +250,17 @@ void RoiAlignRotatedBackwardExecutor::cpuCompute() {
               float g2 = pc.w2 * top_grad_val * 1 / count;
               float g3 = pc.w3 * top_grad_val * 1 / count;
               float g4 = pc.w4 * top_grad_val * 1 / count;
-
-              bottom_grad[bottom_grad_offset + pc.pos1] += g1;
-              bottom_grad[bottom_grad_offset + pc.pos2] += g2;
-              bottom_grad[bottom_grad_offset + pc.pos3] += g3;
-              bottom_grad[bottom_grad_offset + pc.pos4] += g4;
+              if(pc.w1 == 0 && pc.w2 == 0 && pc.w3 == 0 && pc.w4 == 0){
+                bottom_grad[bottom_grad_offset + pc.pos1] += 0;
+                bottom_grad[bottom_grad_offset + pc.pos2] += 0;
+                bottom_grad[bottom_grad_offset + pc.pos3] += 0;
+                bottom_grad[bottom_grad_offset + pc.pos4] += 0;
+              }else{
+                bottom_grad[bottom_grad_offset + pc.pos1] += g1;
+                bottom_grad[bottom_grad_offset + pc.pos2] += g2;
+                bottom_grad[bottom_grad_offset + pc.pos3] += g3;
+                bottom_grad[bottom_grad_offset + pc.pos4] += g4;
+              }
               ++pre_calc_idx;
               theory_ops_ += 4;
             }

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_forward/roi_align_rotated_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_forward/roi_align_rotated_forward.cpp
@@ -238,10 +238,14 @@ void RoiAlignRotatedForwardExecutor::cpuCompute() {
           for (int iy = 0; iy < roi_bin_grid_h; ++iy) {
             for (int ix = 0; ix < roi_bin_grid_w; ++ix) {
               auto pc = pre_calc[pre_calc_idx];
-              output_val += pc.w1 * offset_features[pc.pos1 + c_idx] +
-                            pc.w2 * offset_features[pc.pos2 + c_idx] +
-                            pc.w3 * offset_features[pc.pos3 + c_idx] +
-                            pc.w4 * offset_features[pc.pos4 + c_idx];
+              if (pc.w1 == 0 && pc.w2 == 0 && pc.w3 == 0 && pc.w4 == 0) {
+                output_val += 0;
+              } else {
+                output_val += pc.w1 * offset_features[pc.pos1 + c_idx] +
+                              pc.w2 * offset_features[pc.pos2 + c_idx] +
+                              pc.w3 * offset_features[pc.pos3 + c_idx] +
+                              pc.w4 * offset_features[pc.pos4 + c_idx];
+              }
               ++pre_calc_idx;
               theory_ops_ += 8;
             }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Fix roi_align_rotated cpu compute

## 2. Modification

1) bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_forward/roi_align_rotated_forward.cpp
2) bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_align_rotated_backward/roi_align_rotated_backward.cpp

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [x] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

370:
[       OK ] roi_align_rotated_forward/TestSuite.mluOp/200 (26 ms)
[----------] 201 tests from roi_align_rotated_forward/TestSuite (67630 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 201 cases of 1 op(s).
ALL PASSED.
[==========] 201 test cases from 1 test suite ran. (68419 ms total)
[  PASSED  ] 201 test cases.

590:
[       OK ] roi_align_rotated_forward/TestSuite.mluOp/200 (39 ms)
[----------] 201 tests from roi_align_rotated_forward/TestSuite (81601 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 201 cases of 1 op(s).
ALL PASSED.
[==========] 201 test cases from 1 test suite ran. (82130 ms total)
[  PASSED  ] 201 test cases.




