### PR TITLE
[Feature](bangc-ops):roi_crop_backward support nan/inf

### DIFF
--- a/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
+++ b/bangc-ops/kernels/roi_crop/roi_crop_block.mlu
@@ -128,7 +128,7 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       }
     }
     __bang_write_value(nram_pong, 4 * c_limit, 0);
-    __asm__ volatile("sync;\n\t");
+    __sync();
     while (c_rem > 0) {
       c_slice = c_slice < c_rem ? c_slice : c_rem;
       // load the next input to nram
@@ -210,7 +210,7 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
         c_offset += c_slice;
         swap(nram_ping, nram_pong);
         __bang_write_value(nram_pong, 4 * c_limit, 0);
-        __asm__ volatile("sync;\n\t");
+        __sync();
         break;
       }
       // compute
@@ -234,7 +234,7 @@ __mlu_global__ void MLUKernelRoiCropForward(const T *input, const int batch,
       c_offset += c_slice;
       swap(nram_ping, nram_pong);
       __bang_write_value(nram_pong, 4 * c_limit, 0);
-      __asm__ volatile("sync;\n\t");
+      __sync();
     }
   }
 }
@@ -295,8 +295,6 @@ __mlu_global__ void MLUKernelRoiCropBackward(
         between(i_tl_x, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
     bool bottomRightIsIn =
         between(i_tl_x + 1, 0, width - 1) && between(i_tl_y + 1, 0, height - 1);
-    if (!topLeftIsIn && !topRightIsIn && !bottomLeftIsIn && !bottomRightIsIn)
-      continue;
 
     // load the first input to nram
     if (is_first_bin) {
@@ -358,7 +356,7 @@ __mlu_global__ void MLUKernelRoiCropBackward(
       c_offset += c_slice;
       swap(nram_ping, nram_pong);
       nram_output = nram_ping + c_limit;
-      __asm__ volatile("sync;\n\t");
+      __sync();
     }
   }
 }

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -4595,7 +4595,7 @@ mluOpRoiCropForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Note
- * - On MLU300, the inputs \b grid with NaN or infinity are not supported.
+ * - On MLU300, the input \b grid with NaN or infinity are not supported.
  * - On MLU500, the inputs \b grid and \b grad_output with NaN or infinity are supported.
  *
  * @par Example

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -4595,7 +4595,8 @@ mluOpRoiCropForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Note
- * - None.
+ * - On MLU300, the inputs \b grid with NaN or infinity are not supported.
+ * - On MLU500, the inputs \b grid and \b grad_output with NaN or infinity are supported.
  *
  * @par Example
  * - None.

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -4595,7 +4595,7 @@ mluOpRoiCropForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Note
- * - On MLU300, the input \b grid with NaN or infinity are not supported.
+ * - On MLU300, the input \b grid with NaN or infinity is not supported.
  * - On MLU500, the inputs \b grid and \b grad_output with NaN or infinity are supported.
  *
  * @par Example


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改算子逻辑，使其支持nan/inf

## 2. Modification

1) modified:   bangc-ops/kernels/roi_crop/roi_crop_block.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |     通过     | ALL PASSED.<br>[==========] 15 test cases from 1 test suite ran. (4120 ms total)<br>[  PASSED  ] 15 test cases.          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |
