### PR TITLE
[Fix](bangc-ops): r0.4 modify CMakeList to solve the single-operator link error

### DIFF
--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -142,12 +142,13 @@ endif()
 set(LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${MLUOP_SYMBOL_VIS_FILE}")
 message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
 add_library(mluopscore STATIC ${core_src_files})
+target_link_libraries(mluopscore cnrt cndrv)
 
 bang_add_library(mluops SHARED ${src_files})
 target_link_libraries(mluops
   -Wl,--start-group
-  ${obj_files} 
-  -Wl,--whole-archive mluopscore -Wl,--no-whole-archive
+  ${obj_files}
+  mluopscore
   cnrt cndrv dl
   -Wl,--end-group
 )

--- a/bangc-ops/test/mlu_op_gtest/CMakeLists.txt
+++ b/bangc-ops/test/mlu_op_gtest/CMakeLists.txt
@@ -171,7 +171,8 @@ endif()
 
 add_library(mluop_api_gtest_obj OBJECT ${MLUOP_API_TEST_DIR} ${MLUOP_API_GTEST_DIR})
 add_executable(mluop_api_gtest $<TARGET_OBJECTS:mluop_api_gtest_obj>)
-target_link_libraries(mluop_api_gtest cnrt cndev cndrv cndev pthread gtest_shared mluops stdc++ m dl)
+target_link_libraries(mluop_api_gtest mluops)
+target_link_libraries(mluop_api_gtest cnrt cndev cndrv pthread gtest_shared stdc++ m dl)
 target_link_libraries(mluop_api_gtest ${LIBXML2_LIBRARIES} ${EXTRA_LIBS})
 set_target_properties(mluop_api_gtest
   PROPERTIES


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

- r0.4分支出现单算子编译报 link error 问题：

> 修改编译脚本解决单算子编译 link error 问题，出错日志：
> ./build.sh --filter="abs"
../lib/libmluopscore.a(context.cpp.o): In function `mluOpCreate':
context.cpp:(.text+0x1119): undefined reference to `cnCtxGetCurrent'
context.cpp:(.text+0x1690): undefined reference to `cnCtxGetDevice'
context.cpp:(.text+0x183b): undefined reference to `cnSharedContextAcquire'
context.cpp:(.text+0x19ec): undefined reference to `cnDeviceGetAttribute'
context.cpp:(.text+0x1b96): undefined reference to `cnDeviceGetAttribute'
context.cpp:(.text+0x1d40): undefined reference to `cnDeviceGetAttribute'
context.cpp:(.text+0x1de6): undefined reference to `cnDeviceGetAttribute'
context.cpp:(.text+0x1e91): undefined reference to `cnDeviceGetAttribute'
context.cpp:(.text+0x1f37): undefined reference to `cnDeviceGetName'
context.cpp:(.text+0x2034): undefined reference to `cnGetCtxConfigParam_pt'
context.cpp:(.text+0x2104): undefined reference to `cnGetCtxConfigParam_pt'
../lib/libmluopscore.a(context.cpp.o): In function `mluOpUpdateContextInformation':
context.cpp:(.text+0x2359): undefined reference to `cnQueueGetContext'
context.cpp:(.text+0x256a): undefined reference to `cnGetCtxConfigParam_pt'
context.cpp:(.text+0x28ea): undefined reference to `cnGetCtxConfigParam_pt'
../lib/libmluopscore.a(context.cpp.o): In function `mluOpContext::initJobNum(CNcontext_st*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
context.cpp:(.text._ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x4a): undefined reference to `cnGetCtxMaxParallelUnionTasks'
context.cpp:(.text._ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x24f): undefined reference to `cnGetCtxMaxParallelUnionTasks'
context.cpp:(.text._ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x3f7): undefined reference to `cnGetCtxMaxParallelUnionTasks'
context.cpp:(.text._ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x5a7): undefined reference to `cnGetCtxMaxParallelUnionTasks'
context.cpp:(.text._ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x757): undefined reference to `cnGetCtxMaxParallelUnionTasks'
../lib/libmluopscore.a(context.cpp.o):context.cpp:(.text._ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN12mluOpContext10initJobNumEP12CNcontext_stRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x8ff): more undefined references to `cnGetCtxMaxParallelUnionTasks' follow
collect2: error: ld returned 1 exit status
mlu_op_gtest/CMakeFiles/mluop_api_gtest.dir/build.make:76: recipe for target 'test/mluop_api_gtest' failed
make[2]: *** [test/mluop_api_gtest] Error 1
CMakeFiles/Makefile2:438: recipe for target 'mlu_op_gtest/CMakeFiles/mluop_api_gtest.dir/all' failed
make[1]: *** [mlu_op_gtest/CMakeFiles/mluop_api_gtest.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[100%] Built target mluop_gtest
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
 
 

> ./build.sh --filter="poly_nms"
/usr/bin/ld: ../lib/libmluops.so.0.4.2: undefined reference to symbol 'cnSharedContextAcquire'
/home/wushaoqiang/projs_platform_wsq/devops/mluops-rxx/bangc-ops/dep_libs_extract/neuware/lib64/libcndrv.so: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
mlu_op_gtest/CMakeFiles/mluop_api_gtest.dir/build.make:82: recipe for target 'test/mluop_api_gtest' failed
make[2]: *** [test/mluop_api_gtest] Error 1
CMakeFiles/Makefile2:438: recipe for target 'mlu_op_gtest/CMakeFiles/mluop_api_gtest.dir/all' failed
make[1]: *** [mlu_op_gtest/CMakeFiles/mluop_api_gtest.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[100%] Built target mluop_gtest
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
 

## 2. Modification

- 根因说明：编译可执行文件mluop_api_gtest 时 报link错误
> mluopscore.a 是 需要 依赖 cndrv 中的符号
> 编译可执行文件 mluop_api_gtest 时，需要依赖mluops.so 以及 core.a，但并没有显示的指定依赖core.a，导致编译mluop_api_gtest时，按照mluops.so的依赖行为进行链接，
> 因编译mluops.so时，对mlucore.a 使用了--whole-archive 选项，导致编译mluop_api_gtest时，依赖core.a时继承了该选项，但依旧按照 mluop_api_gtest 的所需的符号加载其他依赖库的符号，比如cnrv，最终导致core.a中的一些符号找不到定义，报错 “undefined reference to xxx "；
> 经过测试，不同算子，报的link错误不同；

- 修改方案：
> 修改bangc-ops下CMakeList：显示指定 libmluopscore.a 依赖的库  cnrt cndrv： target_link_libraries(mluopscore cnrt cndrv)；
> 针对 mluopscore.a 根据 libmluops.so 按需加载 mluopscore.a 中的符号，即针对 mluopscore 去掉 -Wl,--whole-archive 链接选项；
> 修改test下的 CMakeList.txt 编译 mluop_api_gtest 可执行文件时的链接库顺序；

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

- host 端编译 
> - 单算子编译: ./build.sh --filter="abs" 通过
> - 单算子编译: ./build.sh --filter="fill_zero" 通过
> - 单算子编译: ./build.sh --filter="div" 通过
> - 单算子编译: ./build.sh --filter="sqrt" 通过
> - 单算子编译: ./build.sh --filter="yolo_box" 通过
> - 单算子编译: ./build.sh --filter="log" 通过
> - 单算子编译: ./build.sh --filter="ball_query" 通过
> - 单算子编译: ./build.sh --filter="generate_proposals_v2" 通过
> - 多算子编译: ./build.sh --filter="yolo_box;poly_nms;abs" 通过
> - 多算子编译: ./build.sh --filter="generate_proposals_v2;div;log;copy;abs"  通过
> - 全算子编译: ./build.sh 通过

- docker 容器中编译
> - 单算子编译: ./build.sh --filter="abs" 通过
> - 多算子编译: ./build.sh --filter="yolo_box;poly_nms;abs" 通过
> - 全算子编译: ./build.sh 通过

