### PR TITLE
[Fix](bangc-ops):del roi_crop_forward some logs code

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
@@ -64,11 +64,9 @@ void RoiCropForwardExecutor::printDataInfo() {
 
 int RoiCropForwardExecutor::getTopLeft(const float grid_yx_value,
                                        const int input_hw, float* weight) {
-  VLOG(4) << "[RoiCropForwardExecutor] call getTopLeft() Begin.";
   float xcoord = (grid_yx_value + 1) * (input_hw - 1) / 2;
   int point = floor(xcoord);
   *weight = 1 - (xcoord - point);
-  VLOG(4) << "[RoiCropForwardExecutor] call getTopLeft() End.";
   return point;
 }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

删除r0.4版本下，roi_crop_forward算子vlog打印部分的代码

## 2. Modification

1）modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_crop_forward/roi_crop_forward.cpp
