### PR TITLE
[Fix](bangc-ops):fix psroipool __float2int_rn to __float2int_rd

### DIFF
--- a/bangc-ops/kernels/psroipool/psroipool_block.mlu
+++ b/bangc-ops/kernels/psroipool/psroipool_block.mlu
@@ -34,9 +34,9 @@ template <typename T>
 __mlu_func__ T scalarRound(T key) {
 #if __BANG_ARCH__ >= 370
   if (sizeof(T) == 2) {
-    return (T)(__half2int_rn(T(key)));
+    return (T)(__half2int_rd(T(key)));
   } else {
-    return (T)(__float2int_rn(T(key)));
+    return (T)(__float2int_rd(T(key)));
   }
 #else
   int key_remain = ((int)key) % 2;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改 psroipool算子标量计算中四舍五入方式

## 2. Modification

1）modified:   bangc-ops/kernels/psroipool/psroipool_block.mlu

