### PR TITLE
[Featrue] (bangc-ops) use fillv3 op to fill -1 in host

### DIFF
--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_block.mlu
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs_block.mlu
@@ -271,7 +271,7 @@ __mlu_global__ void MLUBlockDefaultGetIndicePairKernel3(
     int32_t *index_job_start =
         (int32_t *)indice_index_ptr + (offset_l_job + j) * len_l;
     int32_t *mask_job_start = (int32_t *)mask_all + mask_offset * len_l;
-    int32_t core_len_l_invalid = 0, core_offset_l_valid = 0;
+    int32_t core_offset_l_valid = 0;
     int32_t valid_l_num_now = 0;
     int32_t repeat = (len_l + core_num_l - 1) / core_num_l;
     int32_t rem_num_l =
@@ -293,23 +293,6 @@ __mlu_global__ void MLUBlockDefaultGetIndicePairKernel3(
       if (valid_l_num_now > 0) {
         __memcpy((char *)store_valid_ptr, (char *)nram_output,
                  valid_l_num_now * sizeof(int32_t), NRAM2GDRAM);
-      }
-    }
-    core_len_l_invalid = len_l - core_offset_l_valid;
-    if (core_len_l_invalid > 0) {
-      int32_t *store_invalid_ptr =
-          (int32_t *)indice_pair + store_offset * len_l + core_offset_l_valid;
-      int32_t repeat_store =
-          (core_len_l_invalid + 4 * core_num_l - 1) / (4 * core_num_l);
-      for (int k = 0; k < repeat_store; ++k) {
-        int32_t store_num_l = k == (repeat_store - 1)
-                                  ? core_len_l_invalid % (4 * core_num_l)
-                                  : 4 * core_num_l;
-        __bang_write_value((int32_t *)nram_input, store_num_l, (int)-1);
-        int32_t *store_invalid_ptr_last =
-            store_invalid_ptr + k * 4 * core_num_l;
-        __memcpy((char *)store_invalid_ptr_last, (char *)nram_input,
-                 store_num_l * sizeof(int), NRAM2GDRAM);
       }
     }
   }

--- a/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.cpp
+++ b/bangc-ops/kernels/get_indice_pairs/normal_get_indice_pairs.cpp
@@ -998,6 +998,10 @@ mluOpStatus_t NormalGetIndicePairsKernel(
     kernel3_input_addr = indice_index_in_ptr;
     kernel3_output_addr = indice_pairs;
     kernel3_mask_addr = mask_all_ptr;
+    fill_value = -1;
+    INTERNAL_CHECK(interface_name, MLUOP_STATUS_SUCCESS ==
+                launchFillOp(handle, interface_name, indice_pairs,
+                kernel_volume * 2 * input_active_site, fill_value));
     INTERNAL_CHECK(
         interface_name,
         MLUOP_STATUS_SUCCESS ==
@@ -1184,6 +1188,10 @@ mluOpStatus_t NormalGetIndicePairsKernel(
     kernel3_input_addr = indice_index_in_ptr;
     kernel3_output_addr = indice_pairs;
     kernel3_mask_addr = mask_all_ptr;
+    fill_value = -1;
+    INTERNAL_CHECK(interface_name, MLUOP_STATUS_SUCCESS ==
+                   launchFillOp(handle, interface_name, indice_pairs,
+                   kernel_volume * 2 * input_active_site, fill_value));
     INTERNAL_CHECK(
         interface_name,
         MLUOP_STATUS_SUCCESS ==


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

[MLU Hardware Time      ]: 7361 (us)
[MLU Interface Time     ]: 240.636 (us)
[MLU IO Efficiency      ]: 0.0152187
[MLU Compute Efficiency ]: 0.0515717
[MLU Workspace Size     ]: 5.34811e+08 (Bytes)
[MLU TheoryOps          ]: 8.74642e+08 (Ops)
[MLU TheoryIOs          ]: 3.09727e+08 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] /home/wrong_test_03092/get_indice_pairs/get_indice_pairs_data_included_int32_1678351107924.pb
[       OK ] get_indice_pairs/TestSuite.mluOp/0 (1257427 ms)
[----------] 1 test from get_indice_pairs/TestSuite (1257427 ms total)

[----------] Global test environment tear-down
[2023-3-14 10:18:14] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
[==========] 1 test case 

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
