### PR TITLE
[Fix](bangc-ops) : fix subm=1 cpu

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/get_indice_pairs/get_indice_pairs.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/get_indice_pairs/get_indice_pairs.cpp
@@ -329,13 +329,16 @@ void GetIndicePairsExecutor::cpuGetIndicePairs(
   };
 
   if (sub_m) {
+    // prepareSubmGridKernel
     for (int j = 0; j < num_act_in; ++j) {
       index =
           getIndex(indice_in + j * (NDim + 1) + 1, out_spatail_shape, NDim) +
-          spatail_volume * (indice_in + j * (NDim + 1))[0];
+          spatail_volume * ((indice_in + j * (NDim + 1))[0]);
       grid_out[index] = j;
     }
-    indice_out = indice_in;
+    for (int j = 0; j < num_act_in * (NDim + 1); j++) {
+      indice_out[j] = indice_in[j];
+    }
   }
 
   for (int j = 0; j < num_act_in; ++j) {
@@ -349,11 +352,12 @@ void GetIndicePairsExecutor::cpuGetIndicePairs(
       index = getIndex(point_ptr, out_spatail_shape, NDim) +
               spatail_volume * batchIdx;
       if (sub_m) {
-        if (grid_out[index] > 1) {
-          indice_pairs[offset * 2 * num_act_in + indice_num[offset]] = j;
-          indice_pairs[offset * 2 * num_act_in + num_act_in +
-                       indice_num[offset]] = grid_out[index];
+        if (grid_out[index] > -1) {
+          int32_t  oldNum = indice_num[offset];
           indice_num[offset]++;
+          indice_pairs[offset * 2 * num_act_in + oldNum] = j;
+          indice_pairs[offset * 2 * num_act_in + num_act_in +
+                       oldNum] = grid_out[index];
         }
       } else {
         int32_t oldNum = indice_num[offset];


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

fix  cpu code when in subm =1  mode 
## 2. Modification
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/get_indice_pairs/get_indice_pairs.cpp

jira:
http://jira.cambricon.com/browse/CNNLCORE-11555?filter=-1

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

MLU Hardware Time      ]: 177 (us)
[MLU Interface Time     ]: 241.633 (us)
[MLU IO Efficiency      ]: 0.0569271
[MLU Compute Efficiency ]: 0.0168927
[MLU Workspace Size     ]: 5.50499e+07 (Bytes)
[MLU TheoryOps          ]: 6.88899e+06 (Ops)
[MLU TheoryIOs          ]: 2.78584e+07 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/get_indice_pairs/test_cases/case_1.prototxt
[       OK ] get_indice_pairs/TestSuite.mluOp/0 (239 ms)
[----------] 1 test from get_indice_pairs/TestSuite (239 ms total)

[----------] Global test environment tear-down
[2023-3-29 14:38:38] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
[==========] 1 test case from 1 test suite ran. (972 ms total)
[  PASSED  ] 1 test case.
root@MLU590-M9-76:/home/work/mlu-ops/bangc-ops/build/test# 


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
