### PR TITLE
[Feature](bangc-ops): improve focal_loss_sigmoid_backward precision by using supass inst

### DIFF
--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -25,6 +25,7 @@
 #include <float.h>
 
 #include "kernels/kernel.h"
+#include "kernels/utils/common.h"
 
 #define PING 0
 #define PONG 1
@@ -36,7 +37,7 @@ namespace backward {
 /*
  * Functions Table
  * |----------|---------------------------------------------|
- * |  Math    | sigmoid                                     |
+ * |  Math    | sigmoid, computeLogE                        |
  * |----------|---------------------------------------------|
  * |  I0      | loadInputFwd, loadWeightFwd, storeOutputFwd |
  * |----------|---------------------------------------------|
@@ -48,6 +49,19 @@ __mlu_func__ void sigmoid(T *dst_data, const T *src_data,
   __bang_active_exphp(dst_data, dst_data, elem_count);
   __bang_add_scalar(dst_data, dst_data, T(1), elem_count);
   __bang_active_reciphp(dst_data, dst_data, elem_count);
+}
+
+__mlu_func__ void computeLogE(float *nram_dst, float *nram_src,
+                              const int32_t deal_num) {
+#if __BANG_ARCH__ >= 372
+  int x2d = 0x3f317217;
+  float rlog2e = *(float *)&x2d;
+  __bang_log((float *)nram_dst, (float *)nram_src, deal_num);
+  __bang_mul_scalar((float *)nram_dst, (float *)nram_src,
+                    (float)rlog2e, deal_num);
+#else
+  __bang_active_loghp((float *)nram_dst, (float *)nram_src, deal_num);
+#endif
 }
 
 template <typename T>
@@ -145,7 +159,11 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
   __bang_write_value((float *)nram_alpha_t, compute_num, (float)(alpha - 1.0));
 
   // 1. pt = 1 - sigmoid(x)
+#if __BANG_ARCH__ >= 372
+  computeSigmoid((float *)nram_pt, (float *)nram_input, NULL, 0, compute_num);
+#else
   sigmoid((float *)nram_pt, (float *)nram_input, compute_num);
+#endif
   __bang_mul_scalar((float *)nram_pt, (float *)nram_pt, (float)(-1),
                     compute_num);
   __bang_add_scalar((float *)nram_pt, (float *)nram_pt, (float)1, compute_num);
@@ -178,10 +196,10 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
                     compute_num);
   __bang_cycle_maxequal((float *)nram_temp, (float *)nram_temp,
                         (float *)nram_flt_min, compute_num, nfu_align_num);
-  __bang_active_loghp((float *)nram_temp, (float *)nram_temp, compute_num);
+  computeLogE((float *)nram_temp, (float *)nram_temp, compute_num);
   __bang_cycle_mul((float *)nram_temp, (float *)nram_temp, (float *)nram_gamma,
                    compute_num, nfu_align_num);
-  __bang_active_exphp((float *)nram_temp, (float *)nram_temp, compute_num);
+  computeExp((float *)nram_temp, (float *)nram_temp, NULL, 0, compute_num);
   __bang_mul((float *)nram_temp, (float *)nram_temp, (float *)nram_alpha_t,
              compute_num);
   __bang_mul_scalar((float *)nram_temp, (float *)nram_temp, (float)(-1),
@@ -190,7 +208,7 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
   // 4. output = 1 - pt - gamma * pt * log(max(pt, FLT_MIN))
   __bang_cycle_maxequal((float *)nram_output, (float *)nram_pt,
                         (float *)nram_flt_min, compute_num, nfu_align_num);
-  __bang_active_loghp((float *)nram_output, (float *)nram_output, compute_num);
+  computeLogE((float *)nram_output, (float *)nram_output, compute_num);
   __bang_mul((float *)nram_output, (float *)nram_output, (float *)nram_pt,
              compute_num);
   __bang_cycle_mul((float *)nram_output, (float *)nram_output,

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -7028,7 +7028,7 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * @param[in] prefer
  * The algorithm used to compute the output.
  * For detailed information, see ::mluOpComputationPreference_t. Currently, only
- * \p MLUOP_COMPUTATION_FAST is supported.
+ * \p MLUOP_COMPUTATION_HIGH_PRECISION is supported.
  * @param[in] reduction
  * The reduction mode used to compute the operation.
  * For detailed information, see ::mluOpLossReduction_t. Currently, only
@@ -7066,10 +7066,10 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * @par Data Type
  * - The supported data types of input tensor \b input, \b target, \b weight , and output
  *   tensor \b output are as follows：
- *   - input: float
+ *   - input: float, half
  *   - target: int32
- *   - weight: float
- *   - grad_input: float
+ *   - weight: float, half
+ *   - grad_input: float, half
  *
  * @par Data Layout
  * - The supported data layout of the input tensors and output tensors must be \p MLUOP_LAYOUT_ARRAY.
@@ -7079,11 +7079,12 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * - The shape of \b input and \b grad_input must be consistent.
  * - The shape of \b target is [N] when the shape of \b input is [N, C].
  * - The shape of \b weight is [C] when the shape of \b input is [N, C].
+ * - \b input value should be in the range of [-5, 5] when the data type of \b input is half.
  * - \b target value should be in the range of [0, C] when \b weight is NULL and the shape of
  *   \b input is [N, C].
  * - \b target value should be in the range of [0, C-1] when \b weight is not NULL and the
  *   shape of \b input is [N, C].
- * - prefer only supports MLUOP_COMPUTATION_FAST currently.
+ * - prefer only supports MLUOP_COMPUTATION_HIGH_PRECISION currently.
  * - reduction only supports \p MLUOP_LOSS_REDUCTION_NONE currently.
  * - The layout of \b input, \b target, \b weight and \b grad_input must be ARRAY.
  *
@@ -7091,9 +7092,12 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Note
- * - If the shape of \b input is set to [N, C], the length of C should be in the range of [0, 13615] when
- *   \b weight is NULL on MLU300 series. The length of C should be in the range of [0, 12544] when
+ * - If the shape of \b input is set to [N, C], the length of C should be in the range of [0, 16339] when
+ *   \b weight is NULL on MLU300 series. The length of C should be in the range of [0, 14848] when
  *   \b weight is not NULL on MLU300 series.
+ * - If the shape of \b input is set to [N, C], the length of C should be in the range of [0, 9785] when
+ *   \b weight is NULL on MLU500 series. The length of C should be in the range of [0, 8864] when
+ *   \b weight is not NULL on MLU500 series.
  * - \b weight does not support positive infinity and negative infinity currently.
  * - \b gamma should be in the range of [0, 10000] on MLU300 series.
  *

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/test_case/case_0.prototxt
@@ -39,8 +39,8 @@ input {
   dtype: DTYPE_FLOAT
   random_data: {
     seed: 23
-    upper_bound: 330
-    lower_bound: 0
+    upper_bound: 20
+    lower_bound: -20
     distribution: UNIFORM
   }
 }
@@ -55,7 +55,7 @@ output {
   dtype: DTYPE_FLOAT
 }
 focal_loss_sigmoid_backward_param: {
-  prefer: 0
+  prefer: 1
   reduction: 0
   alpha: 0.25
   gamma: 2

--- a/docs/bangc-docs/design_docs/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.md
+++ b/docs/bangc-docs/design_docs/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.md
@@ -40,30 +40,30 @@
 
 example:
 
-| 算子功能简介                                  | focal_loss_sigmoid 算子反向                                  |
-| --------------------------------------------| ----------------------------------------------------------- |
-| 需求来源                                      | PyTorch                                                    |
-| 应用网络                                      | mmdet-retinanet                                            |
-| 输入数据类型                                  | `input,weight,grad_output` 数据类型需一致，为 float；`target`数据类型为int32；`reduction`为枚举类 |
-| 输入标量参数                                  | `alpha`、`gamma`的数据类型均为float                                                    |
-| 输入 Shape                                   | `input`: [N, C]<br />`target`: [N]<br />`weight`: [C]<br /> `grad_output`: [N, C]   |
-| 输入 Layout                                  | ARRAY                                                                               |
-| 输出数据类型                                  | float                                                                                |
-| 输出 Shape                                   | 输出shape 受 `reduction`模式影响，`reduction`模式为`None`时输出shape为[N, C]              |
-| 输出 Layout                                  | ARRAY                                                       |
-| 模式(可选）                                   | `reduction`：暂不支持`None`以外模式                            |
-| 是否含有 dim/axis 等类似语义的参数且该参数支持负数/其他特殊处理| 无 |
-| 是否含有 labels/index 等类似语义的参数且该参数支持负数/界外情况/其他特殊处理 | 无  |
-| 是否需要支持原位                               | 否                                                       |
-| 是否需要支持 stride 机制                       | 否                                                       |
-| 是否需要支持广播                               | 否                                                       |
-| 0 元素检查是否直接返回                         | 是                                                        |
-| 其他特殊需求(在线量化，融合，转数提前等，可选)     | 无                                                        |
-| 本次开发优先支持的规模/模式                     | 无                            |
+| 算子功能简介                                                 | focal_loss_sigmoid 算子反向                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| 需求来源                                                     | PyTorch                                                      |
+| 应用网络                                                     | mmdet-retinanet                                              |
+| 输入数据类型                                                 | `input,weight,grad_output` 数据类型需一致，为 float/half；`target`数据类型为int32；`reduction`为枚举类 |
+| 输入标量参数                                                 | `alpha`、`gamma`的数据类型均为float                          |
+| 输入 Shape                                                   | `input`: [N, C]<br />`target`: [N]<br />`weight`: [C]<br /> `grad_output`: [N, C] |
+| 输入 Layout                                                  | ARRAY                                                        |
+| 输出数据类型                                                 | float/half                                                   |
+| 输出 Shape                                                   | 输出shape 受 `reduction`模式影响，`reduction`模式为`None`时输出shape为[N, C] |
+| 输出 Layout                                                  | ARRAY                                                        |
+| 模式(可选）                                                  | `reduction`：暂不支持`None`以外模式                          |
+| 是否含有 dim/axis 等类似语义的参数且该参数支持负数/其他特殊处理 | 无                                                           |
+| 是否含有 labels/index 等类似语义的参数且该参数支持负数/界外情况/其他特殊处理 | 无                                                           |
+| 是否需要支持原位                                             | 否                                                           |
+| 是否需要支持 stride 机制                                     | 否                                                           |
+| 是否需要支持广播                                             | 否                                                           |
+| 0 元素检查是否直接返回                                       | 是                                                           |
+| 其他特殊需求(在线量化，融合，转数提前等，可选)               | 无                                                           |
+| 本次开发优先支持的规模/模式                                  | 无                                                           |
 
 ### 1.2 算子功能和应用场景描述
 
-`FocalLoss` 是在标准`CrossEntropy` 的基础上修改得到的，其目的是通过减少易分类样本的加权系数，解决难易样本数量不平衡的问题，从而使得模型在训练时更专注于难分类的样本。本算子应用于基于mmdetection的RetinaNet网络。focalLossSigmoidBackward的功能是对focalLossSigmoidForward进行求导运算，给定输入数据（input）、对应标签值（target）、平衡因子（alpha)、调节因子（gamma)，加权系数数据（weight），输出梯度数据（grad_output），通过focal loss反向公式运算，得到对输入数据的梯度值（grad_input)。
+`FocalLoss` 是在标准`CrossEntropy` 的基础上修改得到的，其目的是通过减少易分类样本的加权系数，解决难易样本数量不平衡的问题，从而使得模型在训练时更专注于难分类的样本。本算子应用于基于mmdetection的RetinaNet网络。focalLossSigmoidBackward的功能是对focalLossSigmoidForward进行求导运算，给定输入数据（input）、对应标签值（target）、平衡因子（alpha)、调节因子（gamma)，加权系数数据（weight），通过focal loss反向公式运算，得到对输入数据的梯度值（grad_input)。
 
 相关参考链接为：https://zhuanlan.zhihu.com/p/80594704
 
@@ -81,20 +81,29 @@ p_t =
 p,   & target[n] = c \\
 1-p, & otherwise
 \end{cases}
-\\
+```
+```math
 \alpha_t =
 \begin{cases}
 \alpha,   & target[n]=c \\
 1-\alpha, & otherwise
 \end{cases}
-\\
-FL(p_t) = -\alpha_t(1-p_t)^\gamma log(p_t) \\
+```
+```math
+FL(p_t) = -\alpha_t(1-p_t)^\gamma log(p_t)
+```
+```math
 FL =
 \begin{cases}
 -\alpha(1-p)^\gamma log(p), & target[n]=c\\
 -(1-\alpha)p^\gamma log(1-p), & otherwise
 \end{cases}
-\\n=0,1,2,3,...,N - 1 \\c=0,1,2,3,...,C-1
+```
+```math
+n = 0,1,2,3,...,N - 1
+```
+```math
+c = 0,1,2,3,...,C-1
 ```
 
 - `p` 为 `input` 通过`Sigmoid`计算所得的概率值
@@ -113,13 +122,13 @@ FL^{'} =
 \end{cases}
 ```
 
-如果存在weight输入，则需乘以weight。最后再乘以grad_output，得到算子最终的输出grad_input
+如果存在weight输入，则需乘以weight，得到算子最终的输出grad_input
 
 ```math
 gradInput = FL^{'} *weight* gradOutput =
 \begin{cases}
 -\alpha*(1-p)^\gamma*(1-p-\gamma*p*log(p))*weight[target[n]]*gradOuput & target[n]=c \\
--(1-\alpha)*p^\gamma*(\gamma*(1-p)*log(1-p)-p)*weight[target[n]]*gradOutput & otherwise
+-(1-\alpha)*p^\gamma*(\gamma*(1-p)*log(1-p)-p)*weight[target[n]] & otherwise
 \end{cases}
 ```
 
@@ -131,15 +140,13 @@ gradInput = FL^{'} *weight* gradOutput =
 | prefer           | 运算模式               | 输入              | const mluOpComputationPreference_t | /        | /                                       |
 | reduction        | 规约模式               | 输入              | const mluOpLossReduction_t         | /        | /                                       |
 | input_desc       | 输入预测值张量描述符   | 输入                | const mluOpTensorDescriptor_t      | /        | /                                       |
-| input            | 输入数据               | 输入              | float                             | ARRAY    | 二维数据，形状为[N,C]                   |
+| input            | 输入数据               | 输入              | float/half                        | ARRAY    | 二维数据，形状为[N,C]                   |
 | target_desc      | 输入数据对应标签描述符 | 输入                | const mluOpTensorDescriptor_t      | /        | /                                       |
 | target           | 输入数据对应标签       | 输入               | int32                             | ARRAY    | 一维数据，形状为[N]                     |
 | weight_desc      | 加权系数张量描述符         | 输入              | const mluOpTensorDescriptor_t      | /        | /                                       |
 | weight           | 加权系数数据               | 输入              | float                             | ARRAY    | 一维数据，形状为[C]                     |
 | alpha            | 平衡因子               | 输入              | float                             | 标量     | 无                                      |
 | gamma            | 调节因子               | 输入              | float                             | 标量     | 200系列板卡：[0, 8]<br>MLU370:[0, 1000] |
-| grad_output_desc | 梯度张量描述符         | 输入              | const mluOpTensorDescriptor_t      | /        | /                                       |
-| grad_output      | 梯度数据               | 输入              | float                             | ARRAY    | 二维数据，形状为[N,C]                   |
 | grad_input_desc  | 输出张量描述符         | 输入              | const mluOpTensorDescriptor_t      | /        | /                                       |
 | grad_input       | 输出数据               | 输出              | float                             | ARRAY    | 二维数据，形状为[N,C]                   |
 
@@ -149,7 +156,7 @@ gradInput = FL^{'} *weight* gradOutput =
 | ------------ | ------------------------------------------------------------ |
 | 数据类型限制 | 数据类型需与1.3小节匹配                                      |
 | 布局限制     | 物理布局需与1.3小节匹配                                      |
-| 规模限制     | 1.gamma暂不支持小于等于0的规模<br>2. 当weight为NULL时，target中元素的取值为[0，C]；当weight不为NULL时，target中元素的取值为[0，C-1]<br>3. 此版本优先支持多核之间C维度不拆的case。当weight为NULL时，在MLU200系列板卡中C的范围需在[0, 8154]， MLU370板卡中C的范围需在[0，13615]；当weight不为NULL时，在MLU200系列板卡中C的范围需在[0, 7520]， MLU370板卡中C的范围需在[0，12544]；<br>4. 由于硬件激活指令精度不足，在MLU200系列板块中，gamma的取值范围需在[0, 8]，在MLU370中，gamma的取值范围需在[0, 10000]<br>5. grad_output 和 weight 暂不支持包含 inf 和 -inf 的输入 |
+| 规模限制     | 1.gamma暂不支持小于等于0的规模<br>2. 当weight为NULL时，target中元素的取值为[0，C]；当weight不为NULL时，target中元素的取值为[0，C-1]<br>3. 此版本优先支持多核之间C维度不拆的case。当weight为NULL时，在MLU200系列板卡中C的范围需在[0, 8154]， MLU370板卡中C的范围需在[0，13615]；当weight不为NULL时，在MLU200系列板卡中C的范围需在[0, 7520]， MLU370板卡中C的范围需在[0，12544]；<br>4. 由于硬件激活指令精度不足，在MLU200系列板块中，gamma的取值范围需在[0, 8]，在MLU370中，gamma的取值范围需在[0, 10000]<br>5. weight 暂不支持包含 inf 和 -inf 的输入 |
 | 功能限制     | 1. reduction为预留参数，暂不支持None以外的情况<br>2.reduction为预留参数，暂不支持HIGH_PRECISION模式<br>3.此版本暂不支持输入数据为half类型 |
 
 ### 1.5 验收标准
@@ -232,8 +239,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(mluOpHandle_t handle,
                                                           const void *target,
                                                           const mluOpTensorDescriptor_t weight_desc,
                                                           const void *weight,
-                                                          const mluOpTensorDescriptor_t grad_output_desc,
-                                                          const void *grad_output,
                                                           const float alpha,
                                                           const float gamma,
                                                           const mluOpTensorDescriptor_t grad_input_desc,
@@ -258,7 +263,14 @@ FL^{'} =
 -\alpha*(1-p)^\gamma*(1-p-\gamma*p*log(p)) & target[n]=c \\
 -(1-\alpha)*p^\gamma*(\gamma*(1-p)*log(1-p)-p) & otherwise
 \end{cases}
-\\n=0,1,2,3,...,N - 1 \\c=0,1,2,3,...,C-1\\
+```
+```math
+n = 0,1,2,3,...,N - 1
+```
+```math
+c = 0,1,2,3,...,C-1
+```
+```math
 gradInput = FL^{'}*gradOutput
 ```
 
@@ -267,36 +279,36 @@ gradInput = FL^{'}*gradOutput
 ```math
 pt_{n,c} =
 \begin{cases}
-p_{n,c},  & target[n]=c \\
-1-p_{n,c}, & otherwise
+p_{n,c} ,  & target[n]=c \\
+1-p_{n,c} , & otherwise
 \end{cases}
-\\
+```
+```math
 \alpha t_{n,c} =
 \begin{cases}
 \alpha,  & target[n]=c \\
 \alpha-1, & otherwise
 \end{cases}
-\\n=0,1,2,3,...,N-1 \\c=0,1,2,3,...,C-1
+```
+```math
+n = 0,1,2,3,...,N-1
+```
+```math
+c = 0,1,2,3,...,C-1
 ```
 
 进行向量化后，`mluOpFocalLossSigmoidBackward`的计算公式可以表示为
 
 ```math
-FL^{'} = -\alpha t*(1-pt)^\gamma*(1-pt-\gamma*pt*log(pt))
+temp = FL^{'} = -\alpha t*(1-pt)^\gamma*(1-pt-\gamma*pt*log(pt))
        = -\alpha t* e^{\gamma*log(1-pt)} *(1-pt-\gamma*pt*log(pt))
 ```
 
 如果存在weight，则需将以上结果乘以weight:
 
 ```math
-temp = FL^{'}[n][c]*weight[target[n]]
-```
-
-然后会再乘以grad_output，得到最终的输出。
-
-```math
-gradInput = temp*gradOutput
-          = (-\alpha t* e^{\gamma*log(1-pt)} *(1-pt-\gamma*pt*log(pt)))*weight[target[n]]*gradOutput
+gradInput = temp*weight[target[n]]
+          = (-\alpha t* e^{\gamma*log(1-pt)} *(1-pt-\gamma*pt*log(pt)))*weight[target[n]]
 ```
 
 
@@ -306,9 +318,13 @@ gradInput = temp*gradOutput
 target[n]的取值为[0，C]，在构造$`p_t`$和$`\alpha _t`$的过程中，考虑到target[n] =c时只有N个数，其余N*(C-1)个数为otherwise时的取值。因此先将$`p_t`$和$`\alpha _t`$的元素值都初始化为otherwise的值，再遍历N维度来设置target[n] =c时的取值。
 
 ```math
-p = sigmoid(input) \\
-pt = 1-p \\
-\alpha t = nramSet(\alpha-1) \\
+p = sigmoid(input)
+```
+```math
+pt = 1-p
+```
+```math
+\alpha t = nramSet(\alpha-1)
 ```
 
 ```cpp
@@ -320,11 +336,16 @@ for (int n = 0; n < N; n++) {
 ```
 
 ```math
-temp  = -\alpha t* e^{\gamma*log(1-pt)} \\
-output = (1-pt-\gamma*pt*log(pt)) \\
-output = output * temp \\
-output = output[n][c] * weight[target[n]] \\
-output = output * gradOutput;
+temp  = -\alpha t* e^{\gamma*log(1-pt)}
+```
+```math
+output = (1-pt-\gamma*pt*log(pt))
+```
+```math
+output = output * temp
+```
+```math
+output = output[n][c] * weight[target[n]]
 ```
 
 ### 3.2 伪代码实现


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

improve focal_loss_sigmoid_backward precision by using supass inst

## 2. Modification

modified:   kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
modified:   kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
modified:   mlu_op.h
modified:   test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/test_case/case_0.prototxt


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          U1       |
|        3       |Layouts                               |          ARRAY       |
|        4       |Whether multi-dimensions are supported|         none                             |
|        5       |Whether element zero is supported     |             none                         |
|        6       |Data type(half/float)                 |           half / float           |
|        7       |Whether there is size limit           |              none                        |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

MLU370 & MLU590


[       OK ] focal_loss_sigmoid_backward/TestSuite.mluOp/1029 (19 ms)
[----------] 1030 tests from focal_loss_sigmoid_backward/TestSuite (61090 ms total)

[----------] Global test environment tear-down
[2023-4-21 14:37:24] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 1030 cases of 1 op(s).
ALL PASSED.
[==========] 1030 test cases from 1 test suite ran. (62805 ms total)
[  PASSED  ] 1030 test cases.


LCOV - code coverage report
  Directory [Sort by Line Coverage [Sort_by_line_coverage] Functions [Sort_by
  name]                                                    function_coverage]
  kernels                [100.0%]   100.0 %5 / 5          -      0 / 0
  kernels/           [[97.7%](https://github.com/Cambricon/mlu-ops/pull/641#)][97.7%] 97.7 % 421 / 431      86.7 %13 / 15