### PR TITLE
[Feature](bangc-ops):support nan/inf

### DIFF
--- a/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
+++ b/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
@@ -100,8 +100,6 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
         between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
     bool bottomRightIsIn =
         between(i_tl_x + 1, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
-    if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
-      continue;
 
     if (is_first_bin) {
       // load the first input to nram
@@ -179,9 +177,6 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
             between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
         bool bottomRightIsIn = between(i_tl_x + 1, 0, width - 1) &&
                                between(i_tl_y + 1, 0, height - 1);
-        if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn &&
-            !bottomRightIsIn)
-          continue;
         int pongc_slice = c_limit < channel ? c_limit : channel;
 
         i_tl_offset = i_offset + i_tl_y * width * channel + i_tl_x * channel;
@@ -205,6 +200,18 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
           __memcpy_async(nram_pong + 3 * c_limit, input + i_br_offset,
                          pongc_slice * sizeof(T), GDRAM2NRAM);
         }
+      }
+      if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn &&
+          !bottomRightIsIn) {
+        // store
+        __memcpy(output + o_offset + c_offset, nram_ping, c_slice * sizeof(T),
+                 NRAM2GDRAM);
+        c_rem -= c_slice;
+        c_offset += c_slice;
+        swap(nram_ping, nram_pong);
+        __bang_write_value(nram_pong, 4 * c_limit, 0);
+        __asm__ volatile("sync;\n\t");
+        break;
       }
       // compute
       __bang_mul_scalar(nram_ping, nram_ping, i_tl_x_weight * i_tl_y_weight,

--- a/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
+++ b/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
@@ -295,8 +295,6 @@ __mlu_global__ void MLUKernelRoiCropBackward(
         between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
     bool bottomRightIsIn =
         between(i_tl_x + 1, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
-    if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
-      continue;
 
     // load the first input to nram
     if (is_first_bin) {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改算子逻辑使其支持nan/inf的cases

## 2. Modification

1) modified:   bangc-ops/kernels/roi_crop/roi_crop_block.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).


