### PR TITLE
[TEST](bangc-ops):add moe_dispatch_backward_data api check cases

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -97,11 +97,11 @@ class indice_convolution_backward_filter : public testing::Test {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&indice_pairs_,
                                mluOpGetTensorElementNum(indice_pairs_desc_) *
-                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&indice_pairs_,
-                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
 

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
@@ -97,11 +97,11 @@ class indice_convolution_forward : public testing::Test {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&indice_pairs_,
                                mluOpGetTensorElementNum(indice_pairs_desc_) *
-                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&indice_pairs_,
-                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
 

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
@@ -1,0 +1,357 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class moe_dispatch_backward_data : public testing::Test {
+ public:
+  void setParam(bool handle, bool gates_desc, bool gates, bool indices_desc,
+                bool indices, bool locations_desc, bool locations,
+                bool dispatch_desc, bool dispatch, bool grad_input_desc,
+                bool grad_input) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (gates_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&gates_desc_));
+      std::vector<int> gates_dims{1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(gates_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 1,
+                                           gates_dims.data()));
+    }
+
+    if (gates) {
+      if (gates_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&gates_, mluOpGetTensorElementNum(gates_desc_) *
+                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&gates_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (indices_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indices_desc_));
+      std::vector<int> indices_dims{1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(indices_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 1,
+                                           indices_dims.data()));
+    }
+
+    if (indices) {
+      if (indices_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indices_, mluOpGetTensorElementNum(indices_desc_) *
+                                      mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indices_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (locations_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&locations_desc_));
+      std::vector<int> locations_dims{1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(locations_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 1,
+                                           locations_dims.data()));
+    }
+
+    if (locations) {
+      if (locations_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&locations_, mluOpGetTensorElementNum(locations_desc_) *
+                                        mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&locations_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (dispatch_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&dispatch_desc_));
+      std::vector<int> dispatch_dims{4, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(dispatch_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           dispatch_dims.data()));
+    }
+
+    if (dispatch) {
+      if (dispatch_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&dispatch_, mluOpGetTensorElementNum(dispatch_desc_) *
+                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&dispatch_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (grad_input_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_input_desc_));
+      std::vector<int> grad_input_dims{1, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(grad_input_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           grad_input_dims.data()));
+    }
+
+    if (grad_input) {
+      if (grad_input_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&grad_input_,
+                               mluOpGetTensorElementNum(grad_input_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&grad_input_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+  }
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpMoeDispatchBackwardData(
+        handle_, gates_desc_, gates_, indices_desc_, indices_, locations_desc_,
+        locations_, dispatch_desc_, dispatch_, samples_, capacity_, hidden_,
+        num_experts_, grad_input_desc_, grad_input_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (gates_desc_) {
+      VLOG(4) << "Destroy gates_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(gates_desc_));
+      gates_desc_ = nullptr;
+    }
+
+    if (gates_) {
+      VLOG(4) << "Destroy gates";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(gates_));
+      gates_ = nullptr;
+    }
+
+    if (indices_desc_) {
+      VLOG(4) << "Destroy indices_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indices_desc_));
+      indices_desc_ = nullptr;
+    }
+
+    if (indices_) {
+      VLOG(4) << "Destroy indices";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      indices_ = nullptr;
+    }
+
+    if (locations_desc_) {
+      VLOG(4) << "Destroy locations_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(locations_desc_));
+      locations_desc_ = nullptr;
+    }
+
+    if (locations_) {
+      VLOG(4) << "Destroy locations";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      locations_ = nullptr;
+    }
+
+    if (dispatch_desc_) {
+      VLOG(4) << "Destroy dispatch_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(dispatch_desc_));
+      dispatch_desc_ = nullptr;
+    }
+
+    if (dispatch_) {
+      VLOG(4) << "Destroy dispatch";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      dispatch_ = nullptr;
+    }
+
+    if (grad_input_desc_) {
+      VLOG(4) << "Destroy dispatch_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(grad_input_desc_));
+      grad_input_desc_ = nullptr;
+    }
+
+    if (grad_input_) {
+      VLOG(4) << "Destroy dispatch";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      grad_input_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t gates_desc_ = nullptr;
+  void *gates_ = nullptr;
+  mluOpTensorDescriptor_t indices_desc_ = nullptr;
+  void *indices_ = nullptr;
+  mluOpTensorDescriptor_t locations_desc_ = nullptr;
+  void *locations_ = nullptr;
+  mluOpTensorDescriptor_t dispatch_desc_ = nullptr;
+  void *dispatch_ = nullptr;
+  int samples_ = 1;
+  int capacity_ = 2;
+  int hidden_ = 1;
+  int num_experts_ = 2;
+  mluOpTensorDescriptor_t grad_input_desc_ = nullptr;
+  void *grad_input_ = nullptr;
+};
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_gates_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_gates_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_indices_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_indices_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_locations_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_locations_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_dispatch_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_dispatch_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_grad_input_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, false, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+TEST_F(moe_dispatch_backward_data, BAD_PARAM_grad_input_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, false);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_data";
+  }
+}
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
@@ -160,67 +160,67 @@ class moe_dispatch_backward_data : public testing::Test {
   void destroy() {
     if (handle_) {
       CNRT_CHECK(cnrtQueueSync(handle_->queue));
-      VLOG(4) << "Destroy handle";
+      VLOG(4) << "Destroy handle_";
       MLUOP_CHECK(mluOpDestroy(handle_));
       handle_ = nullptr;
     }
 
     if (gates_desc_) {
-      VLOG(4) << "Destroy gates_desc";
+      VLOG(4) << "Destroy gates_desc_";
       MLUOP_CHECK(mluOpDestroyTensorDescriptor(gates_desc_));
       gates_desc_ = nullptr;
     }
 
     if (gates_) {
-      VLOG(4) << "Destroy gates";
+      VLOG(4) << "Destroy gates_";
       GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(gates_));
       gates_ = nullptr;
     }
 
     if (indices_desc_) {
-      VLOG(4) << "Destroy indices_desc";
+      VLOG(4) << "Destroy indices_desc_";
       MLUOP_CHECK(mluOpDestroyTensorDescriptor(indices_desc_));
       indices_desc_ = nullptr;
     }
 
     if (indices_) {
-      VLOG(4) << "Destroy indices";
+      VLOG(4) << "Destroy indices_";
       GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
       indices_ = nullptr;
     }
 
     if (locations_desc_) {
-      VLOG(4) << "Destroy locations_desc";
+      VLOG(4) << "Destroy locations_desc_";
       MLUOP_CHECK(mluOpDestroyTensorDescriptor(locations_desc_));
       locations_desc_ = nullptr;
     }
 
     if (locations_) {
-      VLOG(4) << "Destroy locations";
+      VLOG(4) << "Destroy locations_";
       GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
       locations_ = nullptr;
     }
 
     if (dispatch_desc_) {
-      VLOG(4) << "Destroy dispatch_desc";
+      VLOG(4) << "Destroy dispatch_desc_";
       MLUOP_CHECK(mluOpDestroyTensorDescriptor(dispatch_desc_));
       dispatch_desc_ = nullptr;
     }
 
     if (dispatch_) {
-      VLOG(4) << "Destroy dispatch";
+      VLOG(4) << "Destroy dispatch_";
       GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
       dispatch_ = nullptr;
     }
 
     if (grad_input_desc_) {
-      VLOG(4) << "Destroy dispatch_desc";
+      VLOG(4) << "Destroy grad_input_desc_";
       MLUOP_CHECK(mluOpDestroyTensorDescriptor(grad_input_desc_));
       grad_input_desc_ = nullptr;
     }
 
     if (grad_input_) {
-      VLOG(4) << "Destroy dispatch";
+      VLOG(4) << "Destroy grad_input_";
       GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
       grad_input_ = nullptr;
     }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
@@ -443,20 +443,68 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
-    bad_params, moe_dispatch_backward_data_general,
+    bad_samples, moe_dispatch_backward_data_general,
     testing::Combine(
-        testing::Values(MoeDispatchBackwardDataDescParam{-1, 1, 1, 1},
-                        MoeDispatchBackwardDataDescParam{1, -1, 1, 1},
-                        MoeDispatchBackwardDataDescParam{1, 1, -1, 1},
-                        MoeDispatchBackwardDataDescParam{1, 1, 1, -1}),
+        testing::Values(MoeDispatchBackwardDataDescParam{-1, 1, 1, 1}),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         1, std::vector<int>({1}))),
+                                         1, std::vector<int>({-1}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         1, std::vector<int>({1}))),
+                                         1, std::vector<int>({-1}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
-                                         1, std::vector<int>({1}))),
+                                         1, std::vector<int>({-1}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({-1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_capacity, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, -1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({-1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_hidden, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, -1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, -1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, -1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_num_experts, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 1, -1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({-1, 1}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          2, std::vector<int>({1, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
@@ -1,0 +1,498 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+#include "core/context.h"
+
+#define LARGE_TENSOR_NUM ((uint64_t)2147483648)
+
+namespace mluopapitest {
+typedef std::tuple<int, int, int, int> MoeDispatchBackwardDataDescParam;
+typedef std::tuple<MoeDispatchBackwardDataDescParam, MLUOpTensorParam,
+                   MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, mluOpDevType_t, mluOpStatus_t>
+    MoeDispatchBackwardDataParam;
+class moe_dispatch_backward_data_general
+    : public testing::TestWithParam<MoeDispatchBackwardDataParam> {
+ public:
+  void SetUp() {
+    try {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+
+      device_ = std::get<6>(GetParam());
+      expected_status_ = std::get<7>(GetParam());
+      if (!(device_ == MLUOP_UNKNOWN_DEVICE || device_ == handle_->arch)) {
+        VLOG(4) << "Device does not match, skip testing.";
+        return;
+      }
+      MoeDispatchBackwardDataDescParam op_param = std::get<0>(GetParam());
+      std::tie(samples_, capacity_, hidden_, num_experts_) = op_param;
+
+      MLUOpTensorParam gates_params = std::get<1>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&gates_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          gates_desc_, gates_params.get_layout(), gates_params.get_dtype(),
+          gates_params.get_dim_nb(), gates_params.get_dim_size().data()));
+
+      if (mluOpGetTensorElementNum(gates_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&gates_,
+                       mluOpDataTypeBytes(gates_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&gates_, mluOpDataTypeBytes(gates_params.get_dtype()) *
+                                    mluOpGetTensorElementNum(gates_desc_)));
+      }
+
+      MLUOpTensorParam indices_params = std::get<2>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indices_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indices_desc_, indices_params.get_layout(),
+          indices_params.get_dtype(), indices_params.get_dim_nb(),
+          indices_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(indices_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indices_,
+                       mluOpDataTypeBytes(indices_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&indices_,
+                               mluOpDataTypeBytes(indices_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(indices_desc_)));
+      }
+
+      MLUOpTensorParam locations_params = std::get<3>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&locations_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          locations_desc_, locations_params.get_layout(),
+          locations_params.get_dtype(), locations_params.get_dim_nb(),
+          locations_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(locations_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&locations_,
+                       mluOpDataTypeBytes(locations_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&locations_,
+                       mluOpDataTypeBytes(locations_params.get_dtype()) *
+                           mluOpGetTensorElementNum(locations_desc_)));
+      }
+
+      MLUOpTensorParam dispatch_params = std::get<4>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&dispatch_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          dispatch_desc_, dispatch_params.get_layout(),
+          dispatch_params.get_dtype(), dispatch_params.get_dim_nb(),
+          dispatch_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(dispatch_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&dispatch_,
+                       mluOpDataTypeBytes(dispatch_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&dispatch_,
+                               mluOpDataTypeBytes(dispatch_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(dispatch_desc_)));
+      }
+
+      MLUOpTensorParam grad_input_params = std::get<5>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_input_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          grad_input_desc_, grad_input_params.get_layout(),
+          grad_input_params.get_dtype(), grad_input_params.get_dim_nb(),
+          grad_input_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(grad_input_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&grad_input_,
+                       mluOpDataTypeBytes(grad_input_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&grad_input_,
+                       mluOpDataTypeBytes(grad_input_params.get_dtype()) *
+                           mluOpGetTensorElementNum(grad_input_desc_)));
+      }
+
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in moe_dispatch_backward_data_general.";
+    }
+  }
+
+  bool compute() {
+    if (!(device_ == MLUOP_UNKNOWN_DEVICE || device_ == handle_->arch)) {
+      VLOG(4) << "Device does not match, skip testing.";
+      destroy();
+      return true;
+    }
+
+    mluOpStatus_t status = mluOpMoeDispatchBackwardData(
+        handle_, gates_desc_, gates_, indices_desc_, indices_, locations_desc_,
+        locations_, dispatch_desc_, dispatch_, samples_, capacity_, hidden_,
+        num_experts_, grad_input_desc_, grad_input_);
+    destroy();
+    return status == expected_status_;
+  }
+
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = NULL;
+    }
+    if (gates_desc_) {
+      VLOG(4) << "Destroy gates_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(gates_desc_));
+      gates_desc_ = nullptr;
+    }
+
+    if (gates_) {
+      VLOG(4) << "Destroy gates";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(gates_));
+      gates_ = nullptr;
+    }
+
+    if (indices_desc_) {
+      VLOG(4) << "Destroy indices_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indices_desc_));
+      indices_desc_ = nullptr;
+    }
+
+    if (indices_) {
+      VLOG(4) << "Destroy indices";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      indices_ = nullptr;
+    }
+
+    if (locations_desc_) {
+      VLOG(4) << "Destroy locations_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(locations_desc_));
+      locations_desc_ = nullptr;
+    }
+
+    if (locations_) {
+      VLOG(4) << "Destroy locations";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      locations_ = nullptr;
+    }
+
+    if (dispatch_desc_) {
+      VLOG(4) << "Destroy dispatch_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(dispatch_desc_));
+      dispatch_desc_ = nullptr;
+    }
+
+    if (dispatch_) {
+      VLOG(4) << "Destroy dispatch";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      dispatch_ = nullptr;
+    }
+
+    if (grad_input_desc_) {
+      VLOG(4) << "Destroy dispatch_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(grad_input_desc_));
+      grad_input_desc_ = nullptr;
+    }
+
+    if (grad_input_) {
+      VLOG(4) << "Destroy dispatch";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      grad_input_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t gates_desc_ = nullptr;
+  void *gates_ = nullptr;
+  mluOpTensorDescriptor_t indices_desc_ = nullptr;
+  void *indices_ = nullptr;
+  mluOpTensorDescriptor_t locations_desc_ = nullptr;
+  void *locations_ = nullptr;
+  mluOpTensorDescriptor_t dispatch_desc_ = nullptr;
+  void *dispatch_ = nullptr;
+  int samples_ = 1;
+  int capacity_ = 1;
+  int hidden_ = 1;
+  int num_experts_ = 1;
+  mluOpTensorDescriptor_t grad_input_desc_ = nullptr;
+  void *grad_input_ = nullptr;
+  mluOpDevType_t device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(moe_dispatch_backward_data_general, api_test) {
+  try {
+    EXPECT_TRUE(compute());
+  } catch (const std::exception &e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in moe_dispatch_backward_data_general";
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{0, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 0, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_3, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 1, 0}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_4, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 0, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 0}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_gates_dtype_dim_shape, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_indices_dtype_dim_shape, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_locations_dtype_dim_shape, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_dispatch_dtype_dim_shape, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({2, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_grad_input_dtype_dim_shape, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 2}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_params, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam{-1, 1, 1, 1},
+                        MoeDispatchBackwardDataDescParam{1, -1, 1, 1},
+                        MoeDispatchBackwardDataDescParam{1, 1, -1, 1},
+                        MoeDispatchBackwardDataDescParam{1, 1, 1, -1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_1, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam(1, 1024, 1025, 2048)),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2097152, 1025}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1025}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_2, moe_dispatch_backward_data_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardDataDescParam(1, 25, 2097152, 41)),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1025, 2097152}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 2097152}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
@@ -147,7 +147,6 @@ class moe_dispatch_backward_data_general
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_input_desc_)));
       }
-
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
              << " in moe_dispatch_backward_data_general.";


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

添加moe_dispatch_backard_data 防呆测例

## 2. Modification
1.moe_dispatch_backward_data.cpp文件：
 - 检查描述符指针：handle、indices_desc、 locations_desc、input_desc、dispatch_desc、grad_gates_desc为空防呆；
 - 检查指针：indices、locations、input、dispatch、grad_gates为空防呆

2.moe_dispatch_backward_data_general.cpp文件：
 - 对输入输出支持的 dtype、layout 以及 shape 进行防呆
 - 0 元素检查防呆，VLOG(5)打印信息，返回MLUOP_STATUS_SUCCESS
 - 对参数samples、capacity、hidden、num_experts值进行防呆
 - large tensor防呆：对indices_desc、 locations_desc、input_desc、dispatch_desc、grad_gates_desc的检查

3. 修正indice_convolution_forward、indice_convolution_backward_backward_filter dtype
