### PR TITLE
[Fix](bangc-ops): replace MLULOG to LOG(ERROR)

### DIFF
--- a/bangc-ops/kernels/abs/abs_block.mlu
+++ b/bangc-ops/kernels/abs/abs_block.mlu
@@ -25,6 +25,7 @@
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define ABS_NRAM_USED MAX_NRAM_SIZE
 #define ABS_SRAM_USED (CORE_DIM * ABS_NRAM_USED)
@@ -86,7 +87,7 @@ void MLUOP_WIN_API Kernel3StagePipelineAbs(cnrtDim3_t k_dim,
           (void *)x, (void *)y, num, 0.0);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -107,7 +108,7 @@ void MLUOP_WIN_API Kernel5StagePipelineAbs(cnrtDim3_t k_dim,
           (void *)x, (void *)y, num, 0.0);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/ball_query/ball_query_union1.mlu
+++ b/bangc-ops/kernels/ball_query/ball_query_union1.mlu
@@ -27,6 +27,7 @@
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 #define COORD_NUM 3
 
@@ -331,7 +332,7 @@ void MLUOP_WIN_API KernelBallQuery(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
           (half *)xyz, (int32_t *)idx);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
     }; break;
   }
 }

--- a/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_union1.mlu
+++ b/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_union1.mlu
@@ -26,6 +26,7 @@
 #include "kernels/box_iou_rotated/box_iou_rotated_nonaligned.h"
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
+#include "core/logging.h"
 
 __mlu_global__ void MLUKernelBoxIouRotated(const float *box1, const float *box2,
                                            float *ious, const int32_t num_box1,
@@ -128,7 +129,7 @@ void MLUOP_WIN_API KernelBoxIouRotated(cnrtDim3_t k_dim,
           aligned);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
     }; break;
   }
 }

--- a/bangc-ops/kernels/div/div_block.mlu
+++ b/bangc-ops/kernels/div/div_block.mlu
@@ -25,6 +25,7 @@
 #include "kernels/binary_op/binary_op_3pipeline.h"
 #include "kernels/kernel.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define HIGH_BOUND 1e5
 #define LOW_BOUND 1e-10
@@ -212,7 +213,7 @@ void MLUOP_WIN_API Kernel3StagePipelineDiv(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/log/log_block.mlu
+++ b/bangc-ops/kernels/log/log_block.mlu
@@ -25,6 +25,7 @@
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define LOG_LOW_BOUND 1e-8
 #define LOG_SCALE 1e12
@@ -183,7 +184,7 @@ void MLUOP_WIN_API Kernel3StagePipelineLog(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -208,7 +209,7 @@ void MLUOP_WIN_API Kernel5StagePipelineLog(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/sqrt/sqrt_block.mlu
+++ b/bangc-ops/kernels/sqrt/sqrt_block.mlu
@@ -26,6 +26,7 @@
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
 #include "kernels/debug.h"
+#include "core/logging.h"
 
 #define SQRT_HIGH_BOUND 1e4
 #define SQRT_SCALE 1e-6
@@ -243,7 +244,7 @@ void MLUOP_WIN_API Kernel3StagePipelineSqrt(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -268,7 +269,7 @@ void MLUOP_WIN_API Kernel5StagePipelineSqrt(
       }
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }
@@ -290,7 +291,7 @@ void MLUOP_WIN_API Kernel3StagePipelineSqrtBackward(
           (void *)y, (void *)diff_y, (void *)x, num);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }

--- a/bangc-ops/kernels/three_interpolate_forward/three_interpolate_union1.mlu
+++ b/bangc-ops/kernels/three_interpolate_forward/three_interpolate_union1.mlu
@@ -25,6 +25,7 @@
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
+#include "core/logging.h"
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
@@ -336,7 +337,7 @@ void MLUOP_WIN_API KernelThreeInterpolateForward(
           c_limit_size, m_limit_size, n_limit_size, (half *)output);
     }; break;
     default: {
-      MLULOG("Not implemented.\n");
+      LOG(ERROR) << "Not implemented.";
       break;
     }
   }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

r0.4 分支：修改.mlu 源文件中 MLULOG 为LOG(ERROR)

## 2. Modification

        modified:   kernels/abs/abs_block.mlu
        modified:   kernels/ball_query/ball_query_union1.mlu
        modified:   kernels/box_iou_rotated/box_iou_rotated_union1.mlu
        modified:   kernels/div/div_block.mlu
        modified:   kernels/log/log_block.mlu
        modified:   kernels/sqrt/sqrt_block.mlu
        modified:   kernels/three_interpolate_forward/three_interpolate_union1.mlu

## 3. Test Report
-  加 -d （debug）编译，全算子编译通过
