### PR TITLE
[Fix](bangc-ops): nms_rotated not support for large tensor

### DIFF
--- a/bangc-ops/kernels/nms_rotated/nms_rotated.cpp
+++ b/bangc-ops/kernels/nms_rotated/nms_rotated.cpp
@@ -57,9 +57,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetNmsRotatedWorkspaceSize(
   PARAM_CHECK("[mluOpGetNmsRotatedWorkspaceSize]", handle != nullptr);
   PARAM_CHECK("[mluOpGetNmsRotatedWorkspaceSize]", boxes_desc != nullptr);
   PARAM_CHECK("[mluOpGetNmsRotatedWorkspaceSize]", workspace_size != nullptr);
-  const int box_num = boxes_desc->dims[0];
-  const int box_dim = boxes_desc->dims[1];
-  int total_num = box_num * box_dim + box_num;
+  const uint64_t box_num = boxes_desc->dims[0];
+  const uint64_t box_dim = boxes_desc->dims[1];
+  uint64_t total_num = box_num * box_dim + box_num;
   *workspace_size = total_num * mluop::getSizeOfDataType(boxes_desc->dtype);
   return MLUOP_STATUS_SUCCESS;
 }
@@ -97,6 +97,8 @@ mluOpNmsRotated(mluOpHandle_t handle, const float iou_threshold,
     return MLUOP_STATUS_BAD_PARAM;
   }
 
+  const uint64_t tensor_boxes_num = mluOpGetTensorElementNum(boxes_desc);
+  TENSOR_NUM_CHECK("[mluOpNmsRotated]", tensor_boxes_num, LARGE_TENSOR_NUM, "");
   // 0-element check, after dim and shape check
   if (boxes_desc->dims[0] == 0) {
     VLOG(5) << "[mluOpNmsRotated] Skip zero element boxes.";

--- a/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -394,8 +394,7 @@ __mlu_global__ void MLUKernelNmsRotated(const T *boxes,
                                         const int32_t box_num,
                                         const int32_t box_dim,
                                         const float iou_threshold) {
-  PERF_TIME_BEGIN();
-
+  // PERF_TIME_BEGIN();
   BoxesTranpose(boxes, input_boxes, box_num, box_dim);
   __sync_cluster();
   T *scores_data = input_scores;
@@ -439,7 +438,7 @@ __mlu_global__ void MLUKernelNmsRotated(const T *boxes,
                 scores_load_dir, scores_store_dir, boxes_load_dir, exit);
 
   result_num[0] = output_box_num;
-  PERF_TIME_END();
+  // PERF_TIME_END();
 }
 
 void MLUOP_WIN_API mluOpUnionKernelNmsRotatedFloat(

--- a/docs/bangc-docs/design_docs/nms_rotated/nms_rotated.md
+++ b/docs/bangc-docs/design_docs/nms_rotated/nms_rotated.md
@@ -79,9 +79,9 @@ NmsRotated 算子有 2 个输入 Tensor，分别为 `boxes`[N,5] or [N,6], `scor
 ### 1.4 算子限制
 
 | 限制类型     | 详细说明                                                                           |
-| -----------  | ---------------------------------------------------------------------------------- |
-| 输入限制     | 输入 `boxes`，`scores`的shape 必须满足要求: boxes[N, 5]或[N, 6] 和 scores:[N]      |
-| 输入限制     | 输入 `boxes`不支持输入 nan 或 inf。                                               |
+| -----------  | ------------------------------------------------------------------------------- |
+| 输入限制     | 输入 `boxes`，`scores`的shape 必须满足要求: boxes[N, 5]或[N, 6] 和 scores:[N]         |
+| 输入限制     | 输入 `boxes`, `scores`不支持输入 nan 或 inf。                                               |
 | 输入限制     | 输入参数 `iou_threshold` 仅支持输入float, 可支持nan与inf                           |
 | 输出限制     | 输出 `output`的shape 必须满足: [N]                                                 |
 | 输出限制     | 输出 `result_num` 仅支持 int32\* 类型                                              |
@@ -93,8 +93,8 @@ NmsRotated 算子有 2 个输入 Tensor，分别为 `boxes`[N,5] or [N,6], `scor
 限制说明：
 
 - 不支持`scores`中存在相同score的情况。参考接口和mlu所选择框的index不一致。
-- `scores`中可支持inf，不支持nan和-inf。支持出现一个inf，多个inf时不满足上述说明。不支持nan，因为参考接口nan score等同于inf，优先被选择。mlu中`__bang_max` 选择正常数据，不选择nan。不支持-inf，因为-inf的score等价于box被移除，不会被选择。
-- `boxes`不支持nan/inf, sin/cos和参考接口的bit级无法保持一致。
+- `scores`不支持nan/inf。出现多个inf时不满足上述说明。不支持nan，因为参考接口nan score等同于inf，会被选择。mlu中`__bang_max` 选择正常数据，不选择nan。
+- `boxes`不支持nan/inf。sin/cos和参考接口的bit级无法保持一致。
 
 ### 1.5 验收标准
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

nms_rotated not support large tensor

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multidimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
