### PR TITLE
[Fix](bangc-ops):fix ballquery gencase macro function

### DIFF
--- a/bangc-ops/kernels/ball_query/ball_query.mlu
+++ b/bangc-ops/kernels/ball_query/ball_query.mlu
@@ -157,8 +157,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("ball_query");
     GEN_CASE_HANDLE(handle);
-    GEN_CASE_DATA(true, "input1", new_xyz, new_xyz_desc, -1, 1);
-    GEN_CASE_DATA(true, "input2", xyz, xyz_desc, -1, 1);
+    GEN_CASE_DATA_REAL(true, "input1", new_xyz, new_xyz_desc);
+    GEN_CASE_DATA_REAL(true, "input2", xyz, xyz_desc);
     GEN_CASE_DATA(false, "output", idx, idx_desc, 0, 0);
     GEN_CASE_OP_PARAM_SINGLE(0, "ball_query", "min_radius", min_radius);
     GEN_CASE_OP_PARAM_SINGLE(0, "ball_query", "max_radius", max_radius);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -5839,7 +5839,7 @@ mluOpThreeInterpolateBackward(mluOpHandle_t handle,
  *
  * @param[in] handle
  * Handle to an MLUOP context that is used to manage MLU devices and
- * queues in the sqrt backward operation. For detailed information, see
+ * queues in the Ballquery operation. For detailed information, see
  * ::mluOpHandle_t.
  * @param[in] new_xyz_desc
  * The descriptor of the new_xyz tensors, which indicates the center of the ball.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

当前算子的性能和真值有关，在适配GEN_CASE时，应该使用GEN_CASE_DATA_REAL宏。
在mluops.h头文件中的@param[in] handle 描述中，把算子名写错了。

## 2. Modification

本次修改成了保存真值的GEN_CASE_DATA_REAL宏；纠正了在mluops.h中@param[in] handle 描述的错误算子名。

## 3. Test Report

修改后的测试报告：https://wiki.cambricon.com/pages/viewpage.action?pageId=273646201

### 3.1 Modification Details

不涉及算子性能和精度
