### PR TITLE
[Feature](bangc-ops) : adjust mlu_op_kernel.h

### DIFF
--- a/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.h
+++ b/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.h
@@ -29,6 +29,48 @@
 #include "mlu_op.h"
 #include "kernels/get_indice_pairs/get_indice_pairs_structs.h"
 
+void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel1(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    void *mask_all_ws, void *indice_index_in_ws, void *indice_out_expand_ws,
+    void *indices, FilterSpace filter_space, InputSpace input_space,
+    OutputSpace output_space, Stride stride, Dilation dilation,
+    Padding padding, int32_t core_num_l, int32_t input_active_site,
+    int32_t batch_size);
+
+void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel2(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    void *step_index_ptr, int32_t num_act_out, int32_t core_num_l);
+
+void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel3(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    void *indice_pairs, void *input_addr, void *mask_addr,
+    int32_t input_active_site, int32_t kernel_volume, int32_t core_num_l);
+
+void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel4(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    void *out_indices, void *input_addr, OutputSpace host_output_space,
+    int32_t len_l, int32_t core_num_l);
+
+void MLUOP_WIN_API mluOpBlockBalanceGetIndicePairKernel(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    void *balance_input, void *balance_mask, void *balance_output,
+    int32_t len_l, int32_t kernel_volume, int32_t core_num_l,
+    int32_t output_size);
+
+void MLUOP_WIN_API mluOpBlockSubmGetIndicePairKernel1(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    void *mask_all_ptr, void *indice_index_in_ptr, void *indice_in_expand_ptr,
+    void *out_indices_expand_ptr, void *indices, FilterSpace host_filter_space,
+    InputSpace host_input_space, OutputSpace host_output_space,
+    Stride host_stride, Dilation host_dilation, Padding host_padding,
+    int32_t core_num_l, int32_t input_active_site, int32_t batch_size);
+
+void MLUOP_WIN_API mluOpBlockSubmGetIndicePairKernel2(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    void *out_indices, void *mask_all_ptr, void *out_indices_expand_ptr,
+    void *indices, int32_t len_1_one, int32_t len_l_two,
+    int32_t core_num_l_one, int32_t core_num_l_two);
+
 mluOpStatus_t getNormalGetIndicePairsWorkspaceSize(
     mluOpHandle_t handle, const std::string interface_name,
     const mluOpSparseConvolutionDescriptor_t sparse_conv_desc,

--- a/bangc-ops/mlu_op_kernel.h
+++ b/bangc-ops/mlu_op_kernel.h
@@ -25,7 +25,6 @@
 
 #include <stdint.h>
 #include "cnrt.h"
-#include "kernels/get_indice_pairs/get_indice_pairs_structs.h"
 
 #ifndef MLUOP_WIN_API
 #ifdef _WIN32
@@ -127,49 +126,6 @@ void MLUOP_WIN_API mluOpBlockKernel3StagePipelineDivHalfHighAcc(
 void MLUOP_WIN_API mluOpBlockKernel3StagePipelineDivFloatFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const void *x, const void *y, void *z, int num);
-
-/* getIndicePairs */
-void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel1(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *mask_all_ws, void *indice_index_in_ws, void *indice_out_expand_ws,
-    void *indices, FilterSpace filter_space, InputSpace input_space,
-    OutputSpace output_space, Stride stride, Dilation dilation,
-    Padding padding, int32_t core_num_l, int32_t input_active_site,
-    int32_t batch_size);
-
-void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel2(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *step_index_ptr, int32_t num_act_out, int32_t core_num_l);
-
-void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel3(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *indice_pairs, void *input_addr, void *mask_addr,
-    int32_t input_active_site, int32_t kernel_volume, int32_t core_num_l);
-
-void MLUOP_WIN_API mluOpBlockDefaultGetIndicePairKernel4(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *out_indices, void *input_addr, OutputSpace host_output_space,
-    int32_t len_l, int32_t core_num_l);
-
-void MLUOP_WIN_API mluOpBlockBalanceGetIndicePairKernel(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *balance_input, void *balance_mask, void *balance_output,
-    int32_t len_l, int32_t kernel_volume, int32_t core_num_l,
-    int32_t output_size);
-
-void MLUOP_WIN_API mluOpBlockSubmGetIndicePairKernel1(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *mask_all_ptr, void *indice_index_in_ptr, void *indice_in_expand_ptr,
-    void *out_indices_expand_ptr, void *indices, FilterSpace host_filter_space,
-    InputSpace host_input_space, OutputSpace host_output_space,
-    Stride host_stride, Dilation host_dilation, Padding host_padding,
-    int32_t core_num_l, int32_t input_active_site, int32_t batch_size);
-
-void MLUOP_WIN_API mluOpBlockSubmGetIndicePairKernel2(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    void *out_indices, void *mask_all_ptr, void *out_indices_expand_ptr,
-    void *indices, int32_t len_1_one, int32_t len_l_two,
-    int32_t core_num_l_one, int32_t core_num_l_two);
 
 /* FillZero */
 void MLUOP_WIN_API mluOpBlockKernelFillZeroByte(cnrtDim3_t k_dim,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation
调整 mlu_op_kernel.h 头文件结构，勿包含 get_indice_pairs 相关内容	

## 2. Modification

调整 mlu_op_kernel.h 头文件结构，勿包含 get_indice_pairs 相关内容	

## 3. Test Report
[MLU Hardware Time      ]: 111 (us)
[MLU Interface Time     ]: 53.622 (us)
[MLU IO Efficiency      ]: 0.00988979
[MLU Compute Efficiency ]: 0.0145
[MLU Workspace Size     ]: 5.71098e+06 (Bytes)
[MLU TheoryOps          ]: 3.70829e+06 (Ops)
[MLU TheoryIOs          ]: 3.0351e+06 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] /home/get_indice_pairs/get_indice_pairs_data_included_int32_1675738558214.pb
[       OK ] get_indice_pairs/TestSuite.mluOp/201 (10 ms)
[----------] 202 tests from get_indice_pairs/TestSuite (86526 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 202 cases of 1 op(s).
ALL PASSED.
[==========] 202 test cases from 1 test suite ran. (87022 ms total)
[  PASSED  ] 202 test cases.



### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
