### PR TITLE
[Fix](bangc-ops): fix moe_backward_gate some case accuracy out of range

### DIFF
--- a/bangc-ops/kernels/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/bangc-ops/kernels/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -35,18 +35,12 @@
 static void policyFunc(const mluOpHandle_t handle, const int samples,
                        cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
   int max_core_num = mluop::runtime::getCoreNumOfJobLimitCapability(handle);
+  k_dim->x = max_core_num;
+  k_dim->y = 1;
+  k_dim->z = 1;
   if (samples > max_core_num) {
-    // union1 policy func
     *k_type = CNRT_FUNC_TYPE_UNION1;
-    // dimx equals to num of mlu cores in each cluster
-    k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
-    // dimy equals to num of current available clusters
-    k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
-    k_dim->z = 1;
   } else {
-    k_dim->x = max_core_num;
-    k_dim->y = 1;
-    k_dim->z = 1;
     *k_type = mluop::runtime::getJobLimitCapabilityCnrtFuncType(handle);
   }
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修复 590M9上部分case 多次测试，概率性出现精度越界问题.

## 2. Modification

- moe_dispatch_backward_gate.cpp：修改任务策略函数
原因分析：policyFunc 策略函数实现存在问题，在MLU590M9（实际最大 core_num 为48）上通过getCoreNumOfJobLimitCapability() 接口获取的最大 max_core_num 为32，当 samples=36 时，判断 samples>max_core_num 条件成立，policyFunc 函数中会重新给 k_dim->x = 4 / y=12 / z=1 赋值（x*y*z = 48）且任务类型为U1，导致在主流程中执行时，判断samples > (x \* y \* z = 48) 为假，调用了 mluOpUnionKernelMoeDispatchBwdGate1 ，而 mluOpUnionKernelMoeDispatchBwdGate1 需要进行核间同步 __sync_all_ipu()，此时任务类型为U1（正确应为U8）导致核间同步存在问题，出现概率性的精度越界。


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          U1 <br> Un    |
|        3       |Layouts                               |          ARRAY      |
|        4       |Whether multi-dimensions are supported|            no                          |
|        5       |Whether element zero is supported     |          yes                            |
|        6       |Data type(half/float)                 |          float         |
|        7       |Whether there is size limit           |                             no         |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [x] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check
无

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|      通过    |     |

 ./mluop_gtest --gtest_filter="moe_dispatch_backward_gate*"/8 --cases_dir=/data/mlu-ops/debug/wangxin1/moe_dispatch_backward_gate_cases/default_platform/ --gtest_repeat=1000  

 [ SUMMARY  ] Total 78000 cases of 1000 op(s).
ALL PASSED.
[==========] 1 test case from 1 test suite ran. (57 ms total)
[  PASSED  ] 1 test case. 

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
