### PR TITLE
[Fix](bangc-ops): r0.4 remove old install package when extract cntoolkit in independent_build.

### DIFF
--- a/bangc-ops/independent_build.sh
+++ b/bangc-ops/independent_build.sh
@@ -148,6 +148,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               echo "real_path $REAL_PATH"
               wget -A deb -m -p -E -k -K -np ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR}
               for filename in ../${REAL_PATH}*.deb; do
@@ -176,6 +179,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               echo "real_path $REAL_PATH"
               wget -A deb -m -p -E -k -K -np ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR}
               for filename in ../${REAL_PATH}*.deb; do
@@ -202,6 +208,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               echo "real_path $REAL_PATH"
               wget -A rpm -m -p -E -k -K -np ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR}
               for filename in ../${REAL_PATH}*.rpm; do
@@ -227,6 +236,9 @@ prepare_cntoolkit () {
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
               echo "real_path $REAL_PATH"
               wget -A rpm -m -p -E -k -K -np ${PACKAGE_PATH}
+              if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
+                rm -rf ${PACKAGE_EXTRACT_DIR}
+              fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
               pushd ${PACKAGE_EXTRACT_DIR}
               for filename in ../${REAL_PATH}*.rpm; do


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

 r0.4 remove old install package when extract cntoolkit in independent_build.

## 2. Modification

bangc-ops/independent_build.sh

