### PR TITLE
[Fix](bangc-ops): r0.5 remove old install package when extract cntoolkit in independent_build.

### DIFF
--- a/bangc-ops/independent_build.sh
+++ b/bangc-ops/independent_build.sh
@@ -147,6 +147,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               prog_log_info "cntoolkit url: ${REAL_PATH}"
               wget -A deb -m -p -E -k -K -np -q ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR} > /dev/null
               for filename in ../${REAL_PATH}*.deb; do
@@ -174,6 +177,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               prog_log_info "cntoolkit url: ${REAL_PATH}"
               wget -A deb -m -p -E -k -K -np -q ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR} > /dev/null
               for filename in ../${REAL_PATH}*.deb; do
@@ -201,6 +207,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               prog_log_info "cntoolkit url: ${REAL_PATH}"
               wget -A rpm -m -p -E -k -K -np -q ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR} > /dev/null
               for filename in ../${REAL_PATH}*.rpm; do
@@ -228,6 +237,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               echo "real_path $REAL_PATH"
               wget -A rpm -m -p -E -k -K -np ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR}
               for filename in ../${REAL_PATH}*.rpm; do


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

r0.5 remove old install package when extract cntoolkit in independent_build.

## 2. Modification

bangc-ops/independent_build.sh
