### PR TITLE
[Feature](bangc-ops):Modify binary to source code

### DIFF
--- a/bangc-ops/kernels/bbox_overlaps/bbox_overlaps.cpp
+++ b/bangc-ops/kernels/bbox_overlaps/bbox_overlaps.cpp
@@ -20,15 +20,188 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
-#include "kernels/kernel_wrapper/wrapper.h"
+#include "bbox_overlaps.h"
+
+#include "core/logging.h"
+#include "core/gen_case.h"
+#include "core/runtime/device.h"
+#include "core/tensor.h"
+#include "core/type.h"
+
+// policyFunc
+static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
+                       cnrtFunctionType_t *k_type,
+                       const int32_t batch_num_all) {
+  uint32_t union_num = mluop::runtime::getClusterLimitCapability(handle);
+  uint32_t core_dim = handle->core_num_per_cluster;
+  uint32_t core_num = union_num * core_dim;
+
+  // Union1 policyFunc
+  *k_type = CNRT_FUNC_TYPE_UNION1;
+  k_dim->x = core_dim;
+  uint32_t need_core_num = (batch_num_all + core_dim - 1) / core_dim * core_dim;
+  if (need_core_num < core_num) {
+    k_dim->y = need_core_num / core_dim;
+  } else {
+    k_dim->y = union_num;
+  }
+  k_dim->z = 1;
+  return;
+}
 
 mluOpStatus_t MLUOP_WIN_API mluOpBboxOverlaps(
     mluOpHandle_t handle, const int mode, const bool aligned, const int offset,
     const mluOpTensorDescriptor_t bbox1_desc, const void *bbox1,
     const mluOpTensorDescriptor_t bbox2_desc, const void *bbox2,
     const mluOpTensorDescriptor_t ious_desc, void *ious) {
-  bboxOverlapsWrapper wrapper;
-  mluOpStatus_t ret = wrapper.invoke(handle, mode, aligned, offset, bbox1_desc,
-                                     bbox1, bbox2_desc, bbox2, ious_desc, ious);
-  return ret;
+  PARAM_CHECK("[mluOpBboxOverlaps]", handle != NULL);
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox1_desc != NULL);
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox2_desc != NULL);
+  PARAM_CHECK("[mluOpBboxOverlaps]", ious_desc != NULL);
+
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox1_desc->dtype == MLUOP_DTYPE_FLOAT ||
+                                         bbox1_desc->dtype == MLUOP_DTYPE_HALF);
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox1_desc->dtype == bbox2_desc->dtype);
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox1_desc->dtype == ious_desc->dtype);
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox1_desc->dim == 2);
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox2_desc->dim == 2);
+
+  // param check
+  if (mode != 1 && mode != 0) {
+    LOG(ERROR) << "[mluOpBboxOverlaps] Check failed: The mode must be 0 or 1, "
+                  "but now is "
+               << mode << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  if (bbox1_desc->dims[bbox1_desc->dim - 1] != 4 && bbox1_desc->dims[0] != 0) {
+    LOG(ERROR)
+        << "[mluOpBboxOverlaps] Check failed: The Boxes' last dimenstion "
+           "should be 4 or "
+        << "the first dimension should be 0. But now bbox1's last dimension is "
+        << bbox1_desc->dims[bbox1_desc->dim - 1]
+        << ", bbox1's first dimension is " << bbox1_desc->dims[0] << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  if (bbox2_desc->dims[bbox2_desc->dim - 1] != 4 && bbox2_desc->dims[0] != 0) {
+    LOG(ERROR)
+        << "[mluOpBboxOverlaps] Check failed: The Boxes' last dimenstion "
+           "should  be 4 or "
+        << "the first dimension should be 0. But now bbox2's last dimension is "
+        << bbox2_desc->dims[bbox2_desc->dim - 1]
+        << ", bbox2's first dimension is " << bbox2_desc->dims[0] << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  if (offset != 1 && offset != 0) {
+    LOG(ERROR) << "[mluOpBboxOverlaps] Check failed: The offset must be 0 or "
+                  "1,  but now is "
+               << offset << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  // param check
+  int32_t rows = bbox1_desc->dims[0];
+  int32_t cols = bbox2_desc->dims[0];
+  int32_t batch_num_all = rows;
+
+  if (ious_desc->dims[0] != rows) {
+    LOG(ERROR) << "[mluOpBboxOverlaps] Check failed: Whether it is aligned "
+                  "mode or not,"
+               << "ious_desc->dims[0] == bbox1_desc->dims[0]. But now "
+               << "ious_desc->dims[0] is " << ious_desc->dims[0]
+               << ", bbox1_desc->dims[0] is " << rows << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  if (aligned) {
+    if (rows != cols) {
+      LOG(ERROR) << "[mluOpBboxOverlaps] Check failed: If it is aligned mode, "
+                 << "bbox1_desc->dims[0] == bbox2_desc->dims[0]. But now "
+                 << "bbox1_desc->dims[0] is " << rows
+                 << ", bbox2_desc->dims[0] is " << cols << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+    if (rows * cols == 0) {
+      if ((ious_desc->dims[0] == rows) &&
+          (ious_desc->dims[ious_desc->dim - 1] == 1)) {
+        return MLUOP_STATUS_SUCCESS;
+      } else {
+        LOG(ERROR)
+            << "[mluOpBboxOverlaps] Check failed: If it is aligned mode and "
+            << "rows * cols = 0, ious_desc's first dim should be 0, "
+            << "and ious_desc's last dim should be 1. "
+            << "But now ious_desc's first dim is " << ious_desc->dims[0]
+            << ", and ious_desc's last dim is "
+            << ious_desc->dims[ious_desc->dim - 1] << ".";
+        return MLUOP_STATUS_BAD_PARAM;
+      }
+    } else if ((ious_desc->dims[0] != rows || ious_desc->dim != 1)) {
+      LOG(ERROR) << "[mluOpBboxOverlaps] Check failed: If it is aligned mode, "
+                 << "ious_desc's first dim should equal to bbox1's first dim, "
+                    "ious_desc's dim "
+                 << "should be 1. But now ious_desc's first dim is "
+                 << ious_desc->dims[0] << ", bbox1's first dim is " << rows
+                 << ", and ious_desc's dim is " << ious_desc->dim << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+  } else {
+    if (ious_desc->dim != 2) {
+      LOG(ERROR)
+          << "[mluOpBboxOverlaps] Check failed: If it is non-aligned mode, "
+          << "ious_desc->dim == 2. But now ious_desc->dim is " << ious_desc->dim
+          << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+    if (ious_desc->dims[0] != rows ||
+        ious_desc->dims[ious_desc->dim - 1] != cols) {
+      LOG(ERROR)
+          << "[mluOpBboxOverlaps] Check failed: If it is non-aligned mode, "
+          << "ious_desc's first dim should be " << rows << ", ious_desc's last "
+          << "dim should be " << cols << "."
+          << "But now ious_desc's first dim is " << ious_desc->dims[0]
+          << ", and ious_desc's last dim is "
+          << ious_desc->dims[ious_desc->dim - 1] << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+    if (rows * cols == 0) {
+      return MLUOP_STATUS_SUCCESS;
+    }
+  }
+
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox1 != NULL);
+  PARAM_CHECK("[mluOpBboxOverlaps]", bbox2 != NULL);
+  PARAM_CHECK("[mluOpBboxOverlaps]", ious != NULL);
+
+  // generate mluOpBboxOverlaps prototxt start!
+  if (MLUOP_GEN_CASE_ON_NEW) {
+    GEN_CASE_START("bbox_overlaps");
+    GEN_CASE_HANDLE(handle);
+    GEN_CASE_DATA_REAL(true, "input", bbox1, bbox1_desc);
+    GEN_CASE_DATA_REAL(true, "input", bbox2, bbox2_desc);
+    GEN_CASE_DATA(false, "output", ious, ious_desc, 0, 0);
+    GEN_CASE_OP_PARAM_SINGLE(0, "bbox_overlaps", "mode", mode);
+    GEN_CASE_OP_PARAM_SINGLE(1, "bbox_overlaps", "aligned", aligned);
+    GEN_CASE_OP_PARAM_SINGLE(2, "bbox_overlaps", "offset", offset);
+    GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
+  }
+  // generate mluOpBboxOverlaps prototxt end!
+
+  mluOpDataType_t k_datatype = bbox1_desc->dtype;
+  cnrtDim3_t k_dim;
+  cnrtFunctionType_t k_type;
+
+  policyFunc(handle, &k_dim, &k_type, batch_num_all);
+  VLOG(5) << "  kDim :[ " << k_dim.x << ", " << k_dim.y << ", " << k_dim.z
+          << " ]";
+
+  VLOG(5) << "Launch Kernel KernelBboxOverlaps";
+  KERNEL_CHECK(
+      (KernelBboxOverlaps(k_dim, k_type, handle->queue, k_datatype, bbox1,
+                          bbox2, ious, rows, cols, mode, aligned, offset)));
+  VLOG(5) << "Kernel KernelBboxOverlaps.";
+
+  GEN_CASE_END();
+  return MLUOP_STATUS_SUCCESS;
 }

--- a/bangc-ops/kernels/bbox_overlaps/bbox_overlaps.h
+++ b/bangc-ops/kernels/bbox_overlaps/bbox_overlaps.h
@@ -1,0 +1,34 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef KERNELS_BBOX_OVERLAPS_BBOX_OVERLAPS_H
+#define KERNELS_BBOX_OVERLAPS_BBOX_OVERLAPS_H
+
+#include "mlu_op.h"
+
+void MLUOP_WIN_API KernelBboxOverlaps(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    mluOpDataType_t d_type, const void *bbox1, const void *bbox2, void *ious,
+    const int32_t num_bboxl, const int32_t num_bbox2, const int32_t mode,
+    const bool aligned, const int32_t offset);
+
+#endif  // KERNELS_BBOX_OVERLAPS_BBOX_OVERLAPS_H

--- a/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
+++ b/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
@@ -1,0 +1,318 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "bbox_overlaps.h"
+
+#include "kernels/kernel.h"
+#include "kernels/debug.h"
+#include "kernels/utils/common.h"
+#include "mlu.h"
+
+#define ALIGN_SIZE NFU_ALIGN_SIZE
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define COORD_NUM 4
+
+__nram__ char nmem_buf[MAX_NRAM_SIZE];
+
+template <typename T>
+__mlu_device__ void bbox_overlaps_workflow(
+    T *vec_b1_x1, T *vec_b1_y1, T *vec_b1_x2, T *vec_b1_y2, T *vec_b2_x1,
+    T *vec_b2_y1, T *vec_b2_x2, T *vec_b2_y2, T *vec_left, T *vec_right,
+    T *vec_top, T *vec_bottom, const T *bbox1, const T *bbox2, void *ious,
+    const int32_t offset, const int32_t mode, const int32_t batches_stride,
+    const int32_t num_bbox1, const int32_t num_bbox2, const bool aligned) {
+  int32_t task_batch_stride = (num_bbox1 + taskDim - 1) / taskDim;
+  int32_t batch_start = taskId * task_batch_stride;
+  int32_t batch_per_task = batch_start + task_batch_stride < num_bbox1
+                               ? task_batch_stride
+                               : num_bbox1 - batch_start;
+  batch_per_task = MAX(batch_per_task, 0);
+  const int32_t is_high_precision = 1;
+  if (aligned) {
+    int32_t num_loop_cpy = batch_per_task / batches_stride;
+    int32_t num_rem_cpy_batches = batch_per_task % batches_stride;
+    num_loop_cpy = num_rem_cpy_batches > 0 ? num_loop_cpy + 1 : num_loop_cpy;
+    for (int32_t i = 0; i < num_loop_cpy; i++) {
+      int32_t index = batch_start + i * batches_stride;
+      int32_t handle_batches = index + batches_stride > num_bbox1
+                                   ? num_rem_cpy_batches
+                                   : batches_stride;
+      int32_t b1 = index;
+      int32_t b2 = index;
+
+      int32_t base1 = b1 * COORD_NUM;
+      __memcpy(vec_b1_x1, &bbox1[base1], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+      __memcpy(vec_b1_y1, &bbox1[base1 + 1], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+      __memcpy(vec_b1_x2, &bbox1[base1 + 2], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+      __memcpy(vec_b1_y2, &bbox1[base1 + 3], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+
+      int32_t base2 = b2 * COORD_NUM;
+      __memcpy(vec_b2_x1, &bbox2[base2], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+      __memcpy(vec_b2_y1, &bbox2[base2 + 1], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+      __memcpy(vec_b2_x2, &bbox2[base2 + 2], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+      __memcpy(vec_b2_y2, &bbox2[base2 + 3], sizeof(T), GDRAM2NRAM, sizeof(T),
+               COORD_NUM * sizeof(T), handle_batches - 1);
+
+      // get the width and height
+      __bang_maxequal(vec_left, vec_b1_x1, vec_b2_x1, batches_stride);
+      __bang_minequal(vec_right, vec_b1_x2, vec_b2_x2, batches_stride);
+      __bang_maxequal(vec_top, vec_b1_y1, vec_b2_y1, batches_stride);
+      __bang_minequal(vec_bottom, vec_b1_y2, vec_b2_y2, batches_stride);
+
+      // right - left + offset ---> left
+      __bang_sub(vec_left, vec_right, vec_left, batches_stride);
+      __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
+
+      // bottom - top + offset ---> right
+      __bang_sub(vec_right, vec_bottom, vec_top, batches_stride);
+      __bang_add_scalar(vec_right, vec_right, (T)offset, batches_stride);
+
+      // zero vector ---> bottom
+      __bang_write_value(vec_bottom, batches_stride, (T)0);
+
+      // width --> vec_left
+      __bang_maxequal(vec_left, vec_bottom, vec_left, batches_stride);
+      T *width = vec_left;
+      // height --> vec_right
+      __bang_maxequal(vec_right, vec_bottom, vec_right, batches_stride);
+      T *height = vec_right;
+
+      // get the b1_area
+      // (b1_x2 - b1_x1 + offset)  --->  vec_top
+      __bang_sub(vec_top, vec_b1_x2, vec_b1_x1, batches_stride);
+      __bang_add_scalar(vec_top, vec_top, (T)offset, batches_stride);
+
+      // (b1_y2 - b1_y1 + offset)  --->  vec_bottom
+      __bang_sub(vec_bottom, vec_b1_y2, vec_b1_y1, batches_stride);
+      __bang_add_scalar(vec_bottom, vec_bottom, (T)offset, batches_stride);
+
+      // b1_area = (b1_x2 - b1_x1 + offset) * (b1_y2 - b1_y1 + offset) --->
+      // vec_top;
+      __bang_mul(vec_top, vec_top, vec_bottom, batches_stride);
+      T *b1_area = vec_top;
+
+      // get the b2_area
+      // (b2_x2 - b2_x1 + offset)  --->  b2_x1
+      __bang_sub(vec_b2_x1, vec_b2_x2, vec_b2_x1, batches_stride);
+      __bang_add_scalar(vec_b2_x1, vec_b2_x1, (T)offset, batches_stride);
+
+      // (b2_y2 - b2_y1 + offset)  --->  b2_y1
+      __bang_sub(vec_b2_y1, vec_b2_y2, vec_b2_y1, batches_stride);
+      __bang_add_scalar(vec_b2_y1, vec_b2_y1, (T)offset, batches_stride);
+
+      // b2_area = (b2_x2 - b2_x1 + offset) * (b2_y2 - b2_y1 + offset) --->
+      // b2_x1;
+      __bang_mul(vec_b2_x1, vec_b2_x1, vec_b2_y1, batches_stride);
+      T *b2_area = vec_b2_x1;
+
+      // inter_s = width * height
+      __bang_mul(height, width, height, batches_stride);
+      T *inter_s = height;
+
+      // offset vector ---> vec_b2_y1
+      __bang_write_value(vec_b2_y1, batches_stride, T(offset));
+      T *vec_offset = vec_b2_y1;
+
+      if (mode == 0) {
+        __bang_add(b1_area, b1_area, b2_area, batches_stride);
+        __bang_sub(b1_area, b1_area, inter_s, batches_stride);
+        __bang_maxequal(b1_area, vec_offset, b1_area, batches_stride);
+      } else {
+        __bang_maxequal(b1_area, vec_offset, b1_area, batches_stride);
+      }
+      T *base_s = b1_area;
+
+      // ious = inter_s / base_s
+      computeDiv(width, inter_s, base_s, vec_b2_x2, is_high_precision,
+                 batches_stride);
+      __memcpy((T *)ious + index, width, handle_batches * sizeof(T),
+               NRAM2GDRAM);
+    }
+  } else {
+    int32_t num_loop_cpy = num_bbox2 / batches_stride;
+    int32_t num_rem_cpy_batches = num_bbox2 % batches_stride;
+    num_loop_cpy = num_rem_cpy_batches > 0 ? num_loop_cpy + 1 : num_loop_cpy;
+    for (int32_t i = 0; i < batch_per_task; i++) {
+      int32_t index1 = batch_start + i;
+      int32_t b1 = index1;
+      int32_t base1 = b1 * COORD_NUM;
+
+      // set bbox1 and bbox2 to nram
+      __bang_write_value(vec_b1_x1, batches_stride, bbox1[base1]);
+      __bang_write_value(vec_b1_y1, batches_stride, bbox1[base1 + 1]);
+      __bang_write_value(vec_b1_x2, batches_stride, bbox1[base1 + 2]);
+      __bang_write_value(vec_b1_y2, batches_stride, bbox1[base1 + 3]);
+
+      for (int32_t j = 0; j < num_loop_cpy; j++) {
+        int32_t index2 = j * batches_stride;
+        int32_t handle_batches = index2 + batches_stride > num_bbox2
+                                     ? num_rem_cpy_batches
+                                     : batches_stride;
+        int32_t b2 = index2;
+        int32_t base2 = b2 * COORD_NUM;
+
+        // copy bbox2 to nram
+        __memcpy(vec_b2_x1, &bbox2[base2], sizeof(T), GDRAM2NRAM, sizeof(T),
+                 COORD_NUM * sizeof(T), handle_batches - 1);
+        __memcpy(vec_b2_y1, &bbox2[base2 + 1], sizeof(T), GDRAM2NRAM, sizeof(T),
+                 COORD_NUM * sizeof(T), handle_batches - 1);
+        __memcpy(vec_b2_x2, &bbox2[base2 + 2], sizeof(T), GDRAM2NRAM, sizeof(T),
+                 COORD_NUM * sizeof(T), handle_batches - 1);
+        __memcpy(vec_b2_y2, &bbox2[base2 + 3], sizeof(T), GDRAM2NRAM, sizeof(T),
+                 COORD_NUM * sizeof(T), handle_batches - 1);
+
+        // get the width and height
+        __bang_maxequal(vec_left, vec_b1_x1, vec_b2_x1, batches_stride);
+        __bang_minequal(vec_right, vec_b1_x2, vec_b2_x2, batches_stride);
+        __bang_maxequal(vec_top, vec_b1_y1, vec_b2_y1, batches_stride);
+        __bang_minequal(vec_bottom, vec_b1_y2, vec_b2_y2, batches_stride);
+
+        // right - left + offset ---> left
+        __bang_sub(vec_left, vec_right, vec_left, batches_stride);
+        __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
+        // bottom - top + offset ---> right
+        __bang_sub(vec_right, vec_bottom, vec_top, batches_stride);
+        __bang_add_scalar(vec_right, vec_right, (T)offset, batches_stride);
+
+        // zero vector ---> bottom
+        __bang_write_value(vec_bottom, batches_stride, (T)0);
+
+        // width --> vec_left
+        __bang_maxequal(vec_left, vec_bottom, vec_left, batches_stride);
+        T *width = vec_left;
+        // height --> vec_right
+        __bang_maxequal(vec_right, vec_bottom, vec_right, batches_stride);
+        T *height = vec_right;
+
+        // get the b1_area
+        // (b1_x2 - b1_x1 + offset)  --->  vec_top
+        __bang_sub(vec_top, vec_b1_x2, vec_b1_x1, batches_stride);
+        __bang_add_scalar(vec_top, vec_top, (T)offset, batches_stride);
+        // (b1_y2 - b1_y1 + offset)  --->  vec_bottom
+        __bang_sub(vec_bottom, vec_b1_y2, vec_b1_y1, batches_stride);
+        __bang_add_scalar(vec_bottom, vec_bottom, (T)offset, batches_stride);
+        // b1_area = (b1_x2 - b1_x1 + offset) * (b1_y2 - b1_y1 + offset) --->
+        // vec_top;
+        __bang_mul(vec_top, vec_top, vec_bottom, batches_stride);
+        T *b1_area = vec_top;
+
+        // get the b2_area
+        // (b2_x2 - b2_x1 + offset)  --->  b2_x1
+        __bang_sub(vec_b2_x1, vec_b2_x2, vec_b2_x1, batches_stride);
+        __bang_add_scalar(vec_b2_x1, vec_b2_x1, (T)offset, batches_stride);
+        // (b2_y2 - b2_y1 + offset)  --->  b2_y1
+        __bang_sub(vec_b2_y1, vec_b2_y2, vec_b2_y1, batches_stride);
+        __bang_add_scalar(vec_b2_y1, vec_b2_y1, (T)offset, batches_stride);
+        // b2_area = (b2_x2 - b2_x1 + offset) * (b2_y2 - b2_y1 + offset) --->
+        // b2_x1;
+        __bang_mul(vec_b2_x1, vec_b2_x1, vec_b2_y1, batches_stride);
+        T *b2_area = vec_b2_x1;
+
+        // inter_s = width * height
+        __bang_mul(height, width, height, batches_stride);
+        T *inter_s = height;
+
+        // offset vector ---> vec_b2_y1
+        __bang_write_value(vec_b2_y1, batches_stride, T(offset));
+        T *vec_offset = vec_b2_y1;
+
+        if (mode == 0) {
+          __bang_add(b1_area, b1_area, b2_area, batches_stride);
+          __bang_sub(b1_area, b1_area, inter_s, batches_stride);
+          __bang_maxequal(b1_area, vec_offset, b1_area, batches_stride);
+        } else {
+          __bang_maxequal(b1_area, vec_offset, b1_area, batches_stride);
+        }
+        T *base_s = b1_area;
+
+        // ious = inter_s / base_s
+        computeDiv(width, inter_s, base_s, vec_b2_x2, is_high_precision,
+                   batches_stride);
+        int32_t gdram_offset = index1 * num_bbox2 + index2;
+        __memcpy((T *)ious + gdram_offset, width, handle_batches * sizeof(T),
+                 NRAM2GDRAM);
+      }
+    }
+  }
+}
+
+template <typename T>
+__mlu_global__ void MLUUnion1BboxOverlapsKernel(
+    const T *bbox1, const T *bbox2, T *ious, const int32_t num_bboxl,
+    const int32_t num_bbox2, const int32_t mode, const bool aligned,
+    const int32_t offset) {
+  int32_t align_bytes = PAD_DOWN(MAX_NRAM_SIZE, ALIGN_SIZE);
+  int32_t nram_stride = align_bytes / ALIGN_SIZE / 12 * ALIGN_SIZE;
+
+  void *vec_b1_x1 = nmem_buf;
+  void *vec_b1_y1 = nmem_buf + nram_stride;
+  void *vec_b1_x2 = nmem_buf + 2 * nram_stride;
+  void *vec_b1_y2 = nmem_buf + 3 * nram_stride;
+
+  void *vec_b2_x1 = nmem_buf + 4 * nram_stride;
+  void *vec_b2_y1 = nmem_buf + 5 * nram_stride;
+  void *vec_b2_x2 = nmem_buf + 6 * nram_stride;
+  void *vec_b2_y2 = nmem_buf + 7 * nram_stride;
+
+  void *vec_left = nmem_buf + 8 * nram_stride;
+  void *vec_right = nmem_buf + 9 * nram_stride;
+  void *vec_top = nmem_buf + 10 * nram_stride;
+  void *vec_bottom = nmem_buf + 11 * nram_stride;
+
+  int32_t vec_length = nram_stride / sizeof(T);
+  bbox_overlaps_workflow((T *)vec_b1_x1, (T *)vec_b1_y1, (T *)vec_b1_x2,
+                         (T *)vec_b1_y2, (T *)vec_b2_x1, (T *)vec_b2_y1,
+                         (T *)vec_b2_x2, (T *)vec_b2_y2, (T *)vec_left,
+                         (T *)vec_right, (T *)vec_top, (T *)vec_bottom,
+                         (T *)bbox1, (T *)bbox2, (T *)ious, offset, mode,
+                         vec_length, num_bboxl, num_bbox2, aligned);
+}
+
+void MLUOP_WIN_API KernelBboxOverlaps(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    mluOpDataType_t d_type, const void *bbox1, const void *bbox2, void *ious,
+    const int32_t num_bboxl, const int32_t num_bbox2, const int32_t mode,
+    const bool aligned, const int32_t offset) {
+  switch (d_type) {
+    case MLUOP_DTYPE_HALF: {
+      MLUUnion1BboxOverlapsKernel<<<k_dim, k_type, queue>>>(
+          (half *)bbox1, (half *)bbox2, (half *)ious, num_bboxl, num_bbox2,
+          mode, aligned, offset);
+    }; break;
+    case MLUOP_DTYPE_FLOAT: {
+      MLUUnion1BboxOverlapsKernel<<<k_dim, k_type, queue>>>(
+          (float *)bbox1, (float *)bbox2, (float *)ious, num_bboxl, num_bbox2,
+          mode, aligned, offset);
+    }; break;
+    default: {
+      MLULOG("Not implemented.\n");
+      break;
+    }
+  }
+}

--- a/bangc-ops/kernels/kernel_wrapper/wrapper.h
+++ b/bangc-ops/kernels/kernel_wrapper/wrapper.h
@@ -49,12 +49,6 @@
     mluOpHandle_t, const mluOpTensorDescriptor_t[], const void *const *,      \
     uint32_t, const mluOpTensorDescriptor_t, void *, void *, size_t
 
-#define BBOXOVERLAPS_PARAM_TYPE                                               \
-    mluOpHandle_t, const int, const bool, const int,                          \
-    const mluOpTensorDescriptor_t, const void *,                              \
-    const mluOpTensorDescriptor_t, const void *,                              \
-    const mluOpTensorDescriptor_t, void *
-
 #define COPY_PARAM_TYPE                                                       \
     mluOpHandle_t, const mluOpTensorDescriptor_t, const void *,               \
     const mluOpTensorDescriptor_t, void *
@@ -185,7 +179,6 @@
 /* Kernel register */
 KERNEL_REGISTER(addN, ADDN_PARAM_TYPE);
 KERNEL_REGISTER(addNV2, ADDNV2_PARAM_TYPE);
-KERNEL_REGISTER(bboxOverlaps, BBOXOVERLAPS_PARAM_TYPE);
 KERNEL_REGISTER(copy, COPY_PARAM_TYPE);
 KERNEL_REGISTER(expand, EXPAND_PARAM_TYPE);
 KERNEL_REGISTER(fill, FILL_PARAM_TYPE);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

将算子bbox_overlaps二进制形式改为源码支持

## 2. Modification

1）modified:   bangc-ops/kernels/bbox_overlaps/bbox_overlaps.cpp
2）new file:   bangc-ops/kernels/bbox_overlaps/bbox_overlaps.h
3）new file:   bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
4）modified:   bangc-ops/kernels/kernel_wrapper/wrapper.h

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

[----------] Global test environment tear-down
[ SUMMARY  ] Total 2911 cases of 1 op(s).
ALL PASSED.
[==========] 2911 test cases from 1 test suite ran. (25216 ms total)
[  PASSED  ] 2911 test cases.
root@1f850b463c25:/tudejiang/mlu-ops/bangc-ops/build/test# exit