### PR TITLE
[Fix](bangc-ops): fix independent_build, libproto version info, pre-commit and coverage test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/case_list.cpp
 bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/op_register.h
+bangc-ops/daily.software.cambricon.com/
+dependency.txt
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ MLU-OPS 旨在通过提供示例代码，供开发者参考使用，可用于开
 - 寒武纪 MLU 驱动：
   - 运行时依赖驱动 v4.20.11 或更高版本。
 - 外部链接库：
-  - libxml2-dev、libprotobuf-dev、protobuf-compiler、llvm-6.0-dev
+  - libxml2-dev、libprotobuf-dev<=3.8.0、protobuf-compiler<=3.8.0、llvm-6.0-dev
 - Python环境：
   - 依赖Python-3.8.0版本。
 

--- a/bangc-ops/independent_build.sh
+++ b/bangc-ops/independent_build.sh
@@ -107,6 +107,7 @@ usage () {
 
 prepare_cntoolkit () {
   pushd ../
+  pushd ../ > /dev/null
   python2 json_parser.py
   output='dependency.txt'
   MODULE_VERSION=""
@@ -114,14 +115,14 @@ prepare_cntoolkit () {
 
   # dep-package-version
   PACKAGE_MODULES=`cat $output | awk -F ':' '{print $1}'`
-  echo "PACKAGE_MODULES: $PACKAGE_MODULES"
+  prog_log_info "PACKAGE_MODULES: $PACKAGE_MODULES"
 
   PACKAGE_BRANCH=`cat $output | awk -F ':' '{print $2}'`
-  echo "PACKAGE_BRANCH: $PACKAGE_BRANCH"
-
+  prog_log_info "PACKAGE_BRANCH: $PACKAGE_BRANCH"
+  
   PACKAGE_MODULE_VERS=`cat $output | awk -F ':' '{print $3}'`
-  echo "PACKAGE_MODULE_VERS: $PACKAGE_MODULE_VERS"
-  popd
+  prog_log_info "PACKAGE_MODULE_VERS: $PACKAGE_MODULE_VERS"
+  popd > /dev/null
 
   PACKAGE_SERVER="http://daily.software.cambricon.com"
   PACKAGE_OS="Linux"
@@ -133,7 +134,7 @@ prepare_cntoolkit () {
 
   n=${#arr_vers[@]}
 
-  echo "number of dependency: $n"
+  sub_pkg_to_extract=(cncc cnas cnperf cngdb cndrv cnrt cnbin cnpapi cndev cntoolkit-cloud)
 
   if [ -f "/etc/os-release" ]; then
       source /etc/os-release
@@ -146,26 +147,29 @@ prepare_cntoolkit () {
               PACKAGE_PATH=${PACKAGE_SERVER}"/"${arr_branch[$i]}"/"${arr_modules[$i]}"/"${PACKAGE_OS}"/"${PACKAGE_ARCH}"/"${PACKAGE_DIST}"/"${PACKAGE_DIST_VER}"/"${arr_vers[$i]}"/"
               echo "PACKAGE_PATH: $PACKAGE_PATH"
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
-              echo "real_path $REAL_PATH"
-              wget -A deb -m -p -E -k -K -np ${PACKAGE_PATH}
+              prog_log_info "cntoolkit url: ${REAL_PATH}"
+              wget -A deb -m -p -E -k -K -np -q ${PACKAGE_PATH}
               if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
                 rm -rf ${PACKAGE_EXTRACT_DIR}
               fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
-              pushd ${PACKAGE_EXTRACT_DIR}
+              pushd ${PACKAGE_EXTRACT_DIR} > /dev/null
               for filename in ../${REAL_PATH}*.deb; do
                 echo "filename: $filename"
                 dpkg -X ${filename} .
-                echo "test succeuss"
+                dpkg -x --force-overwrite ${filename} .
+                prog_log_info "extract ${filename}"
                 if [ ${arr_modules[$i]} == "cntoolkit" ]; then
                   pure_ver=`echo ${arr_vers[$i]} | cut -d '-' -f 1`
-                  echo "pure_ver: ${pure_ver}"
-                  for lib in var/${arr_modules[$i]}"-"${pure_ver}/*.deb; do
-                    dpkg -X $lib ./
+                  for pkg in ${sub_pkg_to_extract[@]}
+                  do
+                    local fname=$(ls -1 ./var/cntoolkit-${pure_ver}/${pkg}* | grep -E "${pkg}[^[:alnum:]][0-9].*")
+                    prog_log_info "extract ${fname}"
+                    dpkg -x --force-overwrite ${fname} ./
                   done
                 fi
               done
-              popd
+              popd > /dev/null
           done
 
       elif [ ${ID} == "debian" ]; then
@@ -177,25 +181,27 @@ prepare_cntoolkit () {
               PACKAGE_PATH=${PACKAGE_SERVER}"/"${arr_branch[$i]}"/"${arr_modules[$i]}"/"${PACKAGE_OS}"/"${PACKAGE_ARCH}"/"${PACKAGE_DIST}"/"${PACKAGE_DIST_VER}"/"${arr_vers[$i]}"/"
               echo "PACKAGE_PATH: $PACKAGE_PATH"
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
-              echo "real_path $REAL_PATH"
-              wget -A deb -m -p -E -k -K -np ${PACKAGE_PATH}
+              prog_log_info "cntoolkit url: ${REAL_PATH}"
+              wget -A deb -m -p -E -k -K -np -q ${PACKAGE_PATH}
               if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
                 rm -rf ${PACKAGE_EXTRACT_DIR}
               fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
-              pushd ${PACKAGE_EXTRACT_DIR}
+              pushd ${PACKAGE_EXTRACT_DIR} > /dev/null
               for filename in ../${REAL_PATH}*.deb; do
-                echo "filename: $filename"
-                dpkg -X ${filename} ./
+                prog_log_info "extract ${filename}"
+                dpkg -x --force-overwrite ${filename} ./
                 if [ ${arr_modules[$i]} == "cntoolkit" ]; then
                   pure_ver=`echo ${arr_vers[$i]} | cut -d '-' -f 1`
-                  echo "pure_ver: ${pure_ver}"
-                  for lib in var/${arr_modules[$i]}"-"${pure_ver}/*.deb; do
-                    dpkg -X $lib ./
+                  for pkg in ${sub_pkg_to_extract[@]}
+                  do
+                    local fname=$(ls -1 ./var/cntoolkit-${pure_ver}/${pkg}* | grep -E "${pkg}[^[:alnum:]][0-9].*")
+                    prog_log_info "extract ${fname}"
+                    dpkg -x --force-overwrite ${fname} ./
                   done
                 fi
               done
-              popd
+              popd > /dev/null
           done
 
       elif [ ${ID} == "centos" ]; then
@@ -206,25 +212,27 @@ prepare_cntoolkit () {
               PACKAGE_PATH=${PACKAGE_SERVER}"/"${arr_branch[$i]}"/"${arr_modules[$i]}"/"${PACKAGE_OS}"/"${PACKAGE_ARCH}"/"${PACKAGE_DIST}"/"${PACKAGE_DIST_VER}"/"${arr_vers[$i]}"/"
               echo "PACKAGE_PATH: $PACKAGE_PATH"
               REAL_PATH=`echo ${PACKAGE_PATH} | awk -F '//' '{print $2}'`
-              echo "real_path $REAL_PATH"
-              wget -A rpm -m -p -E -k -K -np ${PACKAGE_PATH}
+              prog_log_info "cntoolkit url: ${REAL_PATH}"
+              wget -A rpm -m -p -E -k -K -np -q ${PACKAGE_PATH}
               if [ -d ${PACKAGE_EXTRACT_DIR} ]; then
                 rm -rf ${PACKAGE_EXTRACT_DIR}
               fi
               mkdir -p ${PACKAGE_EXTRACT_DIR}
-              pushd ${PACKAGE_EXTRACT_DIR}
+              pushd ${PACKAGE_EXTRACT_DIR} > /dev/null
               for filename in ../${REAL_PATH}*.rpm; do
-                echo "filename: $filename"
-                rpm2cpio $filename | cpio -div
+                prog_log_info "extract ${filename}"
+                rpm2cpio $filename | cpio -u -di
                 if [ ${arr_modules[$i]} == "cntoolkit" ]; then
                   pure_ver=`echo ${arr_vers[$i]} | cut -d '-' -f 1`
-                  echo "pure_ver: ${pure_ver}"
-                  for lib in var/${arr_modules[$i]}"-"${pure_ver}/*.rpm; do
-                    rpm2cpio $lib | cpio -div
+                  for pkg in ${sub_pkg_to_extract[@]}
+                  do
+                    local fname=$(ls -1 ./var/cntoolkit-${pure_ver}/${pkg}* | grep -E "${pkg}[^[:alnum:]][0-9].*")
+                    prog_log_info "extract ${fname}"
+                    rpm2cpio ${fname} | cpio -u -di
                   done
                 fi
               done
-              popd
+              popd > /dev/null
           done
       elif [ ${ID} == "kylin" ]; then
           for (( i =0; i < ${n}; i++))
@@ -357,8 +365,8 @@ fi
 
 if [[ "$(g++ --version | head -n1 | awk '{ print $3 }' | cut -d '.' -f1)" < "5" ]]; then
   prog_log_note "we do not support g++<5, try to activate devtoolset-7 env"
-  source /opt/rh/devtoolset-7/enable && echo "devtoolset-7 activated" \
-    || ( echo "source devtoolset-7 failed, ignore this info if you have set env TOOLCHAIN_ROOT, TARGET_C_COMPILER, TARGET_CXX_COMPILER properly (see more details in README.md)" && sleep 4 ) # I hope user will see it
+  source /opt/rh/devtoolset-7/enable && prog_log_warn "devtoolset-7 activated" \
+    || ( prog_log_warn "source devtoolset-7 failed, ignore this info if you have set env TOOLCHAIN_ROOT, TARGET_C_COMPILER, TARGET_CXX_COMPILER properly (see more details in README.md)" && sleep 4 ) # I hope user will see it
 fi
 
 if [ ! -d "$BUILD_PATH" ]; then
@@ -366,7 +374,7 @@ if [ ! -d "$BUILD_PATH" ]; then
 fi
 
 if [ "${MLUOP_BUILD_PREPARE_ONLY}" = "ON" ]; then
-  prog_log_info "You hae called prepare cntoolkit explicitly."	  
+  prog_log_info "You have called prepare cntoolkit explicitly."	  
   prepare_cntoolkit
   exit -1
 elif [ "${MLUOP_BUILD_PREPARE}" = "ON" ]; then

--- a/bangc-ops/independent_build.sh
+++ b/bangc-ops/independent_build.sh
@@ -106,7 +106,6 @@ usage () {
 }
 
 prepare_cntoolkit () {
-  pushd ../
   pushd ../ > /dev/null
   python2 json_parser.py
   output='dependency.txt'
@@ -156,7 +155,7 @@ prepare_cntoolkit () {
               pushd ${PACKAGE_EXTRACT_DIR} > /dev/null
               for filename in ../${REAL_PATH}*.deb; do
                 echo "filename: $filename"
-                dpkg -X ${filename} .
+                dpkg -x ${filename} .
                 dpkg -x --force-overwrite ${filename} .
                 prog_log_info "extract ${filename}"
                 if [ ${arr_modules[$i]} == "cntoolkit" ]; then

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -70,7 +70,7 @@ typedef enum {
        dimensions, etc.*/
   MLUOP_STATUS_INTERNAL_ERROR = 4,
   /*!< An error occurs inside of the function, which may indicate an internal error or bug in
-       the library. This error is usually caused by failing to call cnrtMemcpyAsync. 
+       the library. This error is usually caused by failing to call cnrtMemcpyAsync.
        Check whether the memory passed to the function is deallocated before the completion
        of the routine. */
   MLUOP_STATUS_ARCH_MISMATCH = 5,
@@ -154,7 +154,7 @@ typedef enum {
 /*!
  * @brief Describes the options that can help choose the best suited algorithm used
  * for implementation of the activation and accumulation operation.
- * 
+ *
  */
 typedef enum {
   MLUOP_COMPUTATION_FAST = 0,
@@ -901,7 +901,7 @@ mluOpResetTensorDescriptor(mluOpTensorDescriptor_t desc);
  * this function. If ::mluOpSetTensorDescriptor is called, you do not need to specify the
  * strides of all dimensions and the strides are inferred by parameters passed to this function.
  *
- * This function does not support all the operations in this version. 
+ * This function does not support all the operations in this version.
  *
  * @param[in] desc
  * The descriptor of the tensor desc. For detailed information, see ::mluOpTensorDescriptor_t.
@@ -1334,7 +1334,7 @@ mluOpGetTensorElementNum(const mluOpTensorDescriptor_t desc);
  * @par Note
  * - The on-chip data type is only used on the operations that support fixed-point computing. It
  *   has no effect on other operations. If you call this function to get on-chip data type for an
- *   operation that does support fixed-point computing, ::MLUOP_STATUS_BAD_PARAM is returned. 
+ *   operation that does support fixed-point computing, ::MLUOP_STATUS_BAD_PARAM is returned.
  *
  * @par Example
  * - None.
@@ -2194,7 +2194,7 @@ mluOpGetGenerateProposalsV2WorkspaceSize(mluOpHandle_t handle,
  * @param[in] workspace
  * Pointer to the MLU memory that stores the extra workspace.
  * @param[in] workspace_size
- * The size of the extra workspace in bytes that needs to be used in ::mluOpGenerateProposalsV2. 
+ * The size of the extra workspace in bytes that needs to be used in ::mluOpGenerateProposalsV2.
  * @param[in] rpn_rois_desc
  * The descriptor of the output tensor. For detailed information,
  * see ::mluOpTensorDescriptor_t.
@@ -2359,7 +2359,7 @@ mluOpGetPolyNmsWorkspaceSize(mluOpHandle_t handle,
  * @param[in] workspace
  * Pointer to the MLU memory that stores the extra workspace.
  * @param[in] workspace_size
- * The size of the extra workspace in bytes that needs to be used in ::mluOpPolyNms. 
+ * The size of the extra workspace in bytes that needs to be used in ::mluOpPolyNms.
  * @param[in] output_desc
  * The descriptor of the output tensor. For detailed information,
  * see ::mluOpTensorDescriptor_t.
@@ -3376,7 +3376,7 @@ mluOpYoloBox(mluOpHandle_t handle,
 
 // Group:VoxelPooling
 /*!
- * @brief Adds the eigenvalues of all the channels on the same x and y coordinates, 
+ * @brief Adds the eigenvalues of all the channels on the same x and y coordinates,
  * and then pools them to all the channels in the bev 2D area on the corresponding coordinates.
  *
  * @param[in] handle
@@ -3396,19 +3396,23 @@ mluOpYoloBox(mluOpHandle_t handle,
  * @param[in] num_voxel_z
  * The number of voxels for dimZ.
  * @param[in] geom_xyz_desc
- * The descriptor of the tensor \b geom_xyz. For detailed information, see ::mluOpTensorDescriptor_t.
+ * The descriptor of the tensor \b geom_xyz. For detailed information, see
+ * ::mluOpTensorDescriptor_t.
  * @param[in] geom_xyz
  * Pointer to the MLU memory that stores the input tensor.
  * @param[in] input_features_desc
- * The descriptor of the tensor \b input_features. For detailed information, see ::mluOpTensorDescriptor_t.
+ * The descriptor of the tensor \b input_features. For detailed information, see
+ * ::mluOpTensorDescriptor_t.
  * @param[in] input_features
  * Pointer to the MLU memory that stores the input tensor.
  * @param[in] output_features_desc
- * The descriptor of the tensor \b output_features. For detailed information, see ::mluOpTensorDescriptor_t.
+ * The descriptor of the tensor \b output_features. For detailed information, see
+ * ::mluOpTensorDescriptor_t.
  * @param[out] output_features
  * Pointer to the MLU memory that stores the output tensor.
  * @param[in] pos_memo_desc
- * The descriptor of the tensor \b pos_memo. For detailed information, see ::mluOpTensorDescriptor_t.
+ * The descriptor of the tensor \b pos_memo. For detailed information, see
+ * ::mluOpTensorDescriptor_t.
  * @param[out] pos_memo
  * Pointer to the MLU memory that stores the output tensor.
  *

--- a/tools/commitlint.py
+++ b/tools/commitlint.py
@@ -25,7 +25,7 @@
 import sys
 import re
 
-types = ('[Feature]', '[Fix]', '[Docs]', '[WIP]')
+types = ('[Feature]', '[Fix]', '[Docs]', '[TEST]', '[WIP]')
 scopes = ('(bangc-ops)', '(bangpy-ops)','(mlu-ops)')
 
 #get header
@@ -40,13 +40,13 @@ def valid_commit_msg(commit_msg):
     res = re.match(r'(?P<type>\[\w+\])(?P<scope>\(\w+-ops\))(?P<colon>:)(?P<subject> *\w+)', commit_msg)
     if res == None:
         print("\033[0;35m-- please input standard format for commit: {[type](scope): <subject> }\033[0m")
-        print("\033[0;35m-- the type should be one of: 'Feature', 'Fix', 'Docs', 'WIP' \033[0m")
+        print("\033[0;35m-- the type should be one of: 'Feature', 'Fix', 'Docs', 'TEST', 'WIP' \033[0m")
         print("\033[0;35m-- the msg_scope should be one of: 'bangc-ops', 'bangpy-ops', 'mlu-ops' \033[0m")
         return False
     else:
         msg_type = res.groupdict()['type'].lstrip().rstrip()
         if msg_type not in types:
-            print("\033[0;35m-- type not match, the type should be one of: 'Feature', 'Fix', 'Docs', 'WIP' \033[0m")
+            print("\033[0;35m-- type not match, the type should be one of: 'Feature', 'Fix', 'Docs', 'TEST', 'WIP' \033[0m")
             print("\033[0;35m-- please input standard format for commit: {[type](scope): <subject> }\033[0m")
             return False
 

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -114,8 +114,17 @@ function process () {
     # generate report
     genhtml ${temp_dir_}/info/* -o result
 
+    for arg in ${test_cmd_}; do
+        if [[ ${arg} == "--gtest_filter="* ]]; then
+            op_dir_name=${arg##*=}
+        fi
+    done
     # show the coverage test report
-    html2text ${temp_dir_}/result/index.html
+    if [[ ! -z ${op_dir_name} ]]; then
+        html2text ${temp_dir_}/result/kernels/${op_dir_name}/index.html
+    else
+        html2text ${temp_dir_}/result/index.html
+    fi
 }
 
 function main () {
@@ -123,7 +132,7 @@ function main () {
         echo " NEUWARE_HOME:  "${NEUWARE_HOME}
         export PATH="${NEUWARE_HOME}/bin":$PATH
         export LD_LIBRARY_PATH="${NEUWARE_HOME}/lib64":$LD_LIBRARY_PATH
-        export MLUOPS_GTEST_FILL_RAM=OFF
+        export MLUOP_GTEST_FILL_RAM=OFF
     else
         printf "${RED} ERROR: please export NEUWARE_HOME variable first!\n${NC}"
         exit 1

--- a/tools/format2google
+++ b/tools/format2google
@@ -30,7 +30,7 @@ fi
 
 file_list=$(find ${input} -name "*.cc" -or -name "*.cpp" \
   -or -name "*.mlu" -or -name "*.h" -or -name "*.hpp")
-mluop_name="bangc-ops/mlu_op.h"
+mluop_name="mlu_op.h"
 for file in ${file_list}; do
   echo "clang-formating ${file} ..."
   if [[ $file == *${mluop_name} ]]; then

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -55,6 +55,15 @@ else
   echo "-- [pre-commit] cpplint PASSED."
 fi
 
+format_mluop_h=$(tools/format2google ${bangc_mlu_op_h})
+diff_mluop_h=$(git diff ${bangc_mlu_op_h})
+
+if [[ ${diff_mluop_h} != "" ]]; then
+  echo ${diff_mluop_h}
+  echo "Please tools/format2google bangc-ops/mlu_op.h!"
+  exit -1
+fi
+
 echo "-- [pre-commit] Check __bang_printf or printf or std::cout or \
 assert() in kernel code..."
 for i in ${filenames} ; do


### PR DESCRIPTION

## 1. Motivation

Sync independent build, libproto version restriction info, pre-commit and coverage test set up to master.
## 2. Modification

modified:   .gitignore
modified:   README.md
modified:   bangc-ops/independent_build.sh
modified:   bangc-ops/mlu_op.h
modified:   tools/commitlint.py
modified:   tools/coverage.sh
modified:   tools/format2google
modified:   tools/pre-commit

## 3. Test Report
 all operators:
[----------] Global test environment tear-down
[ SUMMARY  ] Total 37 cases of 22 op(s).
ALL PASSED.
[==========] 37 test cases from 22 test suites ran. (8030 ms total)
[  PASSED  ] 37 test cases.

single op abs:
[----------] Global test environment tear-down
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
[==========] 1 test case from 1 test suite ran. (140 ms total)
[  PASSED  ] 1 test case.

coverage:  ball_query test
ilename [Sort by     Line Coverage [Sort_by_line_coverage] Functions [Sort_by
name]                                                       function_coverage]
ball_query.mlu        [74.8%][74.8%] 74.8 %113 / 151       100.0 %3 / 3
ball_query_union1.mlu [99.2%][99.2%] 99.2 %235 / 237       100.0 %8 / 8

### 3.4 Summary Analysis

All test have been passed.