### PR TITLE
[Feature](bangc-ops):support nan/inf

### DIFF
--- a/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
+++ b/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
@@ -100,8 +100,6 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
         between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
     bool bottomRightIsIn =
         between(i_tl_x + 1, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
-    if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
-      continue;
 
     if (is_first_bin) {
       // load the first input to nram
@@ -179,9 +177,6 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
             between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
         bool bottomRightIsIn = between(i_tl_x + 1, 0, width - 1) &&
                                between(i_tl_y + 1, 0, height - 1);
-        if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn &&
-            !bottomRightIsIn)
-          continue;
         int pongc_slice = c_limit < channel ? c_limit : channel;
 
         i_tl_offset = i_offset + i_tl_y * width * channel + i_tl_x * channel;
@@ -205,6 +200,18 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
           __memcpy_async(nram_pong + 3 * c_limit, input + i_br_offset,
                          pongc_slice * sizeof(T), GDRAM2NRAM);
         }
+      }
+      if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn &&
+          !bottomRightIsIn) {
+        // store
+        __memcpy(output + o_offset + c_offset, nram_ping, c_slice * sizeof(T),
+                 NRAM2GDRAM);
+        c_rem -= c_slice;
+        c_offset += c_slice;
+        swap(nram_ping, nram_pong);
+        __bang_write_value(nram_pong, 4 * c_limit, 0);
+        __asm__ volatile("sync;\n\t");
+        break;
       }
       // compute
       __bang_mul_scalar(nram_ping, nram_ping, i_tl_x_weight * i_tl_y_weight,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改算子逻辑使其支持nan/inf的cases

## 2. Modification

1）modified:   bangc-ops/kernels/roi_crop/roi_crop_block.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

| Test Point                                      | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | ------------------- | --------------------------- |
| Whether it conforms to the operator restriction | Normal error        |                             |
| Whether illegal parameters are passed           | Normal error        |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

| Test Point         | Description                     | Quantity | Comment                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
| ------------------ | ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Data type test     | float                           | 通过     | float<br />[----------] Global test environment tear-down<br />[2023-3-10 12:25:37] [MLUOP] [Vlog]: TearDown CNRT environment.<br />[ SUMMARY  ] Total 164 cases of 1 op(s).<br />ALL PASSED.<br />[==========] 164 test cases from 1 test suite ran. (979964 ms total)<br />[  PASSED  ] 164 test cases.                                                                                                                                                                                                                                                                             |
| Zero element test  | Whether to support this test    | 通过     | samples=0<br />[MLUOP] [Vlog]:[MoeDispatchBackwardDataExecutor] call compute() begin.<br/>[MLUOP] [Vlog]:[mluOpMoeDispatchBackwardData] Skip zero element tensor.<br/>[MLUOP] [Vlog]:[MoeDispatchBackwardDataExecutor] call compute() end.<br />hidden=0<br />[MLUOP] [Vlog]:[mluOpMoeDispatchBackwardData] Skip zero element tensor.<br/>[MLUOP] [Vlog]:mluopFill start.<br/>[MLUOP] [Vlog]:mluopFill end.<br />capacity=0<br />[MLUOP] [Vlog]:[mluOpMoeDispatchBackwardData] Skip zero element tensor.<br />[MLUOP] [Vlog]:mluopFill start.<br/>[MLUOP] [Vlog]:mluopFill end.<br /> |
| Stability test     | --gtest_repeat=NUM --thread=NUM | 通过     | ./mluop_gtest --gtest_filter="moe_dispatch_backward_data*" --gtest_repeat=100 --thread=100<br />ALL PASSED.<br/>[==========] 1 test case from 1 test suite ran. (2101 ms total)<br/>[  PASSED  ] 1 test case.                                                                                                                                                                                                                                                                                                                                                                         |
| Mult-platform test | MLU370/MLU590                   | 通过     | MLU370:<br />[ SUMMARY  ] Total 110 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 110 test cases from 1 test suite ran. (13244 ms total)<br/>[  PASSED  ] 110 test cases.<br />MLU590<br />[ SUMMARY  ] Total 110 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 110 test cases from 1 test suite ran. (56126 ms total)<br/>[  PASSED  ] 110 test cases.                                                                                                                                                                                                                     |
| Nan/INF test       | Whether to support this test    | 通过     | ALL PASSED.<br/>[==========] 78 test cases from 1 test suite ran. (11056 ms total)<br/>[  PASSED  ] 78 test cases.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
| 防呆测试           | 输入参数防呆测试                | 通过     | 1. 指针为NULL测试： PASS   <br />2.shape / dim测试 ： PASS <br />    3.large tensor测试<br /> ： PASS 4.dtype测试<br />： PASS                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| 代码覆盖率         | 代码覆盖率测试                  | 通过     | Line Coverage [Sort_by   Functions [Sort<br/>Filename [Sort by name]               line_coverage]           by_function<br/>                                                               coverage]<br/>moe_dispatch_backward_data_union1.mlu [95.9%] 95.9 %260 / 271 87.5 %14 / 16<br/>                                      [95.9%]                                                                                                                                                                                                                                                |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU590-M9

| Operation                  | Mlu_hardware_time(us) | Mlu_interface_time(us) | Mlu_io_efficiency | Mlu_compute_efficiency | Mlu_workwpace_size(Bytes) | Data_type | Shape                                                        |
| -------------------------- | --------------------- | ---------------------- | ----------------- | ---------------------- | ------------------------- | --------- | ------------------------------------------------------------ |
| moe_dispatch_backward_data | 106                   | 85.285                 | 0.0640498         | 0.210617               | -1                        | float     | samples: 4608, hidden: 1024, capacity: 2880, num_experts: 2  |
| moe_dispatch_backward_data | 350                   | 29.174                 | 0.0393143         | 0.128823               | -1                        | float     | samples: 18432, hidden: 512, capacity: 11520, num_experts: 2 |

Platform：MLU370-X4

| Operation                  | Mlu_hardware_time(us) | Mlu_interface_time(us) | Mlu_io_efficiency | Mlu_compute_efficiency | Mlu_workwpace_size(Bytes) | Data_type | Shape                                                        |
| -------------------------- | --------------------- | ---------------------- | ----------------- | ---------------------- | ------------------------- | --------- | ------------------------------------------------------------ |
| moe_dispatch_backward_data | 294                   | 149.04                 | 0.209796          | 0.172469               | -1                        | float     | samples: 4608, hidden: 1024, capacity: 2880, num_experts: 2  |
| moe_dispatch_backward_data | 825                   | 46.89                  | 0.150109          | 0.122967               | -1                        | float     | samples: 18432, hidden: 512, capacity: 11520, num_experts: 2 |

### 3.4 Summary Analysis

- float类型数据测试通过。
- half类型数据，因参考接口实现有bug，暂未测试。