### PR TITLE
[Fix](bangc-ops): fix moe_backward_gate some case accuracy out of ran…

### DIFF
--- a/bangc-ops/kernels/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/bangc-ops/kernels/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -35,18 +35,12 @@
 static void policyFunc(const mluOpHandle_t handle, const int samples,
                        cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
   int max_core_num = mluop::runtime::getCoreNumOfJobLimitCapability(handle);
+  k_dim->x = max_core_num;
+  k_dim->y = 1;
+  k_dim->z = 1;
   if (samples > max_core_num) {
-    // union1 policy func
     *k_type = CNRT_FUNC_TYPE_UNION1;
-    // dimx equals to num of mlu cores in each cluster
-    k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
-    // dimy equals to num of current available clusters
-    k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
-    k_dim->z = 1;
   } else {
-    k_dim->x = max_core_num;
-    k_dim->y = 1;
-    k_dim->z = 1;
     *k_type = mluop::runtime::getJobLimitCapabilityCnrtFuncType(handle);
   }
 }


### PR DESCRIPTION
…ge (#539)

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Add new op

## 2. Modification

Add points_in_boxes op

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff3: 0

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block        |
|        3       |Layouts                               |          ARRAY      |
|        4       |Whether multi-dimensions are supported|            NO                          |
|        5       |Whether element zero is supported     |                     NO                 |
|        6       |Data type(half/float)                 |           float           |
|        7       |Whether there is size limit           |      On MLU370, the number of boxes cannot exceed 23404;  on MLU590, the number of boxes cannot exceed 14042.                              |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
