### PR TITLE
[TEST](bangc-ops):add api check for moe_dispatch_backward_gate

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -1,0 +1,392 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class moe_dispatch_backward_gate : public testing::Test {
+ public:
+  void setParam(bool handle, bool indices_desc, bool indices,
+                bool locations_desc, bool locations, bool input_desc,
+                bool input, bool dispatch_desc, bool dispatch,
+                bool grad_gates_desc, bool grad_gates, bool workspace) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (indices_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indices_desc_));
+      std::vector<int> indices_dims{1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(indices_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 1,
+                                           indices_dims.data()));
+    }
+
+    if (indices) {
+      if (indices_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indices_, mluOpGetTensorElementNum(indices_desc_) *
+                                      mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indices_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (locations_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&locations_desc_));
+      std::vector<int> locations_dims{1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(locations_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 1,
+                                           locations_dims.data()));
+    }
+
+    if (locations) {
+      if (locations_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&locations_, mluOpGetTensorElementNum(locations_desc_) *
+                                        mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&locations_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (input_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_desc_));
+      std::vector<int> input_dims{1, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(input_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           input_dims.data()));
+    }
+
+    if (input) {
+      if (input_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&input_, mluOpGetTensorElementNum(input_desc_) *
+                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&input_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (dispatch_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&dispatch_desc_));
+      std::vector<int> dispatch_dims{4, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(dispatch_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           dispatch_dims.data()));
+    }
+
+    if (dispatch) {
+      if (dispatch_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&dispatch_, mluOpGetTensorElementNum(dispatch_desc_) *
+                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&dispatch_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (grad_gates_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_gates_desc_));
+      std::vector<int> grad_gates_dims{1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(grad_gates_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 1,
+                                           grad_gates_dims.data()));
+    }
+
+    if (grad_gates) {
+      if (grad_gates_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&grad_gates_,
+                               mluOpGetTensorElementNum(grad_gates_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&grad_gates_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (workspace) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    }
+  }
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpMoeDispatchBackwardGate(
+        handle_, indices_desc_, indices_, locations_desc_, locations_,
+        input_desc_, input_, dispatch_desc_, dispatch_, samples_, capacity_,
+        hidden_, num_experts_, workspace_, workspace_size_, grad_gates_desc_,
+        grad_gates_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (indices_desc_) {
+      VLOG(4) << "Destroy indices_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indices_desc_));
+      indices_desc_ = nullptr;
+    }
+
+    if (indices_) {
+      VLOG(4) << "Destroy indices_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      indices_ = nullptr;
+    }
+
+    if (locations_desc_) {
+      VLOG(4) << "Destroy locations_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(locations_desc_));
+      locations_desc_ = nullptr;
+    }
+
+    if (locations_) {
+      VLOG(4) << "Destroy locations_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      locations_ = nullptr;
+    }
+
+    if (input_desc_) {
+      VLOG(4) << "Destroy input_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_desc_));
+      input_desc_ = nullptr;
+    }
+
+    if (input_) {
+      VLOG(4) << "Destroy input_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      input_ = nullptr;
+    }
+
+    if (dispatch_desc_) {
+      VLOG(4) << "Destroy dispatch_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(dispatch_desc_));
+      dispatch_desc_ = nullptr;
+    }
+
+    if (dispatch_) {
+      VLOG(4) << "Destroy dispatch_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      dispatch_ = nullptr;
+    }
+
+    if (grad_gates_desc_) {
+      VLOG(4) << "Destroy grad_gates_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(grad_gates_desc_));
+      grad_gates_desc_ = nullptr;
+    }
+
+    if (grad_gates_) {
+      VLOG(4) << "Destroy grad_gates_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_gates_));
+      grad_gates_ = nullptr;
+    }
+
+    if (workspace_) {
+      VLOG(4) << "Destroy workspace";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      workspace_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t indices_desc_ = nullptr;
+  void *indices_ = nullptr;
+  mluOpTensorDescriptor_t locations_desc_ = nullptr;
+  void *locations_ = nullptr;
+  mluOpTensorDescriptor_t input_desc_ = nullptr;
+  void *input_ = nullptr;
+  mluOpTensorDescriptor_t dispatch_desc_ = nullptr;
+  void *dispatch_ = nullptr;
+  int samples_ = 1;
+  int capacity_ = 2;
+  int hidden_ = 1;
+  int num_experts_ = 2;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  mluOpTensorDescriptor_t grad_gates_desc_ = nullptr;
+  void *grad_gates_ = nullptr;
+};
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_indices_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_indices_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_locations_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_locations_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_input_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_input_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_dispatch_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_dispatch_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_grad_gates_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, false, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_grad_gates_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, false,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate, BAD_PARAM_workspace_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             false);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate";
+  }
+}
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_general.cpp
@@ -148,7 +148,6 @@ class moe_dispatch_backward_gate_general
                        mluOpDataTypeBytes(grad_gates_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_gates_desc_)));
       }
-
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
              << " in moe_dispatch_backward_gate_general.";

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_general.cpp
@@ -1,0 +1,558 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+#include "core/context.h"
+
+#define LARGE_TENSOR_NUM ((uint64_t)2147483648)
+
+namespace mluopapitest {
+typedef std::tuple<int, int, int, int> MoeDispatchBackwardGateDescParam;
+typedef std::tuple<MoeDispatchBackwardGateDescParam, MLUOpTensorParam,
+                   MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, mluOpDevType_t, mluOpStatus_t>
+    MoeDispatchBackwardGateParam;
+class moe_dispatch_backward_gate_general
+    : public testing::TestWithParam<MoeDispatchBackwardGateParam> {
+ public:
+  void SetUp() {
+    try {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+
+      target_device_ = std::get<6>(GetParam());
+      expected_status_ = std::get<7>(GetParam());
+      if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+            target_device_ == handle_->arch)) {
+        VLOG(4) << "Device does not match, skip testing.";
+        return;
+      }
+      MoeDispatchBackwardGateDescParam op_param = std::get<0>(GetParam());
+      std::tie(samples_, capacity_, hidden_, num_experts_) = op_param;
+
+      MLUOpTensorParam indices_params = std::get<1>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&indices_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          indices_desc_, indices_params.get_layout(),
+          indices_params.get_dtype(), indices_params.get_dim_nb(),
+          indices_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(indices_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&indices_,
+                       mluOpDataTypeBytes(indices_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&indices_,
+                               mluOpDataTypeBytes(indices_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(indices_desc_)));
+      }
+
+      MLUOpTensorParam locations_params = std::get<2>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&locations_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          locations_desc_, locations_params.get_layout(),
+          locations_params.get_dtype(), locations_params.get_dim_nb(),
+          locations_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(locations_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&locations_,
+                       mluOpDataTypeBytes(locations_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&locations_,
+                       mluOpDataTypeBytes(locations_params.get_dtype()) *
+                           mluOpGetTensorElementNum(locations_desc_)));
+      }
+
+      MLUOpTensorParam input_params = std::get<3>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          input_desc_, input_params.get_layout(), input_params.get_dtype(),
+          input_params.get_dim_nb(), input_params.get_dim_size().data()));
+
+      if (mluOpGetTensorElementNum(input_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&input_,
+                       mluOpDataTypeBytes(input_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&input_, mluOpDataTypeBytes(input_params.get_dtype()) *
+                                    mluOpGetTensorElementNum(input_desc_)));
+      }
+
+      MLUOpTensorParam dispatch_params = std::get<4>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&dispatch_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          dispatch_desc_, dispatch_params.get_layout(),
+          dispatch_params.get_dtype(), dispatch_params.get_dim_nb(),
+          dispatch_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(dispatch_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&dispatch_,
+                       mluOpDataTypeBytes(dispatch_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&dispatch_,
+                               mluOpDataTypeBytes(dispatch_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(dispatch_desc_)));
+      }
+
+      MLUOpTensorParam grad_gates_params = std::get<5>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_gates_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          grad_gates_desc_, grad_gates_params.get_layout(),
+          grad_gates_params.get_dtype(), grad_gates_params.get_dim_nb(),
+          grad_gates_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(grad_gates_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&grad_gates_,
+                       mluOpDataTypeBytes(grad_gates_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&grad_gates_,
+                       mluOpDataTypeBytes(grad_gates_params.get_dtype()) *
+                           mluOpGetTensorElementNum(grad_gates_desc_)));
+      }
+
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in moe_dispatch_backward_gate_general.";
+    }
+  }
+
+  bool compute() {
+    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+          target_device_ == handle_->arch)) {
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status;
+    status = mluOpGetMoeDispatchBackwardGateWorkspaceSize(handle_, input_desc_,
+                                                          &workspace_size_);
+    if (status != MLUOP_STATUS_SUCCESS) {
+      destroy();
+      return expected_status_ == status;
+    }
+    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+
+    status = mluOpMoeDispatchBackwardGate(
+        handle_, indices_desc_, indices_, locations_desc_, locations_,
+        input_desc_, input_, dispatch_desc_, dispatch_, samples_, capacity_,
+        hidden_, num_experts_, workspace_, workspace_size_, grad_gates_desc_,
+        grad_gates_);
+    destroy();
+    return status == expected_status_;
+  }
+
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = NULL;
+    }
+    if (indices_desc_) {
+      VLOG(4) << "Destroy indices_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(indices_desc_));
+      indices_desc_ = nullptr;
+    }
+
+    if (indices_) {
+      VLOG(4) << "Destroy indices_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      indices_ = nullptr;
+    }
+
+    if (locations_desc_) {
+      VLOG(4) << "Destroy locations_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(locations_desc_));
+      locations_desc_ = nullptr;
+    }
+
+    if (locations_) {
+      VLOG(4) << "Destroy locations_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      locations_ = nullptr;
+    }
+
+    if (input_desc_) {
+      VLOG(4) << "Destroy input_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_desc_));
+      input_desc_ = nullptr;
+    }
+
+    if (input_) {
+      VLOG(4) << "Destroy input_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      input_ = nullptr;
+    }
+
+    if (dispatch_desc_) {
+      VLOG(4) << "Destroy dispatch_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(dispatch_desc_));
+      dispatch_desc_ = nullptr;
+    }
+
+    if (dispatch_) {
+      VLOG(4) << "Destroy dispatch_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      dispatch_ = nullptr;
+    }
+
+    if (grad_gates_desc_) {
+      VLOG(4) << "Destroy grad_gates_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(grad_gates_desc_));
+      grad_gates_desc_ = nullptr;
+    }
+
+    if (grad_gates_) {
+      VLOG(4) << "Destroy grad_gates_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_gates_));
+      grad_gates_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t indices_desc_ = nullptr;
+  void *indices_ = nullptr;
+  mluOpTensorDescriptor_t locations_desc_ = nullptr;
+  void *locations_ = nullptr;
+  mluOpTensorDescriptor_t input_desc_ = nullptr;
+  void *input_ = nullptr;
+  mluOpTensorDescriptor_t dispatch_desc_ = nullptr;
+  void *dispatch_ = nullptr;
+  int samples_ = 1;
+  int capacity_ = 2;
+  int hidden_ = 1;
+  int num_experts_ = 2;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  mluOpTensorDescriptor_t grad_gates_desc_ = nullptr;
+  void *grad_gates_ = nullptr;
+  mluOpDevType_t target_device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(moe_dispatch_backward_gate_general, api_test) {
+  try {
+    EXPECT_TRUE(compute());
+  } catch (const std::exception &e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate_general";
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{0, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({0}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 0, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_3, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 1, 0}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_4, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 0, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_indices_dtype_dim_shape, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_locations_dtype_dim_shape, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_input_dtype_dim_shape, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_dispatch_dtype_dim_shape, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_grad_gates_dtype_dim_shape, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({2})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_HALF,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_samples, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{-1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({-1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({-1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({-1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({-1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_capacity, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, -1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({-1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_hidden, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, -1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, -1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, -1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_num_experts, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam{1, 1, 1, -1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({-1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_1, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam(1, 1024, 1025, 2048)),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1025}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({2097152, 1025}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_2, moe_dispatch_backward_gate_general,
+    testing::Combine(
+        testing::Values(MoeDispatchBackwardGateDescParam(1, 25, 2097152, 41)),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 2097152}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1025, 2097152}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_workspace.cpp
@@ -1,0 +1,114 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class moe_dispatch_backward_gate_workspace : public testing::Test {
+ public:
+  void setParam(bool handle, bool input_desc, bool workspace_size) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (input_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_desc_));
+      std::vector<int> input_dims{1, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(input_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           input_dims.data()));
+    }
+
+    if (workspace_size) {
+      size_t size_temp;
+      workspace_size_ = &size_temp;
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpGetMoeDispatchBackwardGateWorkspaceSize(
+        handle_, input_desc_, workspace_size_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (input_desc_) {
+      VLOG(4) << "Destroy input_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_desc_));
+      input_desc_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t input_desc_ = nullptr;
+  size_t *workspace_size_ = nullptr;
+};
+
+TEST_F(moe_dispatch_backward_gate_workspace, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate_workspace";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate_workspace, BAD_PARAM_input_desc_null) {
+  try {
+    setParam(true, false, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate_workspace";
+  }
+}
+
+TEST_F(moe_dispatch_backward_gate_workspace, BAD_PARAM_workspace_size_null) {
+  try {
+    setParam(true, true, false);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in moe_dispatch_backward_gate_workspace";
+  }
+}
+}  // namespace mluopapitest


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

添加moe_dispatch_backward_gate算子的防呆测试

## 2. Modification
1.moe_dispatch_backward_gate.cpp文件：
  - 检查描述符指针：handle、indices_desc、 locations_desc、input_desc、dispatch_desc、grad_gates_desc为空防呆；
  - 检查指针：indices、locations、input、dispatch、grad_gates为空防呆

2.moe_dispatch_backward_gate_workspace.cpp文件：
  - 检查handle、input_desc、workspace_size为空防呆

3.moe_dispatch_backward_gate_general.cpp文件：
  - 对输入输出支持的 dtype、layout 以及 shape 进行防呆
  - 0 元素检查防呆，VLOG(5)打印信息，返回MLUOP_STATUS_SUCCESS
  - 对参数samples、capacity、hidden、num_experts值进行防呆
  - large tensor防呆：对indices_desc、 locations_desc、input_desc、dispatch_desc、grad_gates_desc的检查