### PR TITLE
[Fix](bangc-ops): Fix a host selection error of ms_deform_attn_forward

### DIFF
--- a/bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_forward.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_forward.mlu
@@ -42,17 +42,11 @@ typedef enum {
   MS_DEFORM_ATTN_FORWARD_FAST = 3,
 } MsDeformAttnForwardPolicy;
 
-MsDeformAttnForwardPolicy
-msDeformAttnForwardPolicyFunc(const mluOpHandle_t handle,
-                              cnrtDim3_t *k_dims,
-                              cnrtFunctionType_t *k_type,
-                              const int32_t batch_size,
-                              const int32_t num_keys,
-                              const int32_t num_heads,
-                              const int32_t channels,
-                              const int32_t num_levels,
-                              const int32_t num_queries,
-                              const int32_t num_points) {
+MsDeformAttnForwardPolicy msDeformAttnForwardPolicyFunc(
+    const mluOpHandle_t handle, cnrtDim3_t *k_dims, cnrtFunctionType_t *k_type,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points) {
   // start U1 task
   k_dims->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dims->y =
@@ -62,14 +56,14 @@ msDeformAttnForwardPolicyFunc(const mluOpHandle_t handle,
 
   *k_type = CNRT_FUNC_TYPE_UNION1;
 
-  if (handle->arch >= MLUOP_MLU370 &&
-    num_levels * num_points <= 128 &&
-    num_levels * num_points * channels <= 12288) {
+  if (handle->arch >= MLUOP_MLU370 && num_levels * num_points <= 128 &&
+      num_levels * num_points * channels <= 12288) {
     return MS_DEFORM_ATTN_FORWARD_FAST;
   } else if (num_levels * num_points * 3 * sizeof(int32_t) >
-                 handle->nram_size) {
+             handle->nram_size) {
     return MS_DEFORM_ATTN_FORWARD_DEFAULT;
-  } else if (channels > handle->nram_size / 12 / sizeof(float)) {
+  } else if (channels > handle->nram_size / 12 / sizeof(float) ||
+             channels > 96 || channels < 16) {
     return MS_DEFORM_ATTN_FORWARD_DEFAULT;
   } else {
     return MS_DEFORM_ATTN_FORWARD_SMALL_CHANNEL;
@@ -85,49 +79,48 @@ static mluOpStatus_t paramcheck(
     const mluOpTensorDescriptor_t data_col_desc) {
   // check tensor dim
   // params data_value: [bs, num_keys, num_heads, channels]
-  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
-                 data_value_desc->dim, 4);
+  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]", data_value_desc->dim, 4);
   // params data_spatial_shapes: [num_levels, 2]
-  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
-                 data_spatial_shapes_desc->dim, 2);
+  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]", data_spatial_shapes_desc->dim,
+                 2);
   PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
                  data_spatial_shapes_desc->dims[1], 2);
   // params data_level_start_index: [num_levels]
-  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
-                 data_level_start_index_desc->dim, 1);
+  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]", data_level_start_index_desc->dim,
+                 1);
   // params data_sampling_loc:
   // [bs, num_queries, num_heads, num_levels, num_points, 2]
-  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
-                 data_sampling_loc_desc->dim, 6);
-  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
-                 data_sampling_loc_desc->dims[5], 2);
+  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]", data_sampling_loc_desc->dim, 6);
+  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]", data_sampling_loc_desc->dims[5],
+                 2);
   // params data_attn_weight:
   // [bs, num_queries, num_heads, num_levels, num_points]
-  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
-                 data_attn_weight_desc->dim, 5);
+  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]", data_attn_weight_desc->dim, 5);
   // params data_col: [bs, num_queries, num_heads, channels]
-  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]",
-                 data_col_desc->dim, 4);
+  PARAM_CHECK_EQ("[mluOpMsDeformAttnForward]", data_col_desc->dim, 4);
   // check tensor shape
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               (data_value_desc->dims[0] == data_col_desc->dims[0]) &&
-              (data_sampling_loc_desc->dims[0] == data_col_desc->dims[0]) &&
-              (data_attn_weight_desc->dims[0] == data_col_desc->dims[0]));
+                  (data_sampling_loc_desc->dims[0] == data_col_desc->dims[0]) &&
+                  (data_attn_weight_desc->dims[0] == data_col_desc->dims[0]));
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               (data_value_desc->dims[2] == data_col_desc->dims[2]) &&
-              (data_sampling_loc_desc->dims[2] == data_col_desc->dims[2]) &&
-              (data_attn_weight_desc->dims[2] == data_col_desc->dims[2]));
+                  (data_sampling_loc_desc->dims[2] == data_col_desc->dims[2]) &&
+                  (data_attn_weight_desc->dims[2] == data_col_desc->dims[2]));
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               data_value_desc->dims[3] == data_col_desc->dims[3]);
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
-      (data_spatial_shapes_desc->dims[0] == data_level_start_index_desc->dims[0]) &&    // NOLINT
-      (data_spatial_shapes_desc->dims[0] == data_sampling_loc_desc->dims[3]) &&
-      (data_spatial_shapes_desc->dims[0] == data_attn_weight_desc->dims[3]));
+              (data_spatial_shapes_desc->dims[0] ==
+               data_level_start_index_desc->dims[0]) &&
+                  (data_spatial_shapes_desc->dims[0] ==
+                   data_sampling_loc_desc->dims[3]) &&
+                  (data_spatial_shapes_desc->dims[0] ==
+                   data_attn_weight_desc->dims[3]));
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               (data_sampling_loc_desc->dims[1] == data_col_desc->dims[1]) &&
                   (data_attn_weight_desc->dims[1] == data_col_desc->dims[1]));
-  PARAM_CHECK("[mluOpMsDeformAttnForward]",
-      data_sampling_loc_desc->dims[4] == data_attn_weight_desc->dims[4]);
+  PARAM_CHECK("[mluOpMsDeformAttnForward]", data_sampling_loc_desc->dims[4] ==
+                                                data_attn_weight_desc->dims[4]);
   // check tensor datatype
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               data_value_desc->dtype == MLUOP_DTYPE_FLOAT);
@@ -139,15 +132,13 @@ static mluOpStatus_t paramcheck(
   // data_col datatype must be the same
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               (data_value_desc->dtype == data_col_desc->dtype) &&
-              (data_sampling_loc_desc->dtype == data_col_desc->dtype) &&
-              (data_attn_weight_desc->dtype == data_col_desc->dtype));
+                  (data_sampling_loc_desc->dtype == data_col_desc->dtype) &&
+                  (data_attn_weight_desc->dtype == data_col_desc->dtype));
   return MLUOP_STATUS_SUCCESS;
 }
 
-mluOpStatus_t MLUOP_WIN_API
-mluOpMsDeformAttnForward(
-    mluOpHandle_t handle,
-    const mluOpTensorDescriptor_t data_value_desc,
+mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t data_value_desc,
     const void *data_value,
     const mluOpTensorDescriptor_t data_spatial_shapes_desc,
     const void *data_spatial_shapes,
@@ -156,10 +147,8 @@ mluOpMsDeformAttnForward(
     const mluOpTensorDescriptor_t data_sampling_loc_desc,
     const void *data_sampling_loc,
     const mluOpTensorDescriptor_t data_attn_weight_desc,
-    const void *data_attn_weight,
-    const int32_t im2col_step,
-    const mluOpTensorDescriptor_t data_col_desc,
-    void *data_col) {
+    const void *data_attn_weight, const int32_t im2col_step,
+    const mluOpTensorDescriptor_t data_col_desc, void *data_col) {
   // handle and desc ptr check null
   PARAM_CHECK("[mluOpMsDeformAttnForward]", handle != NULL);
   PARAM_CHECK("[mluOpMsDeformAttnForward]", data_value_desc != NULL);
@@ -170,10 +159,9 @@ mluOpMsDeformAttnForward(
   PARAM_CHECK("[mluOpMsDeformAttnForward]", data_attn_weight_desc != NULL);
   PARAM_CHECK("[mluOpMsDeformAttnForward]", data_col_desc != NULL);
   // check params
-  mluOpStatus_t paramcheck_status =
-      paramcheck(data_value_desc, data_spatial_shapes_desc,
-                 data_level_start_index_desc, data_sampling_loc_desc,
-                 data_attn_weight_desc, data_col_desc);
+  mluOpStatus_t paramcheck_status = paramcheck(
+      data_value_desc, data_spatial_shapes_desc, data_level_start_index_desc,
+      data_sampling_loc_desc, data_attn_weight_desc, data_col_desc);
   if (paramcheck_status != MLUOP_STATUS_SUCCESS) {
     return paramcheck_status;
   }
@@ -182,12 +170,12 @@ mluOpMsDeformAttnForward(
       mluOpGetTensorElementNum(data_sampling_loc_desc);
   size_t data_col_element_num = mluOpGetTensorElementNum(data_col_desc);
   // check large tensor
-  TENSOR_NUM_CHECK("[mluOpMsDeformAttnForward]",
-                   data_value_element_num, LARGE_TENSOR_NUM, "");
-  TENSOR_NUM_CHECK("[mluOpMsDeformAttnForward]",
-                   data_sampling_loc_element_num, LARGE_TENSOR_NUM, "");
-  TENSOR_NUM_CHECK("[mluOpMsDeformAttnForward]",
-                   data_col_element_num, LARGE_TENSOR_NUM, "");
+  TENSOR_NUM_CHECK("[mluOpMsDeformAttnForward]", data_value_element_num,
+                   LARGE_TENSOR_NUM, "");
+  TENSOR_NUM_CHECK("[mluOpMsDeformAttnForward]", data_sampling_loc_element_num,
+                   LARGE_TENSOR_NUM, "");
+  TENSOR_NUM_CHECK("[mluOpMsDeformAttnForward]", data_col_element_num,
+                   LARGE_TENSOR_NUM, "");
   const int32_t batch_size = data_value_desc->dims[0];
   const int32_t num_keys = data_value_desc->dims[1];
   const int32_t num_heads = data_value_desc->dims[2];
@@ -204,9 +192,9 @@ mluOpMsDeformAttnForward(
     VLOG(5) << "mluOpFill_v3 start.";
     const float fill_value = 0.0f;
     PARAM_CHECK("[mluOpMsDeformAttnForward]",
-        MLUOP_STATUS_SUCCESS ==
-            mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST, &fill_value,
-                         data_col_desc, data_col));
+                MLUOP_STATUS_SUCCESS ==
+                    mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST, &fill_value,
+                                 data_col_desc, data_col));
     VLOG(5) << "mluOpFill_v3 end.";
     VLOG(5) << "mluOpMsDeformAttnForward skip zero element.";
     return MLUOP_STATUS_SUCCESS;
@@ -242,15 +230,14 @@ mluOpMsDeformAttnForward(
   }
   cnrtDim3_t k_dims;
   cnrtFunctionType_t k_type;
-  MsDeformAttnForwardPolicy policy =
-      msDeformAttnForwardPolicyFunc(handle, &k_dims, &k_type, batch_size,
-          num_keys, num_heads, channels, num_levels, num_queries, num_points);
+  MsDeformAttnForwardPolicy policy = msDeformAttnForwardPolicyFunc(
+      handle, &k_dims, &k_type, batch_size, num_keys, num_heads, channels,
+      num_levels, num_queries, num_points);
   switch (policy) {
     default: {
       VLOG(5) << "[mluOpMsDeformAttnForward] Policy not supported";
       return MLUOP_STATUS_BAD_PARAM;
-    };
-    break;
+    }; break;
     case MS_DEFORM_ATTN_FORWARD_DEFAULT: {
       switch (k_type) {
         default: {
@@ -258,26 +245,31 @@ mluOpMsDeformAttnForward(
           break;
         }
         case CNRT_FUNC_TYPE_BLOCK: {
-          VLOG(5) <<
-              "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Block, "
+          VLOG(5)
+              << "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Block, "
               << k_dims.x << ", " << k_dims.y << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK(
-              (MLUKernelMsDeformAttnForwardDefault<float><<<k_dims, k_type, handle->queue>>>(        // NOLINT
-                  (char *)data_value, (char *)data_spatial_shapes, (char *)data_level_start_index,   // NOLINT
-                  (char *)data_sampling_loc, (char *)data_attn_weight, batch_size, num_keys,         // NOLINT
-                  num_heads, channels, num_levels, num_queries, num_points, (char *)data_col)));     // NOLINT
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardDefault<float>
+                        <<<k_dims, k_type, handle->queue>>>(
+                            (char *)data_value, (char *)data_spatial_shapes,
+                            (char *)data_level_start_index,
+                            (char *)data_sampling_loc, (char *)data_attn_weight,
+                            batch_size, num_keys,
+                            num_heads, channels, num_levels, num_queries,
+                            num_points, (char *)data_col)));
           break;
         }
         case CNRT_FUNC_TYPE_UNION1: {
-          VLOG(5) <<
-              "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Union"
-                  << k_type / CORE_DIM << ", " << k_dims.x << ", "
-                  << k_dims.y << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK(
-              (MLUKernelMsDeformAttnForwardDefault<float><<<k_dims, k_type, handle->queue>>>(        // NOLINT
-                  (char *)data_value, (char *)data_spatial_shapes, (char *)data_level_start_index,   // NOLINT
-                  (char *)data_sampling_loc, (char *)data_attn_weight, batch_size, num_keys,         // NOLINT
-                  num_heads, channels, num_levels, num_queries, num_points, (char *)data_col)));     // NOLINT
+          VLOG(5) << "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Union"
+                  << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
+                  << ", " << k_dims.z << ">>>";
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardDefault<float>
+                        <<<k_dims, k_type, handle->queue>>>(
+                            (char *)data_value, (char *)data_spatial_shapes,
+                            (char *)data_level_start_index,
+                            (char *)data_sampling_loc, (char *)data_attn_weight,
+                            batch_size, num_keys,
+                            num_heads, channels, num_levels, num_queries,
+                            num_points, (char *)data_col)));
           break;
         }
       }
@@ -290,26 +282,33 @@ mluOpMsDeformAttnForward(
           break;
         }
         case CNRT_FUNC_TYPE_BLOCK: {
-          VLOG(5) <<
-              "Launch Kernel MLUKernelMsDeformAttnForwardSmallChannel<<<Block, "                      // NOLINT
+          VLOG(5)
+              << "Launch Kernel "
+                 "MLUKernelMsDeformAttnForwardSmallChannel<<<Block, "
               << k_dims.x << ", " << k_dims.y << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK(
-              (MLUKernelMsDeformAttnForwardSmallChannel<float><<<k_dims, k_type, handle->queue>>>(    // NOLINT
-                  (char *)data_value, (char *)data_spatial_shapes, (char *)data_level_start_index,    // NOLINT
-                  (char *)data_sampling_loc, (char *)data_attn_weight, batch_size, num_keys,          // NOLINT
-                  num_heads, channels, num_levels, num_queries, num_points, (char *)data_col)));      // NOLINT
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardSmallChannel<float>
+                        <<<k_dims, k_type, handle->queue>>>(
+                            (char *)data_value, (char *)data_spatial_shapes,
+                            (char *)data_level_start_index,
+                            (char *)data_sampling_loc, (char *)data_attn_weight,
+                            batch_size, num_keys,
+                            num_heads, channels, num_levels, num_queries,
+                            num_points, (char *)data_col)));
           break;
         }
         case CNRT_FUNC_TYPE_UNION1: {
-          VLOG(5) <<
-              "Launch Kernel MLUKernelMsDeformAttnForwardSmallChannel<<<Union"
-               << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
-               << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK(
-              (MLUKernelMsDeformAttnForwardSmallChannel<float><<<k_dims, k_type, handle->queue>>>(    // NOLINT
-                  (char *)data_value, (char *)data_spatial_shapes, (char *)data_level_start_index,    // NOLINT
-                  (char *)data_sampling_loc, (char *)data_attn_weight, batch_size, num_keys,          // NOLINT
-                  num_heads, channels, num_levels, num_queries, num_points, (char *)data_col)));      // NOLINT
+          VLOG(5) << "Launch Kernel "
+                     "MLUKernelMsDeformAttnForwardSmallChannel<<<Union"
+                  << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
+                  << ", " << k_dims.z << ">>>";
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardSmallChannel<float>
+                        <<<k_dims, k_type, handle->queue>>>(
+                            (char *)data_value, (char *)data_spatial_shapes,
+                            (char *)data_level_start_index,
+                            (char *)data_sampling_loc, (char *)data_attn_weight,
+                            batch_size, num_keys,
+                            num_heads, channels, num_levels, num_queries,
+                            num_points, (char *)data_col)));
           break;
         }
       }
@@ -319,13 +318,17 @@ mluOpMsDeformAttnForward(
       VLOG(5) << "Launch Kernel MLUKernelMsDeformAttnForwardFast<<<Union"
               << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
               << ", " << k_dims.z << ">>>";
-      KERNEL_CHECK(
-          (MLUKernelMsDeformAttnForwardFast<float><<<k_dims, k_type, handle->queue>>>(                // NOLINT
-                  (char *)data_value, (char *)data_spatial_shapes, (char *)data_level_start_index,    // NOLINT
-                  (char *)data_sampling_loc, (char *)data_attn_weight, batch_size, num_keys,          // NOLINT
-                  num_heads, channels, num_levels, num_queries, num_points, (char *)data_col)));      // NOLINT
+      KERNEL_CHECK((MLUKernelMsDeformAttnForwardFast<float>
+                    <<<k_dims, k_type, handle->queue>>>(
+                        (char *)data_value, (char *)data_spatial_shapes,
+                        (char *)data_level_start_index,
+                        (char *)data_sampling_loc, (char *)data_attn_weight,
+                        batch_size, num_keys,
+                        num_heads, channels, num_levels, num_queries,
+                        num_points, (char *)data_col)));
       break;
     }
-  }  GEN_CASE_END();
+  }
+  GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }

--- a/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -845,7 +845,7 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
     int32_t attn_weight_base_offset =
         b * input_stride_4 + head_idx * input_stride_2;
 
-    if (sram_stay && coreId == MEMCORE_FLAG) {
+    if (sram_stay && __is_mpu()) {
       loadDataValueGdram2Sram(value_sram, (T*)data_value_gdram, b, head_idx,
                               num_keys, num_heads, channels);
     }

--- a/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -26,7 +26,7 @@
 
 #pragma bang walign(64)
 
-#if (__BANG_ARCH__ >= 370)
+#if (__BANG_ARCH__ >= 372)
 
 #define MEMCORE_FLAG (0x80)
 #define BIT_COLLECT_PAD (8)
@@ -207,12 +207,12 @@ __mlu_func__ void getConditionCoordWeight(
   T* cond_point_polation_nram_cond4 = weight_polation_nram + 3 * total_points;
   __bang_ge_scalar(cond_point_polation_nram_cond1, buf_x_floor, (T)0,
                    total_points);
-  __bang_cycle_lt(cond_point_polation_nram_cond2, buf_x_ceil,
-                  spatial_w_bd_nram, total_points, block_points);
+  __bang_cycle_lt(cond_point_polation_nram_cond2, buf_x_ceil, spatial_w_bd_nram,
+                  total_points, block_points);
   __bang_ge_scalar(cond_point_polation_nram_cond3, buf_y_floor, (T)0,
                    total_points);
-  __bang_cycle_lt(cond_point_polation_nram_cond4, buf_y_ceil,
-                  spatial_h_bd_nram, total_points, block_points);
+  __bang_cycle_lt(cond_point_polation_nram_cond4, buf_y_ceil, spatial_h_bd_nram,
+                  total_points, block_points);
   __bang_and(cond_point_polation_nram_tl, cond_point_polation_nram_cond1,
              cond_point_polation_nram_cond4, total_points);
   __bang_and(cond_point_polation_nram_bl, cond_point_polation_nram_cond1,
@@ -305,8 +305,7 @@ __mlu_func__ void getConditionCoordWeight(
   __bang_band((char*)weight_polation_nram_tmp, (char*)weight_polation_nram,
               (char*)cond_point_polation_nram,
               total_points * 4 * sizeof(float));
-  __bang_collect((float*)weight_polation_nram,
-                 (float*)weight_polation_nram_tmp,
+  __bang_collect((float*)weight_polation_nram, (float*)weight_polation_nram_tmp,
                  cond_point_valid_nram, total_points);
   __bang_collect((float*)weight_polation_nram + total_points,
                  (float*)weight_polation_nram_tmp + total_points,
@@ -416,16 +415,16 @@ __mlu_func__ void reduceLevelByConv(
 
     if (w_contain_inf) {
       __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
-      __bang_sumpool(input_pooled, input_trans, valid_num, channels,
-                     4, 1, 4, 1, 1);
+      __bang_sumpool(input_pooled, input_trans, valid_num, channels, 4, 1, 4, 1,
+                     1);
       __bang_cycle_mul(input_pooled, input_pooled, weight_attn_nram,
                        channels * valid_num, valid_num);
       __bang_sumpool(output_nram, input_pooled, 1, channels, valid_num, 1,
                      valid_num, 1, 1);
     } else {
       tileWeight2WramSync(input_wram, input_trans, co, ci, pad_co, pad_ci);
-      __bang_conv(output_nram, weight_compute, input_wram, ci,
-                  1, 1, 1, 1, 1, 1, co);
+      __bang_conv(output_nram, weight_compute, input_wram, ci, 1, 1, 1, 1, 1, 1,
+                  co);
     }
 
   } else {
@@ -486,16 +485,16 @@ __mlu_func__ void loadDataValueXram2NramAsync(
     next = j + 2;
     __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
                    (int8_t*)value_src + offset_1_a, channel_size, DIR,
-                   2 * data_value_stride, 1, data_value_stride, 1,
-                   stride_3_1_a, 1, stride_2_1_a, 1);
+                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
+                   1, stride_2_1_a, 1);
 
     loadNram2Gpr(offset_1_a, stride_2_1_a, stride_3_1_a, offset_1 + next,
                  stride_2_1 + next, stride_3_1 + next);
 
     __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size,
                    (int8_t*)value_src + offset_1_b, channel_size, DIR,
-                   2 * data_value_stride, 1, data_value_stride, 1,
-                   stride_3_1_b, 1, stride_2_1_b, 1);
+                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_b,
+                   1, stride_2_1_b, 1);
 
     loadNram2Gpr(offset_1_b, stride_2_1_b, stride_3_1_b, offset_1 + next + 1,
                  stride_2_1 + next + 1, stride_3_1 + next + 1);
@@ -505,8 +504,8 @@ __mlu_func__ void loadDataValueXram2NramAsync(
     value_offset = loop_num * 2 * channel_size;
     __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
                    (int8_t*)value_src + offset_1_a, channel_size, DIR,
-                   2 * data_value_stride, 1, data_value_stride, 1,
-                   stride_3_1_a, 1, stride_2_1_a, 1);
+                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
+                   1, stride_2_1_a, 1);
   }
 }
 
@@ -527,8 +526,8 @@ __mlu_func__ void countValidSamples(int32_t* sample_valid_count,
   int32_t pad_co = PAD_UP(co, LT_NUM);
   tileWeight2WramSync(wram_buffer, cond_point_valid_nram, co, ci, pad_co,
                       pad_ci);
-  __bang_conv((T*)sample_valid_count, nram_ones, wram_buffer, ci,
-              1, 1, 1, 1, 1, 1, co);
+  __bang_conv((T*)sample_valid_count, nram_ones, wram_buffer, ci, 1, 1, 1, 1, 1,
+              1, co);
   __bang_float2int32(sample_valid_count, (T*)sample_valid_count, deal_n, 0);
 }
 
@@ -607,15 +606,14 @@ __mlu_func__ void broadcastSpatialHW(
            num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
            num_levels - 1);
   __memcpy(spatial_w_bd_nram, (float*)spatial_shapes_nram + 1, sizeof(float),
-           NRAM2NRAM, sizeof(float), num_points - 1,
-           num_points * sizeof(float), num_levels - 1, 0,
-           num_points - 1, 2 * sizeof(float), num_levels - 1);
+           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
+           num_levels - 1);
   __bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
                      num_levels, 0);
   __memcpy(spatial_offset_bd_nram, spatial_offset_nram, sizeof(float),
-           NRAM2NRAM, sizeof(float), num_points - 1,
-           num_points * sizeof(float), num_levels - 1, 0, num_points - 1,
-           sizeof(float), num_levels - 1);
+           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, sizeof(float), num_levels - 1);
 }
 
 template <typename T>
@@ -626,8 +624,7 @@ __mlu_func__ void prepareLoop(
     const char* data_level_start_index_gdram,
     const char* data_spatial_shapes_gdram, const int32_t num_keys,
     const int32_t num_levels, const int32_t num_points,
-    const int32_t max_deal_n, const int32_t mask_size,
-    const int32_t channels) {
+    const int32_t max_deal_n, const int32_t mask_size, const int32_t channels) {
   int32_t pad_num_points_levels =
       PAD_UP(num_levels * num_points, WRAM_ALIGN_SIZE / sizeof(T));
   __bang_write_value(ones_nram, pad_num_points_levels, (T)0);
@@ -656,10 +653,9 @@ __mlu_func__ void loadDataValueGdram2Sram(T* value_sram, T* data_value_gdram,
   for (int32_t i = 0; i < loop_num; i++) {
     int32_t load_num =
         __mluop_min(MAX_MEMCPY_SEGNUM, num_keys - i * MAX_MEMCPY_SEGNUM);
-    size_t src_offset =
-        ((size_t)batch_idx * num_keys + i * MAX_MEMCPY_SEGNUM) *
-            num_heads_channels +
-        head_idx * channels;
+    size_t src_offset = ((size_t)batch_idx * num_keys + i * MAX_MEMCPY_SEGNUM) *
+                            num_heads_channels +
+                        head_idx * channels;
     int32_t dst_offset = i * MAX_MEMCPY_SEGNUM * channels;
     __memcpy(value_sram + dst_offset, (T*)data_value_gdram + src_offset,
              channels * sizeof(T), GDRAM2SRAM, channels * sizeof(T),
@@ -812,9 +808,8 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
   int32_t batch_head = batch_size * num_heads;
   int32_t cluster_avg_batch_head = (batch_head + taskDimY - 1) / taskDimY;
   int32_t cluster_begin_batch_head = taskIdY * cluster_avg_batch_head;
-  int32_t cluster_act_batch_head =
-      __mluop_min(cluster_avg_batch_head,
-                  batch_head - cluster_begin_batch_head);
+  int32_t cluster_act_batch_head = __mluop_min(
+      cluster_avg_batch_head, batch_head - cluster_begin_batch_head);
   int32_t cluster_end_batch_head =
       cluster_begin_batch_head + cluster_act_batch_head;
   // split query into coreDim
@@ -950,7 +945,7 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardFast(
     const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
     const int32_t channels, const int32_t num_levels, const int32_t num_queries,
     const int32_t num_points, char* data_col_gdram) {
-#if (__BANG_ARCH__ >= 370 && __BANG_ARCH__ != 520)
+#if (__BANG_ARCH__ >= 372)
   size_t single_value_size = num_keys * channels * sizeof(T);
   if (single_value_size <= SRAM_FOR_VALUE_SIZE) {
     MLUKernelMsDeformAttnForwardFastImpl<float, 0>(

--- a/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_small_channel_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_small_channel_union1.mlu
@@ -28,46 +28,40 @@
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
 __mlu_func__ void genMask0101(float *mask_ram, int32_t size) {
+#if __BANG_ARCH__ >= 372
   int32_t align_num = NFU_ALIGN_SIZE / sizeof(float);
   for (int32_t i = 0; i < align_num; ++i) {
     mask_ram[i] = i % 2;
   }
-  __asm__ volatile("sync;");
+  __sync();
   __memcpy(mask_ram + align_num, mask_ram, NFU_ALIGN_SIZE, NRAM2NRAM,
            NFU_ALIGN_SIZE, 0, size / align_num - 2);
-  __asm__ volatile("sync;");
+  __sync();
+#endif
 }
 
 template <typename T>
 __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
-    const char *data_value_gdram,
-    const char *data_spatial_shapes_gdram,
+    const char *data_value_gdram, const char *data_spatial_shapes_gdram,
     const char *data_level_start_index_gdram,
-    const char *data_sampling_loc_gdram,
-    const char *data_attn_weight_gdram,
-    const int32_t batch_size,
-    const int32_t num_keys,
-    const int32_t num_heads,
-    const int32_t channels,
-    const int32_t num_levels,
-    const int32_t num_queries,
-    const int32_t num_points,
-    char *data_col_gdram) {
-  if (coreId == 0x80) {
+    const char *data_sampling_loc_gdram, const char *data_attn_weight_gdram,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points, char *data_col_gdram) {
+#if __BANG_ARCH__ >= 372
+  if (__is_mpu()) {
     return;
   }
   size_t block_num_per_core = 0, batch_start = 0, deal_g = 0, offset_g = 0;
   size_t block_num_rem = 0;
-  const size_t grid_total =
-      num_queries * num_heads * num_levels * num_points;
+  const size_t grid_total = num_queries * num_heads * num_levels * num_points;
   if (batch_size >= taskDim) {
     block_num_rem = batch_size % taskDim;
-    block_num_per_core =
-        taskId < block_num_rem ? batch_size / taskDim + 1 :
-                                 batch_size / taskDim;
-    batch_start =
-        taskId < block_num_rem ? taskId * block_num_per_core :
-                                 taskId * block_num_per_core + block_num_rem;
+    block_num_per_core = taskId < block_num_rem ? batch_size / taskDim + 1
+                                                : batch_size / taskDim;
+    batch_start = taskId < block_num_rem
+                      ? taskId * block_num_per_core
+                      : taskId * block_num_per_core + block_num_rem;
     deal_g = grid_total;
     offset_g = 0;
   } else {
@@ -89,9 +83,8 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
   int32_t channel = channels;
   int32_t mult;
   while (true) {
-    deal_num =
-        (MAX_NRAM_SIZE - spatial_size - level_start_index_size) /
-            (8 * channel + 7) / sizeof(T);
+    deal_num = (MAX_NRAM_SIZE - spatial_size - level_start_index_size) /
+               (8 * channel + 7) / sizeof(T);
     deal_num = PAD_DOWN(deal_num, float_align);
     deal_num = PAD_DOWN(deal_num, num_levels * num_points);
     if (deal_num > 0) {
@@ -148,7 +141,7 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
                  num_levels * 2 * sizeof(int32_t), GDRAM2NRAM);
   __memcpy_async(data_level_start_index_nram, data_level_start_index_gdram,
                  num_levels * sizeof(int32_t), GDRAM2NRAM);
-  __asm__ volatile("sync;");
+  __sync();
   for (int32_t batch_idx = batch_start;
        batch_idx < batch_start + block_num_per_core; ++batch_idx) {
     for (int32_t grid_iter = 0; grid_iter <= g_rep; ++grid_iter) {
@@ -162,30 +155,28 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
           io_data_num = g_rem;
         }
       }
-      char *data_col_gdram_start = data_col_gdram +
-          (batch_idx * num_queries * num_heads * channels +
-           (offset_g + grid_iter * deal_num) /
-               (num_levels * num_points) * channels) *
-              sizeof(float);
+      char *data_col_gdram_start =
+          data_col_gdram + (batch_idx * num_queries * num_heads * channels +
+                            (offset_g + grid_iter * deal_num) /
+                                (num_levels * num_points) * channels) *
+                               sizeof(float);
       // load data_sampling_loc
-      __memcpy_async(grid_ram, data_sampling_loc_gdram +
-                               grid_off_base * 2 * sizeof(float),
-                     io_data_num * 2 * sizeof(float), GDRAM2NRAM);
+      __memcpy_async(
+          grid_ram, data_sampling_loc_gdram + grid_off_base * 2 * sizeof(float),
+          io_data_num * 2 * sizeof(float), GDRAM2NRAM);
       genMask0101((float *)mask_ram, deal_num * 2);
-      __asm__ volatile("sync;");
+      __sync();
       // generate x and y coordinate vector
       // generate spatial_x and spatial_y spatial vector
-      __bang_collect((float *)coord_y, (float *)grid_ram,
-                     (float *)mask_ram, deal_num * 2);  // y
-      __bang_collect((float *)spatial_x_temp,
-                     (float *)data_spatial_shapes_nram,
+      __bang_collect((float *)coord_y, (float *)grid_ram, (float *)mask_ram,
+                     deal_num * 2);  // y
+      __bang_collect((float *)spatial_x_temp, (float *)data_spatial_shapes_nram,
                      (float *)mask_ram,
                      num_levels * 2);  // spatial_x
       __bang_not((float *)mask_ram, (float *)mask_ram, deal_num * 2);
-      __bang_collect((float *)coord_x, (float *)grid_ram,
-                     (float *)mask_ram, deal_num * 2);  // x
-      __bang_collect((float *)spatial_y_temp,
-                     (float *)data_spatial_shapes_nram,
+      __bang_collect((float *)coord_x, (float *)grid_ram, (float *)mask_ram,
+                     deal_num * 2);  // x
+      __bang_collect((float *)spatial_y_temp, (float *)data_spatial_shapes_nram,
                      (float *)mask_ram,
                      num_levels * 2);  // spatial_y
       for (int32_t i = 0; i < num_levels; i++) {
@@ -201,32 +192,31 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
       /*
         map x from [0, 1] to [0, spatial_x];
         map y from [0, 1] to [0, spatial_y]
-      */ 
+      */
       __bang_cycle_mul((float *)coord_x, (float *)coord_x,
                        (float *)spatial_x_float, deal_num,
                        num_levels * num_points);
-      __bang_sub_scalar((float *)coord_x, (float *)coord_x,
-                        (float)0.5, deal_num);
+      __bang_sub_scalar((float *)coord_x, (float *)coord_x, (float)0.5,
+                        deal_num);
       __bang_cycle_mul((float *)coord_y, (float *)coord_y,
                        (float *)spatial_y_float, deal_num,
                        num_levels * num_points);
-      __bang_sub_scalar((float *)coord_y, (float *)coord_y,
-                        (float)0.5, deal_num);
+      __bang_sub_scalar((float *)coord_y, (float *)coord_y, (float)0.5,
+                        deal_num);
       __bang_floor((float *)coord_x_low, (float *)coord_x, deal_num);
       __bang_floor((float *)coord_y_low, (float *)coord_y, deal_num);
       // calc index_tl
       const int32_t w_stride = num_heads * channels;
-      __bang_float2int32_rd((int32_t *)coord_x_low_int,
-                            (float *)coord_x_low, deal_num, 0);
-      __bang_float2int32_rd((int32_t *)coord_y_low_int,
-                            (float *)coord_y_low, deal_num, 0);
+      __bang_float2int32_rd((int32_t *)coord_x_low_int, (float *)coord_x_low,
+                            deal_num, 0);
+      __bang_float2int32_rd((int32_t *)coord_y_low_int, (float *)coord_y_low,
+                            deal_num, 0);
       __bang_cycle_mul((int32_t *)index_tl, (int32_t *)coord_y_low_int,
-                       (int32_t *)spatial_x, deal_num,
-                       num_levels * num_points);
+                       (int32_t *)spatial_x, deal_num, num_levels * num_points);
       __bang_add((int32_t *)index_tl, (int32_t *)index_tl,
                  (int32_t *)coord_x_low_int, deal_num);
-      __bang_mul_scalar((int32_t *)index_tl, (int32_t *)index_tl,
-                        w_stride, deal_num);
+      __bang_mul_scalar((int32_t *)index_tl, (int32_t *)index_tl, w_stride,
+                        deal_num);
 #if MS_DEFORM_ATTN_FORWARD_HEADVECTOR
       const int32_t deal_lp_num = deal_num / (num_levels * num_points);
       const int32_t h_rep = deal_lp_num / num_heads;
@@ -240,26 +230,24 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
       }
       if (h_rep > 0) {
         __memcpy((int32_t *)base_ptr_offset + num_heads,
-                 (int32_t *)base_ptr_offset,
-                 num_heads * sizeof(int32_t), NRAM2NRAM,
-                 num_heads * sizeof(int32_t), 0,
-                 h_rep - 1);
+                 (int32_t *)base_ptr_offset, num_heads * sizeof(int32_t),
+                 NRAM2NRAM, num_heads * sizeof(int32_t), 0, h_rep - 1);
       }
       if (h_rep > 0 && h_rem > 0) {
         __memcpy((int32_t *)base_ptr_offset + h_rep * num_heads,
-                 (int32_t *)base_ptr_offset,
-                 h_rem * sizeof(int32_t), NRAM2NRAM);
+                 (int32_t *)base_ptr_offset, h_rem * sizeof(int32_t),
+                 NRAM2NRAM);
       }
-      __bang_transpose((int32_t *)auxiliary_a, (int32_t *)index_tl,
-                       deal_lp_num, num_levels * num_points);
+      __bang_transpose((int32_t *)auxiliary_a, (int32_t *)index_tl, deal_lp_num,
+                       num_levels * num_points);
       __bang_cycle_add((int32_t *)auxiliary_a, (int32_t *)auxiliary_a,
                        (int32_t *)base_ptr_offset, deal_num, deal_lp_num);
       __bang_transpose((int32_t *)index_tl, (int32_t *)auxiliary_a,
                        num_levels * num_points, deal_lp_num);
 #endif
       // calc index_bl
-      __bang_mul_scalar((int32_t *)auxiliary_a, (int32_t *)spatial_x,
-                        w_stride, deal_num);
+      __bang_mul_scalar((int32_t *)auxiliary_a, (int32_t *)spatial_x, w_stride,
+                        deal_num);
       __bang_cycle_add((int32_t *)index_bl, (int32_t *)index_tl,
                        (int32_t *)auxiliary_a, deal_num,
                        num_levels * num_points);
@@ -270,83 +258,83 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
                         (float)1.0, deal_num);
       // mask_tl :
       // 0 <= coord_x_low < spatial_x && 0 <= coord_y_low < spatial_y
-      __bang_ge_scalar((float *)mask_bl, (float *)coord_x_low,
-                       (float)0, deal_num);
+      __bang_ge_scalar((float *)mask_bl, (float *)coord_x_low, (float)0,
+                       deal_num);
       __bang_cycle_le((float *)mask_br, (float *)coord_x_low,
                       (float *)spatial_x_float, deal_num,
                       num_levels * num_points);
-      __bang_and((float *)mask_bl, (float *)mask_bl,
-                 (float *)mask_br, deal_num);
-      __bang_ge_scalar((float *)mask_tr, (float *)coord_y_low,
-                       (float)0, deal_num);
+      __bang_and((float *)mask_bl, (float *)mask_bl, (float *)mask_br,
+                 deal_num);
+      __bang_ge_scalar((float *)mask_tr, (float *)coord_y_low, (float)0,
+                       deal_num);
       __bang_cycle_le((float *)mask_br, (float *)coord_y_low,
                       (float *)spatial_y_float, deal_num,
                       num_levels * num_points);
-      __bang_and((float *)mask_tr, (float *)mask_tr,
-                 (float *)mask_br, deal_num);
-      __bang_and((float *)mask_tl, (float *)mask_tr,
-                 (float *)mask_bl, deal_num);
+      __bang_and((float *)mask_tr, (float *)mask_tr, (float *)mask_br,
+                 deal_num);
+      __bang_and((float *)mask_tl, (float *)mask_tr, (float *)mask_bl,
+                 deal_num);
       // mask_tr :
       // 0 <= coord_x_high < spatial_x && 0 <= coord_y_low < spatial_y
-      __bang_ge_scalar((float *)mask_br, (float *)coord_x_low,
-                       (float)(-1.0), deal_num);
+      __bang_ge_scalar((float *)mask_br, (float *)coord_x_low, (float)(-1.0),
+                       deal_num);
       __bang_cycle_lt((float *)auxiliary_a, (float *)coord_x_low,
-                      (float *)spatial_x_float,
-                      deal_num, num_levels * num_points);
-      __bang_and((float *)mask_br, (float *)mask_br,
-                 (float *)auxiliary_a, deal_num);
-      __bang_and((float *)mask_tr, (float *)mask_tr,
-                 (float *)mask_br, deal_num);
+                      (float *)spatial_x_float, deal_num,
+                      num_levels * num_points);
+      __bang_and((float *)mask_br, (float *)mask_br, (float *)auxiliary_a,
+                 deal_num);
+      __bang_and((float *)mask_tr, (float *)mask_tr, (float *)mask_br,
+                 deal_num);
       // mask_bl :
       // 0 <= coord_x_low < spatial_x && 0 <= coord_y_high < spatial_y
       __bang_ge_scalar((float *)auxiliary_a, (float *)coord_y_low,
                        (float)(-1.0), deal_num);
       __bang_cycle_lt((float *)auxiliary_b, (float *)coord_y_low,
-                      (float *)spatial_y_float,
-                      deal_num, num_levels * num_points);
+                      (float *)spatial_y_float, deal_num,
+                      num_levels * num_points);
       __bang_and((float *)auxiliary_a, (float *)auxiliary_a,
                  (float *)auxiliary_b, deal_num);
-      __bang_and((float *)mask_bl, (float *)mask_bl,
-                 (float *)auxiliary_a, deal_num);
+      __bang_and((float *)mask_bl, (float *)mask_bl, (float *)auxiliary_a,
+                 deal_num);
       // mask_br :
       // 0 <= coord_x_high < spatial_x && 0 <= coord_y_high < spatial_y
-      __bang_and((float *)mask_br, (float *)mask_br,
-                 (float *)auxiliary_a, deal_num);
+      __bang_and((float *)mask_br, (float *)mask_br, (float *)auxiliary_a,
+                 deal_num);
       // calc inner point num
-      __bang_mul_scalar((float *)weight_tl, (float *)mask_tl,
-                        (float)7.0, deal_num);
-      __bang_mul_scalar((float *)weight_tr, (float *)mask_tr,
-                        (float)5.0, deal_num);
-      __bang_add((float *)weight_tl, (float *)weight_tl,
-                 (float *)weight_tr, deal_num);
-      __bang_mul_scalar((float *)weight_tr, (float *)mask_bl,
-                        (float)3.0, deal_num);
-      __bang_add((float *)point_ram, (float *)weight_tr,
-                 (float *)mask_br, deal_num);
-      __bang_add((float *)point_ram, (float *)point_ram,
-                 (float *)weight_tl, deal_num);
+      __bang_mul_scalar((float *)weight_tl, (float *)mask_tl, (float)7.0,
+                        deal_num);
+      __bang_mul_scalar((float *)weight_tr, (float *)mask_tr, (float)5.0,
+                        deal_num);
+      __bang_add((float *)weight_tl, (float *)weight_tl, (float *)weight_tr,
+                 deal_num);
+      __bang_mul_scalar((float *)weight_tr, (float *)mask_bl, (float)3.0,
+                        deal_num);
+      __bang_add((float *)point_ram, (float *)weight_tr, (float *)mask_br,
+                 deal_num);
+      __bang_add((float *)point_ram, (float *)point_ram, (float *)weight_tl,
+                 deal_num);
       // calc interpolation weight
-      __bang_sub((float *)weight_bl, (float *)coord_x_low,
-                 (float *)coord_x, deal_num);
-      __bang_sub((float *)weight_br, (float *)coord_y_low,
-                 (float *)coord_y, deal_num);
-      __bang_add_scalar((float *)weight_bl, (float *)weight_bl,
-                        (float)1.0, deal_num);
-      __bang_add_scalar((float *)weight_br, (float *)weight_br,
-                        (float)1.0, deal_num);
-      __bang_sub((float *)weight_tl, (float *)coord_x,
-                 (float *)coord_x_low, deal_num);
-      __bang_sub((float *)weight_tr, (float *)coord_y,
-                 (float *)coord_y_low, deal_num);
-      __bang_mul((float *)input_tl, (float *)weight_bl,
-                 (float *)weight_br, deal_num);
+      __bang_sub((float *)weight_bl, (float *)coord_x_low, (float *)coord_x,
+                 deal_num);
+      __bang_sub((float *)weight_br, (float *)coord_y_low, (float *)coord_y,
+                 deal_num);
+      __bang_add_scalar((float *)weight_bl, (float *)weight_bl, (float)1.0,
+                        deal_num);
+      __bang_add_scalar((float *)weight_br, (float *)weight_br, (float)1.0,
+                        deal_num);
+      __bang_sub((float *)weight_tl, (float *)coord_x, (float *)coord_x_low,
+                 deal_num);
+      __bang_sub((float *)weight_tr, (float *)coord_y, (float *)coord_y_low,
+                 deal_num);
+      __bang_mul((float *)input_tl, (float *)weight_bl, (float *)weight_br,
+                 deal_num);
       __bang_mul((float *)input_tl + deal_num, (float *)weight_br,
                  (float *)weight_tl, deal_num);
       __bang_mul((float *)input_tl + 2 * deal_num, (float *)weight_bl,
                  (float *)weight_tr, deal_num);
       __bang_mul((float *)input_tl + 3 * deal_num, (float *)weight_tl,
                  (float *)weight_tr, deal_num);
-      __asm__ volatile("sync;");
+      __sync();
       // extend weight
       const int32_t w_rep = channel / ELE_COUNT * ELE_COUNT;
       const int32_t w_rem = channel % ELE_COUNT;
@@ -354,9 +342,8 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
         const int32_t data_sz = 1 * sizeof(float);
         const int32_t dst_str = channel * sizeof(float);
         for (int32_t iter = w_rep; iter < channel; ++iter) {
-          __memcpy_async((float *)weight_tl + iter, (float *)input_tl,
-                         data_sz, NRAM2NRAM, dst_str, data_sz,
-                         4 * deal_num - 1);
+          __memcpy_async((float *)weight_tl + iter, (float *)input_tl, data_sz,
+                         NRAM2NRAM, dst_str, data_sz, 4 * deal_num - 1);
         }
       }
       if (w_rep != 0) {
@@ -365,10 +352,10 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
                              ((float *)input_tl)[i]);
         }
       }
-      __asm__ volatile("sync;");
+      __sync();
       const char *data_value_gdram_start =
           data_value_gdram +
-              batch_idx * num_keys * num_heads * channels * sizeof(float);
+          batch_idx * num_keys * num_heads * channels * sizeof(float);
       const int32_t c_str = deal_num * channel * sizeof(float);
       const int32_t cs_str = num_heads * channels * sizeof(float);
       for (int32_t c_iter = 0; c_iter <= c_rep; ++c_iter) {
@@ -381,100 +368,98 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
           }
         }
         __bang_write_zero((float *)input_tl, 4 * deal_num * channel);
-        __asm__ volatile("sync;");
+        __sync();
         // load data_value
         for (int32_t p_idx = 0; p_idx < io_data_num; ++p_idx) {
-          const int32_t inner_point_num =
-              (int32_t)((float *)point_ram)[p_idx];
+          const int32_t inner_point_num = (int32_t)((float *)point_ram)[p_idx];
           const int32_t tl_offset = ((int32_t *)index_tl)[p_idx];
           const int32_t bl_offset = ((int32_t *)index_bl)[p_idx];
           const int32_t level_start_id =
-              ((int32_t *)data_level_start_index_nram)[(p_idx / num_points) % num_levels];  // NOLINT
+              ((int32_t *)data_level_start_index_nram)[(p_idx / num_points) %
+                                                       num_levels];
 #if MS_DEFORM_ATTN_FORWARD_HEADVECTOR
           const char *data_value_ptr =
               data_value_gdram_start +
               (level_start_id * num_heads * channels + c_iter * channel) *
                   sizeof(float);
 #else
-          const int32_t head_idx =
-              ((p_idx + offset_g + grid_iter * deal_num) / (num_levels * num_points)) % num_heads;  // NOLINT
+          const int32_t head_idx = ((p_idx + offset_g + grid_iter * deal_num) /
+                                    (num_levels * num_points)) %
+                                   num_heads;
           const char *data_value_ptr =
               data_value_gdram_start +
-              (level_start_id * num_heads * channels + head_idx * channels + c_iter * channel) *   // NOLINT
+              (level_start_id * num_heads * channels + head_idx * channels +
+               c_iter * channel) *
                   sizeof(float);
 #endif
           switch (inner_point_num) {
             case 16:  // 4 points are cached.
               __memcpy_async((float *)input_tl + p_idx * channel,
                              (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM, c_str, cs_str, 1);
+                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
+                             cs_str, 1);
               __memcpy_async((float *)input_bl + p_idx * channel,
                              (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM, c_str, cs_str, 1);
+                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
+                             cs_str, 1);
               break;
             case 12:  // 2 points are cached. (top_left, top_right)
               __memcpy_async((float *)input_tl + p_idx * channel,
                              (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM, c_str, cs_str, 1);
+                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
+                             cs_str, 1);
               break;
             case 4:  // 2 points are cached. (bottom_left, bottom_right)
               __memcpy_async((float *)input_bl + p_idx * channel,
                              (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM, c_str, cs_str, 1);
+                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
+                             cs_str, 1);
               break;
             case 10:  // 2 points are cached. (top_left, bottom_left)
               __memcpy_async((float *)input_tl + p_idx * channel,
                              (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM);
+                             c_real_num * sizeof(float), GDRAM2NRAM);
               __memcpy_async((float *)input_bl + p_idx * channel,
                              (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM);
+                             c_real_num * sizeof(float), GDRAM2NRAM);
               break;
             case 6:  // 2 points are cached. (top_right, bottom_right)
-              __memcpy_async((float *)input_tr + p_idx * channel,
-                             (float *)data_value_ptr + tl_offset +
-                                 num_heads * channels,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
-              __memcpy_async((float *)input_br + p_idx * channel,
-                             (float *)data_value_ptr + bl_offset +
-                                 num_heads * channels,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
+              __memcpy_async(
+                  (float *)input_tr + p_idx * channel,
+                  (float *)data_value_ptr + tl_offset + num_heads * channels,
+                  c_real_num * sizeof(float), GDRAM2NRAM);
+              __memcpy_async(
+                  (float *)input_br + p_idx * channel,
+                  (float *)data_value_ptr + bl_offset + num_heads * channels,
+                  c_real_num * sizeof(float), GDRAM2NRAM);
               break;
             case 7:  // 1 point is cached. (top_left)
               __memcpy_async((float *)input_tl + p_idx * channel,
                              (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM);
+                             c_real_num * sizeof(float), GDRAM2NRAM);
               break;
             case 5:  // 1 point is cached. (top_right)
-              __memcpy_async((float *)input_tr + p_idx * channel,
-                             (float *)data_value_ptr + tl_offset +
-                                 num_heads * channels,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
+              __memcpy_async(
+                  (float *)input_tr + p_idx * channel,
+                  (float *)data_value_ptr + tl_offset + num_heads * channels,
+                  c_real_num * sizeof(float), GDRAM2NRAM);
               break;
             case 3:  // 1 point is cached. (bottom_left)
               __memcpy_async((float *)input_bl + p_idx * channel,
                              (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float),
-                             GDRAM2NRAM);
+                             c_real_num * sizeof(float), GDRAM2NRAM);
               break;
             case 1:  // 1 point is cached. (bottom_right)
-              __memcpy_async((float *)input_br + p_idx * channel,
-                             (float *)data_value_ptr + bl_offset +
-                                 num_heads * channels,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
+              __memcpy_async(
+                  (float *)input_br + p_idx * channel,
+                  (float *)data_value_ptr + bl_offset + num_heads * channels,
+                  c_real_num * sizeof(float), GDRAM2NRAM);
               break;
             default:
               continue;
           }
         }
-        __asm__ volatile("sync;");
+        __sync();
         // interpolation
         __bang_mul((float *)input_tl, (float *)input_tl, (float *)weight_tl,
                    4 * deal_num * channel);
@@ -488,12 +473,12 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
                  (float *)data_attn_weight_gdram + grid_off_base,
                  io_data_num * sizeof(float), GDRAM2NRAM);
         // calc data_col, muladd attention weight
-        __bang_transpose((float *)input_tr, (float *)input_tl,
-                         deal_num, channel);
+        __bang_transpose((float *)input_tr, (float *)input_tl, deal_num,
+                         channel);
         __bang_cycle_mul((float *)input_tr, (float *)input_tr,
                          (float *)attn_weight, deal_num * channel, deal_num);
-        __bang_transpose((float *)input_tl, (float *)input_tr,
-                         channel, deal_num);
+        __bang_transpose((float *)input_tl, (float *)input_tr, channel,
+                         deal_num);
         __bang_sumpool((float *)input_bl, (float *)input_tl, channel, 1,
                        io_data_num, 1, num_levels * num_points,
                        num_levels * num_points, 1);
@@ -505,22 +490,15 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
       }
     }
   }
-  __asm__ volatile("sync;");
+  __sync();
+#endif
   return;
 }
 
-
 template __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel<float>(
-    const char *data_value_gdram,
-    const char *data_spatial_shapes_gdram,
+    const char *data_value_gdram, const char *data_spatial_shapes_gdram,
     const char *data_level_start_index_gdram,
-    const char *data_sampling_loc_gdram,
-    const char *data_attn_weight_gdram,
-    const int32_t batch_size,
-    const int32_t num_keys,
-    const int32_t num_heads,
-    const int32_t channels,
-    const int32_t num_levels,
-    const int32_t num_queries,
-    const int32_t num_points,
-    char *data_col_gdram);
+    const char *data_sampling_loc_gdram, const char *data_attn_weight_gdram,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points, char *data_col_gdram);

--- a/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_union1_default.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_union1_default.mlu
@@ -257,7 +257,7 @@ MLUKernelMsDeformAttnForwardDefault(const char *data_value_gdram,
       T weight_next_point = 0;
       T x_next_point = 0;
       T y_next_point = 0;
-      __asm__ volatile("sync;");
+      __sync();
       for (int32_t level_idx = 0; level_idx < num_levels; ++level_idx) {
         for (int32_t point_idx = 0; point_idx < num_points; ++point_idx) {
           // load data
@@ -351,7 +351,7 @@ MLUKernelMsDeformAttnForwardDefault(const char *data_value_gdram,
           weight = weight_next_point;
           x = x_next_point;
           y = y_next_point;
-          __asm__ volatile("sync;");
+          __sync();
         }
       }
       // store
@@ -395,7 +395,7 @@ MLUKernelMsDeformAttnForwardDefault(const char *data_value_gdram,
       T weight_next_point = 0;
       T x_next_point = 0;
       T y_next_point = 0;
-      __asm__ volatile("sync;");
+      __sync();
       for (int32_t level_idx = 0; level_idx < num_levels; ++level_idx) {
         for (int32_t point_idx = 0; point_idx < num_points; ++point_idx) {
           // load data
@@ -488,7 +488,7 @@ MLUKernelMsDeformAttnForwardDefault(const char *data_value_gdram,
           weight = weight_next_point;
           x = x_next_point;
           y = y_next_point;
-          __asm__ volatile("sync;");
+          __sync();
         }
       }
       // store
@@ -500,7 +500,7 @@ MLUKernelMsDeformAttnForwardDefault(const char *data_value_gdram,
       data_col_ping_pong_idx = (data_col_ping_pong_idx + 1) % 2;
     }
   }
-  __asm__ volatile("sync;");
+  __sync();
   return;
 }
 

--- a/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_union1_default.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_union1_default.mlu
@@ -164,7 +164,7 @@ MLUKernelMsDeformAttnForwardDefault(const char *data_value_gdram,
                                     const int32_t num_queries,
                                     const int32_t num_points,
                                     char *data_col_gdram) {
-  if (coreId == 0x80) {
+  if (__is_mpu()) {
     return;
   }
   const size_t spatial_size =


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Temporarily fix a host selection error and fix device arch misleading.

## 2. Modification

modified:   kernels/ms_deform_attn_forward/ms_deform_attn_forward.mlu
modified:   kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu
modified:   kernels/ms_deform_attn_forward/msda_forward_small_channel_union1.mlu


## 3. Test Report

Generate 8 cases and all passed.

[----------] 8 tests from ms_deform_attn_forward/TestSuite (32747 ms total)

[----------] Global test environment tear-down
[2023-4-7 15:37:2] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 8 cases of 1 op(s).
ALL PASSED.
[==========] 8 test cases from 1 test suite ran. (33171 ms total)
[  PASSED  ] 8 test cases.


Generate 23 cases and all passed.
[       OK ] ms_deform_attn_forward/TestSuite.mluOp/22 (3709 ms)
[----------] 23 tests from ms_deform_attn_forward/TestSuite (47510 ms total)

[----------] Global test environment tear-down
[2023-4-7 16:59:2] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 23 cases of 1 op(s).
ALL PASSED.
[==========] 23 test cases from 1 test suite ran. (48664 ms total)
[  PASSED  ] 23 test cases.

  YOU HAVE 7 DISABLED TESTS


