### PR TITLE
[Feature](bangc-ops): add namespace and symbol visibility

### DIFF
--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -133,9 +133,25 @@ endforeach()
 file(GLOB_RECURSE core_src_files ${core_src_files} "${CMAKE_CURRENT_SOURCE_DIR}/core/*.cpp")
 # set(src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp")
 
-bang_add_library(mluops SHARED ${core_src_files} ${src_files})
-target_link_libraries(mluops cnrt cndrv dl)
-target_link_libraries(mluops ${obj_files})
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${MLUOP_SYMBOL_VIS_FILE})
+  message(STATUS "${MLUOP_SYMBOL_VIS_FILE} exists.")
+else()
+  message(FATAL_ERROR "${MLUOP_SYMBOL_VIS_FILE} doesn't exist.")
+endif()
+
+set(LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${MLUOP_SYMBOL_VIS_FILE}")
+message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
+add_library(mluopscore STATIC ${core_src_files})
+
+bang_add_library(mluops SHARED ${src_files})
+target_link_libraries(mluops
+  -Wl,--start-group
+  ${obj_files} 
+  -Wl,--whole-archive mluopscore -Wl,--no-whole-archive
+  cnrt cndrv dl
+  -Wl,--end-group
+)
+target_link_libraries(mluops ${LINK_FLAGS})
 set_target_properties(mluops PROPERTIES
   OUTPUT_NAME "mluops"
   PREFIX      "lib"

--- a/bangc-ops/README.md
+++ b/bangc-ops/README.md
@@ -81,6 +81,20 @@
   <op_name> = ["dep_op1", "dep_op2", ...]
   ```
 
+- gen_symbol_visibility_map.py
+
+  - `gen_symbol_visibility_map.py`脚本用于解析`mlu_op.h`头文件，获取函数名，生成`symbol_visibility.map`配置文件。
+    ```sh
+    MLUOP_ABI {
+	    global: op1_func;op2_func;
+	    local: *;
+    };
+    ```
+    global：表示符号是全局的（外部的）
+    local：表示符号是本地的，即对外不可见
+  - 执行build.sh编译时，将自动执行`gen_symbol_visibility_map.py`生成`symbol_visibility.map`配置文件。
+  - 在编译阶段依据`symbol_visibility.map`文件中global字段定义的符号表，将动态库`libmluops.so`中除global中定义的符号外其他符号定义为local。
+
 - 命令行参数
 
   可通过`./build.sh -h`或`./build.sh --help`，查看命令行参数

--- a/bangc-ops/core/cnlog.cpp
+++ b/bangc-ops/core/cnlog.cpp
@@ -61,6 +61,7 @@
 #define SECONDS_PER_HOUR 3600
 #define HOURS_DIFFERENCE 8
 
+namespace mluop {
 namespace cnlog {
 
 std::ofstream logFile;                       // which file to save log message.
@@ -541,3 +542,4 @@ int initCNLog() {
 
 __attribute__((__unused__)) static int initlog = initCNLog();
 }  // namespace cnlog
+}  // namespace mluop

--- a/bangc-ops/core/cnlog.h
+++ b/bangc-ops/core/cnlog.h
@@ -28,6 +28,7 @@
 #include <fstream>
 #include <string>
 
+namespace mluop {
 namespace cnlog {
 /**
  * @brief: define save in file or not, show on screen or not.
@@ -205,5 +206,6 @@ bool getBoolEnvVar(const std::string &str, bool default_para = false);
 int getLevelEnvVar(const std::string &str, int default_para = false);
 
 }  // namespace cnlog
+}  // namespace mluop
 
 #endif  // CORE_CNLOG_H_

--- a/bangc-ops/core/context.cpp
+++ b/bangc-ops/core/context.cpp
@@ -29,11 +29,12 @@
 #include "core/tool.h"
 #include "kernels/kernel.h"
 
-#define DEP_CHECK_LOG(level)                                                 \
-  cnlog::LogMessage(__FILE__, __LINE__, 4, level, "MLUOP", true, true, true, \
-                    true)                                                    \
+#define DEP_CHECK_LOG(level)                                                  \
+  mluop::cnlog::LogMessage(__FILE__, __LINE__, 4, level, "MLUOP", true, true, \
+                    true, true)                                               \
       .stream()
 
+namespace mluop {
 // see cnrt_function.c deviceCoreVersion for more info.
 struct deviceName name_list_table[] = {
     {"MLU270", MLUOP_MLU270},
@@ -66,6 +67,7 @@ mluOpDevType_t convertDeviceName(char *name) {
              << name << "\n";
   return MLUOP_UNKNOWN_DEVICE;
 }
+}  // namespace mluop
 
 mluOpStatus_t mluOpCheckDependency(bool need_check_min, bool need_check_max,
                                    DepCheckLevel level) {
@@ -183,7 +185,7 @@ mluOpStatus_t mluOpCreate(mluOpHandle_t *handle) {
   }
   ctx->capability_job_limit = (int32_t)ctx_conf_param.unionLimit;
   ctx->arch =
-      convertDeviceName(device_name);  // warning: possible return unknown.
+      mluop::convertDeviceName(device_name);  // warning: may return unknown.
   ctx->sram_size = sram_size - REM_FOR_STACK;
   ctx->device = mlu_dev;
   ctx->cluster_num = cluster_num;
@@ -321,7 +323,7 @@ mluOpStatus_t mluOpGetReservedMemSize(uint64_t *mem_size) {
 
   uint64_t default_reserved_size = 2081ULL * 1024 * 1024;
   uint64_t env_size =
-      getUintEnvVar("MLUOP_MEM_POOL_SIZE", default_reserved_size);
+      mluop::getUintEnvVar("MLUOP_MEM_POOL_SIZE", default_reserved_size);
   *mem_size = static_cast<uint64_t>(env_size);
 
   return MLUOP_STATUS_SUCCESS;

--- a/bangc-ops/core/gen_case.cpp
+++ b/bangc-ops/core/gen_case.cpp
@@ -47,35 +47,35 @@ __attribute__((__unused__)) std::mutex stacks_mutex_;
 // MLUOP_GEN_CASE=2: Generate gen_case file with input data
 // MLUOP_GEN_CASE=3: Print gen_case simple infomation on screen
 __attribute__((__unused__)) int gen_case_mode_ =
-    getUintEnvVar("MLUOP_GEN_CASE", 0);
+    mluop::getUintEnvVar("MLUOP_GEN_CASE", 0);
 
 // MLUOP_GEN_CASE_DUMP_INTERNAL control whether dump internal mluOpapi call
 __attribute__((__unused__)) bool dump_internal_ =
-    getBoolEnvVar("MLUOP_GEN_CASE_DUMP_INTERNAL", false);
+    mluop::getBoolEnvVar("MLUOP_GEN_CASE_DUMP_INTERNAL", false);
 
 // MLUOP_GEN_CASE_OP_NAME control generating prototxt
 // "conv;abs" means only generate prototxt for conv and abs
 // "-conv;-abs" means only not generate prototxt for conv and abs
 __attribute__((__unused__)) std::string op_name_ =
-    getStringEnvVar("MLUOP_GEN_CASE_OP_NAME", "all");
+    mluop::getStringEnvVar("MLUOP_GEN_CASE_OP_NAME", "all");
 
 // MLUOP_GEN_CASE_DUMP_DATA control whether dump input device data in prototxt
 // or not 0 : means not dump 1 : means dump readable value, is default value 2 :
 // means dump hex value
 __attribute__((__unused__)) int dump_data_ =
-    getUintEnvVar("MLUOP_GEN_CASE_DUMP_DATA", 0);
+    mluop::getUintEnvVar("MLUOP_GEN_CASE_DUMP_DATA", 0);
 
 // MLUOP_GEN_CASE_DUMP_DATA_OUTPUT control whether dump output device data in
 // prototxt or not 0 : means not dump, is default value 1 : means dump readable
 // value 2 : means dump hex value
 __attribute__((__unused__)) int dump_data_output_ =
-    getUintEnvVar("MLUOP_GEN_CASE_DUMP_DATA_OUTPUT", 0);
+    mluop::getUintEnvVar("MLUOP_GEN_CASE_DUMP_DATA_OUTPUT", 0);
 
 // MLUOP_GEN_CASE_DUMP_DATA_FILE control whether dump data file separately
 // 0 : means not dump file
 // 1 : means dump file
 __attribute__((__unused__)) int dump_data_file_ =
-    getUintEnvVar("MLUOP_GEN_CASE_DUMP_DATA_FILE", 0);
+    mluop::getUintEnvVar("MLUOP_GEN_CASE_DUMP_DATA_FILE", 0);
 
 bool isGenCaseOn() { return gen_case_mode_ > 0; }
 
@@ -227,7 +227,7 @@ void genCaseData(PbNode *node, bool is_input, std::string id,
     node->appendTensor(is_input, id, device_data, desc_, true, params,
                        distribution, dump_data);
   } else {
-    node->appendTensor(is_input, id, device_data, desc, true, params,
+    node->appendTensor(is_input, id, device_data, desc, false, params,
                        distribution, dump_data);
   }
 }
@@ -471,7 +471,7 @@ void PbNode::dumpDataFile(std::string file_name, std::string folder_name,
         std::ofstream tensor_file;
         tensor_file.open(tensor_file_name.c_str(), std::ios::binary);
         tensor_file.write(reinterpret_cast<const char *>(data),
-                          total_num * getSizeOfDataType(dtype));
+                          total_num * mluop::getSizeOfDataType(dtype));
         tensor_file.close();
       } else {
         if (!shouldDump) {
@@ -480,7 +480,7 @@ void PbNode::dumpDataFile(std::string file_name, std::string folder_name,
           std::ofstream tensor_file;
           tensor_file.open(tensor_file_name.c_str(), std::ios::binary);
           tensor_file.write(reinterpret_cast<const char *>(data),
-                            total_num * getSizeOfDataType(dtype));
+                            total_num * mluop::getSizeOfDataType(dtype));
           tensor_file.close();
         }
       }
@@ -533,7 +533,7 @@ void PbNode::dumpOutputFile() {
             std::ofstream tensor_file;
             tensor_file.open(tensor_file_name.c_str(), std::ios::binary);
             tensor_file.write(reinterpret_cast<const char *>(data),
-                              total_num * getSizeOfDataType(dtype));
+                              total_num * mluop::getSizeOfDataType(dtype));
             tensor_file.close();
           }
         }

--- a/bangc-ops/core/gen_case.h
+++ b/bangc-ops/core/gen_case.h
@@ -94,7 +94,7 @@
       std::string(param_node_name) + std::string("_param"))
 #define GEN_CASE_OP_PARAM_SINGLE_NAME(pos, param_node_name, param_name, value) \
   mluop::gen_case::genCaseOpParam(node, param_name, value, param_node_name)
-#define GEN_CASE_OP_PARAM_ARRAY(pos, op_name, param_name, value, num) \
+#define GEN_CASE_OP_PARAM_ARRAY(pos, param_node_name, param_name, value, num) \
   mluop::gen_case::genCaseOpParam(node, param_name, value, num, \
                     std::string(param_node_name) + std::string("_param"))
 #define GEN_CASE_OP_PARAM_SINGLE_SUB(pos, param_node_name, param_name, value,  \
@@ -405,7 +405,7 @@ class PbNode {
     mluOpDataType_t dtype;
     mluOpGetTensorDescriptor(tensors[index].desc, nullptr, &dtype, nullptr,
                              nullptr);
-    uint64_t data_size = total_num * getSizeOfDataType(dtype);
+    uint64_t data_size = total_num * mluop::getSizeOfDataType(dtype);
     void *data = malloc(data_size);
     if (CNRT_RET_SUCCESS ==
         cnrtMemcpy(data, const_cast<void *>(tensors[index].device_ptr),

--- a/bangc-ops/core/logging.h
+++ b/bangc-ops/core/logging.h
@@ -34,7 +34,7 @@
 #define LARGE_TENSOR_NUM ((uint64_t)2147483648)
 #define LARGE_TENSOR_SIZE ((uint64_t)2147483648)
 
-#define LOG(severity) cnlog::CLOG(MLUOP, severity)
+#define LOG(severity) mluop::cnlog::CLOG(MLUOP, severity)
 
 #define TOKENPASTE(x, y, z) x##y##z
 #define TOKENPASTE2(x, y, z) TOKENPASTE(x, y, z)
@@ -42,7 +42,7 @@
 #define LOG_FIRST_N(severity, n)                                            \
   static std::atomic<int> TOKENPASTE2(LOG_, __LINE__, _OCCURRENCES)(0);     \
   if (MLUOP_PREDICT_FALSE(TOKENPASTE2(LOG_, __LINE__, _OCCURRENCES)++ < n)) \
-  cnlog::CLOG(MLUOP, severity)
+  mluop::cnlog::CLOG(MLUOP, severity)
 
 // CHECK with a error if condition is not true.
 #define CHECK(condition, ...)                                    \
@@ -111,7 +111,7 @@
     if ((__status__) != MLUOP_STATUS_SUCCESS) {                            \
       LOG(ERROR) << api << "BAD return status: " << #status << " returns " \
                  << (__status__) << " (FILE: " << __FILE__                 \
-                 << ", LINE: " << __LINE__ "). " __VA_ARGS__;              \
+                 << ", LINE: " << __LINE__ << "). " __VA_ARGS__;           \
       return (__status__);                                                 \
     }                                                                      \
   }

--- a/bangc-ops/core/mlu_env.cpp
+++ b/bangc-ops/core/mlu_env.cpp
@@ -22,11 +22,11 @@
  *************************************************************************/
 #include "core/mlu_env.h"
 
-__attribute__((__unused__)) int cambricon_tf32_override_ =
-    getUintEnvVar("CAMBRICON_TF32_OVERRIDE", 1);
-
 namespace mluop {
+__attribute__((__unused__)) int cambricon_tf32_override_ =
+    mluop::getUintEnvVar("CAMBRICON_TF32_OVERRIDE", 1);
+
 namespace mlu_env {
-int getCambriconTF32Override() { return cambricon_tf32_override_; }
+int getCambriconTF32Override() { return mluop::cambricon_tf32_override_; }
 }  // namespace mlu_env
 }  // namespace mluop

--- a/bangc-ops/core/tensor.cpp
+++ b/bangc-ops/core/tensor.cpp
@@ -144,7 +144,7 @@ mluOpStatus_t mluOpGetSizeOfDataType(mluOpDataType_t data_type, size_t *size) {
   PARAM_CHECK("[mluOpGetSizeOfDataType]", size != NULL);
 
   if (MLUOP_DTYPE_INVALID != data_type) {
-    *size = getSizeOfDataType(data_type);
+    *size = mluop::getSizeOfDataType(data_type);
     return MLUOP_STATUS_SUCCESS;
   } else {
     LOG(ERROR) << "[mluOpGetSizeOfDataType]:data_type should not be "
@@ -230,7 +230,7 @@ mluOpStatus_t mluOpSetTensorDescriptorDim(mluOpTensorDescriptor_t desc,
   }
   desc->total_element_num = stride_base;
   desc->total_tensor_size =
-      desc->total_element_num * getSizeOfDataType(desc->dtype);
+      desc->total_element_num * mluop::getSizeOfDataType(desc->dtype);
   // judge int overflow situation
   if (MLUOP_PREDICT_FALSE(is_overflow)) {
     std::stringstream tensor_info;
@@ -240,7 +240,8 @@ mluOpStatus_t mluOpSetTensorDescriptorDim(mluOpTensorDescriptor_t desc,
     }
 
     tensor_info << dimSize[dimNb - 1]
-                << "), data_width:" << getSizeOfDataType(desc->dtype) << ".";
+                << "), data_width:"
+                << mluop::getSizeOfDataType(desc->dtype) << ".";
     LOG(WARNING) << "[mluOpSetTensorDescriptor]: overflow max tensor num."
                  << "Currently, mluOp supports tensor num smaller than 2^31,"
                  << "now tensor " << tensor_info.str();
@@ -287,7 +288,7 @@ mluOpStatus_t mluOpSetGroupTensorDescriptors(
     (*(group_desc[i]))->total_element_num = strideBase;
     (*(group_desc[i]))->total_tensor_size =
         (*(group_desc[i]))->total_element_num *
-        getSizeOfDataType(group_dtype[i]);
+        mluop::getSizeOfDataType(group_dtype[i]);
 
     // compute new iterator for next loop.
     group_dimSize_iterator += group_dimNb[i];
@@ -324,7 +325,8 @@ mluOpStatus_t mluOpSetTensorDescriptorEx(mluOpTensorDescriptor_t desc,
   for (int i = 0; i < dimNb; ++i) {
     desc->total_element_num *= dimSize[i];
   }
-  desc->total_tensor_size = desc->total_element_num * getSizeOfDataType(dtype);
+  desc->total_tensor_size =
+      desc->total_element_num * mluop::getSizeOfDataType(dtype);
 
   desc->dtype = dtype;
   desc->layout = layout;

--- a/bangc-ops/core/tool.cpp
+++ b/bangc-ops/core/tool.cpp
@@ -29,6 +29,7 @@
 #define INT31_BITWIDTH 31
 #define INT16_BITWIDTH 16
 
+namespace mluop {
 mluOpStatus_t castDtypeToBitwidth(mluOpDataType_t quantize_dtype,
                                   int *bitwidth) {
   if (bitwidth == NULL) {
@@ -453,3 +454,4 @@ bool getBoolEnvVar(const std::string &str, bool default_para) {
   return (env_var == "1" || env_var == "ON" || env_var == "YES" ||
           env_var == "TRUE");
 }
+}  // namespace mluop

--- a/bangc-ops/core/tool.h
+++ b/bangc-ops/core/tool.h
@@ -33,6 +33,7 @@
 #include "mlu_op.h"
 
 
+namespace mluop {
 // The API is used for no scling factor quantization.
 mluOpStatus_t getPosition(float *input, size_t num, mluOpDataType_t datatype,
                           int *position);
@@ -130,5 +131,6 @@ mluOpStatus_t castFixedToFloat32(const FixedType *src, float *dst,
   }
   return MLUOP_STATUS_SUCCESS;
 }
+}  // namespace mluop
 
 #endif  // CORE_TOOL_H_

--- a/bangc-ops/core/type.cpp
+++ b/bangc-ops/core/type.cpp
@@ -23,6 +23,7 @@
 #include "core/type.h"
 #define to_string(a) #a
 
+namespace mluop {
 size_t getSizeOfDataType(mluOpDataType_t dtype) {
   switch (dtype) {
     case MLUOP_DTYPE_BOOL:
@@ -145,3 +146,4 @@ std::string getNameOfTensorLayout(const mluOpTensorLayout_t layout) {
   }
   return layout_name;
 }
+}  // namespace mluop

--- a/bangc-ops/core/type.h
+++ b/bangc-ops/core/type.h
@@ -29,6 +29,7 @@
 #include "core/logging.h"
 #include "mlu_op.h"
 
+namespace mluop {
 // This function is used to get high 32bit and low 32bit of param value.
 // The hardware hasn't support 8 bytes operation, so if the sizeof(dtype) is 8
 // bytes, sometimes we need to separate 8bytes to two 4bytes. Example:for
@@ -59,4 +60,5 @@ size_t getSizeOfDataType(const mluOpDataType_t dtype);
 std::string getNameOfDataType(const mluOpDataType_t dtype);
 
 std::string getNameOfTensorLayout(const mluOpTensorLayout_t layout);
+}  // namespace mluop
 #endif  // CORE_TYPE_H_

--- a/bangc-ops/gen_symbol_visibility_map.py
+++ b/bangc-ops/gen_symbol_visibility_map.py
@@ -1,0 +1,33 @@
+import re
+import sys
+
+mluop_abi_version = "MLUOP_ABI_1.0 {"
+
+def get_mluops(input_file):
+    ops_str=""
+    pattern = re.compile(r'(?P<api>mluOp\w+) *\(')
+    with open(input_file,'r', encoding='utf8') as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                op = match.groupdict()['api'] + ';'
+                ops_str += op
+    return ops_str
+
+def create_map_file(map_file,ops_str):
+    with open(map_file,'w') as f:
+        f.writelines(mluop_abi_version + "\n")
+        global_str = "\t" + "global: " + ops_str + "\n"
+        f.writelines(global_str)
+        f.writelines("\t" + "local: *;\n")
+        f.writelines("};")
+
+if __name__ == '__main__':
+    if len(sys.argv) > 2:
+        map_file = sys.argv[1]
+        ops_str = ""
+        for arg in sys.argv[2:]:
+            ops_str += get_mluops(arg)
+        create_map_file(map_file,ops_str)
+    else:
+        print("[ERROR] Missing script parameter. Call this script in 'python gen_symbol_visibility_map.py dst_path src_path' way.")

--- a/bangc-ops/kernels/ball_query/ball_query.mlu
+++ b/bangc-ops/kernels/ball_query/ball_query.mlu
@@ -109,7 +109,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
   if (!isSupportType(new_xyz_desc->dtype, support_type, 2)) {
     LOG(ERROR) << "[mluOpBallQuery]:Only half and float are supported in input "
                   "new_xyz tensor, but the data type of tensor is "
-               << getNameOfDataType(new_xyz_desc->dtype) << ".";
+               << mluop::getNameOfDataType(new_xyz_desc->dtype) << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   PARAM_CHECK_EQ("[mluOpBallQuery]", new_xyz_desc->dtype, xyz_desc->dtype);
@@ -117,7 +117,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
   if (idx_desc->dtype != MLUOP_DTYPE_INT32) {
     LOG(ERROR) << "[mluOpBallQuery]:Only int32 is supportedin output idx, but "
                   "data type of tensor is "
-               << getNameOfDataType(idx_desc->dtype) << ".";
+               << mluop::getNameOfDataType(idx_desc->dtype) << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   // check LargeTensor

--- a/bangc-ops/kernels/binary_op/binary_op_host.cpp
+++ b/bangc-ops/kernels/binary_op/binary_op_host.cpp
@@ -40,8 +40,8 @@ void binaryOpPolicyFunc(const mluOpHandle_t &handle,
   int core_number = union_number * core_dim;
 
   int element_num = mluOpGetTensorElementNum(desc);
-  int size =
-      CEIL_ALIGN(element_num * getSizeOfDataType(desc->dtype), align_param);
+  int size = CEIL_ALIGN(element_num * mluop::getSizeOfDataType(desc->dtype),
+                        align_param);
   int core_used = CEIL_ALIGN(size / align_param, core_dim);
   core_used = core_used > core_number ? core_number : core_used;
 

--- a/bangc-ops/kernels/copy/copy.cpp
+++ b/bangc-ops/kernels/copy/copy.cpp
@@ -95,10 +95,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpCopy(mluOpHandle_t handle,
   PARAM_CHECK("[mluOpCopy]", input_desc->dtype == output_desc->dtype);
   size_t num_input = mluOpGetTensorElementNum(input_desc);
   size_t num_output = mluOpGetTensorElementNum(output_desc);
-  size_t size_input =
-      shapeStrideCount(input_desc) * getSizeOfDataType(input_desc->dtype);
-  size_t size_output =
-      shapeStrideCount(output_desc) * getSizeOfDataType(output_desc->dtype);
+  size_t size_input = shapeStrideCount(input_desc) *
+                      mluop::getSizeOfDataType(input_desc->dtype);
+  size_t size_output = shapeStrideCount(output_desc) *
+                       mluop::getSizeOfDataType(output_desc->dtype);
   bool stride_kernel = false;
   if (strideCaseWithNotConsistentDense(2, input_desc, output_desc)) {
     stride_kernel = true;
@@ -127,7 +127,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpCopy(mluOpHandle_t handle,
   size_t total_num = num_input;
 
   // set kernel datatype to int8, set total_num to size
-  const int kDTypeSize = getSizeOfDataType(k_data_type);
+  const int kDTypeSize = mluop::getSizeOfDataType(k_data_type);
   total_num = num_input * kDTypeSize;
 
   // generate copy prototxt start!

--- a/bangc-ops/kernels/expand/expand.cpp
+++ b/bangc-ops/kernels/expand/expand.cpp
@@ -55,8 +55,8 @@ mluOpExpand(mluOpHandle_t handle, const mluOpTensorDescriptor_t input_desc,
   PARAM_CHECK("[mluOpExpand]", output_desc->dim <= MLUOP_DIM_MAX);
   size_t input_num = mluOpGetTensorElementNum(input_desc);
   size_t output_num = mluOpGetTensorElementNum(output_desc);
-  if (getSizeOfDataType(input_desc->dtype) ==
-      getSizeOfDataType(MLUOP_DTYPE_INT64)) {
+  if (mluop::getSizeOfDataType(input_desc->dtype) ==
+      mluop::getSizeOfDataType(MLUOP_DTYPE_INT64)) {
     auto statement_error = "the data type is int64 or complex, ";
     TENSOR_NUM_CHECK("[mluOpExpand]", input_num, INT64_LARGE_TENSOR_NUM,
                      statement_error);
@@ -169,8 +169,8 @@ mluOpExpand(mluOpHandle_t handle, const mluOpTensorDescriptor_t input_desc,
   k_dim.z = 1;
   mluOpDataType_t data_type = input_desc->dtype;
 
-  if (getSizeOfDataType(input_desc->dtype) ==
-      getSizeOfDataType(MLUOP_DTYPE_INT64)) {
+  if (mluop::getSizeOfDataType(input_desc->dtype) ==
+      mluop::getSizeOfDataType(MLUOP_DTYPE_INT64)) {
     input_size *= 2;
     output_size *= 2;
     redims_input[MLUOP_DIM_MAX] = 2;

--- a/bangc-ops/kernels/fill/fill.cpp
+++ b/bangc-ops/kernels/fill/fill.cpp
@@ -95,7 +95,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpFill(mluOpHandle_t handle,
         << "[mluOpFill] output_desc only support "
            "bool/int8/uint8/int16/int32/int64/half/"
         << "float/uint64/uint32/uint16 type. Current output data type is "
-        << getNameOfDataType(output_dtype) << ".";
+        << mluop::getNameOfDataType(output_dtype) << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
 
@@ -114,7 +114,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpFill(mluOpHandle_t handle,
     GEN_CASE_DATA(true, "input", NULL, output_desc, 10, 1);
     GEN_CASE_DATA(false, "output", output, output_desc, 0, 0);
     if (pointer_mode == MLUOP_POINTER_MODE_DEVICE) {
-      size_t output_dtype_size = getSizeOfDataType(output_desc->dtype);
+      size_t output_dtype_size = mluop::getSizeOfDataType(output_desc->dtype);
       void *value_host = malloc(output_dtype_size);
       cnrtMemcpyAsync(value_host, const_cast<void *>(value), output_dtype_size,
                       handle->queue, CNRT_MEM_TRANS_DIR_DEV2HOST);
@@ -185,7 +185,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpFill(mluOpHandle_t handle,
       getTensorShape(output_desc, &output_shape);
       uint32_t value_high = 0, value_low = 0;
       uint64_t host_value = *(uint64_t *)value;
-      getLowAndHighValueFrom64Bits(host_value, &value_high, &value_low);
+      mluop::getLowAndHighValueFrom64Bits(host_value, &value_high, &value_low);
       VLOG(5) << "mluOpFill:Launch Kernel "
                  "MLUUnion1KernelFillHostValueWithStride<<<Union"
               << k_type / CORE_DIM << "," << k_dim.x << ", " << k_dim.y << ", "
@@ -198,7 +198,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpFill(mluOpHandle_t handle,
       uint32_t value_high = 0, value_low = 0;
       uint64_t host_value = *(uint64_t *)value;
 
-      getLowAndHighValueFrom64Bits(host_value, &value_high, &value_low);
+      mluop::getLowAndHighValueFrom64Bits(host_value, &value_high, &value_low);
       VLOG(5) << "mluOpFill:Launch Kernel MLUUnion1KernelFillHostValue<<<Union"
               << k_type / CORE_DIM << "," << k_dim.x << ", " << k_dim.y << ", "
               << k_dim.z << ">>>"

--- a/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.cpp
@@ -78,7 +78,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetGenerateProposalsV2WorkspaceSize(
   PARAM_CHECK_NE(API, H, 0);
   PARAM_CHECK_NE(API, W, 0);
   if ((mluOpGetTensorElementNum(scores_desc) *
-           getSizeOfDataType(scores_desc->dtype) >=
+           mluop::getSizeOfDataType(scores_desc->dtype) >=
        LARGE_TENSOR_SIZE)) {
     LOG(ERROR) << API << " Overflow max tensor size."
                << " Currently, MLU-OPS supports tensor size smaller than 2^31.";
@@ -220,16 +220,16 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
   }
 
   if ((mluOpGetTensorElementNum(scores_desc) *
-           getSizeOfDataType(scores_desc->dtype) >=
+           mluop::getSizeOfDataType(scores_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(bbox_deltas_desc) *
-           getSizeOfDataType(bbox_deltas_desc->dtype) >=
+           mluop::getSizeOfDataType(bbox_deltas_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(anchors_desc) *
-           getSizeOfDataType(anchors_desc->dtype) >=
+           mluop::getSizeOfDataType(anchors_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(variances_desc) *
-           getSizeOfDataType(variances_desc->dtype) >=
+           mluop::getSizeOfDataType(variances_desc->dtype) >=
        LARGE_TENSOR_SIZE)) {
     LOG(ERROR) << API << " Overflow max tensor size."
                << " Currently, MLU-OPS supports tensor size smaller than 2^31.";

--- a/bangc-ops/kernels/nms_rotated/nms_rotated.cpp
+++ b/bangc-ops/kernels/nms_rotated/nms_rotated.cpp
@@ -60,7 +60,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetNmsRotatedWorkspaceSize(
   const int box_num = boxes_desc->dims[0];
   const int box_dim = boxes_desc->dims[1];
   int total_num = box_num * box_dim + box_num;
-  *workspace_size = total_num * getSizeOfDataType(boxes_desc->dtype);
+  *workspace_size = total_num * mluop::getSizeOfDataType(boxes_desc->dtype);
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -140,7 +140,7 @@ mluOpNmsRotated(mluOpHandle_t handle, const float iou_threshold,
   // transpose box [N, box_dim] -> [box_dim, N]
   char *box_workspace = (char*)workspace;
   char *scores_workspace = box_workspace +
-        getSizeOfDataType(boxes_desc->dtype) * box_num * box_dim;
+        mluop::getSizeOfDataType(boxes_desc->dtype) * box_num * box_dim;
 
   VLOG(5) << "[mluOpNmsRotated] launch kernel [" << k_dim.x << ", "
           << k_dim.y << ", " << k_dim.z << "].";

--- a/bangc-ops/kernels/psamask/psamask.cpp
+++ b/bangc-ops/kernels/psamask/psamask.cpp
@@ -173,9 +173,9 @@ mluOpStatus_t checkParams(const mluOpTensorDescriptor_t input_desc,
     LOG(ERROR) << api
                << " Check failed: Only support MLUOP_LAYOUT_NHWC input and "
                   "output, but now input is "
-               << getNameOfTensorLayout(input_desc->layout)
+               << mluop::getNameOfTensorLayout(input_desc->layout)
                << ", and output is "
-               << getNameOfTensorLayout(output_desc->layout) << ".";
+               << mluop::getNameOfTensorLayout(output_desc->layout) << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   if (input_desc->dtype != output_desc->dtype ||
@@ -257,7 +257,7 @@ mluOpStatus_t mluOpPsamaskForward(mluOpHandle_t handle, const int psa_type,
   policyFunc(handle, &k_dim, &k_type, &partition_info, n, h_feature);
   int n_limit_seg, h_limit_seg, w_limit_seg;
   ret = findLimit(handle, partition_info.n_per_core, partition_info.h_per_core,
-                  w_feature, x_c, y_c, getSizeOfDataType(x_data_type),
+                  w_feature, x_c, y_c, mluop::getSizeOfDataType(x_data_type),
                   &n_limit_seg, &h_limit_seg, &w_limit_seg, psa_type, api);
   if (ret != MLUOP_STATUS_SUCCESS) {
     GEN_CASE_END();
@@ -325,7 +325,7 @@ mluOpStatus_t mluOpPsamaskBackward(mluOpHandle_t handle, const int psa_type,
   policyFunc(handle, &k_dim, &k_type, &partition_info, n, h_feature);
   int n_limit_seg, h_limit_seg, w_limit_seg;
   ret = findLimit(handle, partition_info.n_per_core, partition_info.h_per_core,
-                  w_feature, dx_c, dy_c, getSizeOfDataType(dy_type),
+                  w_feature, dx_c, dy_c, mluop::getSizeOfDataType(dy_type),
                   &n_limit_seg, &h_limit_seg, &w_limit_seg, psa_type, api);
   if (ret != MLUOP_STATUS_SUCCESS) {
     GEN_CASE_END();

--- a/bangc-ops/kernels/psroipool/psroipool.cpp
+++ b/bangc-ops/kernels/psroipool/psroipool.cpp
@@ -94,16 +94,16 @@ static mluOpStatus_t psRoiPoolForwardParamCheck(
     }
   }
   if ((mluOpGetTensorElementNum(output_desc) *
-           getSizeOfDataType(output_desc->dtype) >=
+           mluop::getSizeOfDataType(output_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(input_desc) *
-           getSizeOfDataType(input_desc->dtype) >=
+           mluop::getSizeOfDataType(input_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(rois_desc) *
-           getSizeOfDataType(rois_desc->dtype) >=
+           mluop::getSizeOfDataType(rois_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(mapping_channel_desc) *
-           getSizeOfDataType(mapping_channel_desc->dtype) >=
+           mluop::getSizeOfDataType(mapping_channel_desc->dtype) >=
        LARGE_TENSOR_SIZE)) {
     LOG(ERROR) << api << " Overflow max tensor size."
                << " Currently, MLU-OPS supports tensor size smaller than 2^31.";
@@ -182,16 +182,16 @@ static mluOpStatus_t psRoiPoolBackwardParamCheck(
   }
 
   if ((mluOpGetTensorElementNum(top_grad_desc) *
-           getSizeOfDataType(top_grad_desc->dtype) >=
+           mluop::getSizeOfDataType(top_grad_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(bottom_grad_desc) *
-           getSizeOfDataType(bottom_grad_desc->dtype) >=
+           mluop::getSizeOfDataType(bottom_grad_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(rois_desc) *
-           getSizeOfDataType(rois_desc->dtype) >=
+           mluop::getSizeOfDataType(rois_desc->dtype) >=
        LARGE_TENSOR_SIZE) ||
       (mluOpGetTensorElementNum(mapping_channel_desc) *
-           getSizeOfDataType(mapping_channel_desc->dtype) >=
+           mluop::getSizeOfDataType(mapping_channel_desc->dtype) >=
        LARGE_TENSOR_SIZE)) {
     LOG(ERROR) << api << " Overflow max tensor size."
                << " Currently, MLU-OPS supports tensor size smaller than 2^31.";

--- a/bangc-ops/kernels/unary_op/unary_op_host.cpp
+++ b/bangc-ops/kernels/unary_op/unary_op_host.cpp
@@ -38,7 +38,7 @@ void unaryOpPolicyFunc(const mluOpHandle_t &handle,
   size_t core_in_cluster = handle->core_num_per_cluster;
   size_t core_number = union_number * core_in_cluster;
   size_t element_num = mluOpGetTensorElementNum(desc);
-  size_t tensor_size = element_num * getSizeOfDataType(desc->dtype);
+  size_t tensor_size = element_num * mluop::getSizeOfDataType(desc->dtype);
   tensor_size = CEIL_ALIGN(tensor_size, NFU_ALIGN_SIZE);
   size_t need_core = CEIL_ALIGN(tensor_size / NFU_ALIGN_SIZE, core_in_cluster);
   *k_type = CNRT_FUNC_TYPE_UNION1;  // default func type

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/parser.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/parser.cpp
@@ -230,7 +230,7 @@ void Parser::parse(const std::string &file) {
     // shape_count come from value_f/value_i/value_h/value_ui/value_ul and
     // shape. not include stride
     mt->shape_count = getTensorShapeCount(pt);
-    mt->sizeof_dtype = getSizeOfDataType(mt->dtype);
+    mt->sizeof_dtype = mluop::getSizeOfDataType(mt->dtype);
     mt->size_in_bytes = mt->total_count * mt->sizeof_dtype;
 
     if (mt->total_count != mt->shape_count) {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/pb_test_tools.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/pb_test_tools.cpp
@@ -252,7 +252,7 @@ void saveHexDataToFile(const std::string &file, void *data,
     } break;
 
     default: {
-      VLOG(4) << "Unsupported dtype " << getNameOfDataType(dtype);
+      VLOG(4) << "Unsupported dtype " << mluop::getNameOfDataType(dtype);
     } break;
   }
   fout.close();

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/fill/fill.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/fill/fill.cpp
@@ -259,7 +259,7 @@ int64_t FillExecutor::getTheoryOps() {
 int64_t FillExecutor::getTheoryIoSize() {
   auto dtype = parser_->output(0)->dtype;
   int64_t theory_ios =
-      parser_->output(0)->total_count * getSizeOfDataType(dtype);
+      parser_->output(0)->total_count * mluop::getSizeOfDataType(dtype);
   VLOG(4) << "getTheoryIOs: " << theory_ios << " bytes";
   return theory_ios;
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改r0.4分支：

- bangc-ops下公共代码增加namespace
- 修改编译相关脚本，支持符号隐藏功能


## 2. Modification

        modified:   bangc-ops/CMakeLists.txt
        modified:   bangc-ops/README.md
        modified:   bangc-ops/core/cnlog.cpp
        modified:   bangc-ops/core/cnlog.h
        modified:   bangc-ops/core/context.cpp
        modified:   bangc-ops/core/gen_case.cpp
        modified:   bangc-ops/core/gen_case.h
        modified:   bangc-ops/core/logging.h
        modified:   bangc-ops/core/mlu_env.cpp
        modified:   bangc-ops/core/tensor.cpp
        modified:   bangc-ops/core/tool.cpp
        modified:   bangc-ops/core/tool.h
        modified:   bangc-ops/core/type.cpp
        modified:   bangc-ops/core/type.h
        new file:   bangc-ops/gen_symbol_visibility_map.py
        modified:   bangc-ops/independent_build.sh
        modified:   bangc-ops/kernels/ball_query/ball_query.mlu
        modified:   bangc-ops/kernels/binary_op/binary_op_host.cpp
        modified:   bangc-ops/kernels/copy/copy.cpp
        modified:   bangc-ops/kernels/expand/expand.cpp
        modified:   bangc-ops/kernels/fill/fill.cpp
        modified:   bangc-ops/kernels/generate_proposals_v2/generate_proposals_v2.cpp
        modified:   bangc-ops/kernels/nms_rotated/nms_rotated.cpp
        modified:   bangc-ops/kernels/psamask/psamask.cpp
        modified:   bangc-ops/kernels/psroipool/psroipool.cpp
        modified:   bangc-ops/kernels/unary_op/unary_op_host.cpp
        modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/executor.cpp
        modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/parser.cpp
        modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/pb_test_tools.cpp
        modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/fill/fill.cpp


## 3. Test Report

- 测试/release_temp下所有case
./mluop_gtest --cases_dir=/data/mlu-ops/release_temp/
ALL PASSED.
[==========] 7092 test cases from 18 test suites ran. (1000497 ms total)
[  PASSED  ] 7092 test cases.
YOU HAVE 7 DISABLED TESTS

- 测试release_test下所有case
./mluop_gtest --cases_dir=/data/mlu-ops/release_test/
[ SUMMARY  ] Total 1771 cases of 16 op(s).
ALL PASSED.
[==========] 1771 test cases from 16 test suites ran. (3084095 ms total)
[  PASSED  ] 1771 test cases.
YOU HAVE 7 DISABLED TESTS
  

