### PR TITLE
[Fix](bangc-ops): modify kernel_depends.toml of carafe.

### DIFF
--- a/bangc-ops/kernel_depends.toml
+++ b/bangc-ops/kernel_depends.toml
@@ -27,6 +27,7 @@ indice_convolution_backward_filter = ["fill", "transpose", "gather_nd", "matmul"
 indice_convolution_forward = ["add_n", "fill", "gather_nd", "matmul", "scatter_nd", "transpose"]
 three_nn_forward = ["transpose"]
 roipoint_pool3d = ["transpose"]
+carafe = ["fill", "tensor_stride_process"]
 
 
 [bangc-ops.gtest]
@@ -56,5 +57,5 @@ active_rotated_filter_forward = ["active_rotated_filter"]
 deform_roi_pool_forward = ["deform_roi_pool"]
 deform_roi_pool_backward = ["deform_roi_pool"]
 carafe_forward = ["carafe"]
-carafe_backward = ["carafe", "fill", "tensor_stride_process"]
+carafe_backward = ["carafe"]
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Fix compile bug for carafe by adding op name in kernel_depends.toml.

## 2. Modification

modified: bangc-ops/kernel_depends.toml