### PR TITLE
[TEST](indice_convolution_forward):add api check cases for indice_convolution_forward

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
@@ -1,0 +1,362 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class indice_convolution_forward : public testing::Test {
+ public:
+  void setParam(bool handle, bool features_desc, bool features,
+                bool filters_desc, bool filters, bool indice_pairs_desc,
+                bool indice_pairs, bool features_out_desc, bool features_out,
+                bool indice_num, bool worksapce) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_desc_));
+      std::vector<int> features_dims{2, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           features_dims.data()));
+    }
+
+    if (features) {
+      if (features_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&features_, mluOpGetTensorElementNum(features_desc_) *
+                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&features_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (filters_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&filters_desc_));
+      std::vector<int> filters_dims{9, 2, 2, 2, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(filters_desc_, MLUOP_LAYOUT_NDHWC,
+                                           MLUOP_DTYPE_FLOAT, 5,
+                                           filters_dims.data()));
+    }
+
+    if (filters) {
+      if (filters_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&filters_, mluOpGetTensorElementNum(filters_desc_) *
+                                      mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&filters_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (indice_pairs_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
+      std::vector<int> indice_pairs_dims{8, 2, 2};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indice_pairs_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
+          indice_pairs_dims.data()));
+    }
+
+    if (indice_pairs) {
+      if (indice_pairs_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&indice_pairs_,
+                               mluOpGetTensorElementNum(indice_pairs_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&indice_pairs_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (features_out_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_out_desc_));
+      std::vector<int> features_out_dims{10, 9};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          features_out_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+          features_out_dims.data()));
+    }
+
+    if (features_out) {
+      if (features_out_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&features_out_,
+                               mluOpGetTensorElementNum(features_out_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&features_out_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    std::vector<int> num = {1, 1, 1, 1, 1, 1, 1, 1};
+    for (int i = 0; i < num.size(); i++) {
+      if (indice_num) {
+        indice_num_.push_back(num[i]);
+      }
+    }
+
+    if (worksapce) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    }
+  }
+  bool compute(std::vector<mluOpDevType_t> target_device_) {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      if (std::find(target_device_.begin(), target_device_.end(),
+                    handle_->arch) == target_device_.end()) {
+        destroy();
+        return true;
+      }
+    }
+
+    mluOpStatus_t status = mluOpIndiceConvolutionForward(
+        handle_, features_desc_, features_, filters_desc_, filters_,
+        indice_pairs_desc_, indice_pairs_, indice_num_.data(), num_act_out_,
+        inverse_, sub_m_, workspace_, workspace_size_, features_out_desc_,
+        features_out_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (features_desc_) {
+      VLOG(4) << "Destroy features_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_desc_));
+      features_desc_ = nullptr;
+    }
+
+    if (features_) {
+      VLOG(4) << "Destroy features";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+      features_ = nullptr;
+    }
+
+    if (filters_desc_) {
+      VLOG(4) << "Destroy filters_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(filters_desc_));
+      filters_desc_ = nullptr;
+    }
+
+    if (filters_) {
+      VLOG(4) << "Destroy filters";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_));
+      filters_ = nullptr;
+    }
+
+    if (indice_pairs_desc_) {
+      VLOG(4) << "Destroy indice_pairs_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indice_pairs_desc_));
+      indice_pairs_desc_ = nullptr;
+    }
+
+    if (indice_pairs_) {
+      VLOG(4) << "Destroy indice_pairs";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      indice_pairs_ = nullptr;
+    }
+
+    if (workspace_) {
+      VLOG(4) << "Destroy workspace";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      workspace_ = nullptr;
+    }
+
+    if (features_out_desc_) {
+      VLOG(4) << "Destroy features_out_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_out_desc_));
+      features_out_desc_ = nullptr;
+    }
+
+    if (features_out_) {
+      VLOG(4) << "Destroy features_out";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_out_));
+      features_out_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t features_desc_ = nullptr;
+  void *features_ = nullptr;
+  mluOpTensorDescriptor_t filters_desc_ = nullptr;
+  void *filters_ = nullptr;
+  mluOpTensorDescriptor_t indice_pairs_desc_ = nullptr;
+  void *indice_pairs_ = nullptr;
+  std::vector<int64_t> indice_num_;
+  int64_t num_act_out_ = 10;
+  int64_t inverse_ = 0;
+  int64_t sub_m_ = 0;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  mluOpTensorDescriptor_t features_out_desc_ = nullptr;
+  void *features_out_ = nullptr;
+};
+
+TEST_F(indice_convolution_forward, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_features_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_features_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_filters_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_filters_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_indice_pairs_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_indice_pairs_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_features_out_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_features_out_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_indice_num_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, false, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+TEST_F(indice_convolution_forward, BAD_PARAM_workspace_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, false);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward";
+  }
+}
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
@@ -137,16 +137,7 @@ class indice_convolution_forward : public testing::Test {
       GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
-  bool compute(std::vector<mluOpDevType_t> target_device_) {
-    if (handle_) {
-      CNRT_CHECK(cnrtQueueSync(handle_->queue));
-      if (std::find(target_device_.begin(), target_device_.end(),
-                    handle_->arch) == target_device_.end()) {
-        destroy();
-        return true;
-      }
-    }
-
+  mluOpStatus_t compute() {
     mluOpStatus_t status = mluOpIndiceConvolutionForward(
         handle_, features_desc_, features_, filters_desc_, filters_,
         indice_pairs_desc_, indice_pairs_, indice_num_.data(), num_act_out_,
@@ -241,8 +232,7 @@ class indice_convolution_forward : public testing::Test {
 TEST_F(indice_convolution_forward, BAD_PARAM_handle_null) {
   try {
     setParam(false, true, true, true, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -252,8 +242,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_handle_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_features_desc_null) {
   try {
     setParam(true, false, true, true, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -263,8 +252,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_features_desc_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_features_null) {
   try {
     setParam(true, true, false, true, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -274,8 +262,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_features_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_filters_desc_null) {
   try {
     setParam(true, true, true, false, true, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -285,8 +272,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_filters_desc_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_filters_null) {
   try {
     setParam(true, true, true, true, false, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -296,8 +282,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_filters_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_indice_pairs_desc_null) {
   try {
     setParam(true, true, true, true, true, false, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -307,8 +292,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_indice_pairs_desc_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_indice_pairs_null) {
   try {
     setParam(true, true, true, true, true, true, false, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -318,8 +302,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_indice_pairs_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_features_out_desc_null) {
   try {
     setParam(true, true, true, true, true, true, true, false, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -329,8 +312,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_features_out_desc_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_features_out_null) {
   try {
     setParam(true, true, true, true, true, true, true, true, false, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -340,8 +322,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_features_out_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_indice_num_null) {
   try {
     setParam(true, true, true, true, true, true, true, true, true, false, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";
@@ -351,8 +332,7 @@ TEST_F(indice_convolution_forward, BAD_PARAM_indice_num_null) {
 TEST_F(indice_convolution_forward, BAD_PARAM_workspace_null) {
   try {
     setParam(true, true, true, true, true, true, true, true, true, true, false);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward";

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
@@ -1,0 +1,442 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+typedef std::tuple<std::vector<int64_t>, int64_t, int64_t, int64_t>
+    IndiceConvForwardAdditionalParam;
+
+typedef std::tuple<MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, IndiceConvForwardAdditionalParam,
+                   mluOpDevType_t, mluOpStatus_t>
+    IndiceConvolutionForwardParam;
+class indice_convolution_forward_general
+    : public testing::TestWithParam<IndiceConvolutionForwardParam> {
+ public:
+  void SetUp() {
+    try {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+
+      MLUOpTensorParam features_params = std::get<0>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          features_desc_, features_params.get_layout(),
+          features_params.get_dtype(), features_params.get_dim_nb(),
+          features_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(features_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&features_,
+                       mluOpDataTypeBytes(features_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&features_,
+                               mluOpDataTypeBytes(features_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(features_desc_)));
+      }
+
+      MLUOpTensorParam filters_params = std::get<1>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&filters_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          filters_desc_, filters_params.get_layout(),
+          filters_params.get_dtype(), filters_params.get_dim_nb(),
+          filters_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(filters_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&filters_,
+                       mluOpDataTypeBytes(filters_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&filters_,
+                               mluOpDataTypeBytes(filters_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(filters_desc_)));
+      }
+
+      MLUOpTensorParam indice_pairs_params = std::get<2>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indice_pairs_desc_, indice_pairs_params.get_layout(),
+          indice_pairs_params.get_dtype(), indice_pairs_params.get_dim_nb(),
+          indice_pairs_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(indice_pairs_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(
+                &indice_pairs_,
+                mluOpDataTypeBytes(indice_pairs_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indice_pairs_,
+                       mluOpDataTypeBytes(indice_pairs_params.get_dtype()) *
+                           mluOpGetTensorElementNum(indice_pairs_desc_)));
+      }
+
+      MLUOpTensorParam features_out_params = std::get<3>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_out_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          features_out_desc_, features_out_params.get_layout(),
+          features_out_params.get_dtype(), features_out_params.get_dim_nb(),
+          features_out_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(features_out_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(
+                &features_out_,
+                mluOpDataTypeBytes(features_out_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&features_out_,
+                       mluOpDataTypeBytes(features_out_params.get_dtype()) *
+                           mluOpGetTensorElementNum(features_out_desc_)));
+      }
+
+      IndiceConvForwardAdditionalParam additoinal_param_ =
+          std::get<4>(GetParam());
+      std::tie(indice_num_, num_act_out_, inverse_, sub_m_) = additoinal_param_;
+
+      target_device_ = std::get<5>(GetParam());
+      expected_status_ = std::get<6>(GetParam());
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in indice_convolution_forward_general.";
+    }
+  }
+
+  bool compute() {
+    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+          target_device_ == handle_->arch)) {
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status;
+    status = mluOpGetIndiceConvolutionForwardWorkspaceSize(
+        handle_, features_desc_, filters_desc_, indice_pairs_desc_,
+        features_out_desc_, indice_num_.data(), num_act_out_, inverse_, sub_m_,
+        &workspace_size_);
+    if (status != MLUOP_STATUS_SUCCESS) {
+      destroy();
+      return expected_status_ == status;
+    }
+    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+
+    status = mluOpIndiceConvolutionForward(
+        handle_, features_desc_, features_, filters_desc_, filters_,
+        indice_pairs_desc_, indice_pairs_, indice_num_.data(), num_act_out_,
+        inverse_, sub_m_, workspace_, workspace_size_, features_out_desc_,
+        features_out_);
+    destroy();
+    return expected_status_ == status;
+  }
+
+  void destroy() {
+    try {
+      if (handle_) {
+        // CNRT_CHECK(cnrtQueueSync(handle_->queue));
+        MLUOP_CHECK(mluOpDestroy(handle_));
+        handle_ = nullptr;
+      }
+
+      if (features_desc_) {
+        VLOG(4) << "Destroy features_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_desc_));
+        features_desc_ = nullptr;
+      }
+
+      if (features_) {
+        VLOG(4) << "Destroy features";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+        features_ = nullptr;
+      }
+
+      if (filters_desc_) {
+        VLOG(4) << "Destroy filters_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(filters_desc_));
+        filters_desc_ = nullptr;
+      }
+
+      if (filters_) {
+        VLOG(4) << "Destroy filters";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_));
+        filters_ = nullptr;
+      }
+
+      if (indice_pairs_desc_) {
+        VLOG(4) << "Destroy indice_pairs_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(indice_pairs_desc_));
+        indice_pairs_desc_ = nullptr;
+      }
+
+      if (indice_pairs_) {
+        VLOG(4) << "Destroy indice_pairs";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+        indice_pairs_ = nullptr;
+      }
+
+      if (features_out_desc_) {
+        VLOG(4) << "Destroy features_out_desc";
+        MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_out_desc_));
+        features_out_desc_ = nullptr;
+      }
+
+      if (features_out_) {
+        VLOG(4) << "Destroy features_out";
+        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_out_));
+        features_out_ = nullptr;
+      }
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in indice_convolution_forward_general";
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t features_desc_ = nullptr;
+  void *features_ = nullptr;
+  mluOpTensorDescriptor_t filters_desc_ = nullptr;
+  void *filters_ = nullptr;
+  mluOpTensorDescriptor_t indice_pairs_desc_ = nullptr;
+  void *indice_pairs_ = nullptr;
+  std::vector<int64_t> indice_num_;
+  int64_t num_act_out_ = 10;
+  int64_t inverse_ = 0;
+  int64_t sub_m_ = 0;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  mluOpTensorDescriptor_t features_out_desc_ = nullptr;
+  void *features_out_ = nullptr;
+  mluOpDevType_t target_device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(indice_convolution_forward_general, negative) { EXPECT_TRUE(compute()); }
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({0, 0, 0, 0}), 9, 0, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 0, 0, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_features_dtype_dim_shape, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF, 2,
+                             std::vector<int>({2, 3})),  // dtype
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 3,
+                             std::vector<int>({3, 2, 1})),  // dim
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+                             std::vector<int>({2, 4})),  // ci
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+                             std::vector<int>({3, 3}))),  // dim[0]
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_filters_dtype, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_HALF,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_filters_dim_layout, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT, 4,
+                             std::vector<int>({5, 1, 2, 2, 3})),  // dim
+            MLUOpTensorParam(MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_FLOAT, 5,
+                             std::vector<int>({5, 1, 2, 2, 3}))),  // layout
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_indice_pairs_dtype_dim_shape, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64, 3,
+                             std::vector<int>({4, 2, 2})),  // dtype
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 2,
+                             std::vector<int>({4, 2, 2})),  // dim
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
+                             std::vector<int>({5, 2, 2})),  // dim[0]
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
+                             std::vector<int>({4, 3, 2})),  // dim[1]
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
+                             std::vector<int>({4, 2, 3}))),  // dim[2]
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_features_output_dtype_dim_shape, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({9, 5})),  // dtype
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({9, 5})),  // dim
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2,
+                                         std::vector<int>({10, 5})),  // dim[0]
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 6}))),  // co
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_params, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(
+            IndiceConvForwardAdditionalParam(
+                std::vector<int64_t>({-1, 1, 1, 1}), 9, 0, 0),
+            IndiceConvForwardAdditionalParam(std::vector<int64_t>({1, 1, 4, 1}),
+                                             9, 0, 0),
+            IndiceConvForwardAdditionalParam(std::vector<int64_t>({1, 1, 1, 1}),
+                                             19, 0, 0),
+            IndiceConvForwardAdditionalParam(std::vector<int64_t>({1, 1, 1, 1}),
+                                             9, 2, 0),
+            IndiceConvForwardAdditionalParam(std::vector<int64_t>({1, 1, 1, 1}),
+                                             9, 0, 2)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_params_inverse, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 9, 1, 0)),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+// INSTANTIATE_TEST_CASE_P(
+//     bad_large_tensor_features_out, indice_convolution_forward_general,
+//     testing::Combine(
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 5}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_FLOAT,
+//                                          2, std::vector<int>({3, 3}))),
+//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
+//         MLUOP_DTYPE_INT32,
+//                                          3, std::vector<int>({9, 2, 3}))),
+//         testing::Values(
+//             MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+//                              std::vector<int>({47721859, 3, 5, 3}))),
+//         testing::Values(MLUOP_MLU590),
+//         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
@@ -135,8 +135,8 @@ class indice_convolution_forward_general
   }
 
   bool compute() {
-    if (!(target_device_ == MLUOP_MLU370,
-          MLUOP_MLU590 || target_device_ == handle_->arch)) {
+    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+          target_device_ == handle_->arch)) {
       destroy();
       return true;
     }
@@ -256,7 +256,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({0, 0, 0, 0}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -272,21 +272,20 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({0, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 0, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_features_dtype_dim_shape, indice_convolution_forward_general,
     testing::Combine(
-        testing::Values(
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF, 2,
-                             std::vector<int>({2, 3})),  // dtype
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 3,
-                             std::vector<int>({3, 2, 1})),  // dim
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
-                             std::vector<int>({2, 4})),  // ci
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
-                             std::vector<int>({3, 3}))),  // dim[0]
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({2, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({3, 2, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
                                          5, std::vector<int>({5, 1, 2, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
@@ -295,7 +294,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -311,7 +310,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -319,18 +318,17 @@ INSTANTIATE_TEST_CASE_P(
     testing::Combine(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          2, std::vector<int>({2, 3}))),
-        testing::Values(
-            MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT, 4,
-                             std::vector<int>({5, 1, 2, 2, 3})),  // dim
-            MLUOpTensorParam(MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_FLOAT, 5,
-                             std::vector<int>({5, 1, 2, 2, 3}))),  // layout
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({5, 1, 2, 2, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          3, std::vector<int>({4, 2, 2}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -340,22 +338,21 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
                                          5, std::vector<int>({5, 1, 2, 2, 3}))),
-        testing::Values(
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64, 3,
-                             std::vector<int>({4, 2, 2})),  // dtype
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 2,
-                             std::vector<int>({4, 2, 2})),  // dim
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
-                             std::vector<int>({5, 2, 2})),  // dim[0]
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
-                             std::vector<int>({4, 3, 2})),  // dim[1]
-            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
-                             std::vector<int>({4, 2, 3}))),  // dim[2]
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64,
+                                         3, std::vector<int>({4, 2, 2})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 2, 2})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({5, 2, 2})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 3, 2})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -368,17 +365,16 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          3, std::vector<int>({4, 2, 2}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
-                                         2, std::vector<int>({9, 5})),  // dtype
+                                         2, std::vector<int>({9, 5})),
                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({9, 5})),  // dim
+                                         3, std::vector<int>({9, 5})),
                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         2,
-                                         std::vector<int>({10, 5})),  // dim[0]
+                                         2, std::vector<int>({10, 5})),
                         MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         2, std::vector<int>({9, 6}))),  // co
+                                         2, std::vector<int>({9, 6}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -403,7 +399,7 @@ INSTANTIATE_TEST_CASE_P(
                                              9, 2, 0),
             IndiceConvForwardAdditionalParam(std::vector<int64_t>({1, 1, 1, 1}),
                                              9, 0, 2)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -419,16 +415,17 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 1, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_large_tensor_features, indice_convolution_forward_general,
     testing::Combine(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         2, std::vector<int>({21474837, 10}))),
+                                         2, std::vector<int>({21474837, 100}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
-                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+                                         5,
+                                         std::vector<int>({5, 1, 2, 2, 100}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          3,
                                          std::vector<int>({4, 2, 21474837}))),
@@ -436,7 +433,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -453,7 +450,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 89479}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -471,7 +468,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}), 9, 0,
             0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -488,6 +485,6 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({4294968, 500}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 4294968, 0, 0)),
-        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 }  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
@@ -163,7 +163,7 @@ class indice_convolution_forward_general
   void destroy() {
     try {
       if (handle_) {
-        // CNRT_CHECK(cnrtQueueSync(handle_->queue));
+        CNRT_CHECK(cnrtQueueSync(handle_->queue));
         MLUOP_CHECK(mluOpDestroy(handle_));
         handle_ = nullptr;
       }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
@@ -135,7 +135,7 @@ class indice_convolution_forward_general
   }
 
   bool compute() {
-    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+    if (!(target_device_ == MLUOP_MLU370, MLUOP_MLU590 ||
           target_device_ == handle_->arch)) {
       destroy();
       return true;
@@ -256,7 +256,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({0, 0, 0, 0}), 9, 0, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -272,7 +272,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({0, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 0, 0, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -295,7 +295,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -311,7 +311,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -330,7 +330,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -355,7 +355,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -378,7 +378,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 6}))),  // co
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -403,7 +403,7 @@ INSTANTIATE_TEST_CASE_P(
                                              9, 2, 0),
             IndiceConvForwardAdditionalParam(std::vector<int64_t>({1, 1, 1, 1}),
                                              9, 0, 2)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
@@ -419,7 +419,7 @@ INSTANTIATE_TEST_CASE_P(
                                          2, std::vector<int>({9, 5}))),
         testing::Values(IndiceConvForwardAdditionalParam(
             std::vector<int64_t>({1, 1, 1, 1}), 9, 1, 0)),
-        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 // INSTANTIATE_TEST_CASE_P(

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
@@ -135,8 +135,8 @@ class indice_convolution_forward_general
   }
 
   bool compute() {
-    if (!(target_device_ == MLUOP_MLU370, MLUOP_MLU590 ||
-          target_device_ == handle_->arch)) {
+    if (!(target_device_ == MLUOP_MLU370,
+          MLUOP_MLU590 || target_device_ == handle_->arch)) {
       destroy();
       return true;
     }
@@ -422,21 +422,72 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOP_MLU370, MLUOP_MLU590),
         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
-// INSTANTIATE_TEST_CASE_P(
-//     bad_large_tensor_features_out, indice_convolution_forward_general,
-//     testing::Combine(
-//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
-//         MLUOP_DTYPE_FLOAT,
-//                                          2, std::vector<int>({3, 5}))),
-//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
-//         MLUOP_DTYPE_FLOAT,
-//                                          2, std::vector<int>({3, 3}))),
-//         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY,
-//         MLUOP_DTYPE_INT32,
-//                                          3, std::vector<int>({9, 2, 3}))),
-//         testing::Values(
-//             MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
-//                              std::vector<int>({47721859, 3, 5, 3}))),
-//         testing::Values(MLUOP_MLU590),
-//         testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_features, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({21474837, 10}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3,
+                                         std::vector<int>({4, 2, 21474837}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 9, 0, 0)),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_filters, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3000}))),
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT, 5,
+                             std::vector<int>({89479, 2, 2, 2, 3000}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 89479}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1}), 9, 0, 0)),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_indice_pairs, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({89478486, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5, std::vector<int>({5, 3, 2, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3,
+                                         std::vector<int>({12, 2, 89478486}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({9, 5}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}), 9, 0,
+            0)),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_features_output, indice_convolution_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_NDHWC, MLUOP_DTYPE_FLOAT,
+                                         5,
+                                         std::vector<int>({500, 1, 2, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({4, 2, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4294968, 500}))),
+        testing::Values(IndiceConvForwardAdditionalParam(
+            std::vector<int64_t>({1, 1, 1, 1}), 4294968, 0, 0)),
+        testing::Values(MLUOP_MLU370, MLUOP_MLU590),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 }  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_workspace.cpp
@@ -1,0 +1,230 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class indice_convolution_forward_workspace : public testing::Test {
+ public:
+  void setParam(bool handle, bool features_desc, bool filters_desc,
+                bool indice_pairs_desc, bool features_out_desc, bool indice_num,
+                bool workspace_size) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_desc_));
+      std::vector<int> features_dims{2, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           features_dims.data()));
+    }
+
+    if (filters_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&filters_desc_));
+      std::vector<int> filters_dims{9, 2, 2, 2, 7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(filters_desc_, MLUOP_LAYOUT_NDHWC,
+                                           MLUOP_DTYPE_FLOAT, 5,
+                                           filters_dims.data()));
+    }
+
+    if (indice_pairs_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
+      std::vector<int> indice_pairs_dims{8, 2, 2};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indice_pairs_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 3,
+          indice_pairs_dims.data()));
+    }
+
+    if (features_out_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&features_out_desc_));
+      std::vector<int> features_out_dims{10, 9};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          features_out_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+          features_out_dims.data()));
+    }
+
+    std::vector<int> num = {1, 1, 1, 1, 1, 1, 1, 1};
+    for (int i = 0; i < num.size(); i++) {
+      if (indice_num) {
+        indice_num_.push_back(num[i]);
+      }
+    }
+
+    if (workspace_size) {
+      size_t size_temp;
+      workspace_size_ = &size_temp;
+    }
+  }
+
+  bool compute(std::vector<mluOpDevType_t> target_device_) {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      if (std::find(target_device_.begin(), target_device_.end(),
+                    handle_->arch) == target_device_.end()) {
+        destroy();
+        return true;
+      }
+    }
+
+    mluOpStatus_t status = mluOpGetIndiceConvolutionForwardWorkspaceSize(
+        handle_, features_desc_, filters_desc_, indice_pairs_desc_,
+        features_out_desc_, indice_num_.data(), num_act_out_, inverse_, sub_m_,
+        workspace_size_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (features_desc_) {
+      VLOG(4) << "Destroy features_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_desc_));
+      features_desc_ = nullptr;
+    }
+
+    if (filters_desc_) {
+      VLOG(4) << "Destroy filters_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(filters_desc_));
+      filters_desc_ = nullptr;
+    }
+
+    if (indice_pairs_desc_) {
+      VLOG(4) << "Destroy indice_pairs_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indice_pairs_desc_));
+      indice_pairs_desc_ = nullptr;
+    }
+
+    if (features_out_desc_) {
+      VLOG(4) << "Destroy features_out_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(features_out_desc_));
+      features_out_desc_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t features_desc_ = nullptr;
+  mluOpTensorDescriptor_t filters_desc_ = nullptr;
+  mluOpTensorDescriptor_t indice_pairs_desc_ = nullptr;
+  mluOpTensorDescriptor_t features_out_desc_ = nullptr;
+  std::vector<int64_t> indice_num_;
+  int64_t num_act_out_ = 10;
+  int64_t inverse_ = 0;
+  int64_t sub_m_ = 0;
+  size_t *workspace_size_ = nullptr;
+};
+
+TEST_F(indice_convolution_forward_workspace, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward_workspace";
+  }
+}
+
+TEST_F(indice_convolution_forward_workspace, BAD_PARAM_features_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward_workspace";
+  }
+}
+
+TEST_F(indice_convolution_forward_workspace, BAD_PARAM_filters_desc_null) {
+  try {
+    setParam(true, true, false, true, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward_workspace";
+  }
+}
+
+TEST_F(indice_convolution_forward_workspace, BAD_PARAM_indice_pairs_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward_workspace";
+  }
+}
+
+TEST_F(indice_convolution_forward_workspace, BAD_PARAM_features_out_desc_null) {
+  try {
+    setParam(true, true, true, true, false, true, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward_workspace";
+  }
+}
+
+TEST_F(indice_convolution_forward_workspace, BAD_PARAM_indice_num_null) {
+  try {
+    setParam(true, true, true, true, true, false, true);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward_workspace";
+  }
+}
+
+TEST_F(indice_convolution_forward_workspace, BAD_PARAM_workspace_size_null) {
+  try {
+    setParam(true, true, true, true, true, true, false);
+    EXPECT_TRUE(
+        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in indice_convolution_forward_workspace";
+  }
+}
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_workspace.cpp
@@ -86,16 +86,7 @@ class indice_convolution_forward_workspace : public testing::Test {
     }
   }
 
-  bool compute(std::vector<mluOpDevType_t> target_device_) {
-    if (handle_) {
-      CNRT_CHECK(cnrtQueueSync(handle_->queue));
-      if (std::find(target_device_.begin(), target_device_.end(),
-                    handle_->arch) == target_device_.end()) {
-        destroy();
-        return true;
-      }
-    }
-
+  mluOpStatus_t compute() {
     mluOpStatus_t status = mluOpGetIndiceConvolutionForwardWorkspaceSize(
         handle_, features_desc_, filters_desc_, indice_pairs_desc_,
         features_out_desc_, indice_num_.data(), num_act_out_, inverse_, sub_m_,
@@ -154,8 +145,7 @@ class indice_convolution_forward_workspace : public testing::Test {
 TEST_F(indice_convolution_forward_workspace, BAD_PARAM_handle_null) {
   try {
     setParam(false, true, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward_workspace";
@@ -165,8 +155,7 @@ TEST_F(indice_convolution_forward_workspace, BAD_PARAM_handle_null) {
 TEST_F(indice_convolution_forward_workspace, BAD_PARAM_features_desc_null) {
   try {
     setParam(true, false, true, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward_workspace";
@@ -176,8 +165,7 @@ TEST_F(indice_convolution_forward_workspace, BAD_PARAM_features_desc_null) {
 TEST_F(indice_convolution_forward_workspace, BAD_PARAM_filters_desc_null) {
   try {
     setParam(true, true, false, true, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward_workspace";
@@ -187,8 +175,7 @@ TEST_F(indice_convolution_forward_workspace, BAD_PARAM_filters_desc_null) {
 TEST_F(indice_convolution_forward_workspace, BAD_PARAM_indice_pairs_desc_null) {
   try {
     setParam(true, true, true, false, true, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward_workspace";
@@ -198,8 +185,7 @@ TEST_F(indice_convolution_forward_workspace, BAD_PARAM_indice_pairs_desc_null) {
 TEST_F(indice_convolution_forward_workspace, BAD_PARAM_features_out_desc_null) {
   try {
     setParam(true, true, true, true, false, true, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward_workspace";
@@ -209,8 +195,7 @@ TEST_F(indice_convolution_forward_workspace, BAD_PARAM_features_out_desc_null) {
 TEST_F(indice_convolution_forward_workspace, BAD_PARAM_indice_num_null) {
   try {
     setParam(true, true, true, true, true, false, true);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward_workspace";
@@ -220,8 +205,7 @@ TEST_F(indice_convolution_forward_workspace, BAD_PARAM_indice_num_null) {
 TEST_F(indice_convolution_forward_workspace, BAD_PARAM_workspace_size_null) {
   try {
     setParam(true, true, true, true, true, true, false);
-    EXPECT_TRUE(
-        compute(std::vector<mluOpDevType_t>({MLUOP_MLU370, MLUOP_MLU590})));
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
     FAIL() << "MLUOPAPIGTEST: catched " << e.what()
            << " in indice_convolution_forward_workspace";


### PR DESCRIPTION
…volution_forward

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
