### PR TITLE
[Fix](bangc-ops): update foolcheck for indice_convolution_backward_data

### DIFF
--- a/bangc-ops/kernels/indice_convolution_backward_data/indice_convolution_backward_data.cpp
+++ b/bangc-ops/kernels/indice_convolution_backward_data/indice_convolution_backward_data.cpp
@@ -156,6 +156,15 @@ static mluOpStatus_t foolCheckNoPtr(
                  << " of output_grad when sub_m is 1.";
       return MLUOP_STATUS_BAD_PARAM;
     }
+
+    if (indice_num[K / 2] < max_indice_num) {
+      LOG(ERROR) << api
+                 << " The middle number of the indice_num array should be the "
+                 << "maximum of the array when sub_m is 1. Now the maximum is "
+                 << max_indice_num << " while the middle number of the array "
+                 << "is " << indice_num[K / 2] << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
   }
 
   if (output_grad_desc->dims[0] < max_indice_num) {

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8273,8 +8273,10 @@ mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(mluOpHandle_t handle,
  * - The value \b inverse should be 0.
  * - When the value of \b sub_m is 1, the dims D, H and W corresponding to
  *   filter layout should be odd numbers.
- * - When the value of \b sub_m is 1, the dims[0] of \b input_grad and the dims[0] of \b output_grad
- *   should be the same.
+ * - When the value of \b sub_m is 1, the dims[0] of \b input_grad and the dims[0] of
+ *   \b output_grad should be the same.
+ * - When the value of \b sub_m is 1, the middle number of \b indice_num should be the
+ *   maximum number of \b indice_num.
  *
  * @par API Dependency
  * - The function ::mluOpGetIndiceConvolutionBackwardDataWorkspaceSize should


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Complete foolcheck.

## 2. Modification

When the value of \b sub_m is 1, the middle number of \b indice_num should be the maximum number of \b indice_num..

## 3. Test Report

[2023-2-21 10:48:28] [MLUOP] [Error]:[mluOpIndiceConvolutionBackwardData] The middle number of the indice_num array should be the maximum of the array when sub_m is 1. Now the maximum is 116 while the middle number of the array is 44.
[2023-2-21 10:48:28] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpIndiceConvolutionBackwardData( handle_, output_grad_desc, output_grad, filters_desc, filter, indice_pairs_desc, indice_pairs, indice_num_.data(), inverse_, sub_m_, workspace_[0], workspace_size, input_grad_desc, input_grad)"