### PR TITLE
[TEST](bangc-ops):add roipoint_pool3d api check cases

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d.cpp
@@ -35,16 +35,17 @@ namespace mluopapitest {
 class roipoint_pool3d : public testing::Test {
  public:
   void setParam(bool handle, bool points_desc, bool points,
-                bool point_features_desc, bool point_features, bool boxes3d_desc,
-                bool boxes3d, bool pooled_features_desc, bool pooled_features,
-                bool pooled_empty_flag_desc, bool pooled_empty_flag, bool workspace) {
+                bool point_features_desc, bool point_features,
+                bool boxes3d_desc, bool boxes3d, bool pooled_features_desc,
+                bool pooled_features, bool pooled_empty_flag_desc,
+                bool pooled_empty_flag, bool workspace) {
     if (handle) {
       MLUOP_CHECK(mluOpCreate(&handle_));
     }
 
     if (points_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
-      std::vector<int> points_dims{1,1,3};
+      std::vector<int> points_dims{1, 1, 3};
       MLUOP_CHECK(mluOpSetTensorDescriptor(points_desc_, MLUOP_LAYOUT_ARRAY,
                                            MLUOP_DTYPE_FLOAT, 3,
                                            points_dims.data()));
@@ -55,7 +56,7 @@ class roipoint_pool3d : public testing::Test {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
             cnrtMalloc(&points_, mluOpGetTensorElementNum(points_desc_) *
-                                      mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+                                     mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
@@ -65,18 +66,18 @@ class roipoint_pool3d : public testing::Test {
 
     if (point_features_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&point_features_desc_));
-      std::vector<int> point_features_dims{1,1,1};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(point_features_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, 3,
-                                           point_features_dims.data()));
+      std::vector<int> point_features_dims{1, 1, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          point_features_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 3,
+          point_features_dims.data()));
     }
 
     if (point_features) {
       if (point_features_desc) {
-        GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
-            cnrtMalloc(&point_features_, mluOpGetTensorElementNum(point_features_desc_) *
-                                        mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&point_features_,
+                               mluOpGetTensorElementNum(point_features_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&point_features_,
@@ -86,7 +87,7 @@ class roipoint_pool3d : public testing::Test {
 
     if (boxes3d_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&boxes3d_desc_));
-      std::vector<int> boxes3d_dims{1,1,7};
+      std::vector<int> boxes3d_dims{1, 1, 7};
       MLUOP_CHECK(mluOpSetTensorDescriptor(boxes3d_desc_, MLUOP_LAYOUT_ARRAY,
                                            MLUOP_DTYPE_FLOAT, 3,
                                            boxes3d_dims.data()));
@@ -97,7 +98,7 @@ class roipoint_pool3d : public testing::Test {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
             cnrtMalloc(&boxes3d_, mluOpGetTensorElementNum(boxes3d_desc_) *
-                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+                                      mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
@@ -107,39 +108,40 @@ class roipoint_pool3d : public testing::Test {
 
     if (pooled_features_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
-      std::vector<int> pooled_features_dims{1,1,1,4};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_features_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, 4,
-                                           pooled_features_dims.data()));
+      std::vector<int> pooled_features_dims{1, 1, 1, 4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_features_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+          pooled_features_dims.data()));
     }
 
     if (pooled_features) {
       if (pooled_features_desc) {
-        GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
-            cnrtMalloc(&pooled_features_, mluOpGetTensorElementNum(pooled_features_desc_) *
-                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pooled_features_,
+                               mluOpGetTensorElementNum(pooled_features_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
-            cnrtMalloc(&pooled_features_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pooled_features_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
 
     if (pooled_empty_flag_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_empty_flag_desc_));
-      std::vector<int> pooled_empty_flag_dims{1,1};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_empty_flag_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_INT32, 2,
-                                           pooled_empty_flag_dims.data()));
+      std::vector<int> pooled_empty_flag_dims{1, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_empty_flag_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 2,
+          pooled_empty_flag_dims.data()));
     }
 
     if (pooled_empty_flag) {
       if (pooled_empty_flag_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&pooled_empty_flag_,
-                               mluOpGetTensorElementNum(pooled_empty_flag_desc_) *
-                                   mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pooled_empty_flag_,
+                       mluOpGetTensorElementNum(pooled_empty_flag_desc_) *
+                           mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&pooled_empty_flag_,
@@ -153,10 +155,11 @@ class roipoint_pool3d : public testing::Test {
   }
   mluOpStatus_t compute() {
     mluOpStatus_t status = mluOpRoiPointPool3d(
-        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_,
-        points_desc_, points_, point_features_desc_, point_features_,
-        boxes3d_desc_, boxes3d_, workspace_, workspace_size_, pooled_features_desc_, 
-        pooled_features_, pooled_empty_flag_desc_, pooled_empty_flag_);
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_,
+        sampled_pts_num_, points_desc_, points_, point_features_desc_,
+        point_features_, boxes3d_desc_, boxes3d_, workspace_, workspace_size_,
+        pooled_features_desc_, pooled_features_, pooled_empty_flag_desc_,
+        pooled_empty_flag_);
     destroy();
     return status;
   }
@@ -264,8 +267,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_handle_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -275,8 +277,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_points_desc_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -286,8 +287,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_points_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -297,8 +297,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_point_features_desc_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -308,8 +307,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_point_features_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -319,8 +317,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_boxes3d_desc_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -330,8 +327,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_boxes3d_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -341,8 +337,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_pooled_features_desc_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -352,8 +347,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_pooled_features_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -363,8 +357,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_pooled_empty_flag_desc_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -374,8 +367,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_pooled_empty_flag_null) {
              true);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 
@@ -385,8 +377,7 @@ TEST_F(roipoint_pool3d, BAD_PARAM_workspace_null) {
              false);
     EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
   } catch (std::exception &e) {
-    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
-           << " in roipoint_pool3d";
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what() << " in roipoint_pool3d";
   }
 }
 

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d.cpp
@@ -1,0 +1,393 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class roipoint_pool3d : public testing::Test {
+ public:
+  void setParam(bool handle, bool points_desc, bool points,
+                bool point_features_desc, bool point_features, bool boxes3d_desc,
+                bool boxes3d, bool pooled_features_desc, bool pooled_features,
+                bool pooled_empty_flag_desc, bool pooled_empty_flag, bool workspace) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (points_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
+      std::vector<int> points_dims{1,1,3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(points_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           points_dims.data()));
+    }
+
+    if (points) {
+      if (points_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&points_, mluOpGetTensorElementNum(points_desc_) *
+                                      mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&points_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (point_features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&point_features_desc_));
+      std::vector<int> point_features_dims{1,1,1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(point_features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           point_features_dims.data()));
+    }
+
+    if (point_features) {
+      if (point_features_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&point_features_, mluOpGetTensorElementNum(point_features_desc_) *
+                                        mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&point_features_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (boxes3d_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&boxes3d_desc_));
+      std::vector<int> boxes3d_dims{1,1,7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(boxes3d_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           boxes3d_dims.data()));
+    }
+
+    if (boxes3d) {
+      if (boxes3d_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&boxes3d_, mluOpGetTensorElementNum(boxes3d_desc_) *
+                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&boxes3d_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (pooled_features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
+      std::vector<int> pooled_features_dims{1,1,1,4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 4,
+                                           pooled_features_dims.data()));
+    }
+
+    if (pooled_features) {
+      if (pooled_features_desc) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pooled_features_, mluOpGetTensorElementNum(pooled_features_desc_) *
+                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pooled_features_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
+      }
+    }
+
+    if (pooled_empty_flag_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_empty_flag_desc_));
+      std::vector<int> pooled_empty_flag_dims{1,1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_empty_flag_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 2,
+                                           pooled_empty_flag_dims.data()));
+    }
+
+    if (pooled_empty_flag) {
+      if (pooled_empty_flag_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pooled_empty_flag_,
+                               mluOpGetTensorElementNum(pooled_empty_flag_desc_) *
+                                   mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pooled_empty_flag_,
+                               64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
+      }
+    }
+
+    if (workspace) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    }
+  }
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpRoiPointPool3d(
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_,
+        points_desc_, points_, point_features_desc_, point_features_,
+        boxes3d_desc_, boxes3d_, workspace_, workspace_size_, pooled_features_desc_, 
+        pooled_features_, pooled_empty_flag_desc_, pooled_empty_flag_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (points_desc_) {
+      VLOG(4) << "Destroy points_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(points_desc_));
+      points_desc_ = nullptr;
+    }
+
+    if (points_) {
+      VLOG(4) << "Destroy points_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(points_));
+      points_ = nullptr;
+    }
+
+    if (point_features_desc_) {
+      VLOG(4) << "Destroy point_features_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(point_features_desc_));
+      point_features_desc_ = nullptr;
+    }
+
+    if (point_features_) {
+      VLOG(4) << "Destroy point_features_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point_features_));
+      point_features_ = nullptr;
+    }
+
+    if (boxes3d_desc_) {
+      VLOG(4) << "Destroy boxes3d_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(boxes3d_desc_));
+      boxes3d_desc_ = nullptr;
+    }
+
+    if (boxes3d_) {
+      VLOG(4) << "Destroy boxes3d_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes3d_));
+      boxes3d_ = nullptr;
+    }
+
+    if (pooled_features_desc_) {
+      VLOG(4) << "Destroy pooled_features_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_features_desc_));
+      pooled_features_desc_ = nullptr;
+    }
+
+    if (pooled_features_) {
+      VLOG(4) << "Destroy pooled_features_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+      pooled_features_ = nullptr;
+    }
+
+    if (pooled_empty_flag_desc_) {
+      VLOG(4) << "Destroy pooled_empty_flag_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_empty_flag_desc_));
+      pooled_empty_flag_desc_ = nullptr;
+    }
+
+    if (pooled_empty_flag_) {
+      VLOG(4) << "Destroy pooled_empty_flag_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_empty_flag_));
+      pooled_empty_flag_ = nullptr;
+    }
+
+    if (workspace_) {
+      VLOG(4) << "Destroy workspace";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      workspace_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  int batch_size_ = 1;
+  int pts_num_ = 1;
+  int boxes_num_ = 1;
+  int feature_in_len_ = 1;
+  int sampled_pts_num_ = 1;
+  mluOpTensorDescriptor_t points_desc_ = nullptr;
+  void *points_ = nullptr;
+  mluOpTensorDescriptor_t point_features_desc_ = nullptr;
+  void *point_features_ = nullptr;
+  mluOpTensorDescriptor_t boxes3d_desc_ = nullptr;
+  void *boxes3d_ = nullptr;
+  mluOpTensorDescriptor_t pooled_features_desc_ = nullptr;
+  void *pooled_features_ = nullptr;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  mluOpTensorDescriptor_t pooled_empty_flag_desc_ = nullptr;
+  void *pooled_empty_flag_ = nullptr;
+};
+
+TEST_F(roipoint_pool3d, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_points_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_points_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_point_features_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_point_features_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_boxes3d_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_boxes3d_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_pooled_features_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_pooled_features_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false, true, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_pooled_empty_flag_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, false, true,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_pooled_empty_flag_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, false,
+             true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+TEST_F(roipoint_pool3d, BAD_PARAM_workspace_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             false);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d";
+  }
+}
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_general.cpp
@@ -36,9 +36,9 @@
 
 namespace mluopapitest {
 typedef std::tuple<int, int, int, int, int> RoiPointPool3dDescParam;
-typedef std::tuple<RoiPointPool3dDescParam, MLUOpTensorParam,
+typedef std::tuple<RoiPointPool3dDescParam, MLUOpTensorParam, MLUOpTensorParam,
                    MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
-                   MLUOpTensorParam, mluOpDevType_t, mluOpStatus_t>
+                   mluOpDevType_t, mluOpStatus_t>
     RoiPointPool3dParam;
 class roipoint_pool3d_general
     : public testing::TestWithParam<RoiPointPool3dParam> {
@@ -55,24 +55,24 @@ class roipoint_pool3d_general
         return;
       }
       RoiPointPool3dDescParam op_param = std::get<0>(GetParam());
-      std::tie(batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_) = op_param;
+      std::tie(batch_size_, pts_num_, boxes_num_, feature_in_len_,
+               sampled_pts_num_) = op_param;
 
       MLUOpTensorParam points_params = std::get<1>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
-          points_desc_, points_params.get_layout(),
-          points_params.get_dtype(), points_params.get_dim_nb(),
-          points_params.get_dim_size().data()));
+          points_desc_, points_params.get_layout(), points_params.get_dtype(),
+          points_params.get_dim_nb(), points_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(points_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
             cnrtMalloc(&points_,
                        mluOpDataTypeBytes(points_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&points_,
-                               mluOpDataTypeBytes(points_params.get_dtype()) *
-                                   mluOpGetTensorElementNum(points_desc_)));
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&points_, mluOpDataTypeBytes(points_params.get_dtype()) *
+                                     mluOpGetTensorElementNum(points_desc_)));
       }
 
       MLUOpTensorParam point_features_params = std::get<2>(GetParam());
@@ -84,8 +84,9 @@ class roipoint_pool3d_general
       if (mluOpGetTensorElementNum(point_features_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&point_features_,
-                       mluOpDataTypeBytes(point_features_params.get_dtype()) * 10));
+            cnrtMalloc(
+                &point_features_,
+                mluOpDataTypeBytes(point_features_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
@@ -97,8 +98,9 @@ class roipoint_pool3d_general
       MLUOpTensorParam boxes3d_params = std::get<3>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&boxes3d_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
-          boxes3d_desc_, boxes3d_params.get_layout(), boxes3d_params.get_dtype(),
-          boxes3d_params.get_dim_nb(), boxes3d_params.get_dim_size().data()));
+          boxes3d_desc_, boxes3d_params.get_layout(),
+          boxes3d_params.get_dtype(), boxes3d_params.get_dim_nb(),
+          boxes3d_params.get_dim_size().data()));
 
       if (mluOpGetTensorElementNum(boxes3d_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
@@ -106,47 +108,54 @@ class roipoint_pool3d_general
             cnrtMalloc(&boxes3d_,
                        mluOpDataTypeBytes(boxes3d_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
-            cnrtMalloc(&boxes3d_, mluOpDataTypeBytes(boxes3d_params.get_dtype()) *
-                                    mluOpGetTensorElementNum(boxes3d_desc_)));
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&boxes3d_,
+                               mluOpDataTypeBytes(boxes3d_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(boxes3d_desc_)));
       }
 
       MLUOpTensorParam pooled_features_params = std::get<4>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
           pooled_features_desc_, pooled_features_params.get_layout(),
-          pooled_features_params.get_dtype(), pooled_features_params.get_dim_nb(),
+          pooled_features_params.get_dtype(),
+          pooled_features_params.get_dim_nb(),
           pooled_features_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(pooled_features_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&pooled_features_,
-                       mluOpDataTypeBytes(pooled_features_params.get_dtype()) * 10));
+            cnrtMalloc(
+                &pooled_features_,
+                mluOpDataTypeBytes(pooled_features_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&pooled_features_,
-                               mluOpDataTypeBytes(pooled_features_params.get_dtype()) *
-                                   mluOpGetTensorElementNum(pooled_features_desc_)));
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pooled_features_,
+                       mluOpDataTypeBytes(pooled_features_params.get_dtype()) *
+                           mluOpGetTensorElementNum(pooled_features_desc_)));
       }
 
       MLUOpTensorParam pooled_empty_flag_params = std::get<5>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_empty_flag_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
           pooled_empty_flag_desc_, pooled_empty_flag_params.get_layout(),
-          pooled_empty_flag_params.get_dtype(), pooled_empty_flag_params.get_dim_nb(),
+          pooled_empty_flag_params.get_dtype(),
+          pooled_empty_flag_params.get_dim_nb(),
           pooled_empty_flag_params.get_dim_size().data()));
-      if (mluOpGetTensorElementNum(pooled_empty_flag_desc_) >= LARGE_TENSOR_NUM) {
+      if (mluOpGetTensorElementNum(pooled_empty_flag_desc_) >=
+          LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&pooled_empty_flag_,
-                       mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) * 10));
+            cnrtMalloc(
+                &pooled_empty_flag_,
+                mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&pooled_empty_flag_,
-                       mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) *
-                           mluOpGetTensorElementNum(pooled_empty_flag_desc_)));
+            cnrtMalloc(
+                &pooled_empty_flag_,
+                mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) *
+                    mluOpGetTensorElementNum(pooled_empty_flag_desc_)));
       }
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -162,8 +171,9 @@ class roipoint_pool3d_general
     }
     mluOpStatus_t status;
     status = mluOpGetRoiPointPool3dWorkspaceSize(
-        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_, points_desc_, 
-        point_features_desc_, boxes3d_desc_, pooled_features_desc_, pooled_empty_flag_desc_, &workspace_size_);
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_,
+        sampled_pts_num_, points_desc_, point_features_desc_, boxes3d_desc_,
+        pooled_features_desc_, pooled_empty_flag_desc_, &workspace_size_);
     if (status != MLUOP_STATUS_SUCCESS) {
       destroy();
       return expected_status_ == status;
@@ -171,10 +181,11 @@ class roipoint_pool3d_general
     GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
 
     status = mluOpRoiPointPool3d(
-        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_,
-        points_desc_, points_, point_features_desc_, point_features_,
-        boxes3d_desc_, boxes3d_, workspace_, workspace_size_, pooled_features_desc_, 
-        pooled_features_, pooled_empty_flag_desc_, pooled_empty_flag_);
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_,
+        sampled_pts_num_, points_desc_, points_, point_features_desc_,
+        point_features_, boxes3d_desc_, boxes3d_, workspace_, workspace_size_,
+        pooled_features_desc_, pooled_features_, pooled_empty_flag_desc_,
+        pooled_empty_flag_);
     destroy();
     return status == expected_status_;
   }
@@ -361,7 +372,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({1, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));        
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_points_dtype_dim_shape, roipoint_pool3d_general,
@@ -411,7 +422,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({1, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));       
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_boxes3d_dtype_dim_shape, roipoint_pool3d_general,
@@ -436,7 +447,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({1, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));         
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_pooled_features_dtype_dim_shape, roipoint_pool3d_general,
@@ -463,7 +474,7 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({1, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_BAD_PARAM)));           
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_pooled_empty_flag_dtype_dim_shape, roipoint_pool3d_general,
@@ -493,13 +504,16 @@ INSTANTIATE_TEST_CASE_P(
     testing::Combine(
         testing::Values(RoiPointPool3dDescParam{14800, 48367, 1, 1, 1}),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({14800, 48367, 3}))),
+                                         3,
+                                         std::vector<int>({14800, 48367, 3}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({14800, 48367, 1}))),
+                                         3,
+                                         std::vector<int>({14800, 48367, 1}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          3, std::vector<int>({14800, 1, 7}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({14800, 1, 1, 4}))),
+                                         4,
+                                         std::vector<int>({14800, 1, 1, 4}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({14800, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
@@ -514,13 +528,15 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          3, std::vector<int>({14800, 1, 1}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({14800, 48367, 7}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({14800, 48367, 1, 4}))),
+                                         3,
+                                         std::vector<int>({14800, 48367, 7}))),
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+                             std::vector<int>({14800, 48367, 1, 4}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({14800, 48367}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));      
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_large_tensor_3, roipoint_pool3d_general,
@@ -528,16 +544,18 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(RoiPointPool3dDescParam{14800, 1, 1, 1451001, 1}),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          3, std::vector<int>({14800, 1, 3}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         3, std::vector<int>({14800, 1, 1451001}))),
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 3,
+                             std::vector<int>({14800, 1, 1451001}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          3, std::vector<int>({14800, 1, 7}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({14800, 1, 1, 1451004}))),
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+                             std::vector<int>({14800, 1, 1, 1451004}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({14800, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));            
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
     bad_large_tensor_4, roipoint_pool3d_general,
@@ -549,11 +567,12 @@ INSTANTIATE_TEST_CASE_P(
                                          3, std::vector<int>({14800, 1, 1}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          3, std::vector<int>({14800, 1, 7}))),
-        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
-                                         4, std::vector<int>({14800, 1, 48367, 4}))),
+        testing::Values(
+            MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+                             std::vector<int>({14800, 1, 48367, 4}))),
         testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          2, std::vector<int>({14800, 1}))),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
-        testing::Values(MLUOP_STATUS_NOT_SUPPORTED))); 
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 }  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_general.cpp
@@ -1,0 +1,559 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+#include "core/context.h"
+
+#define LARGE_TENSOR_NUM ((uint64_t)2147483648)
+
+namespace mluopapitest {
+typedef std::tuple<int, int, int, int, int> RoiPointPool3dDescParam;
+typedef std::tuple<RoiPointPool3dDescParam, MLUOpTensorParam,
+                   MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, mluOpDevType_t, mluOpStatus_t>
+    RoiPointPool3dParam;
+class roipoint_pool3d_general
+    : public testing::TestWithParam<RoiPointPool3dParam> {
+ public:
+  void SetUp() {
+    try {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+
+      target_device_ = std::get<6>(GetParam());
+      expected_status_ = std::get<7>(GetParam());
+      if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+            target_device_ == handle_->arch)) {
+        VLOG(4) << "Device does not match, skip testing.";
+        return;
+      }
+      RoiPointPool3dDescParam op_param = std::get<0>(GetParam());
+      std::tie(batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_) = op_param;
+
+      MLUOpTensorParam points_params = std::get<1>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          points_desc_, points_params.get_layout(),
+          points_params.get_dtype(), points_params.get_dim_nb(),
+          points_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(points_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&points_,
+                       mluOpDataTypeBytes(points_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&points_,
+                               mluOpDataTypeBytes(points_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(points_desc_)));
+      }
+
+      MLUOpTensorParam point_features_params = std::get<2>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&point_features_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          point_features_desc_, point_features_params.get_layout(),
+          point_features_params.get_dtype(), point_features_params.get_dim_nb(),
+          point_features_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(point_features_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&point_features_,
+                       mluOpDataTypeBytes(point_features_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&point_features_,
+                       mluOpDataTypeBytes(point_features_params.get_dtype()) *
+                           mluOpGetTensorElementNum(point_features_desc_)));
+      }
+
+      MLUOpTensorParam boxes3d_params = std::get<3>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&boxes3d_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          boxes3d_desc_, boxes3d_params.get_layout(), boxes3d_params.get_dtype(),
+          boxes3d_params.get_dim_nb(), boxes3d_params.get_dim_size().data()));
+
+      if (mluOpGetTensorElementNum(boxes3d_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&boxes3d_,
+                       mluOpDataTypeBytes(boxes3d_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&boxes3d_, mluOpDataTypeBytes(boxes3d_params.get_dtype()) *
+                                    mluOpGetTensorElementNum(boxes3d_desc_)));
+      }
+
+      MLUOpTensorParam pooled_features_params = std::get<4>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_features_desc_, pooled_features_params.get_layout(),
+          pooled_features_params.get_dtype(), pooled_features_params.get_dim_nb(),
+          pooled_features_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(pooled_features_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pooled_features_,
+                       mluOpDataTypeBytes(pooled_features_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&pooled_features_,
+                               mluOpDataTypeBytes(pooled_features_params.get_dtype()) *
+                                   mluOpGetTensorElementNum(pooled_features_desc_)));
+      }
+
+      MLUOpTensorParam pooled_empty_flag_params = std::get<5>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_empty_flag_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_empty_flag_desc_, pooled_empty_flag_params.get_layout(),
+          pooled_empty_flag_params.get_dtype(), pooled_empty_flag_params.get_dim_nb(),
+          pooled_empty_flag_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(pooled_empty_flag_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pooled_empty_flag_,
+                       mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) * 10));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&pooled_empty_flag_,
+                       mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) *
+                           mluOpGetTensorElementNum(pooled_empty_flag_desc_)));
+      }
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in roipoint_pool3d_general.";
+    }
+  }
+
+  bool compute() {
+    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+          target_device_ == handle_->arch)) {
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status;
+    status = mluOpGetRoiPointPool3dWorkspaceSize(
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_, points_desc_, 
+        point_features_desc_, boxes3d_desc_, pooled_features_desc_, pooled_empty_flag_desc_, &workspace_size_);
+    if (status != MLUOP_STATUS_SUCCESS) {
+      destroy();
+      return expected_status_ == status;
+    }
+    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+
+    status = mluOpRoiPointPool3d(
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_,
+        points_desc_, points_, point_features_desc_, point_features_,
+        boxes3d_desc_, boxes3d_, workspace_, workspace_size_, pooled_features_desc_, 
+        pooled_features_, pooled_empty_flag_desc_, pooled_empty_flag_);
+    destroy();
+    return status == expected_status_;
+  }
+
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = NULL;
+    }
+    if (points_desc_) {
+      VLOG(4) << "Destroy points_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(points_desc_));
+      points_desc_ = nullptr;
+    }
+
+    if (points_) {
+      VLOG(4) << "Destroy points_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(points_));
+      points_ = nullptr;
+    }
+
+    if (point_features_desc_) {
+      VLOG(4) << "Destroy point_features_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(point_features_desc_));
+      point_features_desc_ = nullptr;
+    }
+
+    if (point_features_) {
+      VLOG(4) << "Destroy point_features_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point_features_));
+      point_features_ = nullptr;
+    }
+
+    if (boxes3d_desc_) {
+      VLOG(4) << "Destroy boxes3d_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(boxes3d_desc_));
+      boxes3d_desc_ = nullptr;
+    }
+
+    if (boxes3d_) {
+      VLOG(4) << "Destroy boxes3d_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes3d_));
+      boxes3d_ = nullptr;
+    }
+
+    if (pooled_features_desc_) {
+      VLOG(4) << "Destroy pooled_features_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_features_desc_));
+      pooled_features_desc_ = nullptr;
+    }
+
+    if (pooled_features_) {
+      VLOG(4) << "Destroy pooled_features_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+      pooled_features_ = nullptr;
+    }
+
+    if (pooled_empty_flag_desc_) {
+      VLOG(4) << "Destroy pooled_empty_flag_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_empty_flag_desc_));
+      pooled_empty_flag_desc_ = nullptr;
+    }
+
+    if (pooled_empty_flag_) {
+      VLOG(4) << "Destroy pooled_empty_flag_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_empty_flag_));
+      pooled_empty_flag_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  int batch_size_ = 1;
+  int pts_num_ = 1;
+  int boxes_num_ = 1;
+  int feature_in_len_ = 1;
+  int sampled_pts_num_ = 1;
+  mluOpTensorDescriptor_t points_desc_ = nullptr;
+  void *points_ = nullptr;
+  mluOpTensorDescriptor_t point_features_desc_ = nullptr;
+  void *point_features_ = nullptr;
+  mluOpTensorDescriptor_t boxes3d_desc_ = nullptr;
+  void *boxes3d_ = nullptr;
+  mluOpTensorDescriptor_t pooled_features_desc_ = nullptr;
+  void *pooled_features_ = nullptr;
+  void *workspace_ = nullptr;
+  size_t workspace_size_ = 64;
+  mluOpTensorDescriptor_t pooled_empty_flag_desc_ = nullptr;
+  void *pooled_empty_flag_ = nullptr;
+  mluOpDevType_t target_device_ = MLUOP_UNKNOWN_DEVICE;
+  mluOpStatus_t expected_status_ = MLUOP_STATUS_BAD_PARAM;
+};
+
+TEST_P(roipoint_pool3d_general, api_test) {
+  try {
+    EXPECT_TRUE(compute());
+  } catch (const std::exception &e) {
+    FAIL() << "MLUOPAPITEST: catched " << e.what()
+           << " in roipoint_pool3d_general";
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{0, 1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({0, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({0, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({0, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({0, 1, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({0, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 0, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 0, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 0, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_3, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 0, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 0, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 0, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 0}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_4, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 1, 0, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 0}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_5, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 1, 1, 0}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 0, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));        
+
+INSTANTIATE_TEST_CASE_P(
+    bad_points_dtype_dim_shape, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({1, 1, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 2})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 1, 3})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 2, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_point_features_dtype_dim_shape, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({1, 1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 2, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));       
+
+INSTANTIATE_TEST_CASE_P(
+    bad_boxes3d_dtype_dim_shape, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         3, std::vector<int>({1, 1, 7})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({2, 1, 7})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 2, 7})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 5}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));         
+
+INSTANTIATE_TEST_CASE_P(
+    bad_pooled_features_dtype_dim_shape, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         4, std::vector<int>({1, 1, 1, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({2, 1, 1, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 2, 1, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 2, 4})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 1, 2}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));           
+
+INSTANTIATE_TEST_CASE_P(
+    bad_pooled_empty_flag_dtype_dim_shape, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{1, 1, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({1, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({1, 1, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT64,
+                                         2, std::vector<int>({1, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({2, 1})),
+                        MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({1, 2}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_1, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{14800, 48367, 1, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 48367, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 48367, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({14800, 1, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({14800, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_2, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{14800, 1, 48367, 1, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 48367, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({14800, 48367, 1, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({14800, 48367}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));      
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_3, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{14800, 1, 1, 1451001, 1}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 1451001}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({14800, 1, 1, 1451004}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({14800, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));            
+
+INSTANTIATE_TEST_CASE_P(
+    bad_large_tensor_4, roipoint_pool3d_general,
+    testing::Combine(
+        testing::Values(RoiPointPool3dDescParam{14800, 1, 1, 1, 48367}),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 3}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 1}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         3, std::vector<int>({14800, 1, 7}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         4, std::vector<int>({14800, 1, 48367, 4}))),
+        testing::Values(MLUOpTensorParam(MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({14800, 1}))),
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_NOT_SUPPORTED))); 
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_workspace.cpp
@@ -35,14 +35,15 @@ namespace mluopapitest {
 class roipoint_pool3d_workspace : public testing::Test {
  public:
   void setParam(bool handle, bool points_desc, bool point_features_desc,
-  bool boxes3d_desc, bool pooled_features_desc, bool pooled_empty_flag_desc, bool size) {
+                bool boxes3d_desc, bool pooled_features_desc,
+                bool pooled_empty_flag_desc, bool size) {
     if (handle) {
       MLUOP_CHECK(mluOpCreate(&handle_));
     }
 
     if (points_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
-      std::vector<int> points_dims{1,1,3};
+      std::vector<int> points_dims{1, 1, 3};
       MLUOP_CHECK(mluOpSetTensorDescriptor(points_desc_, MLUOP_LAYOUT_ARRAY,
                                            MLUOP_DTYPE_FLOAT, 3,
                                            points_dims.data()));
@@ -50,15 +51,15 @@ class roipoint_pool3d_workspace : public testing::Test {
 
     if (point_features_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&point_features_desc_));
-      std::vector<int> point_features_dims{1,1,2};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(point_features_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, 3,
-                                           point_features_dims.data()));
+      std::vector<int> point_features_dims{1, 1, 2};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          point_features_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 3,
+          point_features_dims.data()));
     }
 
     if (boxes3d_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&boxes3d_desc_));
-      std::vector<int> boxes3d_dims{1,1,7};
+      std::vector<int> boxes3d_dims{1, 1, 7};
       MLUOP_CHECK(mluOpSetTensorDescriptor(boxes3d_desc_, MLUOP_LAYOUT_ARRAY,
                                            MLUOP_DTYPE_FLOAT, 3,
                                            boxes3d_dims.data()));
@@ -66,18 +67,18 @@ class roipoint_pool3d_workspace : public testing::Test {
 
     if (pooled_features_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
-      std::vector<int> pooled_features_dims{1,1,1,5};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_features_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, 4,
-                                           pooled_features_dims.data()));
+      std::vector<int> pooled_features_dims{1, 1, 1, 5};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_features_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 4,
+          pooled_features_dims.data()));
     }
 
     if (pooled_empty_flag_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_empty_flag_desc_));
-      std::vector<int> pooled_empty_flag_dims{1,1};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_empty_flag_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_INT32, 2,
-                                           pooled_empty_flag_dims.data()));
+      std::vector<int> pooled_empty_flag_dims{1, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          pooled_empty_flag_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 2,
+          pooled_empty_flag_dims.data()));
     }
 
     if (size) {
@@ -88,8 +89,9 @@ class roipoint_pool3d_workspace : public testing::Test {
 
   mluOpStatus_t compute() {
     mluOpStatus_t status = mluOpGetRoiPointPool3dWorkspaceSize(
-        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_, points_desc_, 
-        point_features_desc_, boxes3d_desc_, pooled_features_desc_, pooled_empty_flag_desc_, size_);
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_,
+        sampled_pts_num_, points_desc_, point_features_desc_, boxes3d_desc_,
+        pooled_features_desc_, pooled_empty_flag_desc_, size_);
     destroy();
     return status;
   }

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_workspace.cpp
@@ -1,0 +1,216 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+#include "api_test_tools.h"
+#include "core/context.h"
+#include "core/tensor.h"
+#include "core/logging.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+
+namespace mluopapitest {
+class roipoint_pool3d_workspace : public testing::Test {
+ public:
+  void setParam(bool handle, bool points_desc, bool point_features_desc,
+  bool boxes3d_desc, bool pooled_features_desc, bool pooled_empty_flag_desc, bool size) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (points_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&points_desc_));
+      std::vector<int> points_dims{1,1,3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(points_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           points_dims.data()));
+    }
+
+    if (point_features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&point_features_desc_));
+      std::vector<int> point_features_dims{1,1,2};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(point_features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           point_features_dims.data()));
+    }
+
+    if (boxes3d_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&boxes3d_desc_));
+      std::vector<int> boxes3d_dims{1,1,7};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(boxes3d_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 3,
+                                           boxes3d_dims.data()));
+    }
+
+    if (pooled_features_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_features_desc_));
+      std::vector<int> pooled_features_dims{1,1,1,5};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_features_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 4,
+                                           pooled_features_dims.data()));
+    }
+
+    if (pooled_empty_flag_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&pooled_empty_flag_desc_));
+      std::vector<int> pooled_empty_flag_dims{1,1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(pooled_empty_flag_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 2,
+                                           pooled_empty_flag_dims.data()));
+    }
+
+    if (size) {
+      size_t size_temp;
+      size_ = &size_temp;
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpGetRoiPointPool3dWorkspaceSize(
+        handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_, sampled_pts_num_, points_desc_, 
+        point_features_desc_, boxes3d_desc_, pooled_features_desc_, pooled_empty_flag_desc_, size_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+    if (points_desc_) {
+      VLOG(4) << "Destroy points_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(points_desc_));
+      points_desc_ = nullptr;
+    }
+    if (point_features_desc_) {
+      VLOG(4) << "Destroy point_features_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(point_features_desc_));
+      point_features_desc_ = nullptr;
+    }
+    if (boxes3d_desc_) {
+      VLOG(4) << "Destroy boxes3d_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(boxes3d_desc_));
+      boxes3d_desc_ = nullptr;
+    }
+    if (pooled_features_desc_) {
+      VLOG(4) << "Destroy pooled_features_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_features_desc_));
+      pooled_features_desc_ = nullptr;
+    }
+    if (pooled_empty_flag_desc_) {
+      VLOG(4) << "Destroy pooled_empty_flag_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(pooled_empty_flag_desc_));
+      pooled_empty_flag_desc_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  int batch_size_ = 1;
+  int pts_num_ = 1;
+  int boxes_num_ = 1;
+  int feature_in_len_ = 1;
+  int sampled_pts_num_ = 1;
+  mluOpTensorDescriptor_t points_desc_ = nullptr;
+  mluOpTensorDescriptor_t point_features_desc_ = nullptr;
+  mluOpTensorDescriptor_t boxes3d_desc_ = nullptr;
+  mluOpTensorDescriptor_t pooled_features_desc_ = nullptr;
+  mluOpTensorDescriptor_t pooled_empty_flag_desc_ = nullptr;
+  size_t *size_ = nullptr;
+};
+
+TEST_F(roipoint_pool3d_workspace, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d_workspace";
+  }
+}
+
+TEST_F(roipoint_pool3d_workspace, BAD_PARAM_points_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d_workspace";
+  }
+}
+
+TEST_F(roipoint_pool3d_workspace, BAD_PARAM_point_features_desc_null) {
+  try {
+    setParam(true, true, false, true, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d_workspace";
+  }
+}
+
+TEST_F(roipoint_pool3d_workspace, BAD_PARAM_boxes3d_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d_workspace";
+  }
+}
+
+TEST_F(roipoint_pool3d_workspace, BAD_PARAM_pooled_features_desc_null) {
+  try {
+    setParam(true, true, true, true, false, true, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d_workspace";
+  }
+}
+
+TEST_F(roipoint_pool3d_workspace, BAD_PARAM_pooled_empty_flag_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d_workspace";
+  }
+}
+
+TEST_F(roipoint_pool3d_workspace, BAD_PARAM_size_null) {
+  try {
+    setParam(true, true, true, true, true, true, false);
+    EXPECT_TRUE(MLUOP_STATUS_BAD_PARAM == compute());
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in roipoint_pool3d_workspace";
+  }
+}
+}  // namespace mluopapitest


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

添加roipoint_pool3d防呆测例

## 2. Modification
1.roipoint_pool3d.cpp文件：
检查描述符指针：handle、points_desc、 point_features_desc、boxes3d_desc、pooled_features_desc、pooled_empty_flag_desc为空防呆；
检查指针：points、point_features、boxes3d、workspace、pooled_features、pooled_empty_flag为空防呆

2.roipoint_pool3d_workspace.cpp文件：
检查描述符指针：handle、points_desc、 point_features_desc、boxes3d_desc、pooled_features_desc、pooled_empty_flag_desc为空防呆；
检查指针：size为空防呆

3.roipoint_pool3d_general.cpp文件：
对输入输出支持的 dtype、layout 以及 shape 进行防呆
0 元素检查防呆，VLOG(5)打印信息，返回MLUOP_STATUS_BAD_PARAM
large tensor防呆


