### PR TITLE
[Feature](bangc-ops): add foolcheck for indice-convbpdata workspace-size ptr

### DIFF
--- a/bangc-ops/kernels/indice_convolution_backward_data/indice_convolution_backward_data.cpp
+++ b/bangc-ops/kernels/indice_convolution_backward_data/indice_convolution_backward_data.cpp
@@ -343,6 +343,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(
     const mluOpTensorDescriptor_t input_grad_desc, const int64_t indice_num[],
     const int64_t inverse, size_t *workspace_size) {
   bool is_zero_element = false;
+  if (workspace_size == NULL) {
+    LOG(ERROR) << "[mluOpGetIndiceConvolutionBackwardDataWorkspaceSize] "
+               << "The pointer workspace_size should not be nullptr.";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
   mluOpStatus_t ret =
       foolCheckNoPtr(handle, output_grad_desc, filters_desc, indice_pairs_desc,
                      indice_num, inverse, 0, input_grad_desc, &is_zero_element);


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Complete the fool check that workspace_size should not be a nullptr in get-workspace-size API.

## 2. Modification

Modify: bangc-ops/kernels/indice_convolution_backward_data/indice_convolution_backward_data.cpp

## 3. Test Report

No kernel function or host invoke logic is modified. So directly using CI as complete test.
Meanwhile, the workspace_size fool-check cannot be tested within google-test
