### PR TITLE
[Feature](bangc-ops): add ms_deform_attn_backward fast kernel

### DIFF
--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.h
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.h
@@ -26,6 +26,9 @@
 
 #include "mlu_op.h"
 
+#define FAST_KERNEL_MAX_NLP   (128)
+#define FAST_KERNEL_MAX_NLPC  (16384)
+
 void MLUOP_WIN_API KernelMsDeformAttnBackwardSmallChannels(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const float *data_value, const int32_t *spatial_shapes,
@@ -37,6 +40,16 @@ void MLUOP_WIN_API KernelMsDeformAttnBackwardSmallChannels(
     float *grad_attn_weight);
 
 void MLUOP_WIN_API KernelMsDeformAttnBackwardDefault(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const float *data_value, const int32_t *spatial_shapes,
+    const int32_t *data_level_start_index, const float *data_sampling_loc,
+    const float *data_attn_weight, const float *grad_output,
+    const int32_t batch, const int32_t spatial_size, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_query,
+    const int32_t num_points, float *grad_value, float *grad_sampling_loc,
+    float *grad_attn_weight);
+
+void MLUOP_WIN_API KernelMsDeformAttnBackwardFast(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const float *data_value, const int32_t *spatial_shapes,
     const int32_t *data_level_start_index, const float *data_sampling_loc,

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_fast_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_fast_union1.mlu
@@ -1,0 +1,566 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#include "kernels/ms_deform_attn_backward/ms_deform_attn_backward.h"
+#include "kernels/ms_deform_attn_forward/ms_deform_attn_utils.h"
+
+#if (__BANG_ARCH__ == 592)
+
+#define MAX_MEMCPY_SEGNUM (65536)
+#define NRAM_REMAIN_SIZE (48 * 1024)
+#define SRAM_REMAIN_SIZE (32 * 1024)
+#define NRAM_AVALIABLE_SIZE (__MLU_NRAM_SIZE__ * 1024 - NRAM_REMAIN_SIZE)
+#define WRAM_AVALIABLE_SIZE (__MLU_WRAM_SIZE__ * 1024)
+#define SRAM_AVALIABLE_SIZE (__MLU_SRAM_SIZE__ * 1024 - SRAM_REMAIN_SIZE)
+
+__nram__ char nram_buffer[NRAM_AVALIABLE_SIZE];
+__mlu_shared__ char sram_buffer[SRAM_AVALIABLE_SIZE];
+__wram__ char wram_buffer[WRAM_AVALIABLE_SIZE];
+
+template <typename T>
+__mlu_func__ void memPolicyBackward(
+    int32_t*& seq_nram, T*& zeros_nram, int32_t*& data_offset_nram,
+    T*& weight_polation_nram, T*& cond_point_polation_nram,
+    T*& cond_point_valid_nram, T*& delta_xy_nram, T*& loc_nram, T*& buf_nram,
+    T*& buf_nram_end, int8_t*& mask_x_nram, int8_t*& mask_y_nram,
+    T*& spatial_offset_bd_nram, T*& spatial_w_bd_nram, T*& spatial_h_bd_nram,
+    int32_t*& spatial_offset_nram, int32_t*& spatial_hw_nram,
+    T*& compute_buffer,  // (5, deal_n, num_levels, num_points, channels)
+    T*& weight_polation_nram_stg2, T*& weight_attn_nram_stg2,
+    int32_t*& offset_nram_stg2, T*& grad_output_nram,
+    int8_t*& bit_cond_nram,          // (4, pad_points / 8)
+    int8_t*& bit_cond_reverse_nram,  // (4, pad_points / 8)
+    T*& cond_nram_stg2,
+    T*& compute_buffer_nram_stg3,  // (4, max_deal_n, num_levels, num_points)
+    T*& delta_xy_nram_stg3,        // (4, max_deal_n, num_levels, num_points)
+    T*& grad_wp_nram_stg3,         // (4, total_deal_n, num_levels, num_points)
+    int32_t*& data_offset_sram, T*& weight_polation_sram, T*& grad_wp_sram,
+    T*& weight_attn_sram, T*& cond_point_polation_sram, T*& delta_xy_sram,
+    char* nram_buffer, char* sram_buffer, int32_t& max_cached_n,
+    int32_t& stage_1_max_deal_n, int32_t& stage_2_max_deal_n,
+    int32_t& stage_3_max_deal_n, int32_t& mask_size,
+    const int32_t nram_avaliable_size, const int32_t sram_avaliable_size,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points) {
+  const int32_t num_points_levels = num_levels * num_points;
+  const int32_t spatial_info_size =
+      PAD_UP(3 * num_levels * sizeof(int32_t), WRAM_ALIGN_SIZE);
+  const int32_t spatial_info_bd_size =
+      PAD_UP(3 * num_points_levels * sizeof(T), WRAM_ALIGN_SIZE);
+  const int32_t zeros_size = PAD_UP(channels * sizeof(T), WRAM_ALIGN_SIZE);
+  const int32_t seq_size = BACKWARD_MAX_NQ_NL_NP * sizeof(int32_t);
+  const int32_t fix_space_size = spatial_info_size +
+                                 2 * BIT_COLLECT_PAD * sizeof(T) +
+                                 spatial_info_bd_size + zeros_size + seq_size;
+  const int32_t left_space_size = nram_avaliable_size - fix_space_size;
+  stage_1_max_deal_n = left_space_size / (24 * num_points_levels * sizeof(T));
+  const int32_t total_points = stage_1_max_deal_n * num_points_levels;
+  const int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
+  mask_size = PAD_UP(total_coord_pad / BIT_COLLECT_PAD, WRAM_ALIGN_SIZE);
+  stage_2_max_deal_n =
+      (left_space_size - 2 * mask_size - 7 * WRAM_ALIGN_SIZE) /
+      ((5 * num_points_levels * channels + 20 * num_points_levels + channels) *
+       sizeof(T));
+  stage_2_max_deal_n =
+      std::min(BACKWARD_MAX_NQ_NL_NP / num_points_levels, stage_2_max_deal_n);
+  stage_3_max_deal_n = (left_space_size - 2 * mask_size - 2 * WRAM_ALIGN_SIZE) /
+                       (12 * num_points_levels * sizeof(T));
+  // fix nram space
+  seq_nram = (int32_t*)(nram_buffer);
+  zeros_nram = (T*)(seq_nram + seq_size / sizeof(int32_t));
+  spatial_offset_nram = (int32_t*)(zeros_nram + zeros_size / sizeof(T));
+  spatial_hw_nram = spatial_offset_nram + num_levels;
+  spatial_offset_bd_nram =
+      (T*)((int8_t*)spatial_offset_nram + spatial_info_size);
+  spatial_w_bd_nram = spatial_offset_bd_nram + num_points_levels;
+  spatial_h_bd_nram = spatial_w_bd_nram + num_points_levels;
+  mask_x_nram = (int8_t*)spatial_offset_bd_nram + spatial_info_bd_size;
+  mask_y_nram = mask_x_nram + mask_size;
+  // stage1 nram space
+  // 4 + 4 + 4 + 4 + 1 + 6
+  data_offset_nram = (int32_t*)(mask_y_nram + mask_size);
+  delta_xy_nram = (T*)(data_offset_nram + 4 * total_points);
+  weight_polation_nram = delta_xy_nram + 4 * total_points;
+  cond_point_polation_nram = weight_polation_nram + 4 * total_points;
+  cond_point_valid_nram = cond_point_polation_nram + 4 * total_points;
+  buf_nram = cond_point_valid_nram + total_points;
+  loc_nram = buf_nram + 4 * total_points;
+  buf_nram_end = buf_nram + 6 * total_points + total_coord_pad;
+  // stage2 nram space
+  const int32_t total_points_stg2 = stage_2_max_deal_n * num_points_levels;
+  const int32_t compute_buffer_size_pad =
+      5 * PAD_UP(total_points_stg2 * channels * sizeof(T), WRAM_ALIGN_SIZE);
+  const int32_t bit_cond_pad_size =
+      PAD_UP(PAD_UP(total_points_stg2, BIT_COLLECT_PAD) / BIT_COLLECT_PAD * 5,
+             WRAM_ALIGN_SIZE);
+  cond_nram_stg2 = (T*)(mask_y_nram + mask_size);
+  bit_cond_nram = (int8_t*)cond_nram_stg2 +
+                  PAD_UP(5 * total_points_stg2 * sizeof(T), WRAM_ALIGN_SIZE);
+  bit_cond_reverse_nram = bit_cond_nram + bit_cond_pad_size;
+  compute_buffer = (T*)(bit_cond_reverse_nram + bit_cond_pad_size);
+  grad_output_nram = compute_buffer + compute_buffer_size_pad / sizeof(T);
+  weight_polation_nram_stg2 = grad_output_nram + stage_2_max_deal_n * channels;
+  weight_attn_nram_stg2 = weight_polation_nram_stg2 + 4 * total_points_stg2;
+  offset_nram_stg2 = (int32_t*)(weight_attn_nram_stg2 + total_points_stg2);
+  // stage3 nram space
+  const int32_t total_points_stg3 = stage_3_max_deal_n * num_points_levels;
+  compute_buffer_nram_stg3 = (T*)(mask_y_nram + mask_size);
+  delta_xy_nram_stg3 = compute_buffer_nram_stg3 + 4 * total_points_stg3;
+  grad_wp_nram_stg3 = delta_xy_nram_stg3 + 4 * total_points_stg3;
+  // sram space: 4 + 4 + 1 + 5 + 4
+  const int32_t polation_info_size = 18 * num_points_levels * sizeof(T);
+  const int32_t avg_sram_size = sram_avaliable_size / coreDim;
+  max_cached_n = avg_sram_size / polation_info_size;
+  const int32_t max_cached_points = max_cached_n * num_points_levels;
+  T* sram_buf_base = (T*)(sram_buffer + avg_sram_size * coreId);
+  data_offset_sram = (int32_t*)sram_buf_base;
+  weight_polation_sram = (T*)(data_offset_sram + 4 * max_cached_points);
+  weight_attn_sram = (T*)(weight_polation_sram + 4 * max_cached_points);
+  cond_point_polation_sram = (T*)(weight_attn_sram + max_cached_points);
+  delta_xy_sram = (T*)(cond_point_polation_sram + 5 * max_cached_points);
+  grad_wp_sram = weight_polation_sram;  // reuse
+}
+
+template <typename T>
+__mlu_func__ void backwardStageTwoLoop(
+    int32_t* seq_nram, T* compute_buffer_nram, T* zeros_nram,
+    T* weight_polation_nram, T* weight_attn_nram, int32_t* offset_nram,
+    T* cond_nram, int8_t* bit_cond_nram, int8_t* bit_cond_reverse_nram,
+    T* grad_output_nram, T* delta_xy_nram, int32_t* data_offset_sram,
+    T* weight_polation_sram, T* grad_wp_sram, T* weight_attn_sram,
+    T* cond_point_polation_sram, T* delta_xy_sram, T* data_value_gdram,
+    T* grad_output_gdram, T* grad_value_gdram, T* grad_attn_weight_gdram,
+    char* wram_buffer, const int32_t total_deal_n, const int32_t max_deal_n,
+    const int32_t input_stride_2, const int32_t input_stride_3,
+    const int32_t output_stride_2, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels,
+    const int32_t num_points) {
+  const int32_t num_levels_points = num_levels * num_points;
+  const int32_t loop_num = (total_deal_n + max_deal_n - 1) / max_deal_n;
+  int32_t* offset_zero_nram_stg2 =
+      offset_nram + 4 * max_deal_n * num_levels_points;
+  const int32_t src_stride = total_deal_n * num_levels_points * sizeof(T);
+  for (int i = 0; i < loop_num; i++) {
+    int32_t deal_n = std::min(total_deal_n - i * max_deal_n, max_deal_n);
+    int32_t copy_size_1 = deal_n * num_levels_points * sizeof(T);
+    int32_t copy_size_2 = deal_n * num_levels_points * sizeof(int32_t);
+    int32_t sram_src_offset = i * max_deal_n * num_levels_points;
+    int32_t nq_nl_np_c = deal_n * num_levels_points * channels;
+    int32_t nq_nl_np = deal_n * num_levels_points;
+    int32_t nq_nl_np_4 = 4 * deal_n * num_levels_points;
+
+    __memcpy_async(grad_output_nram,
+                   grad_output_gdram + i * max_deal_n * output_stride_2,
+                   channels * sizeof(T), GDRAM2NRAM, channels * sizeof(T),
+                   output_stride_2 * sizeof(T), deal_n - 1);
+    __memcpy_async(offset_nram, data_offset_sram + sram_src_offset, copy_size_2,
+                   SRAM2NRAM, copy_size_2, src_stride, 3);
+    __memcpy_async(cond_nram, cond_point_polation_sram + sram_src_offset,
+                   copy_size_1, SRAM2NRAM, copy_size_1, src_stride, 4);
+    __memcpy_async(weight_attn_nram, weight_attn_sram + sram_src_offset,
+                   copy_size_1, SRAM2NRAM);
+    __memcpy_async(weight_polation_nram, weight_polation_sram + sram_src_offset,
+                   copy_size_1, SRAM2NRAM, copy_size_1, src_stride, 3);
+    __bang_write_value(offset_zero_nram_stg2, nq_nl_np_4, (int32_t)0);
+    __sync_move();
+
+    T* tmp_zero = (T*)offset_zero_nram_stg2;
+    int32_t nq_nl_np_pad8 = PAD_UP(nq_nl_np, BIT_COLLECT_PAD);
+    int32_t bit_cond_stride = nq_nl_np_pad8 / BIT_COLLECT_PAD;
+    if (nq_nl_np_pad8 == nq_nl_np) {
+      int32_t bit_cond_stride_4 = 4 * bit_cond_stride;
+      __bang_gt_bitindex((T*)bit_cond_nram, cond_nram, tmp_zero, nq_nl_np_4);
+      __bang_bnot((char*)bit_cond_reverse_nram, (char*)bit_cond_nram,
+                  4 * bit_cond_stride);
+      __bang_gt_bitindex((T*)(bit_cond_nram + bit_cond_stride_4),
+                         cond_nram + nq_nl_np_4, tmp_zero, nq_nl_np);
+      __bang_bnot((char*)(bit_cond_reverse_nram + bit_cond_stride_4),
+                  (char*)(bit_cond_nram + bit_cond_stride_4), bit_cond_stride);
+    } else {
+      for (int j = 0; j < 5; j++) {
+        __bang_gt_bitindex((T*)((int8_t*)bit_cond_nram + j * bit_cond_stride),
+                           cond_nram + j * nq_nl_np, tmp_zero, nq_nl_np_pad8);
+        __bang_bnot((char*)bit_cond_reverse_nram + j * bit_cond_stride,
+                    (char*)bit_cond_nram + j * bit_cond_stride,
+                    bit_cond_stride);
+      }
+    }
+
+    __sync_io_move_compute();
+
+    int32_t buffer_size_pad = PAD_UP(nq_nl_np_c * sizeof(T), WRAM_ALIGN_SIZE);
+    int32_t buffer_data_num = buffer_size_pad / sizeof(T);
+    T* inter_grad = compute_buffer_nram;
+    T* v_ping = inter_grad + buffer_data_num;
+    T* v_pong = v_ping + buffer_data_num;
+    T* value_wp = v_pong + buffer_data_num;
+    T* buffer = value_wp + buffer_data_num;
+
+    for (int j = 0; j < 5; j++) {
+      T* tmp_wp = weight_polation_nram + (j - 1) * nq_nl_np;
+      if (j < 4) {
+        gatherAsync(v_ping, zeros_nram, (unsigned int*)offset_zero_nram_stg2,
+                    bit_cond_reverse_nram + j * bit_cond_stride,
+                    channels * sizeof(T), NRAM2NRAM, channels * sizeof(T),
+                    nq_nl_np);
+        gatherAsync(v_ping, data_value_gdram,
+                    (unsigned int*)offset_nram + j * nq_nl_np,
+                    bit_cond_nram + j * bit_cond_stride, channels * sizeof(T),
+                    GDRAM2NRAM, channels * sizeof(T), nq_nl_np);
+      }
+
+      if (j == 0) {
+        // (n, c) => (n, nl, np, c)
+        __memcpy_async(buffer, grad_output_nram, channels * sizeof(T),
+                       NRAM2NRAM, channels * sizeof(T), num_levels_points - 1,
+                       num_levels_points * channels * sizeof(T), deal_n - 1, 0,
+                       num_levels_points - 1, channels * sizeof(T), deal_n - 1);
+        gatherAsync(buffer, zeros_nram, (unsigned int*)offset_zero_nram_stg2,
+                    bit_cond_reverse_nram + 4 * bit_cond_stride,
+                    channels * sizeof(T), NRAM2NRAM, channels * sizeof(T),
+                    nq_nl_np);
+        __bang_write_value(value_wp, nq_nl_np_c, (T)0);  // clear value*wp
+        __sync_move();
+        // (n, nl, np, c) => (c, n, nl, np)
+        __bang_transpose(v_pong, buffer, nq_nl_np, channels);
+        __sync_compute();
+        // (c, n, nl, np) * (n, nl, np)
+        __bang_cycle_mul(inter_grad, v_pong, weight_attn_nram, nq_nl_np_c,
+                         nq_nl_np);
+        __memcpy_async(wram_buffer, v_pong, buffer_size_pad, NRAM2WRAM);
+      }
+
+      if (j == 4) {
+        __memcpy_async(v_ping, wram_buffer, buffer_size_pad, WRAM2NRAM);
+      }
+
+      if (j > 0) {
+        // (n, nl, np, c) => (c, n, nl, np)
+        __bang_transpose(buffer, v_pong, nq_nl_np, channels);
+        // (c, n, nl, np) * (n, nl, np)
+        __bang_cycle_mul(v_pong, buffer, tmp_wp, nq_nl_np_c, nq_nl_np);
+        __bang_add(value_wp, value_wp, v_pong, nq_nl_np_c);
+        __bang_mul(v_pong, buffer, inter_grad, nq_nl_np_c);
+        // (c, nq, nl, np) => (nq, nl, np)
+        __bang_sumpool(buffer, v_pong, nq_nl_np, channels, 1, channels, 1, 1,
+                       1);
+        __bang_float2int32((int32_t*)v_pong, cond_nram + (j - 1) * nq_nl_np,
+                           nq_nl_np, 0);
+        __bang_mul_scalar((int32_t*)v_pong, (int32_t*)v_pong,
+                          (int32_t)0xffffffff, nq_nl_np);
+        __bang_band((char*)buffer, (char*)buffer, (char*)v_pong,
+                    nq_nl_np * sizeof(T));
+        // (nq, nl, np) => (Nq, nl, np)
+        __sync_compute();
+        __memcpy_async(grad_wp_sram + sram_src_offset +
+                           (j - 1) * total_deal_n * num_levels_points,
+                       buffer, nq_nl_np * sizeof(T), NRAM2SRAM);
+      }
+
+      T* tmp = v_ping;
+      v_ping = v_pong;
+      v_pong = tmp;
+
+      __sync_io_move_compute();
+    }
+
+    // compute grad_attn_weight
+    T* grad_output_bd = v_pong;
+    __bang_mul(v_ping, value_wp, grad_output_bd, nq_nl_np_c);
+    // (c, nq, nl, np) => (nq, nl, np)
+    __bang_sumpool(buffer, v_ping, nq_nl_np, channels, 1, channels, 1, 1, 1);
+    __memcpy(grad_attn_weight_gdram + i * max_deal_n * input_stride_3, buffer,
+             num_levels_points * sizeof(T), NRAM2GDRAM,
+             input_stride_3 * sizeof(T), num_levels_points * sizeof(T),
+             deal_n - 1);
+
+    // compute grad_value
+    for (int k = 0; k < 4; k++) {
+      int offset = k * nq_nl_np;
+      T* tmp_wp = weight_polation_nram + offset;
+      T* tmp_cond = cond_nram + offset;
+      int32_t* tmp_dst_offset = offset_nram + offset;
+      int32_t* tmp_src_offset = (int32_t*)buffer;
+      int32_t valid_count = __bang_sum(tmp_cond, nq_nl_np);
+      if (valid_count > 0) {
+        // (c, n, nl, np) * (n, nl, np)
+        __bang_cycle_mul(v_ping, inter_grad, tmp_wp, nq_nl_np_c, nq_nl_np);
+        // (c, n, nl, np) => (n, nl, np, c)
+        __bang_transpose(v_pong, v_ping, channels, nq_nl_np);
+        // select offset by cond_nram
+        __bang_collect((T*)tmp_dst_offset, (T*)tmp_dst_offset, tmp_cond,
+                       nq_nl_np);
+        __bang_collect((T*)tmp_src_offset, (T*)seq_nram, tmp_cond, nq_nl_np);
+        __bang_mul_scalar(tmp_src_offset, tmp_src_offset, channels,
+                          valid_count);
+        for (int p = 0; p < valid_count; p++) {
+          __bang_atomic_reduce_add(
+              (T*)((int8_t*)grad_value_gdram + tmp_dst_offset[p]),
+              v_pong + tmp_src_offset[p], channels);
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+__mlu_func__ void backwardStageThreeLoop(
+    T* compute_buffer_nram, T* delta_xy_nram, T* grad_wp_nram,
+    T* spatial_h_bd_nram, T* spatial_w_bd_nram, T* delta_xy_sram,
+    T* grad_wp_sram, T* grad_loc_gdram, const int32_t total_deal_n,
+    const int32_t max_deal_n, const int32_t input_stride_2,
+    const int32_t input_stride_3, const int32_t output_stride_2,
+    const int32_t num_heads, const int32_t channels, const int32_t num_levels,
+    const int32_t num_points) {
+  const int32_t loop_num = (total_deal_n + max_deal_n - 1) / max_deal_n;
+  const int32_t num_levels_points = num_levels * num_points;
+  const int32_t src_stride = total_deal_n * num_levels_points * sizeof(T);
+  /*
+    grad_dx    = (grad_w3-grad_w1)*dy + (grad_w4-grad_w2)*(1-dy)
+    grad_loc_x = grad_dx * W
+    grad_dy    = (grad_w3-grad_w4)*dx + (grad_w1-grad_w2)*(1-dx)
+    grad_loc_y = grad_dy * H
+  */
+  for (int i = 0; i < loop_num; i++) {
+    int32_t deal_n = std::min(total_deal_n - i * max_deal_n, max_deal_n);
+    int32_t copy_size = deal_n * num_levels_points * sizeof(T);
+    int32_t sram_src_offset = i * max_deal_n * num_levels_points;
+    int32_t nq_nl_np = deal_n * num_levels_points;
+    T* grad_wp_1 = grad_wp_nram;
+    T* grad_wp_2 = grad_wp_nram + nq_nl_np;
+    T* grad_wp_3 = grad_wp_nram + 2 * nq_nl_np;
+    T* grad_wp_4 = grad_wp_nram + 3 * nq_nl_np;
+    T* dx = delta_xy_nram;
+    T* dx_1 = delta_xy_nram + nq_nl_np;
+    T* dy = delta_xy_nram + 2 * nq_nl_np;
+    T* dy_1 = delta_xy_nram + 3 * nq_nl_np;
+    T* buf_1 = compute_buffer_nram;
+    T* buf_2 = compute_buffer_nram + nq_nl_np;
+    T* buf_3 = compute_buffer_nram + 2 * nq_nl_np;
+    __memcpy(delta_xy_nram, delta_xy_sram + sram_src_offset, copy_size,
+             SRAM2NRAM, copy_size, src_stride, 3);
+    __memcpy(grad_wp_nram, grad_wp_sram + sram_src_offset, copy_size, SRAM2NRAM,
+             copy_size, src_stride, 3);
+    __bang_fusion(FUSION_FSM, buf_1, grad_wp_3, grad_wp_1, dy, nq_nl_np,
+                  nq_nl_np);
+    __bang_fusion(FUSION_FSM, buf_2, grad_wp_4, grad_wp_2, dy_1, nq_nl_np,
+                  nq_nl_np);
+    __bang_add(buf_1, buf_1, buf_2, nq_nl_np);
+    __bang_cycle_mul(buf_1, buf_1, spatial_w_bd_nram, nq_nl_np,
+                     num_levels_points);
+    __bang_fusion(FUSION_FSM, buf_2, grad_wp_3, grad_wp_4, dx, nq_nl_np,
+                  nq_nl_np);
+    __bang_fusion(FUSION_FSM, buf_3, grad_wp_1, grad_wp_2, dx_1, nq_nl_np,
+                  nq_nl_np);
+    __bang_add(buf_2, buf_2, buf_3, nq_nl_np);
+    __bang_cycle_mul(buf_2, buf_2, spatial_h_bd_nram, nq_nl_np,
+                     num_levels_points);
+    __bang_transpose(buf_3, buf_1, 2,
+                     nq_nl_np);  // (2, nq_nl_np) -> (nq_nl_np, 2)
+    __memcpy(grad_loc_gdram + i * max_deal_n * input_stride_3 * 2, buf_3,
+             input_stride_2 * 2 * sizeof(T), NRAM2GDRAM,
+             input_stride_3 * 2 * sizeof(T), input_stride_2 * 2 * sizeof(T),
+             deal_n - 1);
+  }
+}
+
+#endif
+
+__mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardFastKernel(
+    const float* data_value, const int32_t* spatial_shapes,
+    const int32_t* data_level_start_index, const float* data_sampling_loc,
+    const float* data_attn_weight, const float* grad_output,
+    const int32_t batch, const int32_t spatial_size, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_query,
+    const int32_t num_points, float* grad_value, float* grad_sampling_loc,
+    float* grad_attn_weight) {
+#if (__BANG_ARCH__ == 592)
+  using T = float;
+  const int32_t num_keys = spatial_size;
+  const int32_t input_stride_4 =
+      num_query * num_heads * num_levels * num_points;
+  const int32_t input_stride_3 = num_heads * num_levels * num_points;
+  const int32_t input_stride_2 = num_levels * num_points;
+  const int32_t output_stride_3 = num_query * num_heads * channels;
+  const int32_t output_stride_2 = num_heads * channels;
+  const int32_t data_value_stride_3 = num_keys * num_heads * channels;
+
+  int32_t* seq_nram = nullptr;            // (1024)
+  T* zeros_nram = nullptr;                // (channels)
+  int32_t* data_offset_nram = nullptr;    // (4, deal_n, num_levels, num_points)
+  T* weight_polation_nram = nullptr;      // (4, deal_n, num_levels, num_points)
+  T* cond_point_polation_nram = nullptr;  // (4, deal_n, num_levels, num_points)
+  T* cond_point_valid_nram = nullptr;     // (deal_n, num_levels, num_points)
+  T* loc_nram = nullptr;                  // (deal_n, num_levels, num_points, 2)
+  T* buf_nram = nullptr;                  // (6, deal_n, num_levels, num_points)
+  T* buf_nram_end = nullptr;
+  int8_t* mask_x_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
+  int8_t* mask_y_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
+  T* spatial_offset_bd_nram = nullptr;     // (num_levels, num_points)
+  T* spatial_w_bd_nram = nullptr;          // (num_levels, num_points)
+  T* spatial_h_bd_nram = nullptr;          // (num_levels, num_points)
+  int32_t* spatial_offset_nram = nullptr;  // (num_levels)
+  int32_t* spatial_hw_nram = nullptr;      // (num_levels, 2)
+  T* compute_buffer_nram_stg2 =
+      nullptr;  // (deal_n, num_levels, num_points, channels)
+  T* weight_polation_nram_stg2 =
+      nullptr;                          // (4, deal_n, num_levels, num_points)
+  T* delta_xy_nram = nullptr;           // (4, deal_n, num_levels, num_points)
+  T* weight_attn_nram_stg2 = nullptr;   // (1, deal_n, num_levels, num_points)
+  int32_t* offset_nram_stg2 = nullptr;  // (4, deal_n, num_levels, num_points)
+  T* grad_output_nram = nullptr;        // (deal_n, channels)
+  T* cond_nram_stg2 = nullptr;          // (4, deal_n, num_levels, num_points)
+  T* compute_buffer_nram_stg3 =
+      nullptr;                      // (4, max_deal_n, num_levels, num_points)
+  T* delta_xy_nram_stg3 = nullptr;  // (4, max_deal_n, num_levels, num_points)
+  T* grad_wp_nram_stg3 = nullptr;
+  T* value_sram = nullptr;  // (num_keys, channels)
+  int32_t* data_offset_sram = nullptr;
+  T* weight_polation_sram = nullptr;
+  T* grad_wp_sram = nullptr;
+  T* weight_attn_sram = nullptr;
+  T* cond_point_polation_sram = nullptr;
+  T* delta_xy_sram = nullptr;
+  int8_t* bit_cond_nram = nullptr;          // (4, pad_points / 8)
+  int8_t* bit_cond_reverse_nram = nullptr;  // (4, pad_points / 8)
+  int32_t stage_1_max_deal_n = 0;
+  int32_t stage_2_max_deal_n = 0;
+  int32_t stage_3_max_deal_n = 0;
+  int32_t max_cached_n = 0;
+  int32_t mask_size = 0;
+  memPolicyBackward(
+      seq_nram, zeros_nram, data_offset_nram, weight_polation_nram,
+      cond_point_polation_nram, cond_point_valid_nram, delta_xy_nram, loc_nram,
+      buf_nram, buf_nram_end, mask_x_nram, mask_y_nram, spatial_offset_bd_nram,
+      spatial_w_bd_nram, spatial_h_bd_nram, spatial_offset_nram,
+      spatial_hw_nram, compute_buffer_nram_stg2, weight_polation_nram_stg2,
+      weight_attn_nram_stg2, offset_nram_stg2, grad_output_nram, bit_cond_nram,
+      bit_cond_reverse_nram, cond_nram_stg2, compute_buffer_nram_stg3,
+      delta_xy_nram_stg3, grad_wp_nram_stg3, data_offset_sram,
+      weight_polation_sram, grad_wp_sram, weight_attn_sram,
+      cond_point_polation_sram, delta_xy_sram, nram_buffer, sram_buffer,
+      max_cached_n, stage_1_max_deal_n, stage_2_max_deal_n, stage_3_max_deal_n,
+      mask_size, NRAM_AVALIABLE_SIZE, SRAM_AVALIABLE_SIZE, batch, num_keys,
+      num_heads, channels, num_levels, num_query, num_points);
+
+  if (stage_1_max_deal_n <= 0 || stage_2_max_deal_n <= 0) {
+    return;
+  }
+
+  int32_t cluster_begin_batch_head = 0;
+  int32_t cluster_act_batch_head = 0;
+  int32_t cluster_end_batch_head = 0;
+  int32_t core_begin_query = 0;
+  int32_t core_act_query = 0;
+  int32_t core_loop_num = 0;
+  int32_t core_step_query = 0;
+  splitTaskV2(cluster_begin_batch_head, cluster_act_batch_head,
+              cluster_end_batch_head, core_begin_query, core_act_query,
+              core_loop_num, core_step_query, max_cached_n, batch, num_keys,
+              num_heads, channels, num_levels, num_query, num_points);
+
+  prepareLoopV2(seq_nram, zeros_nram, spatial_offset_nram, spatial_hw_nram,
+                mask_x_nram, mask_y_nram, spatial_offset_bd_nram,
+                spatial_h_bd_nram, spatial_w_bd_nram, value_sram,
+                data_level_start_index, spatial_shapes, num_keys, num_levels,
+                num_points, stage_1_max_deal_n, mask_size, channels);
+
+  for (int32_t bh_idx = cluster_begin_batch_head;
+       bh_idx < cluster_end_batch_head; bh_idx++) {
+    int32_t b = bh_idx / num_heads;
+    int32_t head_idx = bh_idx % num_heads;
+    size_t output_base_offset =
+        (size_t)b * output_stride_3 + head_idx * channels;
+    size_t attn_weight_base_offset =
+        (size_t)b * input_stride_4 + head_idx * input_stride_2;
+    size_t data_value_base_offset =
+        (size_t)b * data_value_stride_3 + head_idx * channels;
+
+    for (int32_t i = 0; __is_ipu() && i < core_loop_num; i++) {
+      int32_t deal_n =
+          std::min(core_act_query - core_step_query * i, core_step_query);
+      int32_t core_query_offset = i * core_step_query;
+      size_t attn_weight_offset =
+          attn_weight_base_offset +
+          (core_begin_query + core_query_offset) * input_stride_3;
+      size_t loc_offset = attn_weight_offset * 2;
+      size_t output_offset =
+          output_base_offset +
+          (core_begin_query + core_query_offset) * output_stride_2;
+
+      // compute offset/cond/wp
+      stageOneLoop((T*)data_sampling_loc + loc_offset,
+                   (T*)data_attn_weight + attn_weight_offset, data_offset_nram,
+                   delta_xy_nram, weight_polation_nram,
+                   cond_point_polation_nram, cond_point_valid_nram, loc_nram,
+                   buf_nram, buf_nram_end, mask_x_nram, mask_y_nram,
+                   spatial_offset_bd_nram, spatial_w_bd_nram, spatial_h_bd_nram,
+                   spatial_offset_nram, spatial_hw_nram, data_offset_sram,
+                   delta_xy_sram, weight_polation_sram, weight_attn_sram,
+                   cond_point_polation_sram, true, true, deal_n,
+                   stage_1_max_deal_n, num_heads, channels, num_levels,
+                   num_points, input_stride_2, input_stride_3);
+
+      // compute grad_value/grad_attn_w
+      backwardStageTwoLoop(
+          seq_nram, compute_buffer_nram_stg2, zeros_nram,
+          weight_polation_nram_stg2, weight_attn_nram_stg2, offset_nram_stg2,
+          cond_nram_stg2, bit_cond_nram, bit_cond_reverse_nram,
+          grad_output_nram, delta_xy_nram, data_offset_sram,
+          weight_polation_sram, grad_wp_sram, weight_attn_sram,
+          cond_point_polation_sram, delta_xy_sram,
+          (T*)data_value + data_value_base_offset,
+          (T*)grad_output + output_offset,
+          (T*)grad_value + data_value_base_offset,
+          (T*)grad_attn_weight + attn_weight_offset, wram_buffer, deal_n,
+          stage_2_max_deal_n, input_stride_2, input_stride_3, output_stride_2,
+          num_heads, channels, num_levels, num_points);
+
+      // caompute grad_loc
+      backwardStageThreeLoop(
+          compute_buffer_nram_stg3, delta_xy_nram_stg3, grad_wp_nram_stg3,
+          spatial_h_bd_nram, spatial_w_bd_nram, delta_xy_sram, grad_wp_sram,
+          (T*)grad_sampling_loc + loc_offset, deal_n, stage_3_max_deal_n,
+          input_stride_2, input_stride_3, output_stride_2, num_heads, channels,
+          num_levels, num_points);
+    }
+  }
+#endif
+}
+
+void MLUOP_WIN_API KernelMsDeformAttnBackwardFast(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const float* data_value, const int32_t* spatial_shapes,
+    const int32_t* data_level_start_index, const float* data_sampling_loc,
+    const float* data_attn_weight, const float* grad_output,
+    const int32_t batch, const int32_t spatial_size, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_query,
+    const int32_t num_points, float* grad_value, float* grad_sampling_loc,
+    float* grad_attn_weight) {
+  MLUUnion1KernelMsDeformAttnBackwardFastKernel<<<k_dim, k_type, queue>>>(
+      data_value, spatial_shapes, data_level_start_index, data_sampling_loc,
+      data_attn_weight, grad_output, batch, spatial_size, num_heads, channels,
+      num_levels, num_query, num_points, grad_value, grad_sampling_loc,
+      grad_attn_weight);
+}

--- a/bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_forward.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_forward.mlu
@@ -56,11 +56,14 @@ MsDeformAttnForwardPolicy msDeformAttnForwardPolicyFunc(
 
   *k_type = CNRT_FUNC_TYPE_UNION1;
 
-  if (handle->arch >= MLUOP_MLU370 && num_levels * num_points <= 128 &&
-      num_levels * num_points * channels <= 12288) {
+  int32_t nlp = num_levels * num_points;
+  int32_t nlpc = num_levels * num_points * channels;
+
+  if (handle->arch == MLUOP_MLU370 && nlp <= 128 && nlpc <= 12288) {
     return MS_DEFORM_ATTN_FORWARD_FAST;
-  } else if (num_levels * num_points * 3 * sizeof(int32_t) >
-             handle->nram_size) {
+  } else if (handle->arch == MLUOP_MLU590 && nlp <= 128 && nlpc <= 8192) {
+    return MS_DEFORM_ATTN_FORWARD_FAST;
+  } else if (nlp * 3 * sizeof(int32_t) > handle->nram_size) {
     return MS_DEFORM_ATTN_FORWARD_DEFAULT;
   } else if (channels > handle->nram_size / 12 / sizeof(float) ||
              channels > 96 || channels < 16) {
@@ -248,28 +251,26 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
           VLOG(5)
               << "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Block, "
               << k_dims.x << ", " << k_dims.y << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK((MLUKernelMsDeformAttnForwardDefault<float>
-                        <<<k_dims, k_type, handle->queue>>>(
-                            (char *)data_value, (char *)data_spatial_shapes,
-                            (char *)data_level_start_index,
-                            (char *)data_sampling_loc, (char *)data_attn_weight,
-                            batch_size, num_keys,
-                            num_heads, channels, num_levels, num_queries,
-                            num_points, (char *)data_col)));
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardDefault<
+                        float><<<k_dims, k_type, handle->queue>>>(
+              (char *)data_value, (char *)data_spatial_shapes,
+              (char *)data_level_start_index, (char *)data_sampling_loc,
+              (char *)data_attn_weight, batch_size, num_keys, num_heads,
+              channels, num_levels, num_queries, num_points,
+              (char *)data_col)));
           break;
         }
         case CNRT_FUNC_TYPE_UNION1: {
           VLOG(5) << "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Union"
                   << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
                   << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK((MLUKernelMsDeformAttnForwardDefault<float>
-                        <<<k_dims, k_type, handle->queue>>>(
-                            (char *)data_value, (char *)data_spatial_shapes,
-                            (char *)data_level_start_index,
-                            (char *)data_sampling_loc, (char *)data_attn_weight,
-                            batch_size, num_keys,
-                            num_heads, channels, num_levels, num_queries,
-                            num_points, (char *)data_col)));
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardDefault<
+                        float><<<k_dims, k_type, handle->queue>>>(
+              (char *)data_value, (char *)data_spatial_shapes,
+              (char *)data_level_start_index, (char *)data_sampling_loc,
+              (char *)data_attn_weight, batch_size, num_keys, num_heads,
+              channels, num_levels, num_queries, num_points,
+              (char *)data_col)));
           break;
         }
       }
@@ -282,18 +283,16 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
           break;
         }
         case CNRT_FUNC_TYPE_BLOCK: {
-          VLOG(5)
-              << "Launch Kernel "
-                 "MLUKernelMsDeformAttnForwardSmallChannel<<<Block, "
-              << k_dims.x << ", " << k_dims.y << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK((MLUKernelMsDeformAttnForwardSmallChannel<float>
-                        <<<k_dims, k_type, handle->queue>>>(
-                            (char *)data_value, (char *)data_spatial_shapes,
-                            (char *)data_level_start_index,
-                            (char *)data_sampling_loc, (char *)data_attn_weight,
-                            batch_size, num_keys,
-                            num_heads, channels, num_levels, num_queries,
-                            num_points, (char *)data_col)));
+          VLOG(5) << "Launch Kernel "
+                     "MLUKernelMsDeformAttnForwardSmallChannel<<<Block, "
+                  << k_dims.x << ", " << k_dims.y << ", " << k_dims.z << ">>>";
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardSmallChannel<
+                        float><<<k_dims, k_type, handle->queue>>>(
+              (char *)data_value, (char *)data_spatial_shapes,
+              (char *)data_level_start_index, (char *)data_sampling_loc,
+              (char *)data_attn_weight, batch_size, num_keys, num_heads,
+              channels, num_levels, num_queries, num_points,
+              (char *)data_col)));
           break;
         }
         case CNRT_FUNC_TYPE_UNION1: {
@@ -301,14 +300,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
                      "MLUKernelMsDeformAttnForwardSmallChannel<<<Union"
                   << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
                   << ", " << k_dims.z << ">>>";
-          KERNEL_CHECK((MLUKernelMsDeformAttnForwardSmallChannel<float>
-                        <<<k_dims, k_type, handle->queue>>>(
-                            (char *)data_value, (char *)data_spatial_shapes,
-                            (char *)data_level_start_index,
-                            (char *)data_sampling_loc, (char *)data_attn_weight,
-                            batch_size, num_keys,
-                            num_heads, channels, num_levels, num_queries,
-                            num_points, (char *)data_col)));
+          KERNEL_CHECK((MLUKernelMsDeformAttnForwardSmallChannel<
+                        float><<<k_dims, k_type, handle->queue>>>(
+              (char *)data_value, (char *)data_spatial_shapes,
+              (char *)data_level_start_index, (char *)data_sampling_loc,
+              (char *)data_attn_weight, batch_size, num_keys, num_heads,
+              channels, num_levels, num_queries, num_points,
+              (char *)data_col)));
           break;
         }
       }
@@ -318,14 +316,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
       VLOG(5) << "Launch Kernel MLUKernelMsDeformAttnForwardFast<<<Union"
               << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
               << ", " << k_dims.z << ">>>";
-      KERNEL_CHECK((MLUKernelMsDeformAttnForwardFast<float>
-                    <<<k_dims, k_type, handle->queue>>>(
-                        (char *)data_value, (char *)data_spatial_shapes,
-                        (char *)data_level_start_index,
-                        (char *)data_sampling_loc, (char *)data_attn_weight,
-                        batch_size, num_keys,
-                        num_heads, channels, num_levels, num_queries,
-                        num_points, (char *)data_col)));
+      KERNEL_CHECK((MLUKernelMsDeformAttnForwardFast<
+                    float><<<k_dims, k_type, handle->queue>>>(
+          (char *)data_value, (char *)data_spatial_shapes,
+          (char *)data_level_start_index, (char *)data_sampling_loc,
+          (char *)data_attn_weight, batch_size, num_keys, num_heads, channels,
+          num_levels, num_queries, num_points, (char *)data_col)));
       break;
     }
   }

--- a/bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_utils.h
+++ b/bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_utils.h
@@ -1,0 +1,397 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef KERNELS_MS_DEFORM_ATTN_FORWARD_MS_DEFORM_ATTN_UTILS_H_
+#define KERNELS_MS_DEFORM_ATTN_FORWARD_MS_DEFORM_ATTN_UTILS_H_
+
+#include <math.h>
+#include <algorithm>
+#include "kernels/kernel.h"
+#include "kernels/utils/common.h"
+
+#define BIT_COLLECT_PAD (8)
+#define BACKWARD_MAX_NQ_NL_NP (1024)
+
+#if (__BANG_ARCH__ >= 372)
+
+__mlu_func__ void broadcastSpatialHW(
+    float* spatial_offset_bd_nram,  // (num_levels, num_points)
+    float* spatial_h_bd_nram,       // (num_levels, num_points)
+    float* spatial_w_bd_nram,       // (num_levels, num_points)
+    int32_t* spatial_shapes_nram,   // (num_levels, 2)
+    int32_t* spatial_offset_nram,   // (num_levels)
+    const int32_t num_levels, const int32_t num_points) {
+  __bang_int322float((float*)spatial_shapes_nram, spatial_shapes_nram,
+                     num_levels * 2, 0);
+  __memcpy(spatial_h_bd_nram, spatial_shapes_nram, sizeof(float), NRAM2NRAM,
+           sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
+           num_levels - 1);
+  __memcpy(spatial_w_bd_nram, (float*)spatial_shapes_nram + 1, sizeof(float),
+           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
+           num_levels - 1);
+  __bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
+                     num_levels, 0);
+  __memcpy(spatial_offset_bd_nram, spatial_offset_nram, sizeof(float),
+           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, sizeof(float), num_levels - 1);
+}
+
+template <typename T>
+__mlu_func__ void prepareLoopV2(
+    int32_t* seq_nram, T* zeros_nram, int32_t* spatial_offset_nram,
+    int32_t* spatial_hw_nram, int8_t* mask_x_nram, int8_t* mask_y_nram,
+    T* spatial_offset_bd_nram, T* spatial_h_bd_nram, T* spatial_w_bd_nram,
+    T* value_sram, const void* data_level_start_index_gdram,
+    const void* data_spatial_shapes_gdram, const int32_t num_keys,
+    const int32_t num_levels, const int32_t num_points,
+    const int32_t max_deal_n, const int32_t mask_size, const int32_t channels) {
+  if (seq_nram != nullptr) {
+    for (int i = 0; i < 8; i++) {
+      seq_nram[i] = i;
+    }
+    __bang_add_scalar(seq_nram + 8, seq_nram, 8, 8);     // [0, 7] + 8
+    __bang_add_scalar(seq_nram + 16, seq_nram, 16, 16);  // [0, 15] + 16
+    __bang_add_scalar(seq_nram + 32, seq_nram, 32, 32);  // [0, 31] + 32
+    __bang_add_scalar(seq_nram + 64, seq_nram, 64, 64);
+    __bang_add_scalar(seq_nram + 128, seq_nram, 128, 128);
+    __bang_add_scalar(seq_nram + 256, seq_nram, 256, 256);
+    __bang_add_scalar(seq_nram + 512, seq_nram, 512, 512);  // [0, 511] + 512
+  }
+  __bang_write_value(zeros_nram, channels, (T)0);
+  __bang_write_value(mask_x_nram, mask_size, (char)0x55);
+  __bang_write_value(mask_y_nram, mask_size, (char)0xAA);
+  __memcpy_async(spatial_offset_nram, data_level_start_index_gdram,
+                 num_levels * sizeof(int32_t), GDRAM2NRAM);
+  __memcpy_async(spatial_hw_nram, data_spatial_shapes_gdram,
+                 num_levels * 2 * sizeof(int32_t), GDRAM2NRAM);
+  __sync_io_move_compute();
+  broadcastSpatialHW(spatial_offset_bd_nram, spatial_h_bd_nram,
+                     spatial_w_bd_nram, spatial_hw_nram, spatial_offset_nram,
+                     num_levels, num_points);
+}
+
+/*
+  Split batch*head into taskDimY, the split num_queries into coreDim.
+  This plan is used to staying data_value on SRAM.
+*/
+__mlu_func__ void splitTaskV1(
+    int32_t& cluster_begin_batch_head, int32_t& cluster_act_batch_head,
+    int32_t& cluster_end_batch_head, int32_t& core_begin_query,
+    int32_t& core_act_query, int32_t& core_loop_num, int32_t& core_step_query,
+    const int32_t max_deal_n, const int32_t batch_size, const int32_t num_keys,
+    const int32_t num_heads, const int32_t channels, const int32_t num_levels,
+    const int32_t num_queries, const int32_t num_points) {
+  // split batch*head into taskDimY
+  int32_t batch_head = batch_size * num_heads;
+  int32_t cluster_avg_batch_head = (batch_head + taskDimY - 1) / taskDimY;
+  cluster_begin_batch_head = taskIdY * cluster_avg_batch_head;
+  cluster_act_batch_head =
+      std::min(cluster_avg_batch_head, batch_head - cluster_begin_batch_head);
+  cluster_end_batch_head = cluster_begin_batch_head + cluster_act_batch_head;
+  // split query into coreDim
+  int32_t core_avg_query = (num_queries + coreDim - 1) / coreDim;
+  core_begin_query = coreId * core_avg_query;
+  core_act_query = std::min(num_queries - core_begin_query, core_avg_query);
+  core_loop_num = (core_act_query + max_deal_n - 1) / max_deal_n;
+  core_step_query = core_loop_num > 0
+                        ? (core_act_query + core_loop_num - 1) / core_loop_num
+                        : 0;
+}
+
+/*
+  Split num_queries into taskDim.
+  Each core iterate in batch * head
+*/
+__mlu_func__ void splitTaskV2(
+    int32_t& cluster_begin_batch_head, int32_t& cluster_act_batch_head,
+    int32_t& cluster_end_batch_head, int32_t& core_begin_query,
+    int32_t& core_act_query, int32_t& core_loop_num, int32_t& core_step_query,
+    const int32_t max_deal_n, const int32_t batch_size, const int32_t num_keys,
+    const int32_t num_heads, const int32_t channels, const int32_t num_levels,
+    const int32_t num_queries, const int32_t num_points) {
+  // not split batch*head
+  int32_t batch_head = batch_size * num_heads;
+  cluster_begin_batch_head = 0;
+  cluster_act_batch_head = batch_head;
+  cluster_end_batch_head = batch_head;
+  // split query into taskDim
+  int32_t core_avg_query = (num_queries + taskDim - 1) / taskDim;
+  core_begin_query = taskId * core_avg_query;
+  core_act_query = std::min(num_queries - core_begin_query, core_avg_query);
+  core_loop_num = (core_act_query + max_deal_n - 1) / max_deal_n;
+  core_step_query = core_loop_num > 0
+                        ? (core_act_query + core_loop_num - 1) / core_loop_num
+                        : 0;
+}
+
+template <typename T>
+__mlu_func__ void computePolationWeightOffsetCond(
+    int32_t* data_offset_nram, T* weight_polation_nram,
+    T* cond_point_polation_nram, T* cond_point_valid_nram, T* loc_nram,
+    int8_t* mask_x_nram, int8_t* mask_y_nram, T* spatial_offset_bd_nram,
+    T* spatial_w_bd_nram, T* spatial_h_bd_nram, T* delata_xy_nram, T* buf_nram,
+    const bool cached_delta_xy, const int32_t deal_n, const int32_t num_levels,
+    const int32_t num_points, const int32_t num_heads, const int32_t channels) {
+  int32_t total_points = deal_n * num_levels * num_points;
+  int32_t block_points = num_levels * num_points;
+  T* buf_x_nram = buf_nram;
+  T* buf_y_nram = buf_nram + total_points;
+  T* buf_cond_nram = buf_nram + 2 * total_points;
+  T* buf_x_floor = buf_nram + 2 * total_points;
+  T* buf_x_ceil = buf_nram + 3 * total_points;
+  T* buf_y_floor = buf_nram + 4 * total_points;
+  T* buf_y_ceil = buf_nram + 5 * total_points;
+  //================================================================================================
+  int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
+  __bang_collect_bitindex(buf_x_nram, loc_nram, mask_x_nram, total_coord_pad);
+  __bang_collect_bitindex(buf_y_nram, loc_nram, mask_y_nram, total_coord_pad);
+  // x = loc_x * spatial_w - 0.5; y = loc_y * spatial_h - 0.5;
+  __bang_fusion(FUSION_FMS, buf_x_nram, buf_x_nram, spatial_w_bd_nram, (T)0.5,
+                total_points, block_points);
+  __bang_fusion(FUSION_FMS, buf_y_nram, buf_y_nram, spatial_h_bd_nram, (T)0.5,
+                total_points, block_points);
+  //================================================================================================
+  // get point condition. use buf0, buf1, buf2
+  // (x > -1 && y > -1 && y < spatial_h && x < spatial_w)
+  __bang_gt_scalar(cond_point_valid_nram, buf_x_nram, (T)-1.0, total_points);
+  __bang_gt_scalar(buf_cond_nram, buf_y_nram, (T)-1.0, total_points);
+  __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
+             total_points);
+  __bang_cycle_lt(buf_cond_nram, buf_x_nram, spatial_w_bd_nram, total_points,
+                  block_points);
+  __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
+             total_points);
+  __bang_cycle_lt(buf_cond_nram, buf_y_nram, spatial_h_bd_nram, total_points,
+                  block_points);
+  __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
+             total_points);
+  //================================================================================================
+  __bang_floor(buf_x_floor, buf_x_nram, total_points);
+  __bang_add_scalar(buf_x_ceil, buf_x_floor, 1.0, total_points);
+  __bang_floor(buf_y_floor, buf_y_nram, total_points);
+  __bang_add_scalar(buf_y_ceil, buf_y_floor, 1.0, total_points);
+  T* cond_point_polation_nram_tl = cond_point_polation_nram;
+  T* cond_point_polation_nram_bl = cond_point_polation_nram + total_points;
+  T* cond_point_polation_nram_tr = cond_point_polation_nram + 2 * total_points;
+  T* cond_point_polation_nram_br = cond_point_polation_nram + 3 * total_points;
+  T* cond_point_polation_nram_cond1 = weight_polation_nram;
+  T* cond_point_polation_nram_cond2 = weight_polation_nram + total_points;
+  T* cond_point_polation_nram_cond3 = weight_polation_nram + 2 * total_points;
+  T* cond_point_polation_nram_cond4 = weight_polation_nram + 3 * total_points;
+  __bang_ge_scalar(cond_point_polation_nram_cond1, buf_x_floor, (T)0,
+                   total_points);
+  __bang_cycle_lt(cond_point_polation_nram_cond2, buf_x_ceil, spatial_w_bd_nram,
+                  total_points, block_points);
+  __bang_ge_scalar(cond_point_polation_nram_cond3, buf_y_floor, (T)0,
+                   total_points);
+  __bang_cycle_lt(cond_point_polation_nram_cond4, buf_y_ceil, spatial_h_bd_nram,
+                  total_points, block_points);
+  __bang_and(cond_point_polation_nram_tl, cond_point_polation_nram_cond1,
+             cond_point_polation_nram_cond4, total_points);
+  __bang_and(cond_point_polation_nram_bl, cond_point_polation_nram_cond1,
+             cond_point_polation_nram_cond3, total_points);
+  __bang_and(cond_point_polation_nram_tr, cond_point_polation_nram_cond2,
+             cond_point_polation_nram_cond4, total_points);
+  __bang_and(cond_point_polation_nram_br, cond_point_polation_nram_cond2,
+             cond_point_polation_nram_cond3, total_points);
+  //================================================================================================
+  // get polation weight.
+  T* buf_dx = (T*)data_offset_nram;
+  T* buf_dy = buf_dx + total_points;
+  T* buf_dx_1 = buf_dy + total_points;
+  T* buf_dy_1 = buf_dx_1 + total_points;
+  T* weight_polation_nram_1 = weight_polation_nram;
+  T* weight_polation_nram_2 = weight_polation_nram + 1 * total_points;
+  T* weight_polation_nram_3 = weight_polation_nram + 2 * total_points;
+  T* weight_polation_nram_4 = weight_polation_nram + 3 * total_points;
+  // T* weight_polation_nram_buf = buf_nram + 4 * total_points;
+  __bang_sub(buf_dx, buf_x_floor, buf_x_nram, total_points);  // -dx
+  __bang_sub(buf_dy, buf_y_floor, buf_y_nram, total_points);  // -dy
+  __bang_fusion(FUSION_FSS, buf_dx_1, buf_x_nram, buf_x_floor,
+                (T)1.0,  // dx - 1
+                total_points, total_points);
+  __bang_fusion(FUSION_FSS, buf_dy_1, buf_y_nram, buf_y_floor,
+                (T)1.0,  // dy - 1
+                total_points, total_points);
+  __bang_mul(weight_polation_nram_1, buf_dx_1, buf_dy,
+             total_points);  // (-dy)(dx-1)
+  __bang_mul(weight_polation_nram_2, buf_dx_1, buf_dy_1,
+             total_points);  // (dx-1)*(dy-1)
+  __bang_mul(weight_polation_nram_3, buf_dx, buf_dy,
+             total_points);  // (-dx)*(-dy)
+  __bang_mul(weight_polation_nram_4, buf_dx, buf_dy_1,
+             total_points);  // (-dx)*(dy-1)
+  if (cached_delta_xy) {
+    __bang_sub(delata_xy_nram, buf_x_nram, buf_x_floor, total_points);  // dx
+    __bang_add_scalar(delata_xy_nram + total_points, buf_dx, 1,
+                      total_points);  // 1-dx
+    __bang_sub(delata_xy_nram + 2 * total_points, buf_y_nram, buf_y_floor,
+               total_points);  // dy
+    __bang_add_scalar(delata_xy_nram + 3 * total_points, buf_dy, 1,
+                      total_points);  // 1-dy
+  }
+  //================================================================================================
+  // correct the x,y in [0, w-1] and [0, h-1]
+  T* spatial_w1_bd_nram = buf_nram;
+  T* spatial_h1_bd_nram = buf_nram + block_points;
+  __bang_sub_scalar(spatial_w1_bd_nram, spatial_w_bd_nram, (T)1, block_points);
+  __bang_sub_scalar(spatial_h1_bd_nram, spatial_h_bd_nram, (T)1, block_points);
+  __bang_maxeq_scalar(buf_x_floor, buf_x_floor, (T)0, total_points);
+  __bang_maxeq_scalar(buf_x_ceil, buf_x_ceil, (T)0, total_points);
+  __bang_cycle_minequal(buf_x_floor, buf_x_floor, spatial_w1_bd_nram,
+                        total_points, block_points);
+  __bang_cycle_minequal(buf_x_ceil, buf_x_ceil, spatial_w1_bd_nram,
+                        total_points, block_points);
+  __bang_maxeq_scalar(buf_y_floor, buf_y_floor, (T)0, total_points);
+  __bang_maxeq_scalar(buf_y_ceil, buf_y_ceil, (T)0, total_points);
+  __bang_cycle_minequal(buf_y_floor, buf_y_floor, spatial_h1_bd_nram,
+                        total_points, block_points);
+  __bang_cycle_minequal(buf_y_ceil, buf_y_ceil, spatial_h1_bd_nram,
+                        total_points, block_points);
+  //================================================================================================
+  // offset = y*w + x
+  T* buf_hw_offset = buf_nram;
+  T* data_offset_nram_tl = (T*)data_offset_nram;
+  T* data_offset_nram_bl = data_offset_nram_tl + total_points;
+  T* data_offset_nram_tr = data_offset_nram_bl + total_points;
+  T* data_offset_nram_br = data_offset_nram_tr + total_points;
+  // y_ceil*w + offset + x_floor
+  __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_ceil, spatial_w_bd_nram,
+                spatial_offset_bd_nram, total_points, block_points);
+  __bang_add(data_offset_nram_tl, buf_hw_offset, buf_x_floor, total_points);
+  // y_ceil*w + offset + x_ceil
+  __bang_add(data_offset_nram_tr, buf_hw_offset, buf_x_ceil, total_points);
+  // y_floor*w + offset + x_foor
+  __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_floor, spatial_w_bd_nram,
+                spatial_offset_bd_nram, total_points, block_points);
+  __bang_add(data_offset_nram_bl, buf_hw_offset, buf_x_floor, total_points);
+  // y_floor*w + offset + x_ceil
+  __bang_add(data_offset_nram_br, buf_hw_offset, buf_x_ceil, total_points);
+  __bang_float2int32(data_offset_nram, (T*)data_offset_nram, total_points * 4,
+                     0);
+  int32_t stride = num_heads * channels * sizeof(T);
+  __bang_mul_scalar(data_offset_nram, data_offset_nram, stride,
+                    total_points * 4);
+  //================================================================================================
+  // merge conditions and clear weight, cast conditions to bits
+  T* cond_point_polation_nram_tmp = buf_nram;
+  __bang_cycle_and(cond_point_polation_nram, cond_point_polation_nram,
+                   cond_point_valid_nram, 4 * total_points, total_points);
+  __bang_float2int32((int32_t*)cond_point_polation_nram_tmp,
+                     cond_point_polation_nram, total_points * 4, 0);
+  __bang_mul_scalar((int32_t*)cond_point_polation_nram_tmp,
+                    (int32_t*)cond_point_polation_nram_tmp, (int32_t)0xffffffff,
+                    total_points * 4);
+  __bang_band((char*)weight_polation_nram, (char*)weight_polation_nram,
+              (char*)cond_point_polation_nram_tmp,
+              total_points * 4 * sizeof(float));
+}
+
+/*
+  compute condition, polation_weight, offset and store to SRAM.
+  cache_delta_xy and cache_point_valid is true in backward, false in forward.
+*/
+template <typename T>
+__mlu_func__ void stageOneLoop(
+    T* sampling_loc_gdram, T* weight_attn_gdram, int32_t* data_offset_nram,
+    void* delata_xy_nram, T* weight_polation_nram, T* cond_point_polation_nram,
+    T* cond_point_valid_nram, T* loc_nram, T* buf_nram, T* buf_nram_end,
+    int8_t* mask_x_nram, int8_t* mask_y_nram, T* spatial_offset_bd_nram,
+    T* spatial_w_bd_nram, T* spatial_h_bd_nram, int32_t* spatial_offset_nram,
+    int32_t* spatial_hw_nram, int32_t* data_offset_sram, void* delta_xy_sram,
+    T* weight_polation_sram, T* weight_attn_sram, T* cond_point_polation_sram,
+    const bool cache_delta_xy, const bool cache_point_valid,
+    const int32_t total_deal_n, const int32_t max_deal_n,
+    const int32_t num_heads, const int32_t channels, const int32_t num_levels,
+    const int32_t num_points, const int32_t input_stride_2,
+    const int32_t input_stride_3) {
+  int32_t loop_num = (total_deal_n + max_deal_n - 1) / max_deal_n;
+  int32_t num_levels_points = num_levels * num_points;
+  int32_t sram_offset = 0;
+  int32_t sram_dst_stride = total_deal_n * num_levels_points * sizeof(T);
+  for (int i = 0; i < loop_num; i++) {
+    int32_t deal_n = std::min(total_deal_n - i * max_deal_n, max_deal_n);
+    int32_t deal_point_num = deal_n * num_levels_points;
+    int32_t copy_size = deal_point_num * sizeof(T);
+    __memcpy(loc_nram, sampling_loc_gdram + i * max_deal_n * input_stride_3 * 2,
+             input_stride_2 * 2 * sizeof(T), GDRAM2NRAM,
+             input_stride_2 * 2 * sizeof(T), input_stride_3 * 2 * sizeof(T),
+             deal_n - 1);
+    computePolationWeightOffsetCond(
+        data_offset_nram, weight_polation_nram, cond_point_polation_nram,
+        cond_point_valid_nram, loc_nram, mask_x_nram, mask_y_nram,
+        spatial_offset_bd_nram, spatial_w_bd_nram, spatial_h_bd_nram,
+        (T*)delata_xy_nram, buf_nram, cache_delta_xy, deal_n, num_levels,
+        num_points, num_heads, channels);
+    __memcpy(data_offset_sram + sram_offset, data_offset_nram, copy_size,
+             NRAM2SRAM, sram_dst_stride, copy_size, 3);
+    __memcpy(weight_polation_sram + sram_offset, weight_polation_nram,
+             copy_size, NRAM2SRAM, sram_dst_stride, copy_size, 3);
+    __memcpy(cond_point_polation_sram + sram_offset, cond_point_polation_nram,
+             copy_size, NRAM2SRAM, sram_dst_stride, copy_size, 3);
+    if (cache_point_valid) {
+      __memcpy(cond_point_polation_sram + 4 * total_deal_n * num_levels_points +
+                   sram_offset,
+               cond_point_valid_nram, copy_size, NRAM2SRAM);
+    }
+    if (cache_delta_xy) {
+      __memcpy((T*)delta_xy_sram + sram_offset, delata_xy_nram, copy_size,
+               NRAM2SRAM, sram_dst_stride, copy_size, 3);
+    }
+    __memcpy(buf_nram, weight_attn_gdram + i * max_deal_n * input_stride_3,
+             input_stride_2 * sizeof(T), GDRAM2NRAM, input_stride_2 * sizeof(T),
+             input_stride_3 * sizeof(T), deal_n - 1);
+    __bang_float2int32((int32_t*)cond_point_valid_nram, cond_point_valid_nram,
+                       deal_point_num, 0);
+    __bang_mul_scalar((int32_t*)cond_point_valid_nram,
+                      (int32_t*)cond_point_valid_nram, (int32_t)0xffffffff,
+                      deal_point_num);
+    __bang_band((char*)buf_nram, (char*)buf_nram, (char*)cond_point_valid_nram,
+                deal_n * num_levels * num_points * sizeof(T));
+    __memcpy(weight_attn_sram + sram_offset, buf_nram, copy_size, NRAM2SRAM);
+    sram_offset += deal_point_num;
+  }
+  __sync_io_move_compute();
+}
+#endif
+
+#if (__BANG_ARCH__ == 592)
+__mlu_func__ void gatherAsync(void* dst, void* src, unsigned int* offset,
+                              void* mask, int transfer_size,
+                              mluMemcpyDirection_t dir, int dst_stride,
+                              int transfer_num) {
+  __gather_async(dst, src, offset, mask, transfer_size, dir, dst_stride,
+                 transfer_num);
+}
+
+__mlu_func__ void gatherSync(void* dst, void* src, unsigned int* offset,
+                             void* mask, int transfer_size,
+                             mluMemcpyDirection_t dir, int dst_stride,
+                             int transfer_num) {
+  __gather(dst, src, offset, mask, transfer_size, dir, dst_stride,
+           transfer_num);
+}
+#endif
+
+#endif

--- a/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -20,16 +20,12 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
-#include <math.h>
-#include "kernels/kernel.h"
-#include "kernels/utils/common.h"
+#include "ms_deform_attn_utils.h"
 
 #pragma bang walign(64)
 
 #if (__BANG_ARCH__ >= 372)
 
-#define MEMCORE_FLAG (0x80)
-#define BIT_COLLECT_PAD (8)
 #define MAX_MEMCPY_SEGNUM (65536)
 #define NRAM_REMAIN_SIZE (48 * 1024)
 #define SRAM_REMAIN_SIZE (32 * 1024)
@@ -592,30 +588,6 @@ __mlu_func__ void loadNeighborPolationAttn(
   }
 }
 
-__mlu_func__ void broadcastSpatialHW(
-    float* spatial_offset_bd_nram,  // (num_levels, num_points)
-    float* spatial_h_bd_nram,       // (num_levels, num_points)
-    float* spatial_w_bd_nram,       // (num_levels, num_points)
-    int32_t* spatial_shapes_nram,   // (num_levels, 2)
-    int32_t* spatial_offset_nram,   // (num_levels)
-    const int32_t num_levels, const int32_t num_points) {
-  __bang_int322float((float*)spatial_shapes_nram, spatial_shapes_nram,
-                     num_levels * 2, 0);
-  __memcpy(spatial_h_bd_nram, spatial_shapes_nram, sizeof(float), NRAM2NRAM,
-           sizeof(float), num_points - 1, num_points * sizeof(float),
-           num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
-           num_levels - 1);
-  __memcpy(spatial_w_bd_nram, (float*)spatial_shapes_nram + 1, sizeof(float),
-           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
-           num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
-           num_levels - 1);
-  __bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
-                     num_levels, 0);
-  __memcpy(spatial_offset_bd_nram, spatial_offset_nram, sizeof(float),
-           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
-           num_levels - 1, 0, num_points - 1, sizeof(float), num_levels - 1);
-}
-
 template <typename T>
 __mlu_func__ void prepareLoop(
     T* ones_nram, int32_t* spatial_offset_nram, int32_t* spatial_hw_nram,
@@ -686,7 +658,7 @@ __mlu_func__ void loadDataValueGdram2Sram(T* value_sram, T* data_value_gdram,
   Note: buf_nram is reused in polation computing.
 */
 template <typename T>
-__mlu_func__ void memPolicy(
+__mlu_func__ void memPolicyCommon(
     T*& buf_compute_nram, T*& ones_nram, T*& value_output_nram,
     int32_t*& data_offset_nram, T*& weight_polation_nram,
     T*& cond_point_polation_nram, T*& cond_point_valid_nram, T*& loc_nram,
@@ -793,13 +765,14 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
   T* value_sram = nullptr;                 // (num_keys, channels)
   int32_t max_deal_n = 0;
   int32_t mask_size = 0;
-  memPolicy(buf_compute_nram, ones_nram, value_output_nram, data_offset_nram,
-            weight_polation_nram, cond_point_polation_nram,
-            cond_point_valid_nram, loc_nram, weight_attn_nram, buf_nram,
-            buf_nram_end, mask_x_nram, mask_y_nram, spatial_offset_bd_nram,
-            spatial_w_bd_nram, spatial_h_bd_nram, spatial_offset_nram,
-            spatial_hw_nram, value_sram, max_deal_n, mask_size, batch_size,
-            num_keys, num_heads, channels, num_levels, num_queries, num_points);
+  memPolicyCommon(buf_compute_nram, ones_nram, value_output_nram,
+                  data_offset_nram, weight_polation_nram,
+                  cond_point_polation_nram, cond_point_valid_nram, loc_nram,
+                  weight_attn_nram, buf_nram, buf_nram_end, mask_x_nram,
+                  mask_y_nram, spatial_offset_bd_nram, spatial_w_bd_nram,
+                  spatial_h_bd_nram, spatial_offset_nram, spatial_hw_nram,
+                  value_sram, max_deal_n, mask_size, batch_size, num_keys,
+                  num_heads, channels, num_levels, num_queries, num_points);
   if (max_deal_n <= 0) {
     return;
   }
@@ -851,7 +824,7 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
     }
     __sync_cluster();
 
-    if (coreId != MEMCORE_FLAG) {
+    if (__is_ipu()) {
       if (sram_stay) {
         int32_t buf_size =
             (int)((char*)buf_nram_end - (char*)value_output_nram);
@@ -881,7 +854,7 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
       }
     }
 
-    for (int32_t i = 0; coreId != MEMCORE_FLAG && i < core_loop_num; i++) {
+    for (int32_t i = 0; __is_ipu() && i < core_loop_num; i++) {
       int32_t deal_n =
           i < core_loop_num - 1 ? core_step_query : core_remain_query;
       int32_t load_n =
@@ -934,6 +907,334 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
     __sync_cluster();
   }
 }
+#endif
+
+#if (__BANG_ARCH__ == 592)
+
+/*
+  The shape of each tensor on nram:
+  spatial_offset_nram:       (num_levels)
+  spatial_hw_nram:           (num_levels, 2)
+  spatial_offset_bd_nram:    (num_levels, num_points)
+  spatial_w_bd_nram:         (num_levels, num_points)
+  spatial_h_bd_nram:         (num_levels, num_points)
+  mask_x_nram:               (deal_n, num_levels, num_points, 2) / 8
+  mask_y_nram:               (deal_n, num_levels, num_points, 2) / 8
+  data_offset_nram:          (4, deal_n, num_levels, num_points)
+  weight_polation_nram:      (4, deal_n, num_levels, num_points)
+  cond_point_polation_nram:  (4, deal_n, num_levels, num_points)
+  cond_point_valid_nram:     (deal_n, num_levels, num_points)
+  loc_nram:                  (deal_n, num_levels, num_points, 2)
+  buf_nram:                  (6, deal_n, num_levels, num_points)
+
+  The shape of each tensor on sram:
+  data_offset_nram:          (4, deal_n, num_levels, num_points)
+  weight_polation_nram:      (4, deal_n, num_levels, num_points)
+  cond_point_polation_nram:  (4, deal_n, num_levels, num_points) / 8
+  cond_point_valid_nram:     (deal_n, num_levels, num_points)
+*/
+template <typename T>
+__mlu_func__ void memPolicy590(
+    T*& zeros_nram, int32_t*& data_offset_nram, T*& weight_polation_nram,
+    T*& cond_point_polation_nram, T*& cond_point_valid_nram, T*& loc_nram,
+    T*& buf_nram, T*& buf_nram_end, int8_t*& mask_x_nram, int8_t*& mask_y_nram,
+    T*& spatial_offset_bd_nram, T*& spatial_w_bd_nram, T*& spatial_h_bd_nram,
+    int32_t*& spatial_offset_nram, int32_t*& spatial_hw_nram, T*& value_ping,
+    T*& value_pong, T*& compute_buffer, T*& weight_polation_nram_stg2,
+    T*& weight_attn_nram_stg2, int32_t*& offset_nram_stg2, T*& output_nram,
+    T*& cond_nram_stg2, int32_t*& data_offset_sram, T*& weight_polation_sram,
+    T*& weight_attn_sram, T*& cond_point_polation_sram, char* nram_buffer,
+    char* sram_buffer, int32_t& max_cached_n, int32_t& stage_1_max_deal_n,
+    int32_t& stage_2_max_deal_n, int32_t& mask_size,
+    const int32_t nram_avaliable_size, const int32_t sram_avaliable_size,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points) {
+  int32_t num_points_levels = num_levels * num_points;
+  int32_t spatial_info_size =
+      PAD_UP(3 * num_levels * sizeof(int32_t), WRAM_ALIGN_SIZE);
+  int32_t spatial_info_bd_size =
+      PAD_UP(3 * num_points_levels * sizeof(T), WRAM_ALIGN_SIZE);
+  int32_t zeros_size = PAD_UP(channels * sizeof(T), WRAM_ALIGN_SIZE);
+  int32_t fix_space_size = spatial_info_size + 2 * BIT_COLLECT_PAD * sizeof(T) +
+                           spatial_info_bd_size + zeros_size;
+  int32_t left_space_size = nram_avaliable_size - fix_space_size;
+  stage_1_max_deal_n = left_space_size / (20 * num_points_levels * sizeof(T));
+  int32_t total_points = stage_1_max_deal_n * num_points_levels;
+  int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
+  mask_size = PAD_UP(total_coord_pad / BIT_COLLECT_PAD, WRAM_ALIGN_SIZE);
+  stage_2_max_deal_n =
+      (left_space_size - 2 * mask_size) /
+      ((12 * num_points_levels * channels + 17 * num_points_levels) *
+       sizeof(T));
+  // fix nram space
+  zeros_nram = (T*)(nram_buffer);
+  spatial_offset_nram = (int32_t*)(zeros_nram + zeros_size / sizeof(T));
+  spatial_hw_nram = spatial_offset_nram + num_levels;
+  spatial_offset_bd_nram =
+      (T*)((int8_t*)spatial_offset_nram + spatial_info_size);
+  spatial_w_bd_nram = spatial_offset_bd_nram + num_points_levels;
+  spatial_h_bd_nram = spatial_w_bd_nram + num_points_levels;
+  mask_x_nram = (int8_t*)spatial_offset_bd_nram + spatial_info_bd_size;
+  mask_y_nram = mask_x_nram + mask_size;
+  // stage1 nram space
+  // 4 + 4 + 4 + 1 + 6
+  data_offset_nram = (int32_t*)(mask_y_nram + mask_size);
+  weight_polation_nram = (T*)(data_offset_nram + 4 * total_points);
+  cond_point_polation_nram = weight_polation_nram + 4 * total_points;
+  cond_point_valid_nram = cond_point_polation_nram + 4 * total_points;
+  buf_nram = cond_point_valid_nram + total_points;
+  loc_nram = buf_nram + 4 * total_points;
+  buf_nram_end = buf_nram + 6 * total_points + total_coord_pad;
+  // stage2 nram space
+  int32_t total_points_stg2 = stage_2_max_deal_n * num_points_levels;
+  cond_nram_stg2 = (T*)(mask_y_nram + mask_size);
+  value_ping = cond_nram_stg2 + 4 * total_points_stg2 + BIT_COLLECT_PAD;
+  value_pong = value_ping + 4 * total_points_stg2 * channels;
+  compute_buffer = value_pong + 4 * total_points_stg2 * channels;
+  weight_polation_nram_stg2 = compute_buffer + 4 * total_points_stg2 * channels;
+  weight_attn_nram_stg2 = weight_polation_nram_stg2 + 4 * total_points_stg2;
+  offset_nram_stg2 = (int32_t*)(weight_attn_nram_stg2 + total_points_stg2);
+  // sram space: 4 + 4 + 1 + 4
+  int32_t polation_info_size = 13 * num_points_levels * sizeof(T);
+  int32_t avg_sram_size = sram_avaliable_size / coreDim;
+  max_cached_n = avg_sram_size / polation_info_size;
+  int max_cached_points = max_cached_n * num_points_levels;
+  T* sram_buf_base = (T*)(sram_buffer + avg_sram_size * coreId);
+  data_offset_sram = (int32_t*)sram_buf_base;
+  weight_polation_sram = (T*)(data_offset_sram + 4 * max_cached_points);
+  weight_attn_sram = (T*)(weight_polation_sram + 4 * max_cached_points);
+  cond_point_polation_sram = (T*)(weight_attn_sram + max_cached_points);
+}
+
+template <typename T>
+__mlu_func__ void forwardStageTwoLoop(
+    T* value_ping_nram, T* value_pong_nram, T* compute_buffer_nram,
+    T* zeros_nram, T* weight_polation_nram_stg2, T* weight_attn_nram_stg2,
+    int32_t* offset_nram_stg2, T* output_nram, T* cond_nram_stg2,
+    int32_t* data_offset_sram, T* weight_polation_sram, T* weight_attn_sram,
+    T* cond_point_polation_sram, T* data_value_gdram, T* weight_attn_gdram,
+    T* output_gdram, const int32_t total_deal_n, const int32_t max_deal_n,
+    const int32_t input_stride_2, const int32_t input_stride_3,
+    const int32_t output_stride_2, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels,
+    const int32_t num_points) {
+  int32_t loop_num = (total_deal_n + max_deal_n - 1) / max_deal_n;
+  int32_t num_levels_points = num_levels * num_points;
+  int32_t sram_src_stride = total_deal_n * num_levels_points * sizeof(T);
+  T* value_nram[2] = {value_ping_nram, value_pong_nram};
+  int32_t* offset_zero_nram_stg2 =
+      offset_nram_stg2 + 4 * max_deal_n * num_levels_points;
+  for (int32_t i = 0; i < loop_num + 1; i++) {
+    int32_t compute_idx = i - 1;
+    int32_t compute_offset = compute_idx * max_deal_n;
+    int32_t load_n = std::min(total_deal_n - i * max_deal_n, max_deal_n);
+    int32_t compute_n =
+        std::min(total_deal_n - compute_idx * max_deal_n, max_deal_n);
+    int32_t load_point_num = 4 * load_n * num_levels_points;
+    int32_t nq_nlp_4 = compute_n * num_levels_points * 4;
+    int32_t nq_nlp = compute_n * num_levels_points;
+
+    int32_t total_point_pad_8 = PAD_UP(load_point_num, BIT_COLLECT_PAD);
+    int32_t gather_mask_size = total_point_pad_8 / BIT_COLLECT_PAD;
+    T* v_compute = value_nram[compute_idx % 2];
+    T* v_load = value_nram[i % 2];
+    int8_t* cond_nram_stg2_reverse = (int8_t*)cond_nram_stg2 + gather_mask_size;
+
+    if (i > 0) {
+      int32_t copy_size_1 = compute_n * num_levels_points * sizeof(T);
+      int32_t sram_src_offset = compute_idx * max_deal_n * num_levels_points;
+      __memcpy_async(weight_polation_nram_stg2,
+                     weight_polation_sram + sram_src_offset, copy_size_1,
+                     SRAM2NRAM, copy_size_1, sram_src_stride, 3);
+      __memcpy_async(weight_attn_nram_stg2, weight_attn_sram + sram_src_offset,
+                     copy_size_1, SRAM2NRAM);
+    }
+
+    if (i < loop_num) {
+      int32_t copy_size_1 = load_n * num_levels_points * sizeof(T);
+      int32_t copy_size_2 = load_n * num_levels_points * sizeof(int32_t);
+      int32_t sram_src_offset = i * max_deal_n * num_levels_points;
+      __memcpy_async(offset_nram_stg2, data_offset_sram + sram_src_offset,
+                     copy_size_2, SRAM2NRAM, copy_size_2, sram_src_stride, 3);
+      __memcpy_async(cond_nram_stg2, cond_point_polation_sram + sram_src_offset,
+                     copy_size_1, SRAM2NRAM, copy_size_1, sram_src_stride, 3);
+      __bang_write_value(compute_buffer_nram, load_point_num, (T)0);
+      __bang_write_value(offset_zero_nram_stg2, load_point_num, (int32_t)0);
+      __sync_move();
+      __bang_gt_bitindex(cond_nram_stg2, cond_nram_stg2, compute_buffer_nram,
+                         total_point_pad_8);
+      __bang_bnot((char*)cond_nram_stg2_reverse, (char*)cond_nram_stg2,
+                  gather_mask_size);
+    }
+
+    __sync_io_move_compute();
+
+    if (i < loop_num) {
+      gatherAsync(v_load, zeros_nram, (unsigned int*)offset_zero_nram_stg2,
+                  cond_nram_stg2_reverse, channels * sizeof(T), NRAM2NRAM,
+                  channels * sizeof(T), load_point_num);
+      gatherAsync(v_load, data_value_gdram, (unsigned int*)offset_nram_stg2,
+                  cond_nram_stg2, channels * sizeof(T), GDRAM2NRAM,
+                  channels * sizeof(T), load_point_num);
+    }
+
+    if (i > 0) {
+      __bang_transpose(compute_buffer_nram, v_compute, nq_nlp_4, channels);
+      __bang_cycle_mul(compute_buffer_nram, compute_buffer_nram,
+                       weight_polation_nram_stg2, channels * nq_nlp_4,
+                       nq_nlp_4);
+      __bang_sumpool(v_compute, compute_buffer_nram, nq_nlp, channels, 4, 1, 4,
+                     1, 1);
+      __bang_cycle_mul(v_compute, v_compute, weight_attn_nram_stg2,
+                       channels * nq_nlp, nq_nlp);
+      __bang_transpose(compute_buffer_nram, v_compute, channels, nq_nlp);
+      __bang_sumpool(v_compute, compute_buffer_nram, channels, compute_n,
+                     num_levels_points, 1, num_levels_points, 1, 1);
+      __memcpy(output_gdram + compute_offset * output_stride_2, v_compute,
+               channels * sizeof(T), NRAM2GDRAM, output_stride_2 * sizeof(T),
+               channels * sizeof(T), compute_n - 1);
+    }
+    __sync_io_move_compute();
+  }
+}
+
+// only for 590
+template <typename T>
+__mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
+    const char* data_value_gdram, const char* data_spatial_shapes_gdram,
+    const char* data_level_start_index_gdram,
+    const char* data_sampling_loc_gdram, const char* data_attn_weight_gdram,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points, char* data_col_gdram) {
+  int32_t input_stride_4 = num_queries * num_heads * num_levels * num_points;
+  int32_t input_stride_3 = num_heads * num_levels * num_points;
+  int32_t input_stride_2 = num_levels * num_points;
+  int32_t output_stride_3 = num_queries * num_heads * channels;
+  int32_t output_stride_2 = num_heads * channels;
+  int32_t data_value_stride_3 = num_keys * num_heads * channels;
+
+  T* zeros_nram = nullptr;                // (channels)
+  int32_t* data_offset_nram = nullptr;    // (4, deal_n, num_levels, num_points)
+  T* weight_polation_nram = nullptr;      // (4, deal_n, num_levels, num_points)
+  T* cond_point_polation_nram = nullptr;  // (4, deal_n, num_levels, num_points)
+  T* cond_point_valid_nram = nullptr;     // (deal_n, num_levels, num_points)
+  T* loc_nram = nullptr;                  // (deal_n, num_levels, num_points, 2)
+  T* buf_nram = nullptr;                  // (6, deal_n, num_levels, num_points)
+  T* buf_nram_end = nullptr;
+  int8_t* mask_x_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
+  int8_t* mask_y_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
+  T* spatial_offset_bd_nram = nullptr;     // (num_levels, num_points)
+  T* spatial_w_bd_nram = nullptr;          // (num_levels, num_points)
+  T* spatial_h_bd_nram = nullptr;          // (num_levels, num_points)
+  int32_t* spatial_offset_nram = nullptr;  // (num_levels)
+  int32_t* spatial_hw_nram = nullptr;      // (num_levels, 2)
+  T* value_ping_nram = nullptr;  // (deal_n, num_levels, num_points, channels)
+  T* value_pong_nram = nullptr;  // (deal_n, num_levels, num_points, channels)
+  T* compute_buffer_nram =
+      nullptr;  // (deal_n, num_levels, num_points, channels)
+  T* weight_polation_nram_stg2 =
+      nullptr;                          // (4, deal_n, num_levels, num_points)
+  T* weight_attn_nram_stg2 = nullptr;   // (1, deal_n, num_levels, num_points)
+  int32_t* offset_nram_stg2 = nullptr;  // (4, deal_n, num_levels, num_points)
+  T* output_nram = nullptr;             // (deal_n, channels)
+  T* cond_nram_stg2 = nullptr;          // (4, deal_n, num_levels, num_points)
+  T* value_sram = nullptr;              // (num_keys, channels)
+  int32_t* data_offset_sram = nullptr;
+  T* weight_polation_sram = nullptr;
+  T* wegith_attn_sram = nullptr;
+  T* cond_point_polation_sram = nullptr;
+  int32_t stage_1_max_deal_n = 0;
+  int32_t stage_2_max_deal_n = 0;
+  int32_t max_cached_n = 0;
+  int32_t mask_size = 0;
+  memPolicy590(
+      zeros_nram, data_offset_nram, weight_polation_nram,
+      cond_point_polation_nram, cond_point_valid_nram, loc_nram, buf_nram,
+      buf_nram_end, mask_x_nram, mask_y_nram, spatial_offset_bd_nram,
+      spatial_w_bd_nram, spatial_h_bd_nram, spatial_offset_nram,
+      spatial_hw_nram, value_ping_nram, value_pong_nram, compute_buffer_nram,
+      weight_polation_nram_stg2, weight_attn_nram_stg2, offset_nram_stg2,
+      output_nram, cond_nram_stg2, data_offset_sram, weight_polation_sram,
+      wegith_attn_sram, cond_point_polation_sram, nram_buffer, sram_buffer,
+      max_cached_n, stage_1_max_deal_n, stage_2_max_deal_n, mask_size,
+      NRAM_AVALIABLE_SIZE, SRAM_AVALIABLE_SIZE, batch_size, num_keys, num_heads,
+      channels, num_levels, num_queries, num_points);
+  if (stage_1_max_deal_n <= 0 || stage_2_max_deal_n <= 0) {
+    return;
+  }
+
+  int32_t cluster_begin_batch_head = 0;
+  int32_t cluster_act_batch_head = 0;
+  int32_t cluster_end_batch_head = 0;
+  int32_t core_begin_query = 0;
+  int32_t core_act_query = 0;
+  int32_t core_loop_num = 0;
+  int32_t core_step_query = 0;
+  splitTaskV2(cluster_begin_batch_head, cluster_act_batch_head,
+              cluster_end_batch_head, core_begin_query, core_act_query,
+              core_loop_num, core_step_query, max_cached_n, batch_size,
+              num_keys, num_heads, channels, num_levels, num_queries,
+              num_points);
+
+  prepareLoopV2((int32_t*)nullptr, zeros_nram, spatial_offset_nram,
+                spatial_hw_nram, mask_x_nram, mask_y_nram,
+                spatial_offset_bd_nram, spatial_h_bd_nram, spatial_w_bd_nram,
+                value_sram, data_level_start_index_gdram,
+                data_spatial_shapes_gdram, num_keys, num_levels, num_points,
+                stage_1_max_deal_n, mask_size, channels);
+
+  for (int32_t bh_idx = cluster_begin_batch_head;
+       bh_idx < cluster_end_batch_head; bh_idx++) {
+    int32_t b = bh_idx / num_heads;
+    int32_t head_idx = bh_idx % num_heads;
+    size_t output_base_offset =
+        (size_t)b * output_stride_3 + head_idx * channels;
+    size_t attn_weight_base_offset =
+        (size_t)b * input_stride_4 + head_idx * input_stride_2;
+    size_t data_value_base_offset =
+        (size_t)b * data_value_stride_3 + head_idx * channels;
+
+    for (int32_t i = 0; __is_ipu() && i < core_loop_num; i++) {
+      int32_t deal_n =
+          std::min(core_act_query - core_step_query * i, core_step_query);
+      int32_t core_query_offset = i * core_step_query;
+      size_t attn_weight_offset =
+          attn_weight_base_offset +
+          (core_begin_query + core_query_offset) * input_stride_3;
+      size_t loc_offset = attn_weight_offset * 2;
+      size_t output_offset =
+          output_base_offset +
+          (core_begin_query + i * core_step_query) * output_stride_2;
+
+      // compute offset/cond/wp
+      stageOneLoop((T*)data_sampling_loc_gdram + loc_offset,
+                   (T*)data_attn_weight_gdram + attn_weight_offset,
+                   data_offset_nram, nullptr, weight_polation_nram,
+                   cond_point_polation_nram, cond_point_valid_nram, loc_nram,
+                   buf_nram, buf_nram_end, mask_x_nram, mask_y_nram,
+                   spatial_offset_bd_nram, spatial_w_bd_nram, spatial_h_bd_nram,
+                   spatial_offset_nram, spatial_hw_nram, data_offset_sram,
+                   nullptr, weight_polation_sram, wegith_attn_sram,
+                   cond_point_polation_sram, false, false, deal_n,
+                   stage_1_max_deal_n, num_heads, channels, num_levels,
+                   num_points, input_stride_2, input_stride_3);
+
+      // compute and store output
+      forwardStageTwoLoop(
+          value_ping_nram, value_pong_nram, compute_buffer_nram, zeros_nram,
+          weight_polation_nram_stg2, weight_attn_nram_stg2, offset_nram_stg2,
+          output_nram, cond_nram_stg2, data_offset_sram, weight_polation_sram,
+          wegith_attn_sram, cond_point_polation_sram,
+          (T*)data_value_gdram + data_value_base_offset,
+          (T*)data_attn_weight_gdram + attn_weight_offset,
+          (T*)data_col_gdram + output_offset, deal_n, stage_2_max_deal_n,
+          input_stride_2, input_stride_3, output_stride_2, num_heads, channels,
+          num_levels, num_points);
+    }
+  }
+}
 
 #endif
 
@@ -945,7 +1246,7 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardFast(
     const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
     const int32_t channels, const int32_t num_levels, const int32_t num_queries,
     const int32_t num_points, char* data_col_gdram) {
-#if (__BANG_ARCH__ >= 372)
+#if (__BANG_ARCH__ == 372)
   size_t single_value_size = num_keys * channels * sizeof(T);
   if (single_value_size <= SRAM_FOR_VALUE_SIZE) {
     MLUKernelMsDeformAttnForwardFastImpl<float, 0>(
@@ -960,6 +1261,13 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardFast(
         data_attn_weight_gdram, batch_size, num_keys, num_heads, channels,
         num_levels, num_queries, num_points, data_col_gdram);
   }
+#endif
+
+#if (__BANG_ARCH__ == 592)
+  MLUKernelMsDeformAttnForwardFastImpl<float>(
+      data_value_gdram, data_spatial_shapes_gdram, data_level_start_index_gdram,
+      data_sampling_loc_gdram, data_attn_weight_gdram, batch_size, num_keys,
+      num_heads, channels, num_levels, num_queries, num_points, data_col_gdram);
 #endif
 }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Add optimized kernels for ms_deform_attn_forwrad/backwrad ops.

## 2. Modification

bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.h
bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_fast_union1.mlu
bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_forward.mlu
bangc-ops/kernels/ms_deform_attn_forward/ms_deform_attn_utils.h
bangc-ops/kernels/ms_deform_attn_forward/msda_forward_fast_union1.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |           U1       |
|        3       |Layouts                               |          ARRAY       |
|        4       |Whether multi-dimensions are supported|                 No                     |
|        5       |Whether element zero is supported     |                    Yes                  |
|        6       |Data type(half/float)                 |            float           |
|        7       |Whether there is size limit           |                 No                     |

#### 3.1.3 New Feature Test

Since this ops is merged in other repo, we only focus on whether this ops works well.

For all 3 cases of network, this ops passed unit test.

### 3.2 Summary Analysis

For Accurary

Test Point | Operation | Quantity | Comment
-- | -- | -- | --
 | accurary| ms_deform_attn_backward | 通过 | [==========] 123 test cases from 1 test suite ran. (195191 ms total)<br />[  PASSED  ] 123 test cases.
 | nan/inf| ms_deform_attn_backward | 通过 | [ SUMMARY  ] Total 33 cases of 1 op(s).<br />ALL PASSED.<br />[==========] 33 test cases from 1 test suite ran. (20231 ms total)<br />[  PASSED  ] 33 test cases.
 | accurary | ms_deform_attn_forward | 通过 | [ SUMMARY  ] Total 31 cases of 1 op(s).<br />ALL PASSED.<br />[==========] 31 test cases from 1 test suite ran. (39895 ms total)<br />[  PASSED  ] 31 test cases.

For Efficiency

The new added fast kernels is only for MLU590. The performance of typical cases on MLU590-H8:
|Operation|Mlu_hardware_time baseline(us)|Mlu_hardware_time this (us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Data_type|Shape|
|-------|----|----|----|-----|----|----|----|
|  ms_deform_attn_backward | 132000 |  71113 |  51  |   0.5% | 14%   |  float  | data_value: [6, 30825, 8, 32]<br />data_spatial_shapes: [4, 2]<br />data_level_start_index: [4]<br />data_sampling_loc: [6, 9664, 8, 4, 8, 2]<br />data_attn_weight: [6, 9664, 8, 4, 8]<br />grad_output: [6, 9664, 8, 32]    |
|  ms_deform_attn_backward   | 25078 |  14953  |   18.9 |   1.0% | 11.4%   | float  |  data_value: [2, 40000, 8, 32]data_spatial_shapes: [1, 2]<br />data_level_start_index: [1]<br />data_sampling_loc: [2, 40000, 8, 1, 4, 2]<br />data_attn_weight: [2, 40000, 8, 1, 4]<br />grad_output: [2, 40000, 8, 32]<br />grad_value: [2, 40000, 8, 32]   |
|  ms_deform_attn_forward  | 28000 | 9411 |  51  |   40.8% | 0.7%   |  float  | data_value: [6, 30825, 8, 32]<br />data_spatial_shapes: [4, 2]<br />data_level_start_index: [4]<br />data_sampling_loc: [6, 9664, 8, 4, 8, 2]<br />data_attn_weight: [6, 9664, 8, 4, 8]<br />value_output: [6, 9664, 8, 32]    |
|  ms_deform_attn_forward   | 16500 | 2248  |   18.9 |   31.0% | 0.5%   | float  |  data_value: [2, 40000, 8, 32]data_spatial_shapes: [1, 2]<br />data_level_start_index: [1]<br />data_sampling_loc: [2, 40000, 8, 1, 4, 2]<br />data_attn_weight: [2, 40000, 8, 1, 4]<br />grad_output: [2, 40000, 8, 32]<br />output_value: [2, 40000, 8, 32]   |


