### PR TITLE
[Fix](bangc-ops): add data type check, workspacesize nullptr check to indice_convolution_forward

### DIFF
--- a/bangc-ops/kernels/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/bangc-ops/kernels/indice_convolution_forward/indice_convolution_forward.cpp
@@ -63,7 +63,7 @@ static mluOpStatus_t foolProof(
   PARAM_CHECK(api_name, features_out_desc->dtype == MLUOP_DTYPE_FLOAT ||
                             features_out_desc->dtype == MLUOP_DTYPE_HALF);
   PARAM_CHECK(api_name, features_desc->dtype == features_out_desc->dtype &&
-                            features_desc->dtype == features_out_desc->dtype);
+                            features_desc->dtype == filters_desc->dtype);
 
   // inverse not supported now
   PARAM_CHECK(api_name, sub_m == 0 || sub_m == 1);
@@ -432,13 +432,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetIndiceConvolutionForwardWorkspaceSize(
     return fool_proof;
   }
 
+  // nullptr check
+  PARAM_CHECK(api_name, size != nullptr);
+
   // zero element
-  if (mluOpGetTensorElementNum(filters_desc) == 0) {
-    LOG(ERROR) << api_name << "filters contains zero element. Error.";
-    return MLUOP_STATUS_BAD_PARAM;
-  }
   if (mluOpGetTensorElementNum(features_desc) == 0 ||
       mluOpGetTensorElementNum(indice_pairs_desc) == 0 ||
+      mluOpGetTensorElementNum(filters_desc) == 0 ||
       mluOpGetTensorElementNum(features_out_desc) == 0) {
     VLOG(5) << api_name << "Skip zero element tensor.";
     return MLUOP_STATUS_SUCCESS;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Add missing param check of data type and nullptr to indice_convolution_forward.

## 2. Modification

/mlu-ops/bangc-ops/kernels/indice_convolution_forward/

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          host拼接       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [x] Multidimensional tensor test
- [x] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [x] Nan/INF tests 
- [x] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| filters data type not same with features data type |     Normal error    |         MLUOP_STATUS_BAD_PARAM            |
| pass nullptr as workspace size pointer          |     Normal error    |            MLUOP_STATUS_BAD_PARAM             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |    see below      |
|Mult-tensor test     |Supports 1-8 dims                 |          |     see below     |
|Layout test          |Supports NCHW/NHWC                |          |     see below     |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |     see below     |
|total                   |                                                    |  101  | includes above commented test point |

### 3.4 Summary Analysis

Add param check of data type and nullptr check to indice_convolution_forward.
