### PR TITLE
[Feature](bangc-ops): Make voxelization operator supported mlu200 series. 

### DIFF
--- a/bangc-ops/kernels/utils/common.h
+++ b/bangc-ops/kernels/utils/common.h
@@ -197,7 +197,7 @@ static __mlu_func__ void computeSigmoid(T *nram_dst, T *nram_src,
  * space in NRAM
  * param 'src_count' is the src element count
  * Notes:
- *   the sapces pointed by dst and src can not overlap
+ *   the spaces pointed by dst and src can not overlap
  *   src_count*sizeof(float) should be divisible by 128
  *   src input must be in range of [-2^23, 2^23-1] for MLU270 and MLU290
  *****************************************************************************/

--- a/bangc-ops/kernels/voxelization/voxelization.cpp
+++ b/bangc-ops/kernels/voxelization/voxelization.cpp
@@ -61,13 +61,6 @@ mluOpStatus_t voxelizationParamCheck(
     const mluOpTensorDescriptor_t coors_desc,
     const mluOpTensorDescriptor_t num_points_per_voxel_desc,
     const mluOpTensorDescriptor_t voxel_num_desc, bool is_zero_element) {
-  // check arch
-  if (handle->arch < MLUOP_MLU370) {
-    LOG(ERROR) << "[mluOpVoxelization] The operator only support architecture "
-                  "which is greater than or equal to 372.";
-    return MLUOP_STATUS_ARCH_MISMATCH;
-  }
-
   if (deterministic == true) {
     // check tensor shape
     // params points: [num_points, num_features]
@@ -257,7 +250,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpVoxelization(
     GEN_CASE_DATA(false, "voxel_num", voxel_num, voxel_num_desc, 0, 0);
     GEN_CASE_OP_PARAM_SINGLE(0, "voxelization", "max_points", max_points);
     GEN_CASE_OP_PARAM_SINGLE(1, "voxelization", "max_voxels", max_voxels);
-    GEN_CASE_OP_PARAM_SINGLE(2, "voxelization", "NDim", NDim);
+    GEN_CASE_OP_PARAM_SINGLE(2, "voxelization", "ndim", NDim);
     GEN_CASE_OP_PARAM_SINGLE(3, "voxelization", "deterministic", deterministic);
     GEN_CASE_TEST_PARAM_NEW(false, false, true, 0, 0, 0);
   }

--- a/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
+++ b/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
@@ -28,7 +28,17 @@
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
-#if __BANG_ARCH__ >= 322
+__mlu_func__ void floor(float *dst_ram, float *src_ram, int size) {
+#if (__BANG_ARCH__ >= 322)
+  __bang_floor(dst_ram, src_ram, size);  // This bang interface is for nan/inf
+                                         // temp.
+#else
+  int16 *mid = (int16 *)(dst_ram + size / 2);
+  __bang_float2int16_dn(mid, (float *)src_ram, size, 0);
+  __bang_int162float((float *)dst_ram, mid, size, 0);
+#endif
+}
+
 __mlu_func__ void computeDynamicVoxelize(
     char *points_x, char *points_y, char *points_z, char *auxiliary_a,
     char *auxiliary_b, char *auxiliary_c, const float coors_x_min,
@@ -38,21 +48,25 @@ __mlu_func__ void computeDynamicVoxelize(
   // x - coors_x_min
   __bang_sub_scalar((float *)points_x, (float *)points_x, coors_x_min,
                     deal_num);
-  // y - coors_y_min
-  __bang_sub_scalar((float *)points_y, (float *)points_y, coors_y_min,
-                    deal_num);
-  // z - coors_z_min
-  __bang_sub_scalar((float *)points_z, (float *)points_z, coors_z_min,
-                    deal_num);
   // (x - coors_x_min) / voxel_x
   __bang_mul_scalar((float *)points_x, (float *)points_x, 1.0 / voxel_x,
+                    deal_num);
+
+  // y - coors_y_min
+  __bang_sub_scalar((float *)points_y, (float *)points_y, coors_y_min,
                     deal_num);
   // (y - coors_y_min) / voxel_y
   __bang_mul_scalar((float *)points_y, (float *)points_y, 1.0 / voxel_y,
                     deal_num);
+
+  // z - coors_z_min
+  __bang_sub_scalar((float *)points_z, (float *)points_z, coors_z_min,
+                    deal_num);
   // (z - coors_z_min) / voxel_z
   __bang_mul_scalar((float *)points_z, (float *)points_z, 1.0 / voxel_z,
                     deal_num);
+
+#if __BANG_ARCH__ >= 322
   // c_x = floor((x - coors_x_min) / voxel_x)
   __bang_floor((float *)auxiliary_a, (float *)points_x, deal_num);
   __bang_float2int32((int32_t *)points_x, (float *)auxiliary_a, deal_num, 0);
@@ -69,7 +83,7 @@ __mlu_func__ void computeDynamicVoxelize(
   __bang_lt_scalar((int32_t *)auxiliary_c, (int32_t *)points_x, grid_x,
                    deal_num);
   // 0 <= c_x < grid_x
-  __bang_mul((int32_t *)auxiliary_a, (int32_t *)auxiliary_b,
+  __bang_and((int32_t *)auxiliary_a, (int32_t *)auxiliary_b,
              (int32_t *)auxiliary_c, deal_num);
   // c_y >= 0
   __bang_ge_scalar((int32_t *)auxiliary_b, (int32_t *)points_y, (int32_t)0,
@@ -78,10 +92,10 @@ __mlu_func__ void computeDynamicVoxelize(
   __bang_lt_scalar((int32_t *)auxiliary_c, (int32_t *)points_y, grid_y,
                    deal_num);
   // 0 <= c_y < grid_y
-  __bang_mul((int32_t *)auxiliary_b, (int32_t *)auxiliary_b,
+  __bang_and((int32_t *)auxiliary_b, (int32_t *)auxiliary_b,
              (int32_t *)auxiliary_c, deal_num);
   // c_x >= 0 && c_x < grid_x && c_y >= 0 && c_y < grid_y
-  __bang_mul((int32_t *)auxiliary_a, (int32_t *)auxiliary_a,
+  __bang_and((int32_t *)auxiliary_a, (int32_t *)auxiliary_a,
              (int32_t *)auxiliary_b, deal_num);
   // c_z >= 0
   __bang_ge_scalar((int32_t *)auxiliary_b, (int32_t *)points_z, (int32_t)0,
@@ -90,10 +104,10 @@ __mlu_func__ void computeDynamicVoxelize(
   __bang_lt_scalar((int32_t *)auxiliary_c, (int32_t *)points_z, grid_z,
                    deal_num);
   // 0 <= c_z < grid_z
-  __bang_mul((int32_t *)auxiliary_b, (int32_t *)auxiliary_b,
+  __bang_and((int32_t *)auxiliary_b, (int32_t *)auxiliary_b,
              (int32_t *)auxiliary_c, deal_num);
   // 0 <= c_x < grid_x && 0 <= c_y < grid_y && 0 <= c_z < grid_z
-  __bang_mul((int32_t *)auxiliary_a, (int32_t *)auxiliary_a,
+  __bang_and((int32_t *)auxiliary_a, (int32_t *)auxiliary_a,
              (int32_t *)auxiliary_b, deal_num);
   __bang_not((int32_t *)auxiliary_c, (int32_t *)auxiliary_a, deal_num);
 
@@ -111,15 +125,78 @@ __mlu_func__ void computeDynamicVoxelize(
              deal_num);
   __bang_add((int32_t *)points_z, (int32_t *)points_z, (int32_t *)auxiliary_b,
              deal_num);
+#else
+  // c_x >= 0
+  __bang_ge_scalar((float *)auxiliary_b, (float *)points_x, (float)0, deal_num);
+
+  // c_x < grid_x
+  __bang_write_value((float *)auxiliary_a, deal_num, (float)grid_x);
+  __bang_lt((float *)auxiliary_c, (float *)points_x, (float *)auxiliary_a,
+            deal_num);
+  // 0 <= c_x < grid_x
+  __bang_and((float *)auxiliary_a, (float *)auxiliary_b, (float *)auxiliary_c,
+             deal_num);
+  // c_y >= 0
+  __bang_ge_scalar((float *)auxiliary_b, (float *)points_y, (float)0, deal_num);
+  // c_y < grid_y
+  __bang_write_value((float *)auxiliary_c, deal_num, (float)grid_y);
+  __bang_lt((float *)auxiliary_c, (float *)points_y, (float *)auxiliary_c,
+            deal_num);
+  // 0 <= c_y < grid_y
+  __bang_and((float *)auxiliary_b, (float *)auxiliary_b, (float *)auxiliary_c,
+             deal_num);
+  // c_x >= 0 && c_x < grid_x && c_y >= 0 && c_y < grid_y
+  __bang_and((float *)auxiliary_a, (float *)auxiliary_a, (float *)auxiliary_b,
+             deal_num);
+  // c_z >= 0
+  __bang_ge_scalar((float *)auxiliary_b, (float *)points_z, (float)0, deal_num);
+  // c_z < grid_z
+  __bang_write_value((float *)auxiliary_c, deal_num, (float)grid_z);
+  __bang_lt((float *)auxiliary_c, (float *)points_z, (float *)auxiliary_c,
+            deal_num);
+  // 0 <= c_z < grid_z
+  __bang_and((float *)auxiliary_b, (float *)auxiliary_b, (float *)auxiliary_c,
+             deal_num);
+  // 0 <= c_x < grid_x && 0 <= c_y < grid_y && 0 <= c_z < grid_z
+  __bang_and((float *)auxiliary_a, (float *)auxiliary_a, (float *)auxiliary_b,
+             deal_num);
+  __bang_not((float *)auxiliary_c, (float *)auxiliary_a, deal_num);
+
+  __bang_mul((float *)points_x, (float *)points_x, (float *)auxiliary_a,
+             deal_num);
+  __bang_mul_scalar((float *)auxiliary_b, (float *)auxiliary_c, (float)(-1.0),
+                    deal_num);
+  __bang_add((float *)points_x, (float *)points_x, (float *)auxiliary_b,
+             deal_num);
+  __bang_mul((float *)points_y, (float *)points_y, (float *)auxiliary_a,
+             deal_num);
+  __bang_add((float *)points_y, (float *)points_y, (float *)auxiliary_b,
+             deal_num);
+  __bang_mul((float *)points_z, (float *)points_z, (float *)auxiliary_a,
+             deal_num);
+  __bang_add((float *)points_z, (float *)points_z, (float *)auxiliary_b,
+             deal_num);
+
+  floor((float *)auxiliary_a, (float *)points_x, deal_num);
+  __float2int32((int32_t *)points_x, (float *)auxiliary_b, (float *)auxiliary_a,
+                (float *)auxiliary_c, deal_num);
+
+  floor((float *)auxiliary_a, (float *)points_y, deal_num);
+  __float2int32((int32_t *)points_y, (float *)auxiliary_b, (float *)auxiliary_a,
+                (float *)auxiliary_c, deal_num);
+
+  floor((float *)auxiliary_a, (float *)points_z, deal_num);
+  __float2int32((int32_t *)points_z, (float *)auxiliary_b, (float *)auxiliary_a,
+                (float *)auxiliary_c, deal_num);
+#endif
 }
 
-__mlu_func__ void computePoint2Voxel(char *coors_x, char *coors_y,
-                                     char *coors_z, const int32_t c_x,
-                                     const int32_t c_y, const int32_t c_z,
-                                     const int32_t max_points, int32_t *num,
-                                     int32_t *first_point,
-                                     const int32_t deal_idx,
-                                     const int32_t deal_num) {
+__mlu_func__ void computePoint2Voxel(
+    char *coors_x, char *coors_y, char *coors_z, char *src_addition,
+    char *dst_addition, char *dst, const int32_t c_x, const int32_t c_y,
+    const int32_t c_z, const int32_t max_points, int32_t *num,
+    int32_t *first_point, const int32_t deal_idx, const int32_t deal_num) {
+#if __BANG_ARCH__ >= 322
   __bang_eq_scalar((int32_t *)coors_x, (int32_t *)coors_x, c_x, deal_num);
   __bang_eq_scalar((int32_t *)coors_y, (int32_t *)coors_y, c_y, deal_num);
   __bang_eq_scalar((int32_t *)coors_z, (int32_t *)coors_z, c_z, deal_num);
@@ -136,15 +213,41 @@ __mlu_func__ void computePoint2Voxel(char *coors_x, char *coors_y,
   } else {
     *num += (int32_t)__bang_count((float *)coors_x, deal_num);
   }
-}
+#else
+  __int322float((float *)dst, (float *)dst_addition, (int32_t *)coors_x,
+                (float *)src_addition, deal_num);
+  __bang_write_value((float *)src_addition, deal_num, (float)c_x);
+  __bang_eq((float *)coors_x, (float *)dst, (float *)src_addition, deal_num);
+
+  __int322float((float *)dst, (float *)dst_addition, (int32_t *)coors_y,
+                (float *)src_addition, deal_num);
+  __bang_write_value((float *)src_addition, deal_num, (float)c_y);
+  __bang_eq((float *)coors_y, (float *)dst, (float *)src_addition, deal_num);
+
+  __int322float((float *)dst, (float *)dst_addition, (int32_t *)coors_z,
+                (float *)src_addition, deal_num);
+  __bang_write_value((float *)src_addition, deal_num, (float)c_z);
+  __bang_eq((float *)coors_z, (float *)dst, (float *)src_addition, deal_num);
+
+  __bang_mul((float *)coors_x, (float *)coors_x, (float *)coors_y, deal_num);
+  __bang_mul((float *)coors_x, (float *)coors_x, (float *)coors_z, deal_num);
+  if (*num == 0) {
+    *num = (int32_t)__bang_count((float *)coors_x, deal_num);
+    if (*num > 0) {
+      *first_point =
+          (int32_t)__bang_findfirst1((float *)coors_x, deal_num) + deal_idx;
+    }
+  } else {
+    *num += (int32_t)__bang_count((float *)coors_x, deal_num);
+  }
 #endif
+}
 
 __mlu_global__ void mluDynamicVoxelize(const float *points,
                                        const float *voxel_size_gdram,
                                        const float *coors_range_gdram,
                                        int32_t *coors, const int32_t num_points,
                                        const int32_t num_features) {
-#if __BANG_ARCH__ >= 322
   if (coreId == 0x80) {
     return;
   }
@@ -180,8 +283,8 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
       FLOOR_ALIGN(MAX_NRAM_SIZE / split_num / sizeof(float), NFU_ALIGN_SIZE);
   const int32_t repeat = points_per_core / deal_num;
   const int32_t rem = points_per_core % deal_num;
+  const int32_t rem_align = CEIL_ALIGN(rem, NFU_ALIGN_SIZE);
   const int32_t ping_pong_gap = 3 * deal_num * sizeof(float);
-
   char *points_x = nram_buffer;
   char *points_y = points_x + deal_num * sizeof(float);
   char *points_z = points_y + deal_num * sizeof(float);
@@ -318,7 +421,7 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
                            points_z + (repeat % 2) * ping_pong_gap, auxiliary_a,
                            auxiliary_b, auxiliary_c, coors_x_min, coors_y_min,
                            coors_z_min, voxel_x, voxel_y, voxel_z, grid_x,
-                           grid_y, grid_z, rem);
+                           grid_y, grid_z, rem_align);
     __asm__ volatile("sync;");
     pvLock();
     __memcpy_async(coors_x_start + repeat * deal_num,
@@ -332,26 +435,36 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
                    rem * sizeof(int32_t), NRAM2GDRAM);
     pvUnlock();
   }
-#endif
 }
 
 __mlu_global__ void mluPoint2Voxel(int32_t *coors, int32_t *point_to_pointidx,
                                    int32_t *point_to_voxelidx,
                                    const int32_t num_points,
                                    const int32_t max_points) {
-#if __BANG_ARCH__ >= 322
   if (coreId == 0x80) {
     return;
   }
-
+#if __BANG_ARCH__ >= 322
   const int32_t split_num = 6;
+#else
+  const int32_t split_num = 9;  // one temp space for computePoint2Voxel in
+                                // mlu2xx
+#endif
   const int32_t deal_num =
       FLOOR_ALIGN(MAX_NRAM_SIZE / split_num / sizeof(int32_t), NFU_ALIGN_SIZE);
-  const int32_t ping_pong_gap = 3 * deal_num * sizeof(int32_t);
-
   char *coors_x = nram_buffer;
   char *coors_y = coors_x + deal_num * sizeof(int32_t);
   char *coors_z = coors_y + deal_num * sizeof(int32_t);
+  const int32_t ping_pong_gap = 3 * deal_num * sizeof(int32_t);
+#if __BANG_ARCH__ >= 322
+  char *src_addition = nullptr;
+  char *dst_addition = nullptr;
+  char *dst = nullptr;
+#else
+  char *src_addition = coors_x + 2 * ping_pong_gap;
+  char *dst_addition = src_addition + deal_num * sizeof(int32_t);
+  char *dst = dst_addition + deal_num * sizeof(int32_t);
+#endif
 
   int32_t *coors_z_start = coors;
   int32_t *coors_y_start = coors + num_points;
@@ -370,11 +483,14 @@ __mlu_global__ void mluPoint2Voxel(int32_t *coors, int32_t *point_to_pointidx,
     int32_t c_z = coors_z_start[point_idx];
 
     int32_t deal_total_num = point_idx;
-    int32_t repeat = deal_total_num / deal_num;
-    int32_t rem = deal_total_num % deal_num;
+    const int32_t repeat = deal_total_num / deal_num;
+    const int32_t rem = deal_total_num % deal_num;
+    int32_t rem_align = CEIL_ALIGN(rem, NFU_ALIGN_SIZE);
+#if __BANG_ARCH__ >= 322
+    rem_align = rem;
+#endif
     int32_t num = 0;
     int32_t first_point = -1;
-
     if (repeat > 0) {
       __memcpy_async(coors_x, coors_x_start, deal_num * sizeof(int32_t),
                      GDRAM2NRAM);
@@ -395,14 +511,22 @@ __mlu_global__ void mluPoint2Voxel(int32_t *coors, int32_t *point_to_pointidx,
       __memcpy_async(coors_z + ((i + 1) % 2) * ping_pong_gap,
                      coors_z_start + (i + 1) * deal_num,
                      deal_num * sizeof(int32_t), GDRAM2NRAM);
-      computePoint2Voxel(
-          coors_x + (i % 2) * ping_pong_gap, coors_y + (i % 2) * ping_pong_gap,
-          coors_z + (i % 2) * ping_pong_gap, c_x, c_y, c_z, max_points, &num,
-          &first_point, i * deal_num, deal_num);
+      computePoint2Voxel(coors_x + (i % 2) * ping_pong_gap,
+                         coors_y + (i % 2) * ping_pong_gap,
+                         coors_z + (i % 2) * ping_pong_gap, src_addition,
+                         dst_addition, dst, c_x, c_y, c_z, max_points, &num,
+                         &first_point, i * deal_num, deal_num);
       __asm__ volatile("sync;");
     }
 
     if (rem > 0) {
+      __bang_write_value((int32_t *)(coors_x + (repeat % 2) * ping_pong_gap),
+                         rem_align, -1);
+      __bang_write_value((int32_t *)(coors_y + (repeat % 2) * ping_pong_gap),
+                         rem_align, -1);
+      __bang_write_value((int32_t *)(coors_z + (repeat % 2) * ping_pong_gap),
+                         rem_align, -1);
+
       __memcpy_async(coors_x + (repeat % 2) * ping_pong_gap,
                      coors_x_start + repeat * deal_num, rem * sizeof(int32_t),
                      GDRAM2NRAM);
@@ -416,8 +540,9 @@ __mlu_global__ void mluPoint2Voxel(int32_t *coors, int32_t *point_to_pointidx,
     if (repeat > 0) {
       computePoint2Voxel(coors_x + ((repeat - 1) % 2) * ping_pong_gap,
                          coors_y + ((repeat - 1) % 2) * ping_pong_gap,
-                         coors_z + ((repeat - 1) % 2) * ping_pong_gap, c_x, c_y,
-                         c_z, max_points, &num, &first_point,
+                         coors_z + ((repeat - 1) % 2) * ping_pong_gap,
+                         src_addition, dst_addition, dst, c_x, c_y, c_z,
+                         max_points, &num, &first_point,
                          (repeat - 1) * deal_num, deal_num);
     }
     __asm__ volatile("sync;");
@@ -425,9 +550,9 @@ __mlu_global__ void mluPoint2Voxel(int32_t *coors, int32_t *point_to_pointidx,
     if (rem > 0) {
       computePoint2Voxel(coors_x + (repeat % 2) * ping_pong_gap,
                          coors_y + (repeat % 2) * ping_pong_gap,
-                         coors_z + (repeat % 2) * ping_pong_gap, c_x, c_y, c_z,
-                         max_points, &num, &first_point, repeat * deal_num,
-                         rem);
+                         coors_z + (repeat % 2) * ping_pong_gap, src_addition,
+                         dst_addition, dst, c_x, c_y, c_z, max_points, &num,
+                         &first_point, repeat * deal_num, rem_align);
       __asm__ volatile("sync;");
     }
 
@@ -443,14 +568,12 @@ __mlu_global__ void mluPoint2Voxel(int32_t *coors, int32_t *point_to_pointidx,
       point_to_voxelidx[point_idx] = -1;
     }
   }
-#endif
 }
 
 __mlu_global__ void mluCalcPointsPerVoxel(
     int32_t *point_to_pointidx, int32_t *point_to_voxelidx,
     int32_t *coor_to_voxelidx, int32_t *num_points_per_voxel,
     int32_t *voxel_num, const int32_t max_voxels, const int32_t num_points) {
-#if __BANG_ARCH__ >= 322
   if (coreId == 0) {
     int32_t voxel_num_temp = 0;
     for (int32_t point_idx = 0; point_idx < num_points; ++point_idx) {
@@ -477,7 +600,6 @@ __mlu_global__ void mluCalcPointsPerVoxel(
     }
     *voxel_num = voxel_num_temp;
   }
-#endif
 }
 
 __mlu_global__ void mluAssignVoxelsCoors(
@@ -485,7 +607,6 @@ __mlu_global__ void mluAssignVoxelsCoors(
     int32_t *coor_to_voxelidx, float *voxels, int32_t *coors,
     const int32_t max_points, const int32_t num_points,
     const int32_t num_features) {
-#if __BANG_ARCH__ >= 322
   if (coreId == 0x80) {
     return;
   }
@@ -517,7 +638,6 @@ __mlu_global__ void mluAssignVoxelsCoors(
     }
   }
   __asm__ volatile("sync;");
-#endif
 }
 
 void MLUOP_WIN_API mluOpUnionKernelDynamicVoxelize(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Make voxelization operator supported mlu200 series.

## 2. Modification

mlu-ops/bangc-ops/kernels/voxelization/voxelization.cpp

mlu-ops/bangc-ops/kernels/voxelization/voxelization_kernel.mlu

mlu-ops/bangc-ops/kernels/utils/common.h

## 3. Test Report

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff3: diff3 == 0

#### 3.1.2 Operator Scheme checklist

| No.  | Details                                | Check Results              |
| ---- | -------------------------------------- | -------------------------- |
| 1    | Supported hardware                     | MLU290<br>MLU370<br>MLU590 |
| 2    | Job types                              | block <br> U1              |
| 3    | Layouts                                | ARRAY                      |
| 4    | Whether multi-dimensions are supported | NO                         |
| 5    | Whether element zero is supported      | NO                         |
| 6    | Data type(half/float)                  | half / float etc           |
| 7    | Whether there is size limit            | NO                         |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [x] Multidimensional tensor test
- [x] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

| Test Point                                      | Acceptance Standard | Test Result (Error Message)                                  |
| ----------------------------------------------- | ------------------- | ------------------------------------------------------------ |
| Whether it conforms to the operator restriction | Normal error        | **1. check dims**<br>[2023-2-27 11:35:19] [MLUOP] [Error]:[mluOpVoxelization] Check failed: points_desc->dim == 2. <br>[2023-2-27 11:36:54] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxel_size_desc->dim == 1.<br>[2023-2-27 11:38:17] [MLUOP] [Error]:[mluOpVoxelization] Check failed: coors_range_desc->dim == 1.<br>[2023-2-27 11:39:3] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxels_desc->dim == 3.<br>[2023-2-27 11:40:23] [MLUOP] [Error]:[mluOpVoxelization] Check failed: coors_desc->dim == 2.<br>[2023-2-27 11:40:59] [MLUOP] [Error]:[mluOpVoxelization] Check failed: num_points_per_voxel_desc->dim == 1.<br>[2023-2-27 11:41:32] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxel_num_desc->dim == 1.<br>**2. check dims range **<br>[2023-2-27 11:43:55] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxel_size_desc->dims[0] == 3.<br>2023-2-27 11:44:31] [MLUOP] [Error]:[mluOpVoxelization] Check failed: coors_range_desc->dims[0] == 6.<br>[2023-2-27 11:45:32] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxels_desc->dims[0] == max_voxels.<br>[2023-2-27 11:45:57] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxels_desc->dims[1] == max_points.<br>[2023-2-27 11:46:28] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxels_desc->dims[2] == points_desc->dims[1].<br>[2023-2-27 11:47:21] [MLUOP] [Error]:[mluOpVoxelization] Check failed: coors_desc->dims[0] == max_voxels.<br>[2023-2-27 11:47:52] [MLUOP] [Error]:[mluOpVoxelization] Check failed: coors_desc->dims[1] == 3.<br>[2023-2-27 11:48:22] [MLUOP] [Error]:[mluOpVoxelization] Check failed: num_points_per_voxel_desc->dims[0] == max_voxels.<br>[2023-2-27 11:50:53] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxel_num_desc->dims[0] == 1.<br>**3. check NDim **<br>[2023-2-27 11:52:15] [MLUOP] [Error]:[mluOpVoxelization] Check failed: NDim == 3.<br>**4. check DataType**<br>[2023-2-27 11:53:57] [MLUOP] [Error]:[mluOpVoxelization] Check failed: points_desc->dtype == MLUOP_DTYPE_FLOAT.<br>[2023-2-27 11:54:23] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxel_size_desc->dtype == MLUOP_DTYPE_FLOAT.<br>[2023-2-27 11:54:58] [MLUOP] [Error]:[mluOpVoxelization] Check failed: coors_range_desc->dtype == MLUOP_DTYPE_FLOAT.<br>[2023-2-27 11:55:28] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxels_desc->dtype == MLUOP_DTYPE_FLOAT.<br>[2023-2-27 11:56:7] [MLUOP] [Error]:[mluOpVoxelization] Check failed: voxel_num_desc->dtype == MLUOP_DTYPE_INT32.<br>**5. check largetensor**<br>[2023-2-27 12:2:7] [MLUOP] [Warning]:[mluOpSetTensorDescriptor]: overflow max tensor num.Currently, mluOp supports tensor num smaller than 2^31,now tensor dims:(800000000,3), data_width:4.<br>**6. check zero tensor**<br/>[2023-2-27 14:21:34] [MLUOP] [Error]:[mluOpVoxelization] Check failed: Input zero element tensor. |
| Whether illegal parameters are passed           | Normal error        |                                                              |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

| Test Point         | Description                        | Quantity | Comment                                                      |
| ------------------ | ---------------------------------- | -------- | ------------------------------------------------------------ |
| Data type test     | half/float/int8                    |          | [----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 20 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 20 test cases from 1 test suite ran. (29711 ms total)<br/>[  PASSED  ] 20 test cases. |
| Mult-tensor test   | Supports 1-8 dims                  |          | [----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 20 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 20 test cases from 1 test suite ran. (29711 ms total)<br/>[  PASSED  ] 20 test cases. |
| Layout test        | Supports NCHW/NHWC                 |          |                                                              |
| Zero element test  | Whether to support this test       |          | [----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 20 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 20 test cases from 1 test suite ran. (29711 ms total)<br/>[  PASSED  ] 20 test cases. |
| Stability test     | --gtest_repeat=NUM<br>--thread=NUM |          | [----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 20 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 20 test cases from 1 test suite ran. (29711 ms total)<br/>[  PASSED  ] 20 test cases. |
| Mult-platform test | MLU370/MLU590                      |          | [----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 20 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 20 test cases from 1 test suite ran. (29711 ms total)<br/>[  PASSED  ] 20 test cases. |
| Nan/INF test       | Whether to support this test       |          | [ SUMMARY  ] Total 41 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 41 test cases from 1 test suite ran. (10502 ms total)<br/>[  PASSED  ] 41 test cases. |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU290

| Operation | Mlu_hardware_time(us) | Mlu_interface_time(us) | Mlu_io_efficiency | Mlu_compute_efficiency | Mlu_workwpace_size(Bytes) | Data_type | Shape                                                        |
| --------- | --------------------- | ---------------------- | ----------------- | ---------------------- | ------------------------- | --------- | ------------------------------------------------------------ |
| op_name   | 116536                | 41.98                  | 0.000257431       | 9.07221e-05            | 6.09598e+06               | float     | points:[253999,5]<br>voxels:[30000,20,3]<br> coors:[30000,3] |

Platform：MLU370

| Operation | Mlu_hardware_time(us) | Mlu_interface_time(us) | Mlu_io_efficiency | Mlu_compute_efficiency | Mlu_workwpace_size(Bytes) | Data_type | Shape                                                        |
| --------- | --------------------- | ---------------------- | ----------------- | ---------------------- | ------------------------- | --------- | ------------------------------------------------------------ |
| op_name   | 188943                | 60.45                  | 0.000635111       | 0.000111911            | 6.09598e+06               | float     | points:[253999,5]<br>voxels:[30000,20,3]<br> coors:[30000,3] |

Platform：MLU590

| Operation | Mlu_hardware_time(us) | Mlu_interface_time(us) | Mlu_io_efficiency | Mlu_compute_efficiency | Mlu_workwpace_size(Bytes) | Data_type | Shape                                                        |
| --------- | --------------------- | ---------------------- | ----------------- | ---------------------- | ------------------------- | --------- | ------------------------------------------------------------ |
| op_name   | 189093                | 29.632                 | 9.51911e-05       | 4.96987e-05            | 6.09598e+06               | float     | points:[253999,5]<br>voxels:[30000,20,3]<br> coors:[30000,3] |

### 3.4 Summary Analysis

1. Accuracy meets acceptance criteria, and there is still a certain gap between network-scale performance testing and cuda realization；
2. The logic of operator is related to the strength of the data, and the theoretical value of io efficiency/compute efficiency is not accurate；
3. The operator currently only supports the deterministic model, not the non-deterministic model．