### PR TITLE
[Fix](bangc-ops): fix the description of moe_dispatch_forward op

### DIFF
--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -10560,11 +10560,6 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] input
  * Pointer to the MLU memory that stores the \b input tensor.
- * @param[in] dispatch_desc
- * The descriptor of \b dispatch tensor, which contains dimension, data type and data layout.
- * For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] dispatch
- * Pointer to the MLU memory that stores the \b dispatch tensor.
  * @param[in] samples
  * The number of elements in the \b gates tensor, the \b indices tensor and the \b locations tensor.
  * @param[in] capacity
@@ -10573,6 +10568,11 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
  * The vector length of a single token.
  * @param[in] num_experts
  * The number of experts.
+ * @param[in] dispatch_desc
+ * The descriptor of \b dispatch tensor, which contains dimension, data type and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] dispatch
+ * Pointer to the MLU memory that stores the \b dispatch tensor.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED

--- a/docs/bangc-docs/design_docs/moe_dispatch_forward/moe_dispatch_forward.md
+++ b/docs/bangc-docs/design_docs/moe_dispatch_forward/moe_dispatch_forward.md
@@ -52,7 +52,7 @@ example:
 | 模式(可选）                                   | 否 |
 | 是否含有 dim/axis 等类似语义的参数且该参数支持负数/其他特殊处理| 无 |
 | 是否含有 labels/index 等类似语义的参数且该参数支持负数/界外情况/其他特殊处理 | 无 |
-| 是否需要支持原位                               | 否 |
+| 是否需要支持原位                               | 是 |
 | 是否需要支持 stride 机制                       | 否 |
 | 是否需要支持广播                               | 否 |
 | 0 元素检查是否直接返回                         | 是, 返回MLUOP_STATUS_SUCCESS |
@@ -101,7 +101,7 @@ example:
 | 布局限制     | ARRAY                                                        |
 | 功能限制     | 无                                                           |
 | 数据范围限制 | 有 indices 参数，该参数的取值范围为[0, ..., (num_experts-1)]; <br />有 locations 参数，该参数的取值范围为[0, ..., (capacity-1)] |
-| 原位限制     | 不支持原位                                                   |
+| 原位限制     | 支持原位                                                     |
 | stride 限制  | 不支持 stride 机制                                           |
 | 广播限制     | 不支持广播                                                   |
 | 规模限制     | gates_desc, indices_desc、locations_desc、input_desc的第一个维度大小等于samples <br />input_desc、dispatch_desc的第2个维度大小等于hidden <br />dispatch_desc的第1个维度大小等于num_experts * capacity |


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改算子接口说明和文档

## 2. Modification

mlu_ops.h: 将moe_dispatch_forward的接口注释将dispatch从`in`设置成`out`
docs/bangc-docs/design_docs/moe_dispatch_forward/moe_dispatch_forward.md： 设计文档将`不支持原位`改为`支持原位`


