### PR TITLE
[Fix](bangc-ops) fix get indice pairs zero element

### DIFF
--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs.cpp
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs.cpp
@@ -91,15 +91,6 @@ static mluOpStatus_t internalGetIndicePairs(
   PARAM_CHECK(interface_name, indice_pairs_desc != NULL);
   PARAM_CHECK(interface_name, out_indices_desc != NULL);
   PARAM_CHECK(interface_name, indice_num_desc != NULL);
-  if (!is_get_workspace) {
-    PARAM_CHECK(interface_name, indices != NULL);
-    PARAM_CHECK(interface_name, indice_pairs != NULL);
-    PARAM_CHECK(interface_name, out_indices != NULL);
-    PARAM_CHECK(interface_name, indice_num != NULL);
-    if (workspace_size != 0) {
-      PARAM_CHECK(interface_name, workspace != NULL);
-    }
-  }
   // sparse_conv_desc dimNb  check
   int sparse_conv_dimNb = sparse_conv_desc->dimNb;
 
@@ -127,7 +118,6 @@ static mluOpStatus_t internalGetIndicePairs(
     output_spaces *= sparse_conv_desc->output_space[i];
     input_spaces *= sparse_conv_desc->input_space[i];
   }
-  PARAM_CHECK_GT(interface_name, indices_desc->dims[0], 0);
   PARAM_CHECK_LE(interface_name, indices_desc->dims[0], input_spaces);
 
   for (int i = 0; i < sparse_conv_dimNb - 2; i++) {
@@ -166,6 +156,22 @@ static mluOpStatus_t internalGetIndicePairs(
                      sparse_conv_desc->output_space[i]);
       PARAM_CHECK_EQ(interface_name, sparse_conv_desc->stride[i], 1);
       PARAM_CHECK_EQ(interface_name, sparse_conv_desc->dilation[i], 1);
+    }
+  }
+  if (mluOpGetTensorElementNum(indices_desc) == 0 ||
+      mluOpGetTensorElementNum(indice_pairs_desc) == 0 ||
+      mluOpGetTensorElementNum(out_indices_desc) == 0 ||
+      mluOpGetTensorElementNum(indice_num_desc) == 0) {
+    sparse_conv_desc->num_act_out = 0;
+    return MLUOP_STATUS_SUCCESS;
+  }
+  if (!is_get_workspace) {
+    PARAM_CHECK(interface_name, indices != NULL);
+    PARAM_CHECK(interface_name, indice_pairs != NULL);
+    PARAM_CHECK(interface_name, out_indices != NULL);
+    PARAM_CHECK(interface_name, indice_num != NULL);
+    if (workspace_size != 0) {
+      PARAM_CHECK(interface_name, workspace != NULL);
     }
   }
   // gencase
@@ -218,6 +224,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetIndicePairsWorkspaceSize(
   PARAM_CHECK(interface_name, indice_pairs_desc != NULL);
   PARAM_CHECK(interface_name, out_indices_desc != NULL);
   PARAM_CHECK(interface_name, indice_num_desc != NULL);
+  PARAM_CHECK(interface_name, workspace_size != NULL);
   if (mluOpGetTensorElementNum(indices_desc) == 0 ||
       mluOpGetTensorElementNum(indice_pairs_desc) == 0 ||
       mluOpGetTensorElementNum(out_indices_desc) == 0 ||


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

加入0元素防呆和workspace 防呆

## 2. Modification

加入0元素防呆和workspace 防呆

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

generator case 测试 
[MLU Hardware Time      ]: 112 (us)
[MLU Interface Time     ]: 75.338 (us)
[MLU IO Efficiency      ]: 0.00980148
[MLU Compute Efficiency ]: 0.0143705
[MLU Workspace Size     ]: 5.71098e+06 (Bytes)
[MLU TheoryOps          ]: 3.70829e+06 (Ops)
[MLU TheoryIOs          ]: 3.0351e+06 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] /home/get_indice_pairs/get_indice_pairs_data_included_int32_1675738558214.pb
[       OK ] get_indice_pairs/TestSuite.mluOp/201 (11 ms)
[----------] 202 tests from get_indice_pairs/TestSuite (87864 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 202 cases of 1 op(s).
ALL PASSED.
[==========] 202 test cases from 1 test suite ran. (88368 ms total)
[  PASSED  ] 202 test cases.


### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
