### PR TITLE
[Fix](bangc-ops): unify carafe_forward and carafe_backward op's proto.

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_backward/carafe_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_backward/carafe_backward.cpp
@@ -25,13 +25,13 @@
 
 namespace mluoptest {
 void CarafeBackwardExecutor::paramCheck() {
-  if (!parser_->getProtoNode()->has_carafe_backward_param()) {
+  if (!parser_->getProtoNode()->has_carafe_param()) {
     LOG(ERROR) << "Missing carafe param. ";
   }
 }
 
 void CarafeBackwardExecutor::compute() {
-  auto carafe_desc_node = parser_->getProtoNode()->carafe_backward_param();
+  auto carafe_desc_node = parser_->getProtoNode()->carafe_param();
   int dimnb = carafe_desc_node.dimnb();
   int kernel_size = carafe_desc_node.kernel_size();
   int group_size = carafe_desc_node.group_size();
@@ -63,7 +63,7 @@ void CarafeBackwardExecutor::compute() {
 }
 
 void CarafeBackwardExecutor::cpuCompute() {
-  auto carafe_desc_node = parser_->getProtoNode()->carafe_backward_param();
+  auto carafe_desc_node = parser_->getProtoNode()->carafe_param();
 
   int kernel_size = carafe_desc_node.kernel_size();
   int group_size = carafe_desc_node.group_size();

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_backward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_backward/test_case/case_0.prototxt
@@ -75,7 +75,7 @@ output {
   layout: LAYOUT_NHWC
   dtype: DTYPE_FLOAT
 }
-carafe_backward_param: {
+carafe_param: {
   dimnb: 4
   kernel_size: 5
   group_size: 1

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/carafe_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/carafe_forward.cpp
@@ -32,13 +32,13 @@ std::set<Evaluator::Formula> CarafeForwardExecutor::getCriterionsUse() const {
 }
 
 void CarafeForwardExecutor::paramCheck() {
-  if (!parser_->getProtoNode()->has_carafe_forward_param()) {
+  if (!parser_->getProtoNode()->has_carafe_param()) {
     LOG(ERROR) << "Missing carafe param. ";
   }
 }
 
 void CarafeForwardExecutor::compute() {
-  auto carafe_desc_node = parser_->getProtoNode()->carafe_forward_param();
+  auto carafe_desc_node = parser_->getProtoNode()->carafe_param();
 
   int dim_num = carafe_desc_node.dimnb();
   int kernel_size = carafe_desc_node.kernel_size();
@@ -68,7 +68,7 @@ void CarafeForwardExecutor::cpuCompute() {
   assert(parser_->getInputNum() == 2);
   assert(parser_->getOutputNum() == 1);
 
-  auto carafe_desc_node = parser_->getProtoNode()->carafe_forward_param();
+  auto carafe_desc_node = parser_->getProtoNode()->carafe_param();
 
   int kernel_size = carafe_desc_node.kernel_size();
   int group_size = carafe_desc_node.group_size();

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/test_case/case_0.prototxt
@@ -48,7 +48,7 @@ output {
   dtype: DTYPE_FLOAT
 }
 
-carafe_forward_param: {
+carafe_param: {
   dimnb: 4
   kernel_size: 5
   group_size: 1


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation
合并carafe_forward和carafe_backward算子proto的param id;

## 2. Modification
bangc-ops/test/mlu_op_gtest/pb_gtest/mlu_op_test_proto
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_backward/carafe_backward.cpp
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_backward/test_case/case_0.prototxt
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/carafe_forward.cpp
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/test_case/case_0.prototxt

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block       |
|        3       |Layouts                               |          NHWC      |
|        4       |Whether multi-dimensions are supported|      No                                |
|        5       |Whether element zero is supported     |          Yes                            |
|        6       |Data type(half/float)                 |           half / float           |
|        7       |Whether there is size limit           |            No                          |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [Yes] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

MLU370:
forward + backward：
[ SUMMARY  ] Total 369 cases of 2 op(s).
ALL PASSED.
[==========] 369 test cases from 2 test suites ran. (2107810 ms total)
[  PASSED  ] 369 test cases.

MLU590:
forward：
[ SUMMARY  ] Total 219 cases of 1 op(s).
ALL PASSED.
[==========] 219 test cases from 1 test suite ran. (1952048 ms total)
[  PASSED  ] 219 test cases.

backward：
[ SUMMARY  ] Total 150 cases of 1 op(s).
ALL PASSED.
[==========] 150 test cases from 1 test suite ran. (40418 ms total)
[  PASSED  ] 150 test cases.