### PR TITLE
[Fix](bangc-ops): fix indice_convolution_backward_filter param check　

### DIFF
--- a/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -223,8 +223,9 @@ static mluOpStatus_t baseParamCheck(
                                 : filters_grad_desc->dims[1];
   auto kw = filter_dim_len == 4 ? filters_grad_desc->dims[1]
                                 : filters_grad_desc->dims[2];
-  if (ci != features_desc->dims[1] || ci != indice_pairs_desc->dims[2] ||
-      co != output_grad_desc->dims[1] || 2 != indice_pairs_desc->dims[1] ||
+  if (ci != features_desc->dims[1] || co != output_grad_desc->dims[1] ||
+      features_desc->dims[0] != indice_pairs_desc->dims[2] ||
+      2 != indice_pairs_desc->dims[1] ||
       kd * kh * kw != indice_pairs_desc->dims[0]) {
     shape_check = false;  // interdependent dimension check failed!
   }


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修正防呆检查，之前的防呆检查写错了，导致正确的规模也会被防呆检查拦住。

## 2. Modification

应该检查indice_pairs的最后一个维度和features的第一个维度相同。下意识的搞成卷积里的ci了，写成了和ci进行检查。

## 3. Test Report

### 3.1 Modification Details

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| 　和第一个维度进行检查 |     Normal error    |    [MLUOP] [Error]:[mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize] Shape check failed! Now the shapes are features_desc[512,256], output_grad_desc[512,32], indice_pairs_desc[36,2,256], and filters_grad_desc[2,3,6,256,32].      |

### 3.2 Accuracy Test
不涉及

### 3.4 Summary Analysis

把形状检查的防呆写到了一起。导致第一遍测试防呆，看到了防呆log,就以为功能正常。没想到第一次是吧其它的防住了，不是想要的防呆。
