### PR TITLE
[Feature](bangc-ops): three_interpolate supports the tensor num near …

### DIFF
--- a/bangc-ops/kernels/three_interpolate/three_interpolate.h
+++ b/bangc-ops/kernels/three_interpolate/three_interpolate.h
@@ -28,15 +28,15 @@
 void MLUOP_WIN_API KernelThreeInterpolateForward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const void *features, const void *indices,
-    const void *weights, const int b, const int c, const int m, const int n,
-    const int c_limit_size, const int m_limit_size, const int n_limit_size,
-    void *output);
+    const void *weights, const uint32_t b, const uint32_t c, const uint32_t m,
+    const uint32_t n, const uint32_t c_limit_size, const uint32_t m_limit_size,
+    const uint32_t n_limit_size, void *output);
 
 void MLUOP_WIN_API KernelThreeInterpolateBackward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const void *grad_output, const void *indices,
-    const void *weights, const int b, const int c, const int m, const int n,
-    const int c_limit_size, const int m_limit_size, const int n_limit_size,
-    void *grad_features);
+    const void *weights, const uint32_t b, const uint32_t c, const uint32_t m,
+    const uint32_t n, const uint32_t c_limit_size, const uint32_t m_limit_size,
+    const uint32_t n_limit_size, void *grad_features);
 
 #endif  // KERNELS_THREE_INTERPOLATE_THREE_INTERPOLATE_H

--- a/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
+++ b/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
@@ -35,20 +35,107 @@ __nram__ char nram_buffer[MAX_NRAM_SIZE];
 #define INT16_MAX_MASK 0xffff
 #define INT32_MASK_REPEAT_TIMES 4
 #define INT16_MASK_REPEAT_TIMES 2
+#define INT32_MAX_NUM 2147483647
+#define INT2FLOAT_KEEP_PRECISION_MAX_VALUE 16777216
 
 template <typename T>
-__mlu_func__ void SelectIndicesBetweenMinAndMax(
+__mlu_func__ void memcpy2D(T *dst, const T *src, uint32_t data_size,
+                           mluMemcpyDirection_t dir, uint64_t dst_stride,
+                           uint64_t src_stride, uint32_t segnum) {
+  for (uint32_t loopi = 0; loopi <= segnum; ++loopi) {
+    char *dst_addr = (char *)dst + loopi * dst_stride * sizeof(T);
+    char *src_addr = (char *)src + loopi * src_stride * sizeof(T);
+    __memcpy(dst_addr, src_addr, data_size * sizeof(T), dir);
+  }
+}
+
+template <typename T>
+__mlu_func__ void selectIndicesBetweenMinAndMaxWithoutLimit(
+    int32_t *nram_indices, int32_t *nram_indices_transpose,
+    int32_t *nram_indices_transpose_addition,
+    int32_t *nram_indices_transpose_float,
+    int32_t *nram_indices_transpose_float_addition, T *nram_weights_transpose,
+    const uint32_t m_min, const uint32_t m_max, const uint32_t index,
+    const uint32_t n_limit, const uint32_t c_limit,
+    const uint32_t m_limit_org) {
+#if __BANG_ARCH__ >= 370 && __BANG_ARCH__ != 520
+  // select the offset between the m_min and m_max
+  // judge if less than m_max
+  __bang_ge_scalar((int32_t *)nram_indices_transpose_float_addition,
+                   nram_indices_transpose + index * n_limit, m_max, n_limit);
+  __bang_not((int32_t *)nram_indices_transpose_float_addition,
+             (int32_t *)nram_indices_transpose_float_addition, n_limit);
+  // judge if greater or equal than m_min
+  __bang_ge_scalar((int32_t *)nram_indices_transpose_addition,
+                   nram_indices_transpose + index * n_limit, m_min, n_limit);
+  // get the bool values in the range of [m_min, m_max)
+  __bang_and((int32_t *)nram_indices_transpose_addition,
+             (int32_t *)nram_indices_transpose_float_addition,
+             (int32_t *)nram_indices_transpose_addition, n_limit);
+#if __BANG_ARCH__ >= 322
+  // extra process for the nan/inf
+  // set weights to be 0 for the indices not in range of [m_min, m_max)
+  if (sizeof(T) == sizeof(float)) {
+    int32_t *nram_mask_int32 = (int32_t *)nram_indices_transpose_float_addition;
+    __bang_mul_scalar((int32_t *)nram_mask_int32,
+                      (int32_t *)nram_indices_transpose_addition,
+                      (int32_t)INT32_MAX_MASK, n_limit);
+    __bang_band((char *)(nram_weights_transpose + index * n_limit),
+                (char *)(nram_weights_transpose + index * n_limit),
+                (char *)nram_mask_int32, INT32_MASK_REPEAT_TIMES * n_limit);
+  } else if (sizeof(T) == sizeof(half)) {
+    int16_t *nram_mask_int16 = (int16_t *)nram_indices_transpose_float_addition;
+    __bang_int322int16(nram_mask_int16,
+                       (int32_t *)nram_indices_transpose_addition, n_limit, 0,
+                       0);
+    __bang_mul_scalar((int16_t *)nram_mask_int16, (int16_t *)nram_mask_int16,
+                      (int16_t)INT16_MAX_MASK, n_limit);
+    __bang_band((char *)(nram_weights_transpose + index * n_limit),
+                (char *)(nram_weights_transpose + index * n_limit),
+                (char *)nram_mask_int16, INT16_MASK_REPEAT_TIMES * n_limit);
+  }
+#endif
+  // multiply the indices with values in the range of [m_min, m_max)
+  __bang_mul((int32_t *)nram_indices_transpose_float,
+             nram_indices_transpose + index * n_limit,
+             (int32_t *)nram_indices_transpose_addition, n_limit);
+  // get the bool values not in the range of [m_min, m_max)
+  __bang_not((int32_t *)nram_indices_transpose_float_addition,
+             (int32_t *)nram_indices_transpose_addition, n_limit);
+  // multiply the values not in the range of [m_min, m_max) with
+  // m_limit_org + m_min
+  __bang_mul_scalar((int32_t *)nram_indices_transpose_float_addition,
+                    (int32_t *)nram_indices_transpose_float_addition,
+                    m_limit_org + m_min, n_limit);
+  // add the indices in range of [m_min, m_max) with the special
+  // indices(same as
+  // m_limit_org + m_min) not in range of [m_min, m_max)
+  __bang_add((int32_t *)nram_indices_transpose_float,
+             (int32_t *)nram_indices_transpose_float,
+             (int32_t *)nram_indices_transpose_float_addition, n_limit);
+  // get the relative indices by subtract m_min
+  __bang_sub_scalar((int32_t *)nram_indices_transpose_float,
+                    (int32_t *)nram_indices_transpose_float, m_min, n_limit);
+  // get the beginning offset by multiply c_limit
+  __bang_mul_scalar(nram_indices, (int32_t *)nram_indices_transpose_float,
+                    c_limit, n_limit);
+#endif
+}
+
+template <typename T>
+__mlu_func__ void selectIndicesBetweenMinAndMax(
     int32_t *nram_indices, int32_t *nram_indices_transpose,
     float *nram_indices_transpose_addition, float *nram_indices_transpose_float,
     float *nram_indices_transpose_float_addition, T *nram_weights_transpose,
-    const int32_t m_min, const int32_t m_max, const int32_t index,
-    const int32_t n_limit, const int32_t c_limit, const int32_t m_limit_org) {
-  // select the offset between the m_min and m_max
-  // convert indices from int32_t to float
+    const uint32_t m_min, const uint32_t m_max, const uint32_t index,
+    const uint32_t n_limit, const uint32_t c_limit,
+    const uint32_t m_limit_org) {
+  // convert indices from int32_t to float for 270
   __int322float(nram_indices_transpose_float,
                 nram_indices_transpose_float_addition,
                 nram_indices_transpose + index * n_limit,
                 nram_indices_transpose_addition, n_limit);
+  // select the offset between the m_min and m_max
   // judge if less than m_max
   __bang_ge_scalar(nram_indices_transpose_float_addition,
                    nram_indices_transpose_float, m_max, n_limit);
@@ -106,7 +193,7 @@ __mlu_func__ void SelectIndicesBetweenMinAndMax(
   // get the beginning offset by multiply c_limit
   __bang_mul_scalar(nram_indices_transpose_float, nram_indices_transpose_float,
                     c_limit, n_limit);
-  // convert the indices from float type back to int
+  // convert the indices from float type back to int for 270
   __float2int32(nram_indices, nram_indices_transpose_addition,
                 nram_indices_transpose_float,
                 nram_indices_transpose_float_addition, n_limit);
@@ -115,44 +202,45 @@ __mlu_func__ void SelectIndicesBetweenMinAndMax(
 template <typename T>
 __mlu_global__ void MLUKernelThreeInterpolateForward(
     const T *features, const int *__restrict__ indices, const T *weights,
-    const int b, const int c, const int m, const int n, const int c_limit_size,
-    const int m_limit_size, const int n_limit_size, T *output) {
+    const uint32_t b, const uint32_t c, const uint32_t m, const uint32_t n,
+    const uint32_t c_limit_size, const uint32_t m_limit_size,
+    const uint32_t n_limit_size, T *output) {
   if (__is_mpu()) {
     return;
   }
-  int32_t align_base_128 = NFU_ALIGN_SIZE / sizeof(T);
-  int32_t c_limit = c_limit_size;
-  int32_t m_limit = m_limit_size;
-  int32_t n_limit = n_limit_size;
+  uint32_t align_base_128 = NFU_ALIGN_SIZE / sizeof(T);
+  uint32_t c_limit = c_limit_size;
+  uint32_t m_limit = m_limit_size;
+  uint32_t n_limit = n_limit_size;
 
-  int32_t c_aligned_limit = CEIL_ALIGN(c, c_limit);
-  int32_t m_aligned_limit = CEIL_ALIGN(m, m_limit);
-  int32_t n_aligned_limit = CEIL_ALIGN(n, n_limit);
+  uint32_t c_aligned_limit = CEIL_ALIGN(c, c_limit);
+  uint32_t m_aligned_limit = CEIL_ALIGN(m, m_limit);
+  uint32_t n_aligned_limit = CEIL_ALIGN(n, n_limit);
 
   c_limit = c_limit > c_aligned_limit ? c_aligned_limit : c_limit;
   m_limit = m_limit > m_aligned_limit ? m_aligned_limit : m_limit;
   n_limit = n_limit > n_aligned_limit ? n_aligned_limit : n_limit;
-  int32_t c_limit_org = c_limit;
-  int32_t m_limit_org = m_limit;
-  int32_t n_limit_org = n_limit;
+  uint32_t c_limit_org = c_limit;
+  uint32_t m_limit_org = m_limit;
+  uint32_t n_limit_org = n_limit;
 
-  int32_t c_repeated_times = c_aligned_limit / c_limit;
-  int32_t m_repeated_times = m_aligned_limit / m_limit;
+  uint32_t c_repeated_times = c_aligned_limit / c_limit;
+  uint32_t m_repeated_times = m_aligned_limit / m_limit;
 
-  int32_t batch_n_repeated_times =
+  uint32_t batch_n_repeated_times =
       (b * n_aligned_limit) / (BATCH_LIMIT * n_limit);
-  int32_t batch_n_per_core = batch_n_repeated_times / taskDim;
-  int32_t batch_n_remain = batch_n_repeated_times % taskDim;
+  uint32_t batch_n_per_core = batch_n_repeated_times / taskDim;
+  uint32_t batch_n_remain = batch_n_repeated_times % taskDim;
 
   batch_n_per_core += (taskId < batch_n_remain);
 
-  int32_t features_deal_size = c_limit * m_limit;
-  int32_t indices_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
-  int32_t weights_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
-  int32_t output_deal_size = c_limit * n_limit;
-  int32_t reuse_deal_size = features_deal_size >= output_deal_size
-                                ? features_deal_size
-                                : output_deal_size;
+  uint32_t features_deal_size = c_limit * m_limit;
+  uint32_t indices_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
+  uint32_t weights_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
+  uint32_t output_deal_size = c_limit * n_limit;
+  uint32_t reuse_deal_size = features_deal_size >= output_deal_size
+                                 ? features_deal_size
+                                 : output_deal_size;
 
   /*
    * NRAM partition
@@ -188,23 +276,23 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
   float *nram_indices_transpose_float_addition =
       (float *)(nram_indices_transpose_float + n_limit);  // n_limit
 
-  for (int32_t i = 0; i < batch_n_per_core; ++i) {
+  for (uint32_t i = 0; i < batch_n_per_core; ++i) {
     n_limit = n_limit_org;
-    int32_t current_batch_n = i + taskId * batch_n_per_core;
+    uint32_t current_batch_n = i + taskId * batch_n_per_core;
     current_batch_n += (taskId >= batch_n_remain ? batch_n_remain : 0);
-    int32_t current_batch = current_batch_n * n_limit / n_aligned_limit;
-    int32_t current_n = current_batch_n % (n_aligned_limit / n_limit);
+    uint32_t current_batch = current_batch_n * n_limit / n_aligned_limit;
+    uint32_t current_n = current_batch_n % (n_aligned_limit / n_limit);
 
-    int32_t real_indices_deal_size = indices_deal_size;
-    int32_t actual_n_size = n_limit;
+    uint32_t real_indices_deal_size = indices_deal_size;
+    uint32_t actual_n_size = n_limit;
 
-    int32_t n_segment = n_aligned_limit / n_limit;
-    int32_t n_remain = n % n_limit;
+    uint32_t n_segment = n_aligned_limit / n_limit;
+    uint32_t n_remain = n % n_limit;
     if (n_remain == 0) {
       n_remain = n_limit;
     }
-    int32_t remains = current_batch_n / n_segment;
-    int32_t segments = current_batch_n - remains;
+    uint32_t remains = current_batch_n / n_segment;
+    uint32_t segments = current_batch_n - remains;
 
     int32_t *base_addr_indices =
         (int32_t *)indices +
@@ -216,7 +304,7 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
     T *base_addr_output =
         (T *)output + current_batch * c * n + current_n * n_limit;
 
-    int32_t n_mod_limit = n % n_limit;
+    uint32_t n_mod_limit = n % n_limit;
     if (current_n == (n_aligned_limit / n_limit - 1) && (n_mod_limit != 0)) {
       real_indices_deal_size = n_mod_limit * INDEX_WEIGHT_LAST_DIM;
       actual_n_size = n_mod_limit;
@@ -228,9 +316,8 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
              real_indices_deal_size * sizeof(int32_t), GDRAM2NRAM);
     __memcpy(nram_weights, base_addr_weights,
              real_indices_deal_size * sizeof(T), GDRAM2NRAM);
-
     // transpose the indices and weights
-    for (int32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
+    for (uint32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
       __bang_write_value(nram_indices_transpose + index * n_limit, n_limit, -1);
       __bang_write_zero(nram_weights_transpose + index * n_limit, n_limit);
       __memcpy(nram_indices_transpose + index * n_limit, nram_indices + index,
@@ -247,30 +334,40 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
              weights_deal_size * sizeof(T), NRAM2NRAM);
 #endif
 
-    int32_t c_rem = c;
-    for (int32_t j = 0; j < c_repeated_times; ++j) {
-      int32_t c_slice = c_limit < c_rem ? c_limit : c_rem;
+    uint32_t c_rem = c;
+    for (uint32_t j = 0; j < c_repeated_times; ++j) {
+      uint32_t c_slice = c_limit < c_rem ? c_limit : c_rem;
       c_rem -= c_slice;
-      int32_t c_limit_new = c_limit;
+      uint32_t c_limit_new = c_limit;
       if (c_slice != c_limit && c_slice % c_limit != 0) {
         c_limit_new =
             MIN(CEIL_ALIGN(c_slice % c_limit, align_base_128), c_limit_new);
       }
       // 1.2 load Co*Mo features data
       __bang_write_zero(nram_output, output_deal_size);
-      int32_t m_rem = m;
-      for (int32_t k = 0; k < m_repeated_times; ++k) {
-        int32_t m_slice = m_limit < m_rem ? m_limit : m_rem;
+      uint32_t m_rem = m;
+      for (uint32_t k = 0; k < m_repeated_times; ++k) {
+        uint32_t m_slice = m_limit < m_rem ? m_limit : m_rem;
         m_rem -= m_slice;
-        int32_t m_limit_new = m_limit;
+        uint32_t m_limit_new = m_limit;
         if (m_slice != m_limit && m_slice % m_limit != 0) {
           m_limit_new =
               MIN(CEIL_ALIGN(m_slice % m_limit, align_base_128), m_limit_new);
         }
-        __memcpy(nram_features,
-                 base_addr_features + (j * m * c_limit + k * m_limit),
-                 m_slice * sizeof(T), GDRAM2NRAM, m_limit_new * sizeof(T),
-                 m * sizeof(T), c_slice - 1);
+        uint32_t dst_stride = m_limit_new * sizeof(T);
+        uint64_t src_stride = m * sizeof(T);
+        if (src_stride <= INT32_MAX_NUM) {
+          __memcpy(nram_features,
+                   base_addr_features + (j * m * c_limit + k * m_limit),
+                   m_slice * sizeof(T), GDRAM2NRAM, dst_stride,
+                   src_stride, c_slice - 1);
+        } else {
+          // src_stride in __memcpy is int type, here handles src_stride
+          // overflow int32 max
+          memcpy2D(nram_features,
+                   base_addr_features + (j * m * c_limit + k * m_limit),
+                   m_slice, GDRAM2NRAM, m_limit_new, m, c_slice - 1);
+        }
         // 2. Compute
         __bang_write_zero(nram_features_transpose,
                           features_deal_size + c_limit);
@@ -280,24 +377,44 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
         // channel data
         __bang_transpose(nram_features_transpose, nram_features, c_limit,
                          m_limit);
-        int32_t m_min = k * m_limit_org;
-        int32_t m_max = m_min + m_slice;
-        for (int32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
+        uint32_t m_min = k * m_limit_org;
+        uint32_t m_max = m_min + m_slice;
+        for (uint32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
           __bang_write_zero(nram_features, output_deal_size);
           __bang_write_zero(nram_features_selected, output_deal_size);
           // 2.2 select the offset between the m_min and m_max
           // convert indices from int32_t to float
-          SelectIndicesBetweenMinAndMax(
+#if __BANG_ARCH__ < 370 || __BANG_ARCH__ == 520
+          selectIndicesBetweenMinAndMax(
               nram_indices, nram_indices_transpose,
               nram_indices_transpose_addition, nram_indices_transpose_float,
               nram_indices_transpose_float_addition, nram_weights_transpose,
               m_min, m_max, index, n_limit, c_limit, m_limit_org);
+#else
+          if (m <= INT2FLOAT_KEEP_PRECISION_MAX_VALUE) {
+            // float compute force is bigger than int
+            selectIndicesBetweenMinAndMax(
+                nram_indices, nram_indices_transpose,
+                nram_indices_transpose_addition, nram_indices_transpose_float,
+                nram_indices_transpose_float_addition, nram_weights_transpose,
+                m_min, m_max, index, n_limit, c_limit, m_limit_org);
+          } else {
+            selectIndicesBetweenMinAndMaxWithoutLimit(
+                nram_indices, nram_indices_transpose,
+                (int32_t *)nram_indices_transpose_addition,
+                (int32_t *)nram_indices_transpose_float,
+                (int32_t *)nram_indices_transpose_float_addition,
+                nram_weights_transpose, m_min, m_max, index, n_limit, c_limit,
+                m_limit_org);
+          }
+#endif
           // select the features from m*c to n*c
           // 2.3 select the Mo*Co according to the indices
-          for (int32_t s = 0; s < actual_n_size; ++s) {
+          for (uint32_t s = 0; s < actual_n_size; ++s) {
             // select the features
+            uint32_t selected_index = nram_indices[s];
             __memcpy(nram_features + s * c_limit,
-                     nram_features_transpose + nram_indices[s],
+                     nram_features_transpose + selected_index,
                      c_limit * sizeof(T), NRAM2NRAM);
           }  // n_repeated_times
           // 2.4 transpose from No*Co to Co*No to easily do the mul with No
@@ -332,44 +449,45 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
 template <typename T>
 __mlu_global__ void MLUKernelThreeInterpolateBackward(
     const T *grad_output, const int *__restrict__ indices, const T *weights,
-    const int b, const int c, const int m, const int n, const int c_limit_size,
-    const int m_limit_size, const int n_limit_size, T *grad_features) {
+    const uint32_t b, const uint32_t c, const uint32_t m, const uint32_t n,
+    const uint32_t c_limit_size, const uint32_t m_limit_size,
+    const uint32_t n_limit_size, T *grad_features) {
   if (__is_mpu()) {
     return;
   }
-  int32_t align_base_128 = NFU_ALIGN_SIZE / sizeof(T);
-  int32_t c_limit = c_limit_size;
-  int32_t m_limit = m_limit_size;
-  int32_t n_limit = n_limit_size;
+  uint32_t align_base_128 = NFU_ALIGN_SIZE / sizeof(T);
+  uint32_t c_limit = c_limit_size;
+  uint32_t m_limit = m_limit_size;
+  uint32_t n_limit = n_limit_size;
 
-  int32_t c_aligned_limit = CEIL_ALIGN(c, c_limit);
-  int32_t m_aligned_limit = CEIL_ALIGN(m, m_limit);
-  int32_t n_aligned_limit = CEIL_ALIGN(n, n_limit);
+  uint32_t c_aligned_limit = CEIL_ALIGN(c, c_limit);
+  uint32_t m_aligned_limit = CEIL_ALIGN(m, m_limit);
+  uint32_t n_aligned_limit = CEIL_ALIGN(n, n_limit);
 
   c_limit = c_limit > c_aligned_limit ? c_aligned_limit : c_limit;
   m_limit = m_limit > m_aligned_limit ? m_aligned_limit : m_limit;
   n_limit = n_limit > n_aligned_limit ? n_aligned_limit : n_limit;
-  int32_t c_limit_org = c_limit;
-  int32_t m_limit_org = m_limit;
-  int32_t n_limit_org = n_limit;
+  uint32_t c_limit_org = c_limit;
+  uint32_t m_limit_org = m_limit;
+  uint32_t n_limit_org = n_limit;
 
-  int32_t c_repeated_times = c_aligned_limit / c_limit;
-  int32_t n_repeated_times = n_aligned_limit / n_limit;
+  uint32_t c_repeated_times = c_aligned_limit / c_limit;
+  uint32_t n_repeated_times = n_aligned_limit / n_limit;
 
-  int32_t batch_m_repeated_times =
+  uint32_t batch_m_repeated_times =
       (b * m_aligned_limit) / (BATCH_LIMIT * m_limit);
-  int32_t batch_m_per_core = batch_m_repeated_times / taskDim;
-  int32_t batch_m_remain = batch_m_repeated_times % taskDim;
+  uint32_t batch_m_per_core = batch_m_repeated_times / taskDim;
+  uint32_t batch_m_remain = batch_m_repeated_times % taskDim;
 
   batch_m_per_core += (taskId < batch_m_remain);
 
-  int32_t grad_output_deal_size = c_limit * n_limit;
-  int32_t indices_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
-  int32_t weights_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
-  int32_t grad_features_deal_size = c_limit * m_limit;
-  int32_t reuse_deal_size = grad_output_deal_size >= grad_features_deal_size
-                                ? grad_output_deal_size
-                                : grad_features_deal_size;
+  uint32_t grad_output_deal_size = c_limit * n_limit;
+  uint32_t indices_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
+  uint32_t weights_deal_size = n_limit * INDEX_WEIGHT_LAST_DIM;
+  uint32_t grad_features_deal_size = c_limit * m_limit;
+  uint32_t reuse_deal_size = grad_output_deal_size >= grad_features_deal_size
+                                 ? grad_output_deal_size
+                                 : grad_features_deal_size;
 
   /*
    * NRAM partition
@@ -408,14 +526,14 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
   float *nram_indices_transpose_float_addition =
       (float *)(nram_indices_transpose_float + n_limit);  // n_limit
 
-  for (int32_t i = 0; i < batch_m_per_core; ++i) {
+  for (uint32_t i = 0; i < batch_m_per_core; ++i) {
     m_limit = m_limit_org;
-    int32_t current_batch_m = i + taskId * batch_m_per_core;
+    uint32_t current_batch_m = i + taskId * batch_m_per_core;
     current_batch_m += (taskId >= batch_m_remain ? batch_m_remain : 0);
-    int32_t current_batch = current_batch_m * m_limit / m_aligned_limit;
-    int32_t current_m = current_batch_m % (m_aligned_limit / m_limit);
-    int32_t real_indices_deal_size = indices_deal_size;
-    int32_t actual_m_size = m_limit;
+    uint32_t current_batch = current_batch_m * m_limit / m_aligned_limit;
+    uint32_t current_m = current_batch_m % (m_aligned_limit / m_limit);
+    uint32_t real_indices_deal_size = indices_deal_size;
+    uint32_t actual_m_size = m_limit;
 
     int32_t *base_addr_indices =
         (int32_t *)indices + current_batch * n * INDEX_WEIGHT_LAST_DIM;
@@ -426,31 +544,31 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
                                  /*different batch*/ current_batch * c * m +
                                  /*different m*/ current_m * m_limit;
 
-    int32_t m_mod_limit = m % m_limit;
+    uint32_t m_mod_limit = m % m_limit;
     if (current_m == (m_aligned_limit / m_limit - 1) && (m_mod_limit != 0)) {
       actual_m_size = m_mod_limit;
       m_limit = MIN(CEIL_ALIGN(m_mod_limit, align_base_128), m_limit);
     }
 
-    int32_t m_min = current_m * m_limit_org;
-    int32_t m_max = m_min + actual_m_size;
+    uint32_t m_min = current_m * m_limit_org;
+    uint32_t m_max = m_min + actual_m_size;
 
-    int32_t c_rem = c;
-    for (int32_t j = 0; j < c_repeated_times; ++j) {
-      int32_t c_slice = c_limit < c_rem ? c_limit : c_rem;
+    uint32_t c_rem = c;
+    for (uint32_t j = 0; j < c_repeated_times; ++j) {
+      uint32_t c_slice = c_limit < c_rem ? c_limit : c_rem;
       c_rem -= c_slice;
-      int32_t c_limit_new = c_limit;
+      uint32_t c_limit_new = c_limit;
       if (c_slice != c_limit && c_slice % c_limit != 0) {
         c_limit_new =
             MIN(CEIL_ALIGN(c_slice % c_limit, align_base_128), c_limit_new);
       }
       // initial the nram_grad_features with 0
       __bang_write_zero(nram_grad_features, grad_features_deal_size);
-      int32_t n_rem = n;
-      for (int32_t k = 0; k < n_repeated_times; ++k) {
-        int32_t n_slice = n_limit < n_rem ? n_limit : n_rem;
+      uint32_t n_rem = n;
+      for (uint32_t k = 0; k < n_repeated_times; ++k) {
+        uint32_t n_slice = n_limit < n_rem ? n_limit : n_rem;
         n_rem -= n_slice;
-        int32_t n_limit_new = n_limit;
+        uint32_t n_limit_new = n_limit;
         if (n_slice != n_limit && n_slice % n_limit != 0) {
           n_limit_new =
               MIN(CEIL_ALIGN(n_slice % n_limit, align_base_128), n_limit_new);
@@ -464,12 +582,22 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
                  base_addr_weights + k * n_limit * INDEX_WEIGHT_LAST_DIM,
                  real_indices_deal_size * sizeof(T), GDRAM2NRAM);
         // load grad_output
-        __memcpy(nram_grad_output,
-                 base_addr_grad_output + (j * n * c_limit + k * n_limit),
-                 n_slice * sizeof(T), GDRAM2NRAM, n_limit_new * sizeof(T),
-                 n * sizeof(T), c_slice - 1);
+        uint32_t dst_stride = n_limit_new * sizeof(T);
+        uint64_t src_stride = n * sizeof(T);
+        if (src_stride <= INT32_MAX_NUM) {
+          __memcpy(nram_grad_output,
+                   base_addr_grad_output + (j * n * c_limit + k * n_limit),
+                   n_slice * sizeof(T), GDRAM2NRAM, dst_stride,
+                   src_stride, c_slice - 1);
+        } else {
+          // src_stride in __memcpy is int type, here handles src_stride
+          // overflow int32 max
+          memcpy2D(nram_grad_output,
+                   base_addr_grad_output + (j * n * c_limit + k * n_limit),
+                   n_slice, GDRAM2NRAM, n_limit_new, n, c_slice - 1);
+        }
         // transpose the indices and weights
-        for (int32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
+        for (uint32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
           __bang_write_value(nram_indices_transpose + index * n_limit, n_limit,
                              -1);
           __bang_write_zero(nram_weights_transpose + index * n_limit, n_limit);
@@ -494,14 +622,33 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
                           grad_output_deal_size + c_limit);
         c_limit = c_limit_new;
         n_limit = n_limit_new;
-        for (int32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
+        for (uint32_t index = 0; index < INDEX_WEIGHT_LAST_DIM; ++index) {
           // select the offset between the m_min and m_max
           // convert indices from int32_t to float
-          SelectIndicesBetweenMinAndMax(
+#if __BANG_ARCH__ < 370 || __BANG_ARCH__ == 520
+          selectIndicesBetweenMinAndMax(
               nram_indices, nram_indices_transpose,
               nram_indices_transpose_addition, nram_indices_transpose_float,
               nram_indices_transpose_float_addition, nram_weights_transpose,
               m_min, m_max, index, n_limit, c_limit, m_limit_org);
+#else
+          if (m <= INT2FLOAT_KEEP_PRECISION_MAX_VALUE) {
+            // float compute force is bigger than int
+            selectIndicesBetweenMinAndMax(
+                nram_indices, nram_indices_transpose,
+                nram_indices_transpose_addition, nram_indices_transpose_float,
+                nram_indices_transpose_float_addition, nram_weights_transpose,
+                m_min, m_max, index, n_limit, c_limit, m_limit_org);
+          } else {
+            selectIndicesBetweenMinAndMaxWithoutLimit(
+                nram_indices, nram_indices_transpose,
+                (int32_t *)nram_indices_transpose_addition,
+                (int32_t *)nram_indices_transpose_float,
+                (int32_t *)nram_indices_transpose_float_addition,
+                nram_weights_transpose, m_min, m_max, index, n_limit, c_limit,
+                m_limit_org);
+          }
+#endif
           // mul the grad_output and weights
           __bang_cycle_mul(nram_grad_features_transpose, nram_grad_output,
                            nram_weights_transpose + index * n_limit,
@@ -510,8 +657,8 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
                            nram_grad_features_transpose, c_limit, n_limit);
           // add the mul results to the grad_features selected
           // by the index
-          for (int32_t s = 0; s < n_slice; ++s) {
-            int selected_index = nram_indices[s];
+          for (uint32_t s = 0; s < n_slice; ++s) {
+            uint32_t selected_index = nram_indices[s];
             __bang_add(nram_grad_features + selected_index,
                        nram_grad_features + selected_index,
                        nram_grad_output_transpose + s * c_limit, c_limit);
@@ -541,9 +688,9 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
 void MLUOP_WIN_API KernelThreeInterpolateForward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const void *features, const void *indices,
-    const void *weights, const int b, const int c, const int m, const int n,
-    const int c_limit_size, const int m_limit_size, const int n_limit_size,
-    void *output) {
+    const void *weights, const uint32_t b, const uint32_t c, const uint32_t m,
+    const uint32_t n, const uint32_t c_limit_size, const uint32_t m_limit_size,
+    const uint32_t n_limit_size, void *output) {
   switch (d_type) {
     case MLUOP_DTYPE_FLOAT: {
       MLUKernelThreeInterpolateForward<<<k_dim, k_type, queue>>>(
@@ -565,9 +712,9 @@ void MLUOP_WIN_API KernelThreeInterpolateForward(
 void MLUOP_WIN_API KernelThreeInterpolateBackward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const void *grad_output, const void *indices,
-    const void *weights, const int b, const int c, const int m, const int n,
-    const int c_limit_size, const int m_limit_size, const int n_limit_size,
-    void *grad_features) {
+    const void *weights, const uint32_t b, const uint32_t c, const uint32_t m,
+    const uint32_t n, const uint32_t c_limit_size, const uint32_t m_limit_size,
+    const uint32_t n_limit_size, void *grad_features) {
   switch (d_type) {
     case MLUOP_DTYPE_FLOAT: {
       MLUKernelThreeInterpolateBackward<<<k_dim, k_type, queue>>>(


### PR DESCRIPTION
…to 2g.

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

To support the near to 2g number cases for three_interpolate_forward and three_interpolate_backward operators.

## 2. Modification

ThreeInterpolate

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

回归测试结果：
[----------] Global test environment tear-down
[ SUMMARY  ] Total 560 cases of 2 op(s).
ALL PASSED.
[==========] 560 test cases from 2 test suites ran. (396523 ms total)
[  PASSED  ] 560 test cases.

接近2G num的新增case测试结果：
[----------] Global test environment tear-down
[ SUMMARY  ] Total 12 cases of 2 op(s).
ALL PASSED.
[==========] 12 test cases from 2 test suites ran. (272699 ms total)
[  PASSED  ] 12 test cases.

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
