### PR TITLE
[Feature](bangc-ops): add mutual_information_backward op

### DIFF
--- a/bangc-ops/kernels/mutual_information_backward/mutual_information_backward.cpp
+++ b/bangc-ops/kernels/mutual_information_backward/mutual_information_backward.cpp
@@ -1,0 +1,530 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "mutual_information_backward.h"
+
+#include <algorithm>
+#include <string>
+
+#include "core/context.h"
+#include "core/gen_case.h"
+#include "core/logging.h"
+#include "core/runtime/device.h"
+#include "core/tensor.h"
+#include "core/type.h"
+
+#define API_NAME "[mluOpMutualInformationBackward]"
+
+mluOpStatus_t MLUOP_WIN_API mluOpGetMutualInformationBackwardWorkspaceSize(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc,
+    const mluOpTensorDescriptor_t py_desc,
+    const mluOpTensorDescriptor_t opt_boundary_desc,
+    const mluOpTensorDescriptor_t p_desc,
+    const mluOpTensorDescriptor_t ans_grad_desc,
+    const bool overwrite_ans_grad, size_t *workspace_size) {
+  // Workspace is not required in the current implementation.
+  // This interface will be used when the scale limitation is removed.
+  *workspace_size = 0;
+  return MLUOP_STATUS_SUCCESS;
+}
+
+static mluOpStatus_t checkTensorDim(
+    const mluOpTensorDescriptor_t px_desc,
+    const mluOpTensorDescriptor_t py_desc,
+    const mluOpTensorDescriptor_t opt_boundary_desc,
+    const mluOpTensorDescriptor_t p_desc,
+    const mluOpTensorDescriptor_t ans_grad_desc,
+    const mluOpTensorDescriptor_t px_grad_desc,
+    const mluOpTensorDescriptor_t py_grad_desc) {
+  if (3 != px_desc->dim) {
+    LOG(ERROR) << API_NAME << " The dim of px must be 3. "
+               << "But now the dim of px is " << px_desc->dim << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (3 != py_desc->dim) {
+    LOG(ERROR) << API_NAME << " The dim of py must be 3. "
+               << "But now the dim of py is " << py_desc->dim << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (nullptr != opt_boundary_desc && 2 != opt_boundary_desc->dim) {
+    LOG(ERROR) << API_NAME
+               << " The dim of opt_boundary must be 2 when opt_boundary is "
+               << "not NULL. But now the dim of opt_boundary is "
+               << opt_boundary_desc->dim << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (3 != p_desc->dim) {
+    LOG(ERROR) << API_NAME << " The dim of p must be 3. "
+               << "But now the dim of p is " << p_desc->dim << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (1 != ans_grad_desc->dim) {
+    LOG(ERROR) << API_NAME << " The dim of ans_grad must be 1. "
+               << "But now the dim of ans_grad is "
+               << ans_grad_desc->dim << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (3 != px_grad_desc->dim) {
+    LOG(ERROR) << API_NAME << " The dim of px_grad must be 3. "
+               << "But now the dim of px_grad is " << px_grad_desc->dim << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (3 != py_grad_desc->dim) {
+    LOG(ERROR) << API_NAME << " The dim of py_grad must be 3. "
+               << "But now the dim of py_grad is " << py_grad_desc->dim << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+static mluOpStatus_t checkTensorShape(
+    const mluOpTensorDescriptor_t px_desc,
+    const mluOpTensorDescriptor_t py_desc,
+    const mluOpTensorDescriptor_t opt_boundary_desc,
+    const mluOpTensorDescriptor_t p_desc,
+    const mluOpTensorDescriptor_t ans_grad_desc,
+    const mluOpTensorDescriptor_t px_grad_desc,
+    const mluOpTensorDescriptor_t py_grad_desc) {
+  const int B = px_desc->dims[0];
+  const int S = px_desc->dims[1];
+  const int T = py_desc->dims[2];
+  if (B != py_desc->dims[0] || B != p_desc->dims[0] ||
+      B != ans_grad_desc->dims[0] || B != px_grad_desc->dims[0] ||
+      B != py_grad_desc->dims[0]) {
+    LOG(ERROR) << API_NAME
+               << " px.shape[0], py.shape[0], p.shape[0], ans_grad.shape[0], "
+               << "px_grad.shape[0] and py_grad.shape[0] must be same. But now "
+               << "px.shape[0] is " << px_desc->dims[0]
+               << ", py.shape[0] is " << py_desc->dims[0]
+               << ", p.shape[0] is " << p_desc->dims[0]
+               << ", ans_grad.shape[0] is " << ans_grad_desc->dims[0]
+               << ", px_grad.shape[0] is " << px_grad_desc->dims[0]
+               << ", py_grad.shape[0] is " << py_grad_desc->dims[0] << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  // Currently only supports !modified, so the shape of px must be [B, S, T+1]
+  if (T + 1 != px_desc->dims[2]) {
+    LOG(ERROR) << API_NAME << " Currently only supports the case that "
+               << "px.shape[2] must be equal to py.shape[2] + 1. But now "
+               << "px.shape[2] is " << px_desc->dims[2]
+               << ", py.shape[2] is " << py_desc->dims[2] << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
+  // the shape of py must be [B, S+1, T]
+  if (S + 1 != py_desc->dims[1]) {
+    LOG(ERROR) << API_NAME
+               << " py.shape[1] must be equal to px.shape[1] + 1. "
+               << "But now px.shape[1] is " << px_desc->dims[1]
+               << ", py.shape[1] is " << py_desc->dims[1] << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  // the shape of opt_boundary must be [B, 4]
+  if (nullptr != opt_boundary_desc && (B != opt_boundary_desc->dims[0]
+      || 4 != opt_boundary_desc->dims[1])) {
+    LOG(ERROR) << API_NAME << " When opt_boundary is not NULL, "
+               << "opt_boundary.shape[0] and px.shape[0] must be same, and "
+               << "opt_boundary.shape[1] must be 4. But now "
+               << "px.shape[0] is " << px_desc->dims[0]
+               << ", opt_boundary.shape[0] is " << opt_boundary_desc->dims[0]
+               << ", opt_boundary.shape[1] is " << opt_boundary_desc->dims[1]
+               << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  // the shape of p must be [B, S+1, T+1]
+  if (S + 1 != p_desc->dims[1] || T + 1 != p_desc->dims[2]) {
+    LOG(ERROR) << API_NAME
+               << " p.shape[1] and py.shape[1] must be same, and "
+               << "p.shape[2] must be equal to py.shape[2] + 1. "
+               << "But now p.shape[1] is " << p_desc->dims[1]
+               << ", py.shape[1] is " << py_desc->dims[1]
+               << ", p.shape[2] is " << p_desc->dims[2]
+               << ", py.shape[2] is " << py_desc->dims[2] << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  // the shape of px and px_grad must be same: [B, S, T+1]
+  for (int i = 1; i < px_grad_desc->dim; ++i) {
+    if (px_grad_desc->dims[i] != px_desc->dims[i]) {
+      LOG(ERROR) << API_NAME
+                 << " The shape of px and px_grad must be same. But now "
+                 << "px.shape[" << i << "] is " << px_desc->dims[i]
+                 << ", px_grad.shape[" << i << "] is " << px_grad_desc->dims[i]
+                 << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+  }
+
+  // the shape of py and py_grad must be same: [B, S+1, T]
+  for (int i = 1; i < py_grad_desc->dim; ++i) {
+    if (py_grad_desc->dims[i] != py_desc->dims[i]) {
+      LOG(ERROR) << API_NAME
+                 << " The shape of py and py_grad must be same. But now "
+                 << "py.shape[" << i << "] is " << py_desc->dims[i]
+                 << ", py_grad.shape[" << i << "] is " << py_grad_desc->dims[i]
+                 << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+  }
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+static mluOpStatus_t checkTensorDatatype(
+    const mluOpTensorDescriptor_t px_desc,
+    const mluOpTensorDescriptor_t py_desc,
+    const mluOpTensorDescriptor_t opt_boundary_desc,
+    const mluOpTensorDescriptor_t p_desc,
+    const mluOpTensorDescriptor_t ans_grad_desc,
+    const mluOpTensorDescriptor_t px_grad_desc,
+    const mluOpTensorDescriptor_t py_grad_desc) {
+  if (MLUOP_DTYPE_FLOAT != px_desc->dtype) {
+    LOG(ERROR) << API_NAME
+               << "The data type of px currently only support float. But now "
+               << "the data type of px is "
+               << mluOpGetNameOfDataType(px_desc->dtype) << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+  if (MLUOP_DTYPE_FLOAT != py_desc->dtype) {
+    LOG(ERROR) << API_NAME
+               << "The data type of py currently only support float. But now "
+               << "the data type of py is "
+               << mluOpGetNameOfDataType(py_desc->dtype) << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+  if (nullptr != opt_boundary_desc &&
+      MLUOP_DTYPE_INT64 != opt_boundary_desc->dtype) {
+    LOG(ERROR) << API_NAME
+               << "The data type of opt_boundary currently only support int64."
+               << " But now the data type of opt_boundary is "
+               << mluOpGetNameOfDataType(opt_boundary_desc->dtype) << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+  if (MLUOP_DTYPE_FLOAT != p_desc->dtype) {
+    LOG(ERROR) << API_NAME
+               << "The data type of p currently only support float. But now "
+               << "the data type of p is "
+               << mluOpGetNameOfDataType(p_desc->dtype) << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+  if (MLUOP_DTYPE_FLOAT != ans_grad_desc->dtype) {
+    LOG(ERROR) << API_NAME
+               << "The data type of ans_grad currently only support float. "
+               << "But now the data type of ans_grad is "
+               << mluOpGetNameOfDataType(ans_grad_desc->dtype) << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+  if (MLUOP_DTYPE_FLOAT != px_grad_desc->dtype) {
+    LOG(ERROR) << API_NAME
+               << "The data type of px_grad currently only support float. "
+               << "But now the data type of px_grad is "
+               << mluOpGetNameOfDataType(px_grad_desc->dtype) << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+  if (MLUOP_DTYPE_FLOAT != py_grad_desc->dtype) {
+    LOG(ERROR) << API_NAME
+               << "The data type of py_grad currently only support float. "
+               << "But now the data type of py_grad is "
+               << mluOpGetNameOfDataType(py_grad_desc->dtype) << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+static mluOpStatus_t checkTensorScaleLimit(
+    mluOpHandle_t handle,
+    const mluOpTensorDescriptor_t px_desc,
+    const mluOpTensorDescriptor_t py_desc,
+    const mluOpTensorDescriptor_t opt_boundary_desc,
+    const mluOpTensorDescriptor_t p_desc) {
+  // check large tensor
+  // the shape of px and px_grad are the same,
+  // the shape of py and py_grad are the same,
+  // so there is no need to check the tensor num of px_grad and py_grad
+  if (mluOpGetTensorElementNum(px_desc) >= LARGE_TENSOR_NUM ||
+      mluOpGetTensorElementNum(py_desc) >= LARGE_TENSOR_NUM ||
+      (nullptr != opt_boundary_desc &&
+      mluOpGetTensorElementNum(opt_boundary_desc) >= LARGE_TENSOR_NUM) ||
+      mluOpGetTensorElementNum(p_desc) >= LARGE_TENSOR_NUM) {
+    LOG(ERROR) << API_NAME << " Overflow max tensor num."
+               << " Current operator supports tensor num smaller than 2^31.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
+  const int B = px_desc->dims[0];
+  const int S = px_desc->dims[1];
+  const int T = py_desc->dims[2];
+  // check scale limit for compute term1 and term2
+  int currnet_size = T * (S + 1) + (T + 1) * S + 5 * (T + 1);
+  if (currnet_size > handle->nram_size / sizeof(float)) {
+    LOG(ERROR) << API_NAME << " The num of px.shape[1] * px.shape[2] + "
+               << "py.shape[1] * py.shape[2] + 5 * (py.shape[2] + 1) shoule be "
+               << "less than " << handle->nram_size / sizeof(float)
+               << ". But now it is " << currnet_size << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
+  // check scale limit for compute p_grad
+  currnet_size = T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) +
+                 3 * std::min(S, T) + 4;
+  if (currnet_size > handle->nram_size / sizeof(float)) {
+    LOG(ERROR) << API_NAME << " The num of px.shape[1] * px.shape[2] + "
+               << "py.shape[1] * py.shape[2] + p.shape[1] * p.shape[2] "
+               << "+ 3 * min(px.shape[1], py.shape[2]) + 4 shoule be less than "
+               << handle->nram_size / sizeof(float)
+               << ". But now it is " << currnet_size << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+static mluOpStatus_t checkTensorPtr(
+    const void *px, const void *py, const void *p, const void *ans_grad,
+    const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
+    const void *px_grad, const void *py_grad, const int S, const int T,
+    bool &has_boundary) {
+  if (S > 0) {
+    PARAM_CHECK(API_NAME, px != nullptr);
+    PARAM_CHECK(API_NAME, px_grad != nullptr);
+  } else {
+    VLOG(5) << API_NAME << " px.shape[1] is zero.";
+  }
+
+  if (T > 0) {
+    PARAM_CHECK(API_NAME, py != nullptr);
+    PARAM_CHECK(API_NAME, py_grad != nullptr);
+  } else {
+    VLOG(5) << API_NAME << " py.shape[2] is zero.";
+  }
+
+  PARAM_CHECK(API_NAME, p != nullptr);
+  PARAM_CHECK(API_NAME, ans_grad != nullptr);
+
+  if (nullptr != opt_boundary_desc && nullptr != opt_boundary) {
+    has_boundary = true;
+    VLOG(5) << API_NAME << " opt_boundary is not NULL.";
+
+  } else  if (nullptr == opt_boundary_desc && nullptr == opt_boundary) {
+    has_boundary = false;
+    VLOG(5) << API_NAME << " opt_boundary is NULL.";
+  } else {
+    LOG(ERROR) << API_NAME
+               << " opt_boundary_desc and opt_boundary must both be NULL, "
+               << "or both not be NULL.";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+static mluOpStatus_t mutualInformationBackwardParamCheck(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
+    const mluOpTensorDescriptor_t py_desc, const void *py,
+    const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
+    const mluOpTensorDescriptor_t p_desc, const void *p,
+    const mluOpTensorDescriptor_t ans_grad_desc, void *ans_grad,
+    void *workspace, const size_t workspace_size,
+    const mluOpTensorDescriptor_t px_grad_desc, void *px_grad,
+    const mluOpTensorDescriptor_t py_grad_desc, void *py_grad,
+    bool &has_boundary, bool &zero_element) {
+  // 1. check handle and tensor_desc
+  PARAM_CHECK(API_NAME, handle != nullptr);
+  PARAM_CHECK(API_NAME, px_desc != nullptr);
+  PARAM_CHECK(API_NAME, py_desc != nullptr);
+  PARAM_CHECK(API_NAME, p_desc != nullptr);
+  PARAM_CHECK(API_NAME, ans_grad_desc != nullptr);
+  PARAM_CHECK(API_NAME, px_grad_desc != nullptr);
+  PARAM_CHECK(API_NAME, py_grad_desc != nullptr);
+
+  // since the layout of all tensor is ARRAY, so skip check tensor layout
+
+  // 2. check mlu platform
+  if (handle->arch < 372) {
+    LOG(ERROR) << API_NAME << " Only mlu300 and above devices are supported."
+               << " Please check the device version!";
+    return MLUOP_STATUS_ARCH_MISMATCH;
+  }
+
+  // 3. check tensor dim
+  mluOpStatus_t check_status = checkTensorDim(px_desc, py_desc,
+                                              opt_boundary_desc,
+                                              p_desc, ans_grad_desc,
+                                              px_grad_desc, py_grad_desc);
+  if (MLUOP_STATUS_SUCCESS != check_status) {
+    return check_status;
+  }
+
+  // 4. check tensor shape
+  check_status = checkTensorShape(px_desc, py_desc, opt_boundary_desc,
+                                  p_desc, ans_grad_desc, px_grad_desc,
+                                  py_grad_desc);
+  if (MLUOP_STATUS_SUCCESS != check_status) {
+    return check_status;
+  }
+
+  // 5. check tensor dtype
+  check_status = checkTensorDatatype(px_desc, py_desc, opt_boundary_desc,
+                                     p_desc, ans_grad_desc, px_grad_desc,
+                                     py_grad_desc);
+  if (MLUOP_STATUS_SUCCESS != check_status) {
+    return check_status;
+  }
+
+  // 6. check scale limit
+  check_status = checkTensorScaleLimit(handle, px_desc, py_desc,
+                                       opt_boundary_desc, p_desc);
+  if (MLUOP_STATUS_SUCCESS != check_status) {
+    return check_status;
+  }
+
+  const int B = px_desc->dims[0];
+  const int S = px_desc->dims[1];
+  const int T = py_desc->dims[2];
+
+  // 7. check zero element.
+  if (0 == B || (0 == S && 0 == T)) {
+    zero_element = true;
+    VLOG(5) << API_NAME << " Skip zero element tensor when px.shape[0] is zero "
+                        << "or px.shape[1] and py.shape[2] are both zero.";
+    return MLUOP_STATUS_SUCCESS;
+  }
+
+  // 8 check workspace
+  if (workspace_size > 0) {
+    PARAM_CHECK(API_NAME, workspace != nullptr);
+  }
+
+  // 9. check tensor ptr
+  check_status = checkTensorPtr(px, py, p, ans_grad, opt_boundary_desc,
+                                opt_boundary, px_grad, py_grad, S, T,
+                                has_boundary);
+  if (MLUOP_STATUS_SUCCESS != check_status) {
+    return check_status;
+  }
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+static void mutualInformationBackwardGencase(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
+    const mluOpTensorDescriptor_t py_desc, const void *py,
+    const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
+    const mluOpTensorDescriptor_t p_desc, const void *p,
+    const mluOpTensorDescriptor_t ans_grad_desc, void *ans_grad,
+    const bool overwrite_ans_grad,
+    const mluOpTensorDescriptor_t px_grad_desc, void *px_grad,
+    const mluOpTensorDescriptor_t py_grad_desc, void *py_grad) {
+  GEN_CASE_START("mutual_information_backward");
+  GEN_CASE_HANDLE(handle);
+
+  GEN_CASE_DATA(true, "px", px, px_desc, -1, 1);
+  GEN_CASE_DATA(true, "py", py, py_desc, -1, 1);
+  if (nullptr != opt_boundary) {
+    GEN_CASE_DATA_REAL(true, "opt_boundary", opt_boundary, opt_boundary_desc);
+  }
+  GEN_CASE_DATA(true, "p", p, p_desc, -1, 1);
+  GEN_CASE_DATA(true, "ans_grad", ans_grad, ans_grad_desc, -1, 1);
+  GEN_CASE_DATA(false, "ans_grad", ans_grad, ans_grad_desc, -1, 1);
+  GEN_CASE_DATA(false, "px_grad", px_grad, px_grad_desc, -1, 1);
+  GEN_CASE_DATA(false, "py_grad", py_grad, py_grad_desc, -1, 1);
+
+  GEN_CASE_OP_PARAM_SINGLE(0, "mutual_information_backward",
+                           "overwrite_ans_grad", overwrite_ans_grad);
+  GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
+}
+
+static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
+                       cnrtFunctionType_t *k_type, int batch_size) {
+  int core_num =  mluop::runtime::getClusterLimitCapability(handle) *
+                  mluop::runtime::getCoreNumOfEachUnionCapability(handle);
+  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  k_dim->x = 1;
+  k_dim->y = batch_size < core_num ? batch_size : core_num;
+  k_dim->z = 1;
+}
+
+static mluOpStatus_t launchMutualInformationBackwardKernel(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
+    const mluOpTensorDescriptor_t py_desc, const void *py,
+    const bool has_boundary, const void *opt_boundary, const void *p,
+    const bool overwrite_ans_grad, void *ans_grad, void *px_grad,
+    void *py_grad) {
+  const int B = px_desc->dims[0];
+  const int S = px_desc->dims[1];
+  const int T = py_desc->dims[2];
+
+  cnrtDim3_t k_dim;
+  cnrtFunctionType_t k_type;
+  policyFunc(handle, &k_dim, &k_type, B);
+  VLOG(5) << "Launch Kernel MutualInformationBackward<<<Block "
+          << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";
+  KERNEL_CHECK(kernelMutualInformationBackward(
+      k_dim, k_type, handle->queue, B, S, T, px, py, has_boundary, opt_boundary,
+      p, overwrite_ans_grad, ans_grad, px_grad, py_grad));
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpMutualInformationBackward(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
+    const mluOpTensorDescriptor_t py_desc, const void *py,
+    const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
+    const mluOpTensorDescriptor_t p_desc, const void *p,
+    const mluOpTensorDescriptor_t ans_grad_desc, void *ans_grad,
+    const bool overwrite_ans_grad, void *workspace, const size_t workspace_size,
+    const mluOpTensorDescriptor_t px_grad_desc, void *px_grad,
+    const mluOpTensorDescriptor_t py_grad_desc, void *py_grad) {
+  // 1. paramcheck
+  bool has_boundary = false;
+  bool zero_element = false;
+  mluOpStatus_t check_status = mutualInformationBackwardParamCheck(
+      handle, px_desc, px, py_desc, py, opt_boundary_desc, opt_boundary,
+      p_desc, p, ans_grad_desc, ans_grad, workspace, workspace_size,
+      px_grad_desc, px_grad, py_grad_desc, py_grad, has_boundary, zero_element);
+
+  if (MLUOP_STATUS_SUCCESS != check_status || zero_element) {
+    return check_status;
+  }
+
+  // 2. generate case
+  if (MLUOP_GEN_CASE_ON_NEW) {
+    mutualInformationBackwardGencase(handle, px_desc, px, py_desc, py,
+                                     opt_boundary_desc, opt_boundary,
+                                     p_desc, p, ans_grad_desc, ans_grad,
+                                     overwrite_ans_grad, px_grad_desc, px_grad,
+                                     py_grad_desc, py_grad);
+  }
+
+  // 3. launch kernel
+  mluOpStatus_t return_status = launchMutualInformationBackwardKernel(
+      handle, px_desc, px, py_desc, py, has_boundary, opt_boundary, p,
+      overwrite_ans_grad, ans_grad, px_grad, py_grad);
+
+  GEN_CASE_END();
+  return return_status;
+}

--- a/bangc-ops/kernels/mutual_information_backward/mutual_information_backward.h
+++ b/bangc-ops/kernels/mutual_information_backward/mutual_information_backward.h
@@ -1,0 +1,36 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef KERNELS_MUTUAL_INFORMATION_BACKWARD_H_
+#define KERNELS_MUTUAL_INFORMATION_BACKWARD_H_
+
+#include "mlu_op.h"
+
+
+void MLUOP_WIN_API kernelMutualInformationBackward(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const int B, const int S, const int T, const void *px, const void *py,
+    const bool has_boundary, const void *opt_boundary, const void *p,
+    const bool overwrite_ans_grad, void *ans_grad, void *px_grad,
+    void *py_grad);
+
+#endif  // KERNELS_MUTUAL_INFORMATION_BACKWARD_H_

--- a/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
+++ b/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
@@ -1,0 +1,306 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "mutual_information_backward.h"
+
+#include "kernels/kernel.h"
+#include "kernels/utils/common.h"
+
+__nram__ char nram_buffer[MAX_NRAM_SIZE];
+
+__mlu_func__ void setNanInfToZero(float *src, float *mask, const int num) {
+  __bang_sub(mask, src, src, num);
+  __bang_eq_scalar(mask, mask, 0., num);
+  __bang_float2int32_rn((int *)mask, mask, num, 0);
+  __bang_mul_scalar((int *)mask, (int *)mask, int(-1), num);
+  __bang_band((char *)src, (char *)src, (char *)mask, num * sizeof(float));
+}
+
+__mlu_func__ void safeExp(float *dst, float *src, float *mask, const int num) {
+  setNanInfToZero(src, mask, num);
+  computeExp(dst, src, NULL, 0, num);
+  __bang_band((char *)dst, (char *)dst, (char *)mask, num * sizeof(float));
+  setNanInfToZero(dst, mask, num);
+}
+
+__mlu_func__ void computeTerm1AndTerm2(const int b, const int S, const int T,
+                                       const int s_begin, const int s_end,
+                                       const int t_begin, const int t_end,
+                                       const float *px, const float *py,
+                                       const float *p) {
+  /* *********************nram space split********************** */
+  /* |  term1  |  term2  | cur_p | next_p | large_neg |  mask |*/
+  /* | S*(T+1) | (S+1)*T | t_len | t_len  |  2*t_len  | t_len |*/
+  float *nram_term1 = (float *)nram_buffer;
+  float *nram_term2 = nram_term1 + S * (T + 1);
+  float *nram_cur_p = nram_term2 + (S + 1) * T;
+
+  int t_len = t_end - t_begin + 1;
+
+  float *nram_next_p = nram_cur_p + t_len;
+  float *nram_large_neg = nram_next_p + t_len;
+  float *nram_mask = nram_large_neg + 2 * t_len;
+
+  __bang_write_value(nram_large_neg, 2 * t_len, (float)-1.0e+30);
+
+  for (int i = s_begin; i < s_end; ++i) {
+    // load p to cur_p and next_p
+    __memcpy(nram_cur_p, p + b * (S + 1) * (T + 1) + i * (T + 1) + t_begin,
+             t_len * sizeof(float), GDRAM2NRAM, t_len * sizeof(float),
+             (T + 1) * sizeof(float), 1);
+    __bang_nan_maximum(nram_cur_p, nram_cur_p, nram_large_neg, 2 * t_len);
+
+    // load px to term1
+    __memcpy(nram_term1 + i * (T + 1) + t_begin,
+             px + b * S * (T + 1) + i * (T + 1) + t_begin,
+             t_len * sizeof(float), GDRAM2NRAM);
+    __bang_add(nram_term1 + i * (T + 1) + t_begin,
+               nram_term1 + i * (T + 1) + t_begin, nram_cur_p, t_len);
+    __bang_sub(nram_term1 + i * (T + 1) + t_begin,
+               nram_term1 + i * (T + 1) + t_begin, nram_next_p, t_len);
+    safeExp(nram_term1 + i * (T + 1) + t_begin,
+            nram_term1 + i * (T + 1) + t_begin, nram_mask, t_len);
+
+    if (t_len > 1) {
+      // load py to term2
+      __memcpy(nram_term2 + i * T + t_begin,
+               py + b * (S + 1) * T + i * T + t_begin,
+               (t_len - 1) * sizeof(float), GDRAM2NRAM);
+      __bang_add(nram_term2 + i * T + t_begin, nram_term2 + i * T + t_begin,
+                 nram_cur_p, t_len - 1);
+      __bang_sub(nram_term2 + i * T + t_begin, nram_term2 + i * T + t_begin,
+                 nram_cur_p + 1, t_len - 1);
+      safeExp(nram_term2 + i * T + t_begin, nram_term2 + i * T + t_begin,
+              nram_mask, t_len - 1);
+    }
+  }
+
+  if (t_len > 1) {
+    if (s_begin == s_end) {
+      // load p to next_p
+      __memcpy(nram_next_p,
+               p + b * (S + 1) * (T + 1) + s_end * (T + 1) + t_begin,
+               t_len * sizeof(float), GDRAM2NRAM);
+      __bang_nan_maximum(nram_next_p, nram_next_p, nram_large_neg, t_len);
+    }
+    // compute term2[s_end][:]
+    __memcpy(nram_term2 + s_end * T + t_begin,
+             py + b * (S + 1) * T + s_end * T + t_begin,
+             (t_len - 1) * sizeof(float), GDRAM2NRAM);
+    __bang_add(nram_term2 + s_end * T + t_begin,
+               nram_term2 + s_end * T + t_begin, nram_next_p, t_len - 1);
+    __bang_sub(nram_term2 + s_end * T + t_begin,
+               nram_term2 + s_end * T + t_begin, nram_next_p + 1, t_len - 1);
+    safeExp(nram_term2 + s_end * T + t_begin, nram_term2 + s_end * T + t_begin,
+            nram_mask, t_len - 1);
+  }
+}
+
+__mlu_func__ void computePGrad(const int b, const int S, const int T,
+                               const int s_begin, const int s_end,
+                               const int t_begin, const int t_end,
+                               const bool overwrite_ans_grad, float *ans_grad) {
+  /* ***************************nram space split*************************** */
+  /* |  term1  |  term2  |   p_grad  | cur_term1|zero|cur_term2|cur_p_grad| */
+  /* | S*(T+1) | (S+1)*T |(S+1)*(T+1)|  min_len | 1  | min_len |  min_len | */
+  float *nram_term1 = (float *)nram_buffer;
+  float *nram_term2 = nram_term1 + S * (T + 1);
+  float *nram_p_grad = nram_term2 + (S + 1) * T;
+  float *nram_cur_term1 = nram_p_grad + (S + 1) * (T + 1);
+
+  int s_len = s_end - s_begin + 1;
+  int t_len = t_end - t_begin + 1;
+  int max_len = __mluop_max(s_len, t_len);
+  int min_len = __mluop_min(s_len, t_len);
+
+  float *nram_cur_term2 = nram_cur_term1 + min_len + 1;
+  float *nram_cur_p_grad = nram_cur_term2 + min_len;
+  __bang_write_zero(nram_cur_term1, 3 * min_len + 1);
+
+  // compute the last one: p_grad[b][s_end][t_end] = ans_grad[b]
+  __memcpy_async(nram_p_grad + s_end * (T + 1) + t_end, ans_grad + b,
+                 sizeof(float), GDRAM2NRAM);
+  __sync();
+  nram_cur_p_grad[0] = nram_p_grad[s_end * (T + 1) + t_end];
+
+  int data_num = 0;
+  int s = 0;
+  int t = 0;
+  int term2_s = 0;
+  int term2_t = 0;
+  int term1_num = 0;
+  int term2_num = 0;
+  float *nram_p_grad_for_compute_term1 = nram_cur_p_grad;
+  float *nram_compute_term2 = nram_cur_term2;
+
+  int loop_time = s_len + t_len - 1;
+  for (int i = 1; i < loop_time; ++i) {
+      data_num = i < max_len ? __mluop_min(i + 1, min_len) : loop_time - i;
+      s = i < s_len ? s_end - i : s_begin;
+      t = i < s_len ? t_end : t_end + s_len - i - 1;
+
+      term1_num = i < t_len ? data_num - 1 : data_num;
+      if (term1_num > 0) {
+        __memcpy(nram_cur_term1, nram_term1 + s * (T + 1) + t, sizeof(float),
+                 NRAM2NRAM, sizeof(float), T * sizeof(float), term1_num - 1);
+        nram_p_grad_for_compute_term1 = i >= s_len ? nram_cur_p_grad + 1 :
+                                        nram_cur_p_grad;
+        __bang_mul(nram_cur_term1, nram_cur_term1,
+                   nram_p_grad_for_compute_term1, term1_num);
+      }
+
+      term2_num = data_num;
+      nram_compute_term2 = nram_cur_term2;
+      term2_s = s;
+      term2_t = t;
+      if (i < s_len) {
+        term2_num -= 1;
+        nram_compute_term2 -= 1;
+        term2_s += 1;
+        term2_t -= 1;
+      }
+      if (term2_num > 0) {
+        __memcpy(nram_cur_term2, nram_term2 + term2_s * T + term2_t,
+                 sizeof(float), NRAM2NRAM, sizeof(float),
+                 (T - 1) * sizeof(float), term2_num - 1);
+        __bang_mul(nram_cur_term2, nram_cur_term2, nram_cur_p_grad, term2_num);
+      }
+
+      __bang_add(nram_cur_p_grad, nram_cur_term1, nram_compute_term2, data_num);
+      __memcpy(nram_p_grad + s * (T + 1) + t, nram_cur_p_grad, sizeof(float),
+               NRAM2NRAM, T * sizeof(float), sizeof(float), data_num - 1);
+  }
+
+  if (overwrite_ans_grad) {
+    __memcpy(ans_grad + b, nram_p_grad + s_begin * (T + 1) + t_begin,
+             sizeof(float), NRAM2GDRAM);
+  }
+}
+
+__mlu_func__ void computePxGradAndPyGrad(const int b, const int S, const int T,
+                                         const int s_begin, const int s_end,
+                                         const int t_begin, const int t_end,
+                                         float *px_grad, float *py_grad) {
+  /* ***********nram space split********** */
+  /* |  term1  |  term2  |     p_grad    | */
+  /* | S*(T+1) | (S+1)*T |  (S+1)*(T+1)  | */
+  float *nram_term1 = (float *)nram_buffer;
+  float *nram_term2 = nram_term1 + S * (T + 1);
+  float *nram_p_grad = nram_term2 + (S + 1) * T;
+
+  int t_len = t_end - t_begin + 1;
+
+  for (int i = s_begin; i < s_end; ++i) {
+    // compute term1
+    __bang_mul(nram_term1 + i * (T + 1) + t_begin,
+               nram_term1 + i * (T + 1) + t_begin,
+               nram_p_grad + (i + 1) * (T + 1) + t_begin, t_len);
+
+    if (t_len > 1) {
+      // compute term2
+      __bang_mul(nram_term2 + i * T + t_begin,
+                 nram_term2 + i * T + t_begin,
+                 nram_p_grad + i * (T + 1) + t_begin + 1, t_len - 1);
+    }
+  }
+
+  if (t_len > 1) {
+    // compute term2[s_end][:]
+    __bang_mul(nram_term2 + s_end * T + t_begin,
+               nram_term2 + s_end * T + t_begin,
+               nram_p_grad + s_end * (T + 1) + t_begin + 1, t_len - 1);
+  }
+
+  if (S > 0) {
+    __memcpy(px_grad + b * S * (T + 1), nram_term1, S * (T + 1) * sizeof(float),
+             NRAM2GDRAM);
+  }
+  if (T > 0) {
+    __memcpy(py_grad + b * (S + 1) * T, nram_term2, (S + 1) * T * sizeof(float),
+             NRAM2GDRAM);
+  }
+}
+
+__mlu_global__ void mluBlockMutualInformationBackward(
+    const int B, const int S, const int T, const float *px, const float *py,
+    const bool has_boundary, const int64_t *opt_boundary, const float *p,
+    const bool overwrite_ans_grad, float *ans_grad, float *px_grad,
+    float *py_grad) {
+  const int num_per_core = B / taskDim;
+  const int num_rem = B % taskDim;
+  const int num_cur_core = num_per_core + (taskId < num_rem);
+  const int b_offset = taskId * num_cur_core + (taskId >= num_rem) * num_rem;
+
+  int s_begin = 0;
+  int t_begin = 0;
+  int s_end = S;
+  int t_end = T;
+  if (has_boundary) {
+    int64_t *boundary = (int64_t *)nram_buffer;
+    for (int b = b_offset; b < b_offset + num_cur_core; ++b) {
+      __memcpy(boundary, opt_boundary + 4 * b, 4 * sizeof(int64_t), GDRAM2NRAM);
+      s_begin = boundary[0];
+      t_begin = boundary[1];
+      s_end = boundary[2];
+      t_end = boundary[3];
+      __bang_write_zero((float *)nram_buffer, S * (T + 1) + (S + 1) * T);
+
+      if (s_begin > s_end || t_begin > t_end) {
+        if (S > 0) {
+          __memcpy(px_grad + b * S * (T + 1), (float *)nram_buffer,
+                   S * (T + 1) * sizeof(float), NRAM2GDRAM);
+        }
+        if (T > 0) {
+          __memcpy(py_grad + b * (S + 1) * T,
+                   (float *)nram_buffer + S * (T + 1),
+                   (S + 1) * T * sizeof(float), NRAM2GDRAM);
+        }
+        continue;
+      }
+      computeTerm1AndTerm2(b, S, T, s_begin, s_end, t_begin, t_end, px, py, p);
+      computePGrad(b, S, T, s_begin, s_end, t_begin, t_end, overwrite_ans_grad,
+                   ans_grad);
+      computePxGradAndPyGrad(b, S, T, s_begin, s_end, t_begin, t_end, px_grad,
+                             py_grad);
+    }
+  } else {
+    for (int b = b_offset; b < b_offset + num_cur_core; ++b) {
+      computeTerm1AndTerm2(b, S, T, s_begin, s_end, t_begin, t_end, px, py, p);
+      computePGrad(b, S, T, s_begin, s_end, t_begin, t_end, overwrite_ans_grad,
+                   ans_grad);
+      computePxGradAndPyGrad(b, S, T, s_begin, s_end, t_begin, t_end, px_grad,
+                             py_grad);
+    }
+  }
+}
+
+void MLUOP_WIN_API kernelMutualInformationBackward(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const int B, const int S, const int T, const void *px, const void *py,
+    const bool has_boundary, const void *opt_boundary, const void *p,
+    const bool overwrite_ans_grad, void *ans_grad, void *px_grad,
+    void *py_grad) {
+  mluBlockMutualInformationBackward<<<k_dim, k_type, queue>>>(
+      B, S, T, (float *)px, (float *)py, has_boundary, (int64_t *)opt_boundary,
+      (float *)p, overwrite_ans_grad, (float *)ans_grad, (float *)px_grad,
+      (float *)py_grad);
+}

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -7342,6 +7342,195 @@ mluOpMsDeformAttnBackward(mluOpHandle_t handle,
                           const mluOpTensorDescriptor_t grad_attn_weight_desc,
                           void *grad_attn_weight);
 
+// Group:MutualInformationBackward
+/*!
+ * @brief Returns the size of the MLU memory that is used as an extra workspace
+ * to optimize ::mluOpMutualInformationBackward.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in
+ * ::mluOpMutualInformationBackward. For detailed information, see ::mluOpHandle_t.
+ * @param[in] px_desc
+ * The descriptor of the tensor \b px, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] py_desc
+ * The descriptor of the tensor \b py, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] opt_boundary_desc
+ * The descriptor of the tensor \b opt_boundary, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] p_desc
+ * The descriptor of the tensor \b p, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] ans_grad_desc
+ * The descriptor of the tensor \b ans_grad, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] overwrite_ans_grad
+ * A boolean value indicating whether to overwrite \b ans_grad.
+ * @param[out] workspace_size
+ * Pointer to the MLU memory that stores the returned size of the extra workspace in bytes.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par Data Type
+ * - None.
+ *
+ * @par Data Layout
+ * - None.
+ *
+ * @par Scale Limitations
+ * - None.
+ *
+ * @par API Dependency
+ * - The allocated extra workspace should be passed to ::mluOpMutualInformationBackward.
+ *
+ * @par Note
+ * - Currently the \b workspace_size always returns 0.
+ *   This will be changed when the scale limitation is removed in ::mluOpMutualInformationBackward.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
+                                               const mluOpTensorDescriptor_t px_desc,
+                                               const mluOpTensorDescriptor_t py_desc,
+                                               const mluOpTensorDescriptor_t opt_boundary_desc,
+                                               const mluOpTensorDescriptor_t p_desc,
+                                               const mluOpTensorDescriptor_t ans_grad_desc,
+                                               const bool overwrite_ans_grad,
+                                               size_t *workspace_size);
+
+// Group:MutualInformationBackward
+/*!
+ * @brief Computes the gradients of tensor \b px and tensor \b py.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in the
+ * mutual_information_backward operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] px_desc
+ * The descriptor of the tensor \b px, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] px
+ * Pointer to the MLU memory that stores the tensor \b px.
+ * @param[in] py_desc
+ * The descriptor of the tensor \b py, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] py
+ * Pointer to the MLU memory that stores the tensor \b py.
+ * @param[in] opt_boundary_desc
+ * The descriptor of the input tensor \b opt_boundary, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] opt_boundary
+ * Pointer to the MLU memory that stores the \b opt_boundary tensor.
+ * @param[in] p_desc
+ * The descriptor of the tensor \b p, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] p
+ * Pointer to the MLU memory that stores the tensor \b p.
+ * @param[in] ans_grad_desc
+ * The descriptor of the tensor \b ans_grad, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] ans_grad
+ * Pointer to the MLU memory that stores the tensor \b ans_grad.
+ * @param[in] overwrite_ans_grad
+ * A boolean value indicating whether to overwrite \b ans_grad.
+ * @param[in] workspace
+ * Pointer to the MLU memory that is used as an extra workspace for the mutual_information_backward operation.
+ * For more information about workspace, see "Cambricon BANGC OPS User Guide".
+ * @param[in] workspace_size
+ * The size of the extra workspace in bytes.
+ * @param[in] px_grad_desc
+ * The descriptor of the tensor \b px_grad, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] px_grad
+ * Pointer to the MLU memory that stores the tensor \b px_grad.
+ * @param[in] py_grad_desc
+ * The descriptor of the tensor \b py_grad, which contains dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] py_grad
+ * Pointer to the MLU memory that stores the tensor \b py_grad.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
+ *
+ * @par Data Type
+ * - The supported data types of input and output tensors are as follows:
+ *   - tensor ``px`` : ``float``;
+ *   - tensor ``py`` : ``float``;
+ *   - tensor ``opt_boundary`` : ``int64``;
+ *   - tensor ``ans_grad`` : ``float``;
+ *   - tensor ``px_grad`` : ``float``;
+ *   - tensor ``py_grad`` : ``float``;
+ *
+ * @par Data Layout
+ * - The supported layout of input and output tensors must be \p MLUOP_LAYOUT_ARRAY.
+ *
+ * @par Scale Limitation
+ * - The shape of \b px is 3D([B, S, T + 1]), where B is the batch size, S is the length of symbols
+ *   and T is the length of input.
+ * - The shape of \b py is 3D([B, S + 1, T]).
+ * - The shape of \b opt_boundary is 2D([B, 4]), where each row contains
+     [begin_symbol, begin_frame, end_symbol, end_frame] with
+     "0 <= begin_symbol <= end_symbol <= S" and "0 <= begin_frame <= end_frame <= T".
+     If \b opt_boundary is NULL, it will be treated as [0, 0, S, T].
+ * - The shape of \b p is 3D([B, S + 1, T + 1]).
+ * - The shape of \b ans_grad is 1D([B]).
+ * - The shape of \b px and \b px_grad must be the same.
+ * - The shape of \b py and \b py_grad must be the same.
+ * - The size of each tensor must be in the range of [0, 2^31].
+ *
+ *   - On MLU370, the scale needs to meet the following restrictions:
+ *
+ *     - T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 163840.
+ *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 163840.
+ *
+ *   - On MLU590, the scale needs to meet the following restrictions:
+ *
+ *     - T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 98304.
+ *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 98304.
+ *
+ * @par API Dependency
+ * - Before calling this function to perform ::mluOpMutualInformationBackward, you need to get
+ *   the size of workspace by ::mluOpGetMutualInformationBackwardWorkspaceSize.
+ *
+ * @par Note
+ * - This function is only supported on MLU300 series or above platforms.
+ * - If \b overwrite_ans_grad is true, \b ans_grad will be overwritten.
+ *   If the computation worked correctly, the overwritten value should be the same as the original ans_grad.
+ * - If B is zero, or S and T are both zero, ::MLUOP_STATUS_SUCCESS is returned without
+ *   any changes to \b ans_grad, \b px_grad and \b py_grad tensor.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://github.com/k2-fsa/k2/blob/master/k2/python/csrc/torch/mutual_information_cuda.cu
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpMutualInformationBackward(mluOpHandle_t handle,
+                               const mluOpTensorDescriptor_t px_desc,
+                               const void *px,
+                               const mluOpTensorDescriptor_t py_desc,
+                               const void *py,
+                               const mluOpTensorDescriptor_t opt_boundary_desc,
+                               const void *opt_boundary,
+                               const mluOpTensorDescriptor_t p_desc,
+                               const void *p,
+                               const mluOpTensorDescriptor_t ans_grad_desc,
+                               void *ans_grad,
+                               const bool overwrite_ans_grad,
+                               void *workspace,
+                               const size_t workspace_size,
+                               const mluOpTensorDescriptor_t px_grad_desc,
+                               void *px_grad,
+                               const mluOpTensorDescriptor_t py_grad_desc,
+                               void *py_grad);
+
 // Group:RoiawarePool3d
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.cpp
@@ -1,0 +1,320 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#include "mutual_information_backward.h"
+
+namespace mluoptest {
+
+void MutualInformationBackwardExecutor::initParam() {
+  overwrite_ans_grad_ = parser_->getProtoNode()
+                               ->mutual_information_backward_param()
+                               .overwrite_ans_grad();
+  px_desc_ = tensor_desc_[0].tensor;
+  py_desc_ = tensor_desc_[1].tensor;
+  float *host_ans_grad_in = nullptr;
+  if (tensor_desc_.size() == max_tensor_num_) {
+    opt_boundary_desc_ = tensor_desc_[2].tensor;
+    p_desc_ = tensor_desc_[3].tensor;
+    ans_grad_desc_ = tensor_desc_[4].tensor;
+    px_grad_desc_ = tensor_desc_[6].tensor;
+    py_grad_desc_ = tensor_desc_[7].tensor;
+
+    host_ans_grad_in = (float *)data_vector_[4].host_ptr;
+  } else {
+    p_desc_ = tensor_desc_[2].tensor;
+    ans_grad_desc_ = tensor_desc_[3].tensor;
+    px_grad_desc_ = tensor_desc_[5].tensor;
+    py_grad_desc_ = tensor_desc_[6].tensor;
+
+    host_ans_grad_in = (float *)data_vector_[3].host_ptr;
+  }
+
+  B_ = px_desc_->dims[0];
+  S_ = px_desc_->dims[1];
+  T_ = py_desc_->dims[2];
+
+  px_index_ = Index3D(S_, T_ + 1);
+  py_index_ = Index3D(S_ + 1, T_);
+  p_index_ = Index3D(S_ + 1, T_ + 1);
+
+  ans_grad_in_ = (float *)cpu_runtime_.allocate(B_ * sizeof(float));
+  memcpy(ans_grad_in_, host_ans_grad_in, B_ * sizeof(float));
+}
+
+void MutualInformationBackwardExecutor::workspaceMalloc() {
+  initParam();
+  MLUOP_CHECK(mluOpGetMutualInformationBackwardWorkspaceSize(
+      handle_, px_desc_, py_desc_, opt_boundary_desc_, p_desc_, ans_grad_desc_,
+      overwrite_ans_grad_, &workspace_size_));
+  void *dev_workspace = nullptr;
+  if (workspace_size_ != 0) {
+    dev_workspace = mlu_runtime_.allocate(workspace_size_);
+    eva_->setMluWorkspaceSize(workspace_size_);
+  }
+  workspace_.push_back(dev_workspace);
+}
+
+void MutualInformationBackwardExecutor::workspaceFree() {
+  for (auto ptr : workspace_) {
+    if (ptr) {
+      mlu_runtime_.deallocate(ptr);
+    }
+  }
+}
+
+void MutualInformationBackwardExecutor::paramCheck() {
+  GTEST_CHECK(parser_->getProtoNode()->has_mutual_information_backward_param(),
+             "[MutualInformationBackwardExecutor] Missing param.");
+  GTEST_CHECK(parser_->getInputNum() == 4 || parser_->getInputNum() == 5,
+              "[MutualInformationBackwardExecutor] Input number is wrong.");
+  GTEST_CHECK(parser_->getOutputNum() == 3,
+              "[MutualInformationBackwardExecutor] Output number is wrong.");
+}
+
+void MutualInformationBackwardExecutor::compute() {
+  VLOG(4) << "MutualInformationBackwardExecutor compute.";
+  void *dev_px = data_vector_[0].device_ptr;
+  void *dev_py = data_vector_[1].device_ptr;
+  void *dev_opt_boundary = nullptr;
+  void *dev_p = nullptr;
+  void *dev_ans_grad = nullptr;
+  void *dev_px_grad = nullptr;
+  void *dev_py_grad = nullptr;
+
+  if (tensor_desc_.size() == max_tensor_num_) {
+    dev_opt_boundary = data_vector_[2].device_ptr;
+    dev_p = data_vector_[3].device_ptr;
+    dev_ans_grad = data_vector_[4].device_ptr;
+    dev_px_grad = data_vector_[6].device_ptr;
+    dev_py_grad = data_vector_[7].device_ptr;
+  } else {
+    dev_p = data_vector_[2].device_ptr;
+    dev_ans_grad = data_vector_[3].device_ptr;
+    dev_px_grad = data_vector_[5].device_ptr;
+    dev_py_grad = data_vector_[6].device_ptr;
+  }
+
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpMutualInformationBackward(
+      handle_, px_desc_, dev_px, py_desc_, dev_py, opt_boundary_desc_,
+      dev_opt_boundary, p_desc_, dev_p, ans_grad_desc_, dev_ans_grad,
+      overwrite_ans_grad_, workspace_[0], workspace_size_,
+      px_grad_desc_, dev_px_grad, py_grad_desc_, dev_py_grad));
+  interface_timer_.stop();
+
+  if (tensor_desc_.size() == max_tensor_num_) {
+    data_vector_[4].is_output = true;
+    data_vector_[5].is_output = false;
+    data_vector_[6].is_output = true;
+    data_vector_[7].is_output = true;
+  } else {
+    data_vector_[3].is_output = true;
+    data_vector_[4].is_output = false;
+    data_vector_[5].is_output = true;
+    data_vector_[6].is_output = true;
+  }
+}
+
+void MutualInformationBackwardExecutor::cpuCompute() {
+  float *host_px = (float *)data_vector_[0].host_ptr;
+  float *host_py = (float *)data_vector_[1].host_ptr;
+  int64_t *host_opt_boundary = nullptr;
+  float *host_p = nullptr;
+
+  float *host_ans_grad_in = nullptr;
+  if (tensor_desc_.size() == max_tensor_num_) {
+    host_opt_boundary = (int64_t *)data_vector_[2].host_ptr;
+    host_p = (float *)data_vector_[3].host_ptr;
+    host_ans_grad_in = (float *)data_vector_[4].host_ptr;
+  } else {
+    host_p = (float *)data_vector_[2].host_ptr;
+    host_ans_grad_in = (float *)data_vector_[3].host_ptr;
+  }
+
+  float *host_ans_grad_out = nullptr;
+  float *host_px_grad = nullptr;
+  float *host_py_grad = nullptr;
+  host_ans_grad_out = cpu_fp32_output_[0];
+  memcpy(host_ans_grad_out, ans_grad_in_, B_ * sizeof(float));
+
+  host_px_grad = cpu_fp32_output_[1];
+  host_py_grad = cpu_fp32_output_[2];
+
+  int s_begin = 0;
+  int t_begin = 0;
+  int s_end = S_;
+  int t_end = T_;
+  for (int b = 0; b < B_; ++b) {
+    if (host_opt_boundary != nullptr) {
+      s_begin = (int)host_opt_boundary[b * 4];
+      t_begin = (int)host_opt_boundary[b * 4 + 1];
+      s_end = (int)host_opt_boundary[b * 4 + 2];
+      t_end = (int)host_opt_boundary[b * 4 + 3];
+    }
+
+    computeTerm1AndTerm2(b, s_begin, s_end, t_begin, t_end, host_px, host_py,
+                         host_p);
+    computePGrad(b, s_begin, s_end, t_begin, t_end, host_px, host_py, host_p,
+                 ans_grad_in_, host_ans_grad_out);
+    computePxGradAndPyGrad(b, s_begin, s_end, t_begin, t_end, host_px, host_py,
+                           host_p, host_px_grad, host_py_grad);
+  }
+
+  if (ans_grad_in_) {
+    cpu_runtime_.deallocate(ans_grad_in_);
+  }
+}
+
+float MutualInformationBackwardExecutor::safeExp(float x) {
+  if (x - x != 0) {
+    theory_ops_ += 2;
+    return 0;
+  } else {
+    float ans = std::exp(x);
+    theory_ops_ += 5;
+    if (ans - ans != 0.0) {
+      return 0;
+    }
+    return ans;
+  }
+}
+
+void MutualInformationBackwardExecutor::computeTerm1AndTerm2(
+    const int b, const int s_begin, const int s_end, const int t_begin,
+    const int t_end, float *px, float *py, float *p) {
+  for (int s = s_begin; s <= s_end; ++s) {
+    for (int t = t_begin; t <= t_end; ++t) {
+      theory_ops_++;
+      if (p[p_index_(b, s, t)] < large_neg_num_) {
+        p[p_index_(b, s, t)] = large_neg_num_;
+        theory_ops_++;
+      }
+    }
+  }
+
+  for (int s = s_begin; s <= s_end; ++s) {
+    for (int t = t_begin; t <= t_end; ++t) {
+      if (s < s_end) {
+        // compute term1
+        px[px_index_(b, s, t)] = safeExp(p[p_index_(b, s, t)] +
+                                         px[px_index_(b, s, t)] -
+                                         p[p_index_(b, s + 1, t)]);
+        theory_ops_ += 2;
+      }
+
+      if (t < t_end) {
+        // compute term2
+        py[py_index_(b, s, t)] = safeExp(p[p_index_(b, s, t)] +
+                                         py[py_index_(b, s, t)] -
+                                         p[p_index_(b, s, t + 1)]);
+        theory_ops_ += 2;
+      }
+    }
+  }
+}
+
+void MutualInformationBackwardExecutor::computePGrad(
+    const int b, const int s_begin, const int s_end, const int t_begin,
+    const int t_end, float *term1, float *term2, float *p, float *ans_grad_in,
+    float *ans_grad_out) {
+  // compute p_grad[b][s_end][t_end]
+  p[p_index_(b, s_end, t_end)] = ans_grad_in[b];
+  theory_ops_++;
+
+  // compute p_grad[b][s_end][0:t_end]
+  for (int t = t_end - 1; t >= t_begin; --t) {
+    p[p_index_(b, s_end, t)] = term2[py_index_(b, s_end, t)] *
+                               p[p_index_(b, s_end, t + 1)];
+    theory_ops_++;
+  }
+
+  // compute p_grad[b][0:s_end][t_end]
+  for (int s = s_end - 1; s >= s_begin; --s) {
+    p[p_index_(b, s, t_end)] = term1[px_index_(b, s, t_end)] *
+                               p[p_index_(b, s + 1, t_end)];
+    theory_ops_++;
+  }
+
+  for (int s = s_end - 1; s >= s_begin; --s) {
+    for (int t = t_end - 1; t >= t_begin; --t) {
+      p[p_index_(b, s, t)] = term1[px_index_(b, s, t)] *
+                             p[p_index_(b, s + 1, t)] +
+                             term2[py_index_(b, s, t)] *
+                             p[p_index_(b, s, t + 1)];
+      theory_ops_ += 3;
+    }
+  }
+
+  if (overwrite_ans_grad_ && s_begin <= s_end && t_begin <= t_end) {
+    ans_grad_out[b] = p[p_index_(b, s_begin, t_begin)];
+    theory_ops_++;
+  }
+}
+
+void MutualInformationBackwardExecutor::computePxGradAndPyGrad(
+    const int b, const int s_begin, const int s_end, const int t_begin,
+    const int t_end, float *term1, float *term2, float *p_grad, float *px_grad,
+    float *py_grad) {
+  for (int s = s_begin; s <= s_end; ++s) {
+    for (int t = t_begin; t <= t_end; ++t) {
+      if (s < s_end) {
+        // compute px_grad
+        px_grad[px_index_(b, s, t)] = p_grad[p_index_(b, s + 1, t)] *
+                                      term1[px_index_(b, s, t)];
+      }
+
+      if (t < t_end) {
+        // compute py_grad
+        py_grad[py_index_(b, s, t)] = p_grad[p_index_(b, s, t + 1)] *
+                                      term2[py_index_(b, s, t)];
+      }
+    }
+  }
+
+  for (int s = 0; s <= S_; ++s) {
+    for (int t = 0; t <= T_; ++t) {
+      if (s < S_ && (s < s_begin || s >= s_end) && (t < t_begin || t > t_end)) {
+        px_grad[px_index_(b, s, t)] = 0;
+      }
+
+      if (t < T_ && (s < s_begin || s > s_end) && (t < t_begin || t >= t_end)) {
+        py_grad[py_index_(b, s, t)] = 0;
+      }
+    }
+  }
+
+  theory_ops_ += S_ * (T_ + 1) + (S_ + 1) * T_;
+}
+
+int64_t MutualInformationBackwardExecutor::getTheoryOps() {
+  if (parser_->device() != Device::CPU) {
+    theory_ops_ = 0;
+    if (exe_config_->mlu_only) {
+      baselineOutputMalloc();
+    }
+    cpuCompute();
+  }
+  return theory_ops_;
+}
+
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.h
@@ -1,0 +1,105 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_MUTUAL_INFORMATION_BACKWARD_\
+MUTUAL_INFORMATION_BACKWARD_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_MUTUAL_INFORMATION_BACKWARD_\
+MUTUAL_INFORMATION_BACKWARD_H_
+
+#include "core/tensor.h"
+#include "executor.h"
+#include "mlu_op.h"
+
+namespace mluoptest {
+
+class Index3D {
+ private:
+  int S_ = 0;
+  int T_ = 0;
+
+ public:
+  Index3D() {}
+  explicit Index3D(int S, int T) : S_(S), T_(T) {}
+  ~Index3D() {}
+
+  int operator()(int b, int s, int t) {
+    return b * T_ * S_ + s * T_ + t;
+  }
+};
+
+class MutualInformationBackwardExecutor : public Executor {
+ public:
+  MutualInformationBackwardExecutor() {}
+  ~MutualInformationBackwardExecutor() {}
+
+  void workspaceMalloc() override;
+  void workspaceFree() override;
+  void paramCheck() override;
+  void compute() override;
+  void cpuCompute() override;
+  int64_t getTheoryOps() override;
+
+ private:
+  void initParam();
+  void computeTerm1AndTerm2(const int b, const int s_begin, const int s_end,
+                            const int t_begin, const int t_end, float *px,
+                            float *py, float *p);
+  void computePGrad(const int b, const int s_begin, const int s_end,
+                    const int t_begin, const int t_end, float *term1,
+                    float *term2, float *p, float *ans_grad_in,
+                    float *ans_grad_out);
+  void computePxGradAndPyGrad(const int b, const int s_begin, const int s_end,
+                              const int t_begin, const int t_end, float *term1,
+                              float *term2, float *p_grad, float *px_grad,
+                              float *py_grad);
+  float safeExp(float x);
+
+  mluOpTensorDescriptor_t px_desc_ = nullptr;
+  mluOpTensorDescriptor_t py_desc_ = nullptr;
+  mluOpTensorDescriptor_t opt_boundary_desc_ = nullptr;
+  mluOpTensorDescriptor_t p_desc_ = nullptr;
+  mluOpTensorDescriptor_t ans_grad_desc_ = nullptr;
+  bool overwrite_ans_grad_ = true;
+  size_t workspace_size_ = 0;
+  mluOpTensorDescriptor_t px_grad_desc_ = nullptr;
+  mluOpTensorDescriptor_t py_grad_desc_ = nullptr;
+
+  int B_ = 0;
+  int S_ = 0;
+  int T_ = 0;
+  int64_t theory_ops_ = 0;
+  const float large_neg_num_ = -1.0e+30;
+
+  // max intput num is 5: px, py, opt_boundary, p, ans_grad
+  // max output num is 3: ans_grad, px_grad, py_grad
+  const int max_tensor_num_ = 8;
+
+  float *ans_grad_in_ = nullptr;
+
+  mluoptest::Index3D px_index_;
+  mluoptest::Index3D py_index_;
+  mluoptest::Index3D p_index_;
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_MUTUAL_INFORMATION_BACKWARD_\
+MUTUAL_INFORMATION_BACKWARD_H_

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/test_case/mutual_information_backward.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/test_case/mutual_information_backward.prototxt
@@ -1,0 +1,113 @@
+device: CPU
+op_name: "mutual_information_backward"
+input {
+  id: "px"
+  shape {
+    dims: 1
+    dims: 179
+    dims: 181
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -2.5
+    upper_bound_double: 2.5
+  }
+}
+input {
+  id: "py"
+  shape {
+    dims: 1
+    dims: 180
+    dims: 180
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -2.5
+    upper_bound_double: 2.5
+  }
+}
+input {
+  id: "opt_boundary"
+  shape {
+    dims: 1
+    dims: 4
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_INT64
+  value_l: 0
+  value_l: 0
+  value_l: 10
+  value_l: 10
+}
+input {
+  id: "p"
+  shape {
+    dims: 1
+    dims: 180
+    dims: 181
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -2.5
+    upper_bound_double: 2.5
+  }
+}
+input {
+  id: "ans_grad"
+  shape {
+    dims: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -2.5
+    upper_bound_double: 2.5
+  }
+}
+output {
+  id: "ans_grad"
+  shape {
+    dims: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+}
+output {
+  id: "px_grad"
+  shape {
+    dims: 1
+    dims: 179
+    dims: 181
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+}
+output {
+  id: "py_grad"
+  shape {
+    dims: 1
+    dims: 180
+    dims: 180
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+}
+evaluation_criterion: DIFF1
+evaluation_criterion: DIFF2
+evaluation_threshold: 0.003
+evaluation_threshold: 0.003
+supported_mlu_platform: MLU370
+supported_mlu_platform: MLU590
+handle_param {
+  round_mode: ROUND_OFF_ZERO
+}
+mutual_information_backward_param {
+  overwrite_ans_grad: true
+}

--- a/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
+++ b/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
@@ -1,0 +1,470 @@
+# mutual_information_backward算子开发设计方案
+
+- #### 文档基本信息
+
+| 算子名称    | mutual_information_backward |
+| ----------- | --------------------------- |
+| 编制人/日期 | 唐成达/2023-4-14            |
+| 审批人/日期 | 黄启元/2023-4-14            |
+| 审批人/日期 | 徐文明/2023-4-17            |
+| 审批人/日期 | 光昀轶/2023-4-17            |
+| 审批人/日期 | 寇丽霞/2023-4-17            |
+| 审批人/日期 | 刘亚洲/2023-4-17            |
+| 审批人/日期 | 支金林/2023-4-17            |
+
+- #### 修改记录
+
+| 版本号 | 修订人 | 修订日期  | 修订描述 |
+| ------ | ------ | --------- | -------- |
+| V1.0   | 唐成达 | 2023-4-14 | 首次提交 |
+
+- #### 内容描述
+
+本文档为`mutual_information_backward`算子的设计文档，包括需求分析、接口设计、方案设计、性能优化记录和方案实施部分。
+
+- #### 算子需求 checklist
+
+* 算子接口描述
+* 功能描述
+* 框架版本 + 对应源码路径
+* 需求对应网络
+* 网络中用到的规模
+* 是否需要支持原位
+* 是否需要支持 stride 机制
+* 框架单元测试阈值指标（可选）
+
+## 1 需求分析
+
+### 1.1 算子需求分析
+
+| 算子功能简介                                                 | 求输入px和py的梯度                                           |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| 需求来源                                                     | K2                                                           |
+| 应用网络                                                     | rnnt                                                         |
+| 输入数据类型                                                 | px: float<br/>py: float<br/>opt_boundary(可选): int64<br/>p: float<br/>ans_grad: float |
+| 输入标量参数                                                 | overwrite_ans_grad: bool                                     |
+| 输入 Shape                                                   | px: [B, S, T+1]<br/>py: [B, S+1, T]<br/>opt_boundary: [B, 4] or None<br/>p: [B, S+1, T+1]<br/>ans_grad: [B] |
+| 输入 Layout                                                  | ARRAY                                                        |
+| 输出数据类型                                                 | float                                                        |
+| 输出 Shape                                                   | px_grad: [B, S, T+1]<br/>py_grad: [B, S+1, T]                |
+| 输出 Layout                                                  | ARRAY                                                        |
+| 模式(可选）                                                  | 当前仅支持!modified模式，即rnnt_type=regular                 |
+| 是否含有 dim/axis 等类似语义的参数且该参数支持负数/其他特殊处理 | 无                                                           |
+| 是否含有 labels/index 等类似语义的参数且该参数支持负数/界外情况/其他特殊处理 | opt_boundary为标签和语音输入的边界，shape为[B, 4]其中B为batch，4的含义为[begin_symbol, begin_frame, end_symbol, end_frame]<br/>要求：（**python层已有相关防呆**）<br/>0<= begin_symbol <= end_symbol <= S<br/>0<= begin_frame <= end_frame <= T |
+| 是否需要支持原位                                             | 是，当overwrite_ans_grad为true时，ans_grad需要原位操作       |
+| 是否需要支持 stride 机制                                     | 否                                                           |
+| 是否需要支持广播                                             | 否                                                           |
+| 0 元素检查是否直接返回                                       | 是(当B为0 或 S和T都为0时，内部不做计算，直接返回，其余情况需要计算)                        |
+| 其他特殊需求(在线量化，融合，转数提前等，可选)               | 无                                                           |
+| 本次开发优先支持的规模/模式                                  | !modified模式                                                |
+
+### 1.2 算子功能和应用场景描述
+
+1. 算子功能：mutual_information算子中的反向算子，用于计算px和py的梯度。mutual_information可用于rnnt网络(一种基于RNN的序列到序列方案，可以将任意长度的输入序列转换到任意长度的输出序列)
+
+   **输入参数说明：**
+
+   `px`: 表示当前输出标签的概率(log形式)。在!modified模式下，shape为[B,S,T+1]；在modified模式下。shape为[B,S,T]。当前仅支持!modified模式。其中B为batch，S为输出标签symbol的长度，T为输入语音片段的长度
+
+   `py`: 输入，表示当前输出终止符号(termination_symbol)的概率(log形式)，shape为[B,S+1,T]
+
+   `opt_boundary`: 输入(可选)，表示每个batch输入和输出的边界，shape为[B,4]，其中4的含义为[begin_symbol, begin_frame, end_symbol, end_frame]。当opt_boundary为空时，默认使用B*[0, 0, S, T]进行计算
+
+   `p`: 输入，为前向算子的输出，表示输入T个序列时，输出S个标签的概率，shape为[B,S+1,T+1]
+
+   `ans_grad`: 输入，前向输出`ans`对应的梯度，shape为[B]，为全1矩阵
+
+   `overwrite_ans_grad`: 输入，表示输入`ans_grad`是否需要被复写
+
+   **输出参数说明：**
+
+   `px_grad`: 表示px对应的梯度，shape和px相同
+
+   `py_grad`: 表示py对应的梯度，shape和py相同
+
+   
+
+2. !modified模式的计算公式如下：
+
+   ```math
+   \begin{array}{lcl}
+   term1(b,s,t) = e^{p(b,s,t) + px(b,s,t) - p(b,s+1,t)} \\
+   term2(b,s,t) = e^{p(b,s,t) + py(b,s,t) - p(b,s,t+1)} \\
+   p\_grad(b,s,t) = p\_grad(b,s+1,t) * term1(b,s,t) + p\_grad(b,s,t+1) * term2(b,s,t) \\
+   px\_grad(b,s,t) = p\_grad(b,s+1,t) * term1(b,s,t) \\
+   py\_grad(b,s,t) = p\_grad(b,s,t+1) * term2(b,s,t)
+   \end{array}
+   ```
+
+   
+
+3. nan/inf行为
+
+   通过分析，参考接口代码实现中有对中间结果为nan/inf时进行特殊处理。当p(b,s,t)、term1(b,s,t)和term2(b,s,t)为nan或inf时，需将其置为0。（当输入包含nan/inf时，参考接口cpu和cuda输出结果不一致，mlu实现与参考接口cuda对齐）
+
+   
+
+### 1.3 算子输入输出参数要求
+
+| 参数               | 语义                                                         | 类型（输入/输出） | 支持类型                | 物理布局 | 规模限制 |
+| ------------------ | ------------------------------------------------------------ | ----------------- | ----------------------- | -------- | -------- |
+| handle             | MLU-OPS上下文指针                                            | 输入              | mluOPHandle_t           | /        | 无       |
+| px_desc            | 输入数据px的描述符号，包含px的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
+| px                 | 指向px数据的mlu地址指针                                      | 输入              | float                   | ARRAY    | 无       |
+| py_desc            | 输入数据py的描述符号，包含py的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
+| py                 | 指向py数据的mlu地址指针                                      | 输入              | float                   | ARRAY    | 无       |
+| opt_boundary_desc  | 输入数据opt_boundary的描述符号，包含opt_boundary的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
+| opt_boundary       | 指向opt_boundary数据的mlu地址指针                            | 输入              | int64                   | ARRAY    | 无       |
+| p_desc             | 输入数据p的描述符号，包含p的数据类型、数据维度和布局等信息   | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
+| p                  | 指向p数据的mlu地址指针                                       | 输入              | float                   | ARRAY    | 无       |
+| ans_grad_desc      | 输入数据ans_grad的描述符号，包含ans_grad的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
+| ans_grad           | 指向ans_grad数据的mlu地址指针                                | 输入              | float                   | ARRAY    | 无       |
+| overwrite_ans_grad | 标识ans_grad是否需要复写                                     | 输入              | bool                    | /        | 无       |
+| px_grad_desc       | 输出数据px_grad的描述符号，包含px_grad的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
+| px_grad            | 指向px_grad数据的mlu地址指针                                 | 输出              | float                   | ARRAY    | 无       |
+| py_grad_desc       | 输出数据py_grad的描述符号，包含py_grad的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
+| py_grad            | 指向py_grad数据的mlu地址指针                                 | 输出              | float                   | ARRAY    | 无       |
+
+### 1.4 算子限制
+
+| 限制类型     | 详细说明                                                     |
+| ------------ | ------------------------------------------------------------ |
+| 数据类型限制 | px: float<br/>py: float<br/>opt_boundary: int64<br/>p: float<br/>ans_grad: float<br/>overwrite_ans_grad: bool<br/>px_grad: float<br/>py_grad: float |
+| 布局限制     | ARRAY                                                        |
+| 规模限制     | 不支持large tensor;<br>在MLU370中，<br>T * (S + 1) + (T + 1) * S + 5 * T <= 163840<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 1 <= 163840; <br>在MLU590中，<br>T * (S + 1) + (T + 1) * S + 5 * T <= 98304<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 1 <= 98304;|
+| 功能限制     | 仅支持!modified模式，即输入参数px的shape为 [B, S, T+1]       |
+| 数据范围限制 | opt_boundary的shape为[B, 4]其中B为batch，4的含义为[begin_symbol, begin_frame, end_symbol, end_frame]<br/>要求：（**python层已有相关防呆**）<br/>0<= begin_symbol <= end_symbol <= S<br/>0<= begin_frame <= end_frame <= T |
+| 原位限制     | 仅当overwrite_ans_grad为true时，ans_grad支持原位操作         |
+| stride 限制  | 不支持 stride 机制                                           |
+| 广播限制     | 不支持广播                                                   |
+
+
+
+### 1.5 验收标准
+
+#### 1.5.1 精度验收标准
+
+本算子包含动态规划和指数运算，属于复合类算子，验收标准采用动态阈值为diff1, diff2
+
+
+
+#### 1.5.2 性能验收标准
+
+本次优先交付功能，后续视情况再优化性能
+
+
+
+## 2 算子接口设计
+
+### 2.1 参考接口
+
+- K2
+
+```c++
+std::vector<torch::Tensor> MutualInformationBackwardCuda(
+    torch::Tensor px, torch::Tensor py,
+    torch::optional<torch::Tensor> opt_boundary, torch::Tensor p,
+    torch::Tensor ans_grad, bool overwrite_ans_grad)
+```
+
+### 2.2 接口设计
+
+```c++
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
+                                               const mluOpTensorDescriptor_t px_desc,
+                                               const mluOpTensorDescriptor_t py_desc,
+                                               const mluOpTensorDescriptor_t opt_boundary_desc,
+                                               const mluOpTensorDescriptor_t p_desc,
+                                               const mluOpTensorDescriptor_t ans_grad_desc,
+                                               const bool overwrite_ans_grad,
+                                               size_t *workspace_size)
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpMutualInformationBackward(mluOpHandle_t handle,
+                               const mluOpTensorDescriptor_t px_desc,
+                               const void *px,
+                               const mluOpTensorDescriptor_t py_desc,
+                               const void *py,
+                               const mluOpTensorDescriptor_t opt_boundary_desc,
+                               const void *opt_boundary,
+                               const mluOpTensorDescriptor_t p_desc,
+                               const void *p,
+                               const mluOpTensorDescriptor_t ans_grad_desc,
+                               void *ans_grad,
+                               const bool overwrite_ans_grad,
+                               void *workspace,
+                               const size_t workspace_size,
+                               const mluOpTensorDescriptor_t px_grad_desc,
+                               void *px_grad,
+                               const mluOpTensorDescriptor_t py_grad_desc,
+                               void *py_grad)
+```
+
+## 3 实现方案设计
+
+当前方案存在规模限制，即nram空间一次可处理一个batch的数据
+
+### 3.1 实现方案
+
+由于p_grad计算为动态规划算法，并且当opt_boundary不为空时，每个batch的boundary不一样。因此下面两个方案都是在core间拆分batch，core内对一个batch的数据循环计算。
+
+* step1:  计算term1和term2
+
+  将p,px,py加载到nram上，逐行计算term1和term2，结果存储在nram(term1和term2分别复用px和py的空间)
+
+
+* step2：计算p_grad
+
+  p_grad计算公式：
+
+  ```math
+  p_{grad}(b,s,t) = p_{grad}(b,s+1,t) * term1(b,s,t) + p_{grad}(b,s,t+1) * term2(b,s,t) 
+  ```
+
+  从p_grad计算公式可分析出，p_grad(b,s,t) 依赖 p_grad(b,s+1,t) 和p_grad(b,s,t+1) ，因此p_grad计算可在对角线方向进行并行计算。
+
+  以B=1, T=2，S=2举例，在batch=0时，p_grad的计算过程如下：
+
+  * 第一步: 计算p_grad(0, 2, 2)
+  * 第二步: 计算p_grad(0, 1, 2)，p_grad(0, 2, 1)
+  * 第三步: 计算p_grad(0, 0, 2)，p_grad(0, 1, 1)，p_grad(0, 2, 0)
+  * 第四步: 计算p_grad(0, 0, 1)，p_grad(0, 1, 0)
+  * 第五步: 计算p_grad(0, 0, 0)
+
+  如下表所示，上述每一步计算的位置都是在对角线方向
+
+  | S\T  | t0              | t1              | t2              |
+  | ---- | --------------- | --------------- | --------------- |
+  | s0   | p_grad(0, 0, 0) | p_grad(0, 0, 1) | p_grad(0, 0, 2) |
+  | s1   | p_grad(0, 1, 0) | p_grad(0, 1, 1) | p_grad(0, 1, 2) |
+  | s2   | p_grad(0, 2, 0) | p_grad(0, 2, 1) | p_grad(0, 2, 2) |
+
+  
+
+  在nram从对角线方向读取term1和term2，逐行计算p_grad，结果也存储到NRAM上
+
+* step3：计算px_grad和py_grad
+
+  在nram从读取term1、term2和p_grad，逐行计算px_grad和py_grad，结果存回GDRAM
+
+
+### 3.2 伪代码实现
+
+以下伪代码，以opt_boundary=nullptr举例
+
+```c++
+__mlu_func__ void computeTerm1AndTerm2() {
+    /* *********************nram space split********************** */
+    /* |  term1  |  term2  | cur_p | next_p | large_neg | mask |*/
+    /* | S*(T+1) | (S+1)*T |  T+1  |  T+1   |  2*(T+1)  | T+1  |*/
+    float *term1 = (float *)buffer;
+    float *term2 = term1 + S*(T+1);
+    float *cur_p = term2 + (S+1)*T;
+    float *next_p = cur_p + T + 1;
+    float *large_neg = next_p + T + 1;
+    float *mask = large_neg + 2*(T+1);
+    __bang_write_value(large_neg, 2*(T+1), -1.0e+30);
+
+    for (int i = 0; i < S + 1; ++i) {
+        if (i == S) {
+            // compute term2[S][:]
+            __memcpy(term2 + S * T, py + S * T, T * sizeof(float), GDRAM2NRAM);
+            __memcpy(cur_p, p + S * (T+1), (T+1) * sizeof(float), GDRAM2NRAM);
+            __bang_add(term2 + S * T, term2 + S * T, cur_p, T);
+            __bang_sub(term2 + S * T, term2 + S * T, cur_p + 1, T);
+            safeExp(term2 + S * T, term2 + S * T, mask, T);
+            break;
+        }
+        // load px->term1, py->term2, p->cur_p/next_p
+        __memcpy(term1 + i * (T+1), px + i * (T+1), (T+1) * sizeof(float), GDRAM2NRAM);
+        __memcpy(term2 + i * T, py + i * T, T * sizeof(float), GDRAM2NRAM);
+        __memcpy(cur_p, p + i * (T+1), 2 * (T+1) * sizeof(float), GDRAM2NRAM);
+        
+        __bang_nan_maximum(cur_p, cur_p, large_neg, 2*(T+1));
+
+        // term1(b,s,t) = exp(p(b,s,t) + px(b,s,t) - p(b,s+1,t))
+        __bang_add(term1 + i * (T+1), term1 + i * (T+1), cur_p, T + 1);
+        __bang_sub(term1 + i * (T+1), term1 + i * (T+1), next_p, T + 1);
+        safeExp(term1 + i * (T+1), term1 + i * (T+1), mask, T + 1);
+        
+        // term2(b,s,t) = exp(p(b,s,t) + py(b,s,t) - p(b,s,t+1))
+        __bang_add(term2 + i * T, term2 + i * T, cur_p, T);
+        __bang_sub(term2 + i * T, term2 + i * T, cur_p + 1, T);
+        safeExp(term2 + i * T, term2 + i * T, mask, T);
+    }
+}
+
+__mlu_func__ void safeExp(float *dst, float *src, float *mask, const int num) {
+    setNanInfToZero(src, mask, num);
+    computeExp(dst, src, NULL, 0, num);
+      __bang_band((char *)dst, (char *)dst, (char *)mask, num * sizeof(float));
+    setNanInfToZero(dst, mask, num);
+}
+
+__mlu_func__ void setNanInfToZero(float *src, float *mask, const int num) {
+    __bang_sub(mask, src, src, num);
+    __bang_eq_scalar(mask, mask, 0., num);
+    __bang_float2int32_rn((int *)mask, mask, num, 0);
+    __bang_mul_scalar((int *)mask, (int *)mask, int(-1), num);
+    __bang_band((char *)src, (char *)src, (char *)mask, num * sizeof(float));
+}
+
+__mlu_func__ void computePGrad() {
+    /* ******************************nram space split****************************** */
+    /* |  term1  |  term2  |     p_grad    | cur_term1  | cur_term2  | cur_p_grad | */
+    /* | S*(T+1) | (S+1)*T |  (S+1)*(T+1)  | min(S,T)+1 | min(S,T)+1 |  min(S,T)  | */
+    float *term1 = (float *)buffer;
+    float *term2 = term1 + S*(T+1);
+    float *p_grad = term2 + (S+1)*T;
+    float *cur_term1 = p_grad + (S+1)*(T+1);
+    float *cur_term2 = cur_term1 + min(S,T)+1;
+    float *cur_p_grad = cur_term2 + min(S,T)+1;
+    __bang_write_value(cur_p_grad, min(S,T)+2, 0.0);
+    for (int i = 1; i < S + T + 1; ++i) {
+        int data_num = 1;
+        if (i < T) {
+            data_num = std::min(i + 1, S);
+        } else {
+            data_num = T + S - i;
+        }
+        // p_grad(b,s,t) = p_grad(b,s+1,t) * term1(b,s,t) + p_grad(b,s,t+1) * term2(b,s,t)
+        __memcpy(); // load cur_term1
+        __memcpy(); // load cur_term2
+        __memcpy(); // load cur_p_grad
+        __bang_mul(cur_term1, cur_term1, cur_p_grad, data_num);
+        __bang_mul(cur_term2, cur_term2, cur_p_grad, data_num);
+        __bang_add(cur_p_grad, cur_term1, cur_term2, data_num);
+        __memcpy(); // store cur_p_grad
+    }
+}
+
+__mlu_func__ void computePxGradAndPyGrad() {
+    /* ***********nram space split********** */
+    /* |  term1  |  term2  |     p_grad    | */
+    /* | S*(T+1) | (S+1)*T |  (S+1)*(T+1)  | */
+    float *term1 = (float *)buffer;
+    float *term2 = term1 + S*(T+1);
+    float *p_grad = term2 + (S+1)*T;
+    for (int i = 0; i < S + 1; ++i) {
+        if (i == S) {
+            // compute py_grad[S][:]
+            __bang_mul(term2 + S * T, term2 + S * T, p_grad + S * T + 1, T);
+            break;
+        }
+        // compute py_grad：px_grad(b,s,t) = p_grad(b,s+1,t) * term1(b,s,t)
+        __bang_mul(term1 + i * (T+1), term1 + S * (T+1), p_grad + S * (T+1) , T + 1);
+        // compute py_grad：py_grad(b,s,t) = p_grad(b,s,t+1) * term2(b,s,t)
+        __bang_mul(term2 + i * T, term2 + i * T, p_grad + i * T + 1, T);
+    }
+    __memcpy(px_grad + i * (T+1), term1 + S * (T+1), (T+1) * sizeof(float), NRAM2GDRAM);
+    __memcpy(py_grad + i * T, term2 + i * T, T * sizeof(float), NRAM2GDRAM);
+}
+
+__mlu_global__ void MLUKernelMutualInformationBackward(void *px,
+                                                       void *py,
+                                                       void *opt_boundary,
+                                                       void *p,
+                                                       void *ans_grad,
+                                                       bool overwrite_ans_grad,
+                                                       void *workspace,
+                                                       void *px_grad,
+                                                       void *py_grad) {
+    int num_per_core = batches / taskDim;
+    int num_rem = batches % taskDim;
+    int num_cur_core = num_per_core + (taskId < num_rem);
+    int b_offset = taskId * num_cur_core + (taskId >= num_rem) * num_rem;
+
+    for (int i = b_offset; i < b_offset + num_cur_core; ++i) {
+        computeTerm1AndTerm2();
+        computePGrad();
+        computePxGradAndPyGrad();
+    }
+}
+```
+
+
+
+### 3.3 拆分(任务拆分，多核拆分)
+
+基本任务类型为Block任务，core间按照对batch维度进行拆分，core内对S维度进行循环，在T维度并行计算
+
+
+
+### 3.4 性能优化设计
+
+1、资源分配
+
+NRAW空间划分参考3.2 伪代码实现中的描述
+
+2、流水设计
+
+在B=4, T=104, S=15的规模下，排流水的收益不大，因此暂不排流水。待后续明确支持规模后，视情况进行优化
+
+### 3.5 可维护性设计
+
+1、bangc 代码中加入必要的 log 信息，比如输入的规模、数据类型、layout 这些，以及如果出错会导致程序 core dump 的变量，比如 IO 指令的 data_size、dim xyz 的值等，这些信息都是有利于快速定位问题；
+
+2、对每一个函数命名变量命名都有充分的注释；
+
+3、避免魔鬼数字，对于确定的数字尽量使用公共宏来替代。
+
+### 3.6 测试用例设计
+
+- 算子在网络中用到的规模：
+  暂无
+
+- 边界 case：
+  * T=0; S=0; T= 1; S= 1
+  * opt_boundary中存在begin_symbol = end_symbol
+  * opt_boundary中存在begin_frame = end_frame
+
+其他可根据需要进行补充。算子开发完毕后，补充测试报告链接。
+
+### 3.7 算子防呆检查
+
+1、检查handle/px_desc/py_desc/p_desc/ans_grad_desc/px_grad_desc/py_grad_desc是否为空
+
+2、检查输入输出空间指针px/py/p/ans_grad/px_grad/py_grad是否为空
+
+3、检查opt_boundary_desc和opt_boundary是否同时为空，或者同时不为空
+
+3、检查0 元素，如果输入输出中包含0元素直接返回MLUOP_STATUS_SUCCESS
+
+3、涉及 workspace 算子对于 workspace_size 的检查防呆；
+
+4、检查px的维度为[B, S,T+1]；py的维度为[B, S+1,T]；p的维度为[B, S+1,T+1]；ans_grad的维度为[B]；px_grad的维度为[B, S,T+1]；py_grad的维度为[B, S+1,T]；如果opt_boundary不为空，opt_boundary为维度为[B，4]
+
+5、检查px/py/p/ans_grad/px_grad/py_grad的数据类型为float；如果opt_boundary不为空，opt_boundary的数据类型为int64
+
+6、检查输入输出是否包含large tensor，或者输入规模是否超出限制
+
+
+
+## 4 算子性能/精度问题 & 优化记录
+
+### 4.1 当前存在问题的规模说明
+
+暂无
+
+### 4.2 已经过优化的规模说明
+
+暂无
+
+## 5 方案实施
+
+### 5.1 开发测试计划
+
+- 2023.3.30 算法原理调研与参考接口分析
+- 2023.4.10 设计方案：算子功能+接口设计
+- 2023.4.13 generator开发
+- 2023.4.17 host端开发
+- 2023.4.18 gtest和device端开发
+- 2023.4.24 功能调试与优化
+- 2023.4.27 批量测试与撰写测试报告
+- 2023.5.04 提交PR与代码review
+- 2023.5.06 算子入库
+
+### 5.2 风险分析
+
+* nan/inf状态对齐会降低算子性能

--- a/docs/bangc-docs/user_guide/9_operators/index.rst
+++ b/docs/bangc-docs/user_guide/9_operators/index.rst
@@ -337,6 +337,23 @@ mluOpMsDeformAttnForward
 ---------------------------------
 该算子是Multi-scale deformable attention的正向过程，通过 ``data_spatial_shapes`` 将  ``data_sampling_loc`` 映射到 ``data_value`` 的对应位置，从对应位置取值进行双线性插值，插值结果乘以 ``data_attn_weight`` 获得最终的输出 ``data_col`` 。
 
+.. _mutual_information_backward:
+
+mluOpMutualInformationBackward
+--------------------------------
+该算子是 ``mluOpMutualInformationForward`` 算子的反向，计算输入 ``px`` 和 ``py`` 的梯度。
+
+公式如下：
+.. math::
+
+  \begin{array}{lcl}
+   term1(b,s,t) = e^{p(b,s,t) + px(b,s,t) - p(b,s+1,t)} \\
+   term2(b,s,t) = e^{p(b,s,t) + py(b,s,t) - p(b,s,t+1)} \\
+   p\_grad(b,s,t) = p\_grad(b,s+1,t) * term1(b,s,t) + p\_grad(b,s,t+1) * term2(b,s,t) \\
+   px\_grad(b,s,t) = p\_grad(b,s+1,t) * term1(b,s,t) \\
+   py\_grad(b,s,t) = p\_grad(b,s,t+1) * term2(b,s,t)
+  \end{array}
+
 .. _nms:
 
 mluOpNms


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

add new_op, mutual_information_backward

## 2. Modification

```
new file:   bangc-ops/kernels/mutual_information_backward/mutual_information_backward.cpp
new file:   bangc-ops/kernels/mutual_information_backward/mutual_information_backward.h
new file:   bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
new file:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.cpp
new file:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.h
new file:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/test_case/mutual_information_backward.prototxt
new file:   docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
modified:   bangc-ops/mlu_op.h
modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/mlu_op_test_proto
modified:   docs/bangc-docs/user_guide/9_operators/index.rst
```

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block     |
|        3       |Layouts                               |          ARRAY      |
|        4       |Whether multi-dimensions are supported|             no              |
|        5       |Whether element zero is supported     |                 yes                |
|        6       |Data type(half/float)                 |           float           |
|        7       |Whether there is size limit           |       The shape of “py” is  [B, S + 1, T]<br>On MLU370:<br>T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 163840.<br>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 163840.<br>On MLU590:<br/>T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 98304.<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 98304.          |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |      pass           |
| Whether illegal parameters are passed           |     Normal error    |        pass           |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

| Test Point          | Description                        | Quantity | Comment                                                      |
| ------------------- | ---------------------------------- | -------- | ------------------------------------------------------------ |
| Data type test      | float                              | pass     | [       OK ] mutual_information_backward/TestSuite.mluOp/169 (2 ms)<br/>[----------] 170 tests from mutual_information_backward/TestSuite (7214 ms total)<br/>[----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 170 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 170 test cases from 1 test suite ran. (7603 ms total)<br/>[  PASSED  ] 170 test cases. |
| Zero element test   | Whether to support this test       | pass     | [2023-5-4 20:38:16] [MLUOP] [Vlog]:MutualInformationBackwardExecutor compute.<br/>[2023-5-4 20:38:16] [MLUOP] [Vlog]:[mluOpMutualInformationBackward] Skip zero element tensor when px.shape[0] is zero or px.shape[1] and py.shape[2] are both zero.<br/>[2023-5-4 20:38:16] [MLUOP] [Vlog]:Device free (for workspace). |
| Stability test      | --gtest_repeat=100<br>--thread=100 | pass     | ./mluop_gtest --gtest_filter=*mutual_information_backward* --cases_dir=/projs/cnnl/tangchengda/test_cases  --gtest_repeat=100 --thread=100<br>[ SUMMARY  ] Total 2400 cases of 100 op(s).<br/>ALL PASSED.<br/>[==========] 1 test case from 1 test suite ran. (845 ms total)<br/>[  PASSED  ] 1 test case. |
| Mult-platform test  | MLU370/MLU590                      | pass     | MLU370X4:<br>[       OK ] mutual_information_backward/TestSuite.mluOp/169 (2 ms)<br/>[----------] 170 tests from mutual_information_backward/TestSuite (7214 ms total)<br/><br/>[----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 170 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 170 test cases from 1 test suite ran. (7603 ms total)<br/>[  PASSED  ] 170 test cases.<br>MLU590:<br/>[       OK ] mutual_information_backward/TestSuite.mluOp/169 (18 ms)<br/>[----------] 170 tests from mutual_information_backward/TestSuite (29600 ms total)<br/><br/>[----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 170 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 170 test cases from 1 test suite ran. (30182 ms total)<br/>[  PASSED  ] 170 test cases. |
| Nan/INF test        | Whether to support this test       | pass     | [ SUMMARY  ] Total 170 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 170 test cases from 1 test suite ran. (7603 ms total)<br/>[  PASSED  ] 170 test cases. |
| Memory leak check   | Test result                        | pass     | [ SUMMARY  ] Total 170 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 170 test cases from 1 test suite ran. (7603 ms total)<br/>[  PASSED  ] 170 test cases. |
| Code coverage check | Test result                        | pass     | File - Line Coverage - Functions<br>mutual_information_backward_block.mlu - [100.0% 100.0% 252 / 252] - [100.0% 7 / 7] |


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|mutual_information_backward| 105 | 98.918 | 0.00404762 | 0.0012051 | -1 | float | px:[4, 15, 105], py:[4, 16, 104], p:[4, 16, 105],  ans_grad:[4] |


Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|mutual_information_backward| 77 | 19.918 | 0.000613276 | 0.000730362 | -1 | float | px:[4, 15, 105], py:[4, 16, 104], p:[4, 16, 105],  ans_grad:[4] |


### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
