### PR TITLE
[Feature](bangc-ops): improve focal_loss_sigmoid_backward precision by using supass inst

### DIFF
--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
@@ -190,6 +190,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidForward(
   // generate case prototxt.
   const uint64_t N = input_desc->dims[0];
   const uint64_t C = input_desc->dims[1];
+
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("focal_loss_sigmoid_forward");
     GEN_CASE_HANDLE(handle);
@@ -401,8 +402,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(
       MLUOP_STATUS_SUCCESS) {
     return MLUOP_STATUS_BAD_PARAM;
   }
-  if (prefer != mluOpComputationPreference_t::MLUOP_COMPUTATION_FAST) {
-    LOG(ERROR) << interface_name << "only surpport COMPUTATION_FAST currently.";
+  if (prefer != mluOpComputationPreference_t::MLUOP_COMPUTATION_HIGH_PRECISION) {
+    LOG(ERROR) << interface_name << "only surpport HIGH_PRECISION currently.";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
   if (reduction != mluOpLossReduction_t::MLUOP_LOSS_REDUCTION_NONE) {
@@ -435,7 +436,16 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(
   getDealNAndThresholdC(handle, compute_data_bytes, target_data_bytes, dim_c,
                         &deal_n, &threshold_c, has_weight, is_half);
 
+#define TO_STRING(dtype) #dtype
+#define GET_DTYPE(half_flag) \
+  (half_flag ? TO_STRING(MLUOP_DTYPE_HALF) : TO_STRING(MLUOP_DTYPE_FLOAT))
+
+  VLOG(5) << interface_name << "N: " << dim_n << ", C: " << dim_c
+          << ", alpha: " << alpha <<  ", gamma: " << gamma
+          << ", dtype: " << GET_DTYPE(is_half)
+          << ", has_weight: " << has_weight;
   VLOG(5) << interface_name << "threshold_c: " << threshold_c;
+  VLOG(5) << interface_name << "deal_n: " << deal_n;
   // check C
   if (dim_c > threshold_c) {
     LOG(ERROR) << interface_name
@@ -456,18 +466,27 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(
   PARAM_CHECK(interface_name, target != NULL);
   PARAM_CHECK(interface_name, output != NULL);
 
+
+#define FOCAL_LOSS_GEN_CASE_DATA_REAL(is_input, id, data, data_desc,      \
+                                      upper_bound, lower_bound)           \
+  mluop::gen_case::genCaseData(node, is_input, id, data, data_desc,       \
+                               upper_bound, lower_bound, "UNIFORM", true)
+
   // generate focal_loss_sigmoid_backward prototxt
   if (MLUOP_GEN_CASE_ON_NEW) {
+    const int upper_bound = is_half ? 5 : 20;
+    const int lower_bound = -1 * upper_bound;
     GEN_CASE_START("focal_loss_sigmoid_backward");
     GEN_CASE_HANDLE(handle);
-    GEN_CASE_DATA(true, "input", input, input_desc, 20, -20);
+    FOCAL_LOSS_GEN_CASE_DATA_REAL(true, "input", input, input_desc,
+                                  upper_bound, lower_bound);
+    FOCAL_LOSS_GEN_CASE_DATA_REAL(true, "target", target, target_desc,
+                                  dim_c, 0);
     if (weight != NULL) {
-      GEN_CASE_DATA_REAL(true, "target", target, target_desc);
-      GEN_CASE_DATA(true, "weight", weight, weight_desc, 1, 0);
-    } else {
-      GEN_CASE_DATA(true, "target", target, target_desc, dim_c, 0);
+      FOCAL_LOSS_GEN_CASE_DATA_REAL(true, "weight", weight, weight_desc,
+                                    upper_bound, lower_bound);
     }
-    GEN_CASE_DATA(false, "output", output, output_desc, 20, -20);
+    GEN_CASE_DATA(false, "output", output, output_desc, 0, 0);
     GEN_CASE_OP_PARAM_SINGLE(0, "focal_loss_sigmoid_backward", "prefer",
                              prefer);
     GEN_CASE_OP_PARAM_SINGLE(1, "focal_loss_sigmoid_backward", "reduction",
@@ -479,13 +498,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(
 
   cnrtDim3_t k_dim;
   cnrtFunctionType_t k_type;
-  const int dwidth = mluOpDataTypeBytes(input_desc->dtype);
   policyFunc(handle, &k_dim, &k_type);
 
   VLOG(5) << "Launch Kernel MLUBlockFocalLossSigmoidBackward<<<Union"
           << k_type / CORE_DIM << ", " << k_dim.x << ", " << k_dim.y << ", "
           << k_dim.z << ">>>";
-  if (dwidth == 2) {
+  if (is_half) {
     KERNEL_CHECK((mluOpBlockKernelFocalLossSigmoidBackwardHalf(
         k_dim, k_type, handle->queue, input, target, weight, gamma, alpha,
         dim_n, deal_n, dim_c, output)));

--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
@@ -402,7 +402,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(
       MLUOP_STATUS_SUCCESS) {
     return MLUOP_STATUS_BAD_PARAM;
   }
-  if (prefer != mluOpComputationPreference_t::MLUOP_COMPUTATION_HIGH_PRECISION) {
+  if (prefer !=
+      mluOpComputationPreference_t::MLUOP_COMPUTATION_HIGH_PRECISION) {
     LOG(ERROR) << interface_name << "only surpport HIGH_PRECISION currently.";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }

--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -25,6 +25,7 @@
 #include <float.h>
 
 #include "kernels/kernel.h"
+#include "kernels/utils/common.h"
 
 #define PING 0
 #define PONG 1
@@ -36,7 +37,7 @@ namespace backward {
 /*
  * Functions Table
  * |----------|---------------------------------------------|
- * |  Math    | sigmoid                                     |
+ * |  Math    | sigmoid, computeLogE                        |
  * |----------|---------------------------------------------|
  * |  I0      | loadInputFwd, loadWeightFwd, storeOutputFwd |
  * |----------|---------------------------------------------|
@@ -48,6 +49,19 @@ __mlu_func__ void sigmoid(T *dst_data, const T *src_data,
   __bang_active_exphp(dst_data, dst_data, elem_count);
   __bang_add_scalar(dst_data, dst_data, T(1), elem_count);
   __bang_active_reciphp(dst_data, dst_data, elem_count);
+}
+
+__mlu_func__ void computeLogE(float *nram_dst, float *nram_src,
+                              const int32_t deal_num) {
+#if __BANG_ARCH__ >= 300
+  int x2d = 0x3f317217;
+  float rlog2e = *(float *)&x2d;
+  __bang_log((float *)nram_dst, (float *)nram_src, deal_num);
+  __bang_mul_scalar((float *)nram_dst, (float *)nram_src,
+                    (float)rlog2e, deal_num);
+#else
+  __bang_active_loghp((float *)nram_dst, (float *)nram_src, deal_num);
+#endif
 }
 
 template <typename T>
@@ -145,7 +159,11 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
   __bang_write_value((float *)nram_alpha_t, compute_num, (float)(alpha - 1.0));
 
   // 1. pt = 1 - sigmoid(x)
+#if __BANG_ARCH__ >= 300
+  computeSigmoid((float *)nram_pt, (float *)nram_input, NULL, 0, compute_num);
+#else
   sigmoid((float *)nram_pt, (float *)nram_input, compute_num);
+#endif
   __bang_mul_scalar((float *)nram_pt, (float *)nram_pt, (float)(-1),
                     compute_num);
   __bang_add_scalar((float *)nram_pt, (float *)nram_pt, (float)1, compute_num);
@@ -178,10 +196,10 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
                     compute_num);
   __bang_cycle_maxequal((float *)nram_temp, (float *)nram_temp,
                         (float *)nram_flt_min, compute_num, nfu_align_num);
-  __bang_active_loghp((float *)nram_temp, (float *)nram_temp, compute_num);
+  computeLogE((float *)nram_temp, (float *)nram_temp, compute_num);
   __bang_cycle_mul((float *)nram_temp, (float *)nram_temp, (float *)nram_gamma,
                    compute_num, nfu_align_num);
-  __bang_active_exphp((float *)nram_temp, (float *)nram_temp, compute_num);
+  computeExp((float *)nram_temp, (float *)nram_temp, NULL, 0, compute_num);
   __bang_mul((float *)nram_temp, (float *)nram_temp, (float *)nram_alpha_t,
              compute_num);
   __bang_mul_scalar((float *)nram_temp, (float *)nram_temp, (float)(-1),
@@ -190,7 +208,7 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
   // 4. output = 1 - pt - gamma * pt * log(max(pt, FLT_MIN))
   __bang_cycle_maxequal((float *)nram_output, (float *)nram_pt,
                         (float *)nram_flt_min, compute_num, nfu_align_num);
-  __bang_active_loghp((float *)nram_output, (float *)nram_output, compute_num);
+  computeLogE((float *)nram_output, (float *)nram_output, compute_num);
   __bang_mul((float *)nram_output, (float *)nram_output, (float *)nram_pt,
              compute_num);
   __bang_cycle_mul((float *)nram_output, (float *)nram_output,

--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -53,7 +53,7 @@ __mlu_func__ void sigmoid(T *dst_data, const T *src_data,
 
 __mlu_func__ void computeLogE(float *nram_dst, float *nram_src,
                               const int32_t deal_num) {
-#if __BANG_ARCH__ >= 300
+#if __BANG_ARCH__ >= 372
   int x2d = 0x3f317217;
   float rlog2e = *(float *)&x2d;
   __bang_log((float *)nram_dst, (float *)nram_src, deal_num);
@@ -159,7 +159,7 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
   __bang_write_value((float *)nram_alpha_t, compute_num, (float)(alpha - 1.0));
 
   // 1. pt = 1 - sigmoid(x)
-#if __BANG_ARCH__ >= 300
+#if __BANG_ARCH__ >= 372
   computeSigmoid((float *)nram_pt, (float *)nram_input, NULL, 0, compute_num);
 #else
   sigmoid((float *)nram_pt, (float *)nram_input, compute_num);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -7028,7 +7028,7 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * @param[in] prefer
  * The algorithm used to compute the output.
  * For detailed information, see ::mluOpComputationPreference_t. Currently, only
- * \p MLUOP_COMPUTATION_FAST is supported.
+ * \p MLUOP_COMPUTATION_HIGH_PRECISION is supported.
  * @param[in] reduction
  * The reduction mode used to compute the operation.
  * For detailed information, see ::mluOpLossReduction_t. Currently, only
@@ -7066,10 +7066,10 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * @par Data Type
  * - The supported data types of input tensor \b input, \b target, \b weight , and output
  *   tensor \b output are as follows：
- *   - input: float
+ *   - input: float, half
  *   - target: int32
- *   - weight: float
- *   - grad_input: float
+ *   - weight: float, half
+ *   - grad_input: float, half
  *
  * @par Data Layout
  * - The supported data layout of the input tensors and output tensors must be \p MLUOP_LAYOUT_ARRAY.
@@ -7079,11 +7079,12 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * - The shape of \b input and \b grad_input must be consistent.
  * - The shape of \b target is [N] when the shape of \b input is [N, C].
  * - The shape of \b weight is [C] when the shape of \b input is [N, C].
+ * - \b input value should be in the range of [-5, 5] when the data type of \b input is half.
  * - \b target value should be in the range of [0, C] when \b weight is NULL and the shape of
  *   \b input is [N, C].
  * - \b target value should be in the range of [0, C-1] when \b weight is not NULL and the
  *   shape of \b input is [N, C].
- * - prefer only supports MLUOP_COMPUTATION_FAST currently.
+ * - prefer only supports MLUOP_COMPUTATION_HIGH_PRECISION currently.
  * - reduction only supports \p MLUOP_LOSS_REDUCTION_NONE currently.
  * - The layout of \b input, \b target, \b weight and \b grad_input must be ARRAY.
  *
@@ -7091,9 +7092,12 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Note
- * - If the shape of \b input is set to [N, C], the length of C should be in the range of [0, 13615] when
- *   \b weight is NULL on MLU300 series. The length of C should be in the range of [0, 12544] when
+ * - If the shape of \b input is set to [N, C], the length of C should be in the range of [0, 16339] when
+ *   \b weight is NULL on MLU300 series. The length of C should be in the range of [0, 14848] when
  *   \b weight is not NULL on MLU300 series.
+ * - If the shape of \b input is set to [N, C], the length of C should be in the range of [0, 9785] when
+ *   \b weight is NULL on MLU500 series. The length of C should be in the range of [0, 8864] when
+ *   \b weight is not NULL on MLU500 series.
  * - \b weight does not support positive infinity and negative infinity currently.
  * - \b gamma should be in the range of [0, 10000] on MLU300 series.
  *

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/test_case/case_0.prototxt
@@ -39,8 +39,8 @@ input {
   dtype: DTYPE_FLOAT
   random_data: {
     seed: 23
-    upper_bound: 330
-    lower_bound: 0
+    upper_bound: 20
+    lower_bound: -20
     distribution: UNIFORM
   }
 }
@@ -55,7 +55,7 @@ output {
   dtype: DTYPE_FLOAT
 }
 focal_loss_sigmoid_backward_param: {
-  prefer: 0
+  prefer: 1
   reduction: 0
   alpha: 0.25
   gamma: 2

--- a/docs/bangc-docs/design_docs/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.md
+++ b/docs/bangc-docs/design_docs/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.md
@@ -81,20 +81,29 @@ p_t =
 p,   & target[n] = c \\
 1-p, & otherwise
 \end{cases}
-\\
+```
+```math
 \alpha_t =
 \begin{cases}
 \alpha,   & target[n]=c \\
 1-\alpha, & otherwise
 \end{cases}
-\\
-FL(p_t) = -\alpha_t(1-p_t)^\gamma log(p_t) \\
+```
+```math
+FL(p_t) = -\alpha_t(1-p_t)^\gamma log(p_t)
+```
+```math
 FL =
 \begin{cases}
 -\alpha(1-p)^\gamma log(p), & target[n]=c\\
 -(1-\alpha)p^\gamma log(1-p), & otherwise
 \end{cases}
-\\n=0,1,2,3,...,N - 1 \\c=0,1,2,3,...,C-1
+```
+```math
+n = 0,1,2,3,...,N - 1
+```
+```math
+c = 0,1,2,3,...,C-1
 ```
 
 - `p` 为 `input` 通过`Sigmoid`计算所得的概率值
@@ -254,7 +263,14 @@ FL^{'} =
 -\alpha*(1-p)^\gamma*(1-p-\gamma*p*log(p)) & target[n]=c \\
 -(1-\alpha)*p^\gamma*(\gamma*(1-p)*log(1-p)-p) & otherwise
 \end{cases}
-\\n=0,1,2,3,...,N - 1 \\c=0,1,2,3,...,C-1\\
+```
+```math
+n = 0,1,2,3,...,N - 1
+```
+```math
+c = 0,1,2,3,...,C-1
+```
+```math
 gradInput = FL^{'}*gradOutput
 ```
 
@@ -263,16 +279,22 @@ gradInput = FL^{'}*gradOutput
 ```math
 pt_{n,c} =
 \begin{cases}
-p_{n,c},  & target[n]=c \\
-1-p_{n,c}, & otherwise
+p_{n,c} ,  & target[n]=c \\
+1-p_{n,c} , & otherwise
 \end{cases}
-\\
+```
+```math
 \alpha t_{n,c} =
 \begin{cases}
 \alpha,  & target[n]=c \\
 \alpha-1, & otherwise
 \end{cases}
-\\n=0,1,2,3,...,N-1 \\c=0,1,2,3,...,C-1
+```
+```math
+n = 0,1,2,3,...,N-1
+```
+```math
+c = 0,1,2,3,...,C-1
 ```
 
 进行向量化后，`mluOpFocalLossSigmoidBackward`的计算公式可以表示为
@@ -296,9 +318,13 @@ gradInput = temp*weight[target[n]]
 target[n]的取值为[0，C]，在构造$`p_t`$和$`\alpha _t`$的过程中，考虑到target[n] =c时只有N个数，其余N*(C-1)个数为otherwise时的取值。因此先将$`p_t`$和$`\alpha _t`$的元素值都初始化为otherwise的值，再遍历N维度来设置target[n] =c时的取值。
 
 ```math
-p = sigmoid(input) \\
-pt = 1-p \\
-\alpha t = nramSet(\alpha-1) \\
+p = sigmoid(input)
+```
+```math
+pt = 1-p
+```
+```math
+\alpha t = nramSet(\alpha-1)
 ```
 
 ```cpp
@@ -310,9 +336,15 @@ for (int n = 0; n < N; n++) {
 ```
 
 ```math
-temp  = -\alpha t* e^{\gamma*log(1-pt)} \\
-output = (1-pt-\gamma*pt*log(pt)) \\
-output = output * temp \\
+temp  = -\alpha t* e^{\gamma*log(1-pt)}
+```
+```math
+output = (1-pt-\gamma*pt*log(pt))
+```
+```math
+output = output * temp
+```
+```math
 output = output[n][c] * weight[target[n]]
 ```
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

improve focal_loss_sigmoid_backward precision by using supass inst

## 2. Modification

modified:   kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
modified:   kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
modified:   mlu_op.h
modified:   test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/test_case/case_0.prototxt


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          U1       |
|        3       |Layouts                               |          ARRAY       |
|        4       |Whether multi-dimensions are supported|         none                             |
|        5       |Whether element zero is supported     |             none                         |
|        6       |Data type(half/float)                 |           half / float           |
|        7       |Whether there is size limit           |              none                        |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

MLU370 & MLU590


[       OK ] focal_loss_sigmoid_backward/TestSuite.mluOp/1029 (19 ms)
[----------] 1030 tests from focal_loss_sigmoid_backward/TestSuite (61090 ms total)

[----------] Global test environment tear-down
[2023-4-21 14:37:24] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 1030 cases of 1 op(s).
ALL PASSED.
[==========] 1030 test cases from 1 test suite ran. (62805 ms total)
[  PASSED  ] 1030 test cases.


LCOV - code coverage report
  Directory [Sort by Line Coverage [Sort_by_line_coverage] Functions [Sort_by
  name]                                                    function_coverage]
  kernels                [100.0%]   100.0 %5 / 5          -      0 / 0
  kernels/           [[97.7%](https://github.com/Cambricon/mlu-ops/pull/641#)][97.7%] 97.7 % 421 / 431      86.7 %13 / 15