### PR TITLE
[Fix](bangc-ops): replace MLULOG to LOG(ERROR)

### DIFF
--- a/bangc-ops/kernels/abs/abs_block.mlu
+++ b/bangc-ops/kernels/abs/abs_block.mlu
@@ -25,6 +25,7 @@
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define ABS_NRAM_USED MAX_NRAM_SIZE
 #define ABS_SRAM_USED (CORE_DIM * ABS_NRAM_USED)
@@ -86,7 +87,7 @@ void MLUOP_WIN_API Kernel3StagePipelineAbs(cnrtDim3_t k_dim,
           (void *)x, (void *)y, num, 0.0);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -107,7 +108,7 @@ void MLUOP_WIN_API Kernel5StagePipelineAbs(cnrtDim3_t k_dim,
           (void *)x, (void *)y, num, 0.0);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/active_rotated_filter/active_rotated_filter_unionx.mlu
+++ b/bangc-ops/kernels/active_rotated_filter/active_rotated_filter_unionx.mlu
@@ -23,6 +23,7 @@
 #include "active_rotated_filter.h"
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 #define ROWS 8
@@ -426,7 +427,7 @@ void MLUOP_WIN_API KernelActiveRotatedFilterForward(
           (half *)output_gdram);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
     }; break;
   }
 }

--- a/bangc-ops/kernels/ball_query/ball_query_union1.mlu
+++ b/bangc-ops/kernels/ball_query/ball_query_union1.mlu
@@ -27,6 +27,7 @@
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 #define COORD_NUM 3
 
@@ -331,7 +332,7 @@ void MLUOP_WIN_API KernelBallQuery(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
           (half *)xyz, (int32_t *)idx);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
     }; break;
   }
 }

--- a/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
+++ b/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
@@ -26,6 +26,7 @@
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
 #include "mlu.h"
+#include "core/logging.h"
 
 #define ALIGN_SIZE NFU_ALIGN_SIZE
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -311,7 +312,7 @@ void MLUOP_WIN_API KernelBboxOverlaps(
           mode, aligned, offset);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_union1.mlu
+++ b/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_union1.mlu
@@ -26,6 +26,7 @@
 #include "kernels/box_iou_rotated/box_iou_rotated_nonaligned.h"
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
+#include "core/logging.h"
 
 __mlu_global__ void MLUKernelBoxIouRotated(const float *box1, const float *box2,
                                            float *ious, const int32_t num_box1,
@@ -128,7 +129,7 @@ void MLUOP_WIN_API KernelBoxIouRotated(cnrtDim3_t k_dim,
           aligned);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
     }; break;
   }
 }

--- a/bangc-ops/kernels/carafe/carafe_block.mlu
+++ b/bangc-ops/kernels/carafe/carafe_block.mlu
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include "kernels/utils/common.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 __nram__ char nram_buf[MAX_NRAM_SIZE];
 
@@ -465,7 +466,7 @@ void MLUOP_WIN_API KernelCarafeForward(
           grid_dimG, grid_dimC);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -489,7 +490,7 @@ void MLUOP_WIN_API KernelCarafeBackward(
           (half *)grad_mask, n, hi, wi, c, k_up, group, scale);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/deform_roi_pool/deform_roi_pool_union1.mlu
+++ b/bangc-ops/kernels/deform_roi_pool/deform_roi_pool_union1.mlu
@@ -25,6 +25,7 @@
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 #define ROI_OFFSET 5
 #define FOURSPLIT 4
@@ -695,7 +696,7 @@ void MLUOP_WIN_API KernelDeformRoiPoolForward(
           gamma);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -722,7 +723,7 @@ void MLUOP_WIN_API KernelDeformRoiPoolBackward(
           spatial_scale, sampling_ratio, gamma);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/div/div_block.mlu
+++ b/bangc-ops/kernels/div/div_block.mlu
@@ -25,6 +25,7 @@
 #include "kernels/binary_op/binary_op_3pipeline.h"
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define HIGH_BOUND 1e5
 #define LOW_BOUND 1e-10
@@ -212,7 +213,7 @@ void MLUOP_WIN_API Kernel3StagePipelineDiv(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/log/log_block.mlu
+++ b/bangc-ops/kernels/log/log_block.mlu
@@ -25,6 +25,7 @@
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define LOG_LOW_BOUND 1e-8
 #define LOG_SCALE 1e12
@@ -183,7 +184,7 @@ void MLUOP_WIN_API Kernel3StagePipelineLog(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -208,7 +209,7 @@ void MLUOP_WIN_API Kernel5StagePipelineLog(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/moe_dispatch_backward_data/moe_dispatch_backward_data_union1.mlu
+++ b/bangc-ops/kernels/moe_dispatch_backward_data/moe_dispatch_backward_data_union1.mlu
@@ -25,6 +25,7 @@
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
@@ -327,7 +328,7 @@ void MLUOP_WIN_API KernelMoeDispatchBwdData1(
           samples, capacity, hidden, num_experts, (half *)grad_input);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -351,7 +352,7 @@ void MLUOP_WIN_API KernelMoeDispatchBwdData2(
           samples, capacity, hidden, num_experts, (half *)grad_input);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/moe_dispatch_backward_gate/moe_dispatch_backward_gate_union1.mlu
+++ b/bangc-ops/kernels/moe_dispatch_backward_gate/moe_dispatch_backward_gate_union1.mlu
@@ -25,6 +25,7 @@
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
@@ -376,7 +377,7 @@ void MLUOP_WIN_API KernelMoeDispatchBwdGate1(
           (half *)grad_gates);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -400,7 +401,7 @@ void MLUOP_WIN_API KernelMoeDispatchBwdGate2(
           samples, capacity, hidden, num_experts, (half *)grad_gates);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/moe_dispatch_forward/moe_dispatch_forward_block.mlu
+++ b/bangc-ops/kernels/moe_dispatch_forward/moe_dispatch_forward_block.mlu
@@ -26,6 +26,7 @@
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
@@ -157,7 +158,7 @@ void MLUOP_WIN_API KernelMoeDispatchForward(
           samples, capacity, hidden, num_experts, (half *)dispatch);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/roi_align_rotated/roi_align_rotated_block.mlu
+++ b/bangc-ops/kernels/roi_align_rotated/roi_align_rotated_block.mlu
@@ -30,6 +30,7 @@
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
 #include "mlu.h"
+#include "core/logging.h"
 
 #define ROI_OFFSET 6
 #define SAMPLING_NUM 4
@@ -470,7 +471,7 @@ void MLUOP_WIN_API KernelRoiAlignRotatedForward(
           rois_num, rroiAlignParams, (half *)output);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -494,7 +495,7 @@ void MLUOP_WIN_API KernelRoiAlignRotatedBackward(
           rois_num, rroiAlignParams, (half *)bottom_grad);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
@@ -27,6 +27,7 @@
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 #define ROI_OFFSET 7
 #define FLOAT_NRAM_BUFFER_NUM 14
@@ -430,7 +431,7 @@ void MLUOP_WIN_API KernelPtsIdxOfVoxels(
           out_z, (half *)rois, (half *)pts, (int *)pts_idx_of_voxels);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -456,7 +457,7 @@ void MLUOP_WIN_API KernelRoiawarePool3dForward(
           (half *)pooled_features, (int *)argmax);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -670,7 +671,7 @@ void MLUOP_WIN_API KernelRoiawarePool3dBackward(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/roipoint_pool3d/roipoint_pool3d_union1.mlu
+++ b/bangc-ops/kernels/roipoint_pool3d/roipoint_pool3d_union1.mlu
@@ -27,6 +27,7 @@
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
@@ -554,7 +555,7 @@ void MLUOP_WIN_API KernelRoipointPool3d(
           pooled_features_gdram, pooled_empty_flag_gdram);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/roipoint_pool3d/roipoint_pool3d_union1_large_boxes_num.mlu
+++ b/bangc-ops/kernels/roipoint_pool3d/roipoint_pool3d_union1_large_boxes_num.mlu
@@ -27,6 +27,7 @@
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
@@ -550,7 +551,7 @@ void MLUOP_WIN_API KernelRoipointPool3dLargeBoxesNum(
           pooled_features_gdram, pooled_empty_flag_gdram);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/rotated_feature_align/rotated_feature_align_block.mlu
+++ b/bangc-ops/kernels/rotated_feature_align/rotated_feature_align_block.mlu
@@ -24,6 +24,7 @@
 
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
+#include "core/logging.h"
 
 #define SEG_NUM 10
 #define BBOXES_ALIGN 64
@@ -736,7 +737,7 @@ void MLUOP_WIN_API KernelRotatedFeatureAlignForward(
           offset_rois, (half)spatial_scale, points, (half *)output);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -760,7 +761,7 @@ void MLUOP_WIN_API KernelRotatedFeatureAlignBackward(
           offset_rois, (half)spatial_scale, points, (half *)bottom_input);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/sqrt/sqrt_block.mlu
+++ b/bangc-ops/kernels/sqrt/sqrt_block.mlu
@@ -26,6 +26,7 @@
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define SQRT_HIGH_BOUND 1e4
 #define SQRT_SCALE 1e-6
@@ -243,7 +244,7 @@ void MLUOP_WIN_API Kernel3StagePipelineSqrt(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -268,7 +269,7 @@ void MLUOP_WIN_API Kernel5StagePipelineSqrt(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -290,7 +291,7 @@ void MLUOP_WIN_API Kernel3StagePipelineSqrtBackward(
           (void *)y, (void *)diff_y, (void *)x, num);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
+++ b/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
@@ -25,6 +25,7 @@
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
@@ -555,7 +556,7 @@ void MLUOP_WIN_API KernelThreeInterpolateForward(
           c_limit_size, m_limit_size, n_limit_size, (half *)output);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -579,7 +580,7 @@ void MLUOP_WIN_API KernelThreeInterpolateBackward(
           c_limit_size, m_limit_size, n_limit_size, (half *)grad_features);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/three_nn_forward/three_nn_forward_union1.mlu
+++ b/bangc-ops/kernels/three_nn_forward/three_nn_forward_union1.mlu
@@ -27,6 +27,7 @@
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
@@ -459,7 +460,7 @@ void MLUOP_WIN_API KernelThreeNNForward(
           b, n, m, (half *)unknown, (half *)known, (half *)dist2, (int *)idx);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

修改.mlu中MLULOG 为LOG(ERROR)

## 2. Modification

        modified:   kernels/abs/abs_block.mlu
        modified:   kernels/active_rotated_filter/active_rotated_filter_unionx.mlu
        modified:   kernels/ball_query/ball_query_union1.mlu
        modified:   kernels/bbox_overlaps/bbox_overlaps_union1.mlu
        modified:   kernels/box_iou_rotated/box_iou_rotated_union1.mlu
        modified:   kernels/carafe/carafe_block.mlu
        modified:   kernels/deform_roi_pool/deform_roi_pool_union1.mlu
        modified:   kernels/div/div_block.mlu
        modified:   kernels/log/log_block.mlu
        modified:   kernels/moe_dispatch_backward_data/moe_dispatch_backward_data_union1.mlu
        modified:   kernels/moe_dispatch_backward_gate/moe_dispatch_backward_gate_union1.mlu
        modified:   kernels/moe_dispatch_forward/moe_dispatch_forward_block.mlu
        modified:   kernels/roi_align_rotated/roi_align_rotated_block.mlu
        modified:   kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
        modified:   kernels/roipoint_pool3d/roipoint_pool3d_union1.mlu
        modified:   kernels/roipoint_pool3d/roipoint_pool3d_union1_large_boxes_num.mlu
        modified:   kernels/rotated_feature_align/rotated_feature_align_block.mlu
        modified:   kernels/sqrt/sqrt_block.mlu
        modified:   kernels/three_interpolate/three_interpolate_union1.mlu
        modified:   kernels/three_nn_forward/three_nn_forward_union1.mlu

## 3. Test Report
-  加 -d （debug）编译，全算子编译通过
