### PR TITLE
[Fix](bangc-ops): specify libproto version for master.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/case_list.cpp
 bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/op_register.h
+bangc-ops/daily.software.cambricon.com/
+bangc-ops/symbol_visibility.map
+dependency.txt
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MLU-OPS 旨在通过提供示例代码，供开发者参考使用，可用于开
 - 寒武纪 MLU 驱动：
   - 运行时依赖驱动 v4.20.11 或更高版本。
 - 外部链接库：
-  - libxml2-dev、libprotobuf-dev、protobuf-compiler、llvm-6.0-dev
+  - libxml2-dev、libprotobuf-dev<=3.8.0、protobuf-compiler<=3.8.0、llvm-6.0-dev
 - Python环境：
   - 依赖Python-3.8.0版本。
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Specify libproto version for bangc-ops.

## 2. Modification

modified:   README.md
bangc-ops/daily.software.cambricon.com/
bangc-ops/symbol_visibility.map
dependency.txt
