### PR TITLE
[Fix](bangc-ops): fix indice_convolution_backward_filter param check

### DIFF
--- a/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -175,13 +175,14 @@ static mluOpStatus_t baseParamCheck(
     const mluOpTensorDescriptor_t output_grad_desc,
     const mluOpTensorDescriptor_t indice_pairs_desc,
     const mluOpTensorDescriptor_t filters_grad_desc,
-    const int64_t indice_num[]) {
+    const int64_t indice_num[], const int64_t inverse) {
   PARAM_CHECK(api_name, handle != nullptr);
   PARAM_CHECK(api_name, features_desc != nullptr);
   PARAM_CHECK(api_name, output_grad_desc != nullptr);
   PARAM_CHECK(api_name, indice_pairs_desc != nullptr);
   PARAM_CHECK(api_name, filters_grad_desc != nullptr);
   PARAM_CHECK(api_name, indice_num != nullptr);
+  PARAM_CHECK(api_name, inverse == 0);
 
   // check mlu platform
   if (handle->arch != MLUOP_MLU370 && handle->arch != MLUOP_MLU590) {
@@ -222,9 +223,9 @@ static mluOpStatus_t baseParamCheck(
                                 : filters_grad_desc->dims[1];
   auto kw = filter_dim_len == 4 ? filters_grad_desc->dims[1]
                                 : filters_grad_desc->dims[2];
-  if (ci != features_desc->dims[1] || co != output_grad_desc->dims[1] ||
-      kd * kh * kw != indice_pairs_desc->dims[0] ||
-      2 != indice_pairs_desc->dims[1]) {
+  if (ci != features_desc->dims[1] || ci != indice_pairs_desc->dims[2] ||
+      co != output_grad_desc->dims[1] || 2 != indice_pairs_desc->dims[1] ||
+      kd * kh * kw != indice_pairs_desc->dims[0]) {
     shape_check = false;  // interdependent dimension check failed!
   }
 
@@ -463,7 +464,7 @@ mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(
   PARAM_CHECK(api_name, size != nullptr);
   auto basic_check =
       baseParamCheck(api_name, handle, features_desc, output_grad_desc,
-                     indice_pairs_desc, filters_grad_desc, indice_num);
+                     indice_pairs_desc, filters_grad_desc, indice_num, inverse);
   if (MLUOP_STATUS_SUCCESS != basic_check) {
     return basic_check;
   }
@@ -496,7 +497,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpIndiceConvolutionBackwardFilter(
 
   auto basic_check =
       baseParamCheck(api_name, handle, features_desc, output_grad_desc,
-                     indice_pairs_desc, filters_grad_desc, indice_num);
+                     indice_pairs_desc, filters_grad_desc, indice_num, inverse);
   if (MLUOP_STATUS_SUCCESS != basic_check) {
     return basic_check;
   }

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -38,6 +38,8 @@ void IndiceConvolutionBackwardFilterExecutor::initParam() {
   for (int i = 0; i < op_param.indice_num_size(); i++) {
     indice_num_.push_back(op_param.indice_num(i));
   }
+  inverse_ = op_param.inverse();
+  subm_ = op_param.sub_m();
 
   diffw_trans_ = false;
   // if (MLUOP_LAYOUT_HWCN != diffw_desc_->layout) {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

防呆修改

## 2. Modification

- 补充两条漏掉的防呆，和头文件保持一致。
- gtest传参数修改

## 3. Test Report

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| inverse==0的检查 |     Normal error    |    [MLUOP] [Error]:[mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize] Check failed: inverse == 0                         |
| indice_pairs参数检查           |     Normal error    |       [mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize] Shape check failed! Now the shapes are features_desc[512,56], output_grad_desc[512,32], indice_pairs_desc[36,2,256], and filters_grad_desc[2,3,6,56,32]                      |

### 3.2 Accuracy Test
修改不涉及
### 3.3 Performance Test
修改不涉及

### 3.4 Summary Analysis

- indice_convolution_backward_filter目前不支持inverse不等于０，加上param_check检查
- indice_convolution_backward_filter的gtest里，由于这些参数对算子的实现逻辑没有影响，所以之前没有将op_param中的sub_m和inverse传入接口，而是传的默认值。现在为了测试这些参数的防呆，需要修改成正常传递
