### PR TITLE
[Fix](bangc-ops): fix ms_deform_attn_backward bug

### DIFF
--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -217,27 +217,26 @@ static mluOpStatus_t msDeformAttnBackwardParamCheck(
                   "num_query of the input is zero.";
     return MLUOP_STATUS_BAD_PARAM;
   }
-  if ((num_levels == 0 || num_points == 0) && num_key == 0) {
+  if ((num_levels == 0) || ((num_points == 0) && num_key == 0)) {
     *calc_grad_value_loc_weight_flag = true;
     return MLUOP_STATUS_SUCCESS;
   }
-  if ((num_levels == 0 || num_points == 0) && num_key != 0) {
+  if ((num_points == 0) && (num_key != 0)) {
     *calc_grad_loc_weight_flag = true;
     return MLUOP_STATUS_SUCCESS;
   }
-  if (num_key == 0 && (num_levels != 0 && num_points != 0)) {
+  if ((num_key == 0) && (num_points != 0)) {
     *calc_grad_value_flag = true;
     return MLUOP_STATUS_SUCCESS;
   }
 
+  PARAM_CHECK(API, value != NULL);
   PARAM_CHECK(API, spatial_shapes != NULL);
   PARAM_CHECK(API, level_start_index != NULL);
   PARAM_CHECK(API, sampling_loc != NULL);
   PARAM_CHECK(API, attn_weight != NULL);
   PARAM_CHECK(API, grad_output != NULL);
-  if (num_key != 0) {
-    PARAM_CHECK(API, grad_value != NULL);
-  }
+  PARAM_CHECK(API, grad_value != NULL);
   PARAM_CHECK(API, grad_sampling_loc != NULL);
   PARAM_CHECK(API, grad_attn_weight != NULL);
   return MLUOP_STATUS_SUCCESS;
@@ -269,9 +268,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnBackward(
       grad_sampling_loc_desc, grad_sampling_loc, grad_attn_weight_desc,
       grad_attn_weight, &calc_grad_loc_weight_flag, &calc_grad_value_flag,
       &calc_grad_value_loc_weight_flag);
-  if (MLUOP_STATUS_SUCCESS != param_check_status) {
-    return param_check_status;
-  }
+
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("ms_deform_attn_backward");
     GEN_CASE_HANDLE(handle);
@@ -291,6 +288,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnBackward(
     GEN_CASE_OP_PARAM_SINGLE(0, "ms_deform_attn_backward", "im2col_step",
                              im2col_step);
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
+  }
+  if (MLUOP_STATUS_SUCCESS != param_check_status) {
+    return param_check_status;
   }
 
   if (calc_grad_loc_weight_flag) {

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -81,13 +81,10 @@ mluOpDeformAttnBackwardKernelPolicy_t msDeformAttnBackwardPolicyFunc(
 
   if ((handle->arch == MLUOP_MLU590) && (nlp <= FAST_KERNEL_MAX_NLP) &&
       (nlpc <= FAST_KERNEL_MAX_NLPC)) {
-    VLOG(5) << "===========85 MLUOP_MS_DEFORM_ATTN_BACKWARD_FAST\n";
     return MLUOP_MS_DEFORM_ATTN_BACKWARD_FAST;
-  } else if (num_per_time_theory > 1) {
-    VLOG(5) << "===========88 MLUOP_MS_DEFORM_ATTN_BACKWARD_SMALL_CHANNEL\n";
+  } else if (num_per_time_theory >= 1) {
     return MLUOP_MS_DEFORM_ATTN_BACKWARD_SMALL_CHANNEL;
   }
-  VLOG(5) << "===========91 MLUOP_MS_DEFORM_ATTN_BACKWARD_DEFAULT";
   return MLUOP_MS_DEFORM_ATTN_BACKWARD_DEFAULT;
 }
 

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -30,6 +30,7 @@
 #include "core/type.h"
 #include "core/tool.h"
 #include "kernels/kernel.h"
+#include "kernels/debug.h"
 
 char API[] = "[mluOpMsDeformAttnBackward]";
 
@@ -78,12 +79,15 @@ mluOpDeformAttnBackwardKernelPolicy_t msDeformAttnBackwardPolicyFunc(
   int32_t nlp = num_levels * num_points;
   int32_t nlpc = num_levels * num_points * channels;
 
-  if (handle->arch == MLUOP_MLU590 && nlp <= FAST_KERNEL_MAX_NLP &&
-      nlpc <= FAST_KERNEL_MAX_NLPC) {
+  if ((handle->arch == MLUOP_MLU590) && (nlp <= FAST_KERNEL_MAX_NLP) &&
+      (nlpc <= FAST_KERNEL_MAX_NLPC)) {
+    VLOG(5) << "===========85 MLUOP_MS_DEFORM_ATTN_BACKWARD_FAST\n";
     return MLUOP_MS_DEFORM_ATTN_BACKWARD_FAST;
-  } else if (num_per_time_theory >= 1) {
+  } else if (num_per_time_theory > 1) {
+    VLOG(5) << "===========88 MLUOP_MS_DEFORM_ATTN_BACKWARD_SMALL_CHANNEL\n";
     return MLUOP_MS_DEFORM_ATTN_BACKWARD_SMALL_CHANNEL;
   }
+  VLOG(5) << "===========91 MLUOP_MS_DEFORM_ATTN_BACKWARD_DEFAULT";
   return MLUOP_MS_DEFORM_ATTN_BACKWARD_DEFAULT;
 }
 
@@ -367,7 +371,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnBackward(
           num_points, (float *)grad_value, (float *)grad_sampling_loc,
           (float *)grad_attn_weight)));
     }
-    default: { VLOG(5) << "Not Implemented."; }
+    default: {
+      VLOG(5) << "Not Implemented.";
+    }
   }
 
   GEN_CASE_END();

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -52,115 +52,130 @@ void __mlu_func__ computeGridMaskAndOffset(
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_transpose(nram_loc_h, nram_grad_output_tl + num_deal_grid,
                    num_per_time_real * num_heads * num_levels, num_points);
-  __bang_int322float((float *)nram_spatial_shapes,
-                     (int32_t *)nram_spatial_shapes, num_levels * 2, 0);
+//   __bang_int322float((float *)nram_spatial_shapes,
+//                      (int32_t *)nram_spatial_shapes, num_levels * 2, 0);
 
-  __bang_transpose(nram_grad_output_tr, (float *)nram_spatial_shapes,
+  __bang_transpose((int32_t*)nram_grad_output_tr, (int32_t *)nram_spatial_shapes,
                    num_levels, 2);
-  __bang_mul_scalar(nram_h_stride, nram_grad_output_tr + num_levels, w_stride,
+  __bang_mul_scalar((int32_t*)nram_h_stride, (int32_t*)((int32_t*)nram_grad_output_tr + num_levels), w_stride,
                     num_levels);
-  __memcpy_async(nram_spatial_shapes, nram_grad_output_tr,
-                 num_levels * 2 * sizeof(float), NRAM2NRAM);
-
-  __bang_cycle_mul(nram_loc_w, nram_loc_w,
-                   (float *)nram_spatial_shapes + num_levels, num_deal_grid,
+                 
+  __memcpy_async((int32_t*)nram_spatial_shapes, (int32_t*)nram_grad_output_tr,
+                 num_levels * 2 * sizeof(int32_t), NRAM2NRAM);
+__bang_int322float((float *)nram_spatial_shapes,
+                      (int32_t *)nram_spatial_shapes, num_levels * 2, 0);
+  __bang_cycle_mul((float *)nram_loc_w, (float *)nram_loc_w,
+                   (float *)(nram_spatial_shapes + num_levels), num_deal_grid,
                    num_levels);
-  __bang_cycle_mul(nram_loc_h, nram_loc_h, (float *)(nram_spatial_shapes),
+  __bang_cycle_mul((float *)nram_loc_h, (float *)nram_loc_h, (float *)(nram_spatial_shapes),
                    num_deal_grid, num_levels);
-  __bang_sub_scalar(nram_loc_w, nram_loc_w, 0.5, num_deal_grid);
-  __bang_sub_scalar(nram_loc_h, nram_loc_h, 0.5, num_deal_grid);
+  __bang_sub_scalar((float *)nram_loc_w, (float *)nram_loc_w, 0.5, num_deal_grid);
+  __bang_sub_scalar((float *)nram_loc_h, (float *)nram_loc_h, 0.5, num_deal_grid);
+
   // get mask. (h_im > -1 && w_im > -1 && h_im < spatial_h && w_im < spatial_w)
-  __bang_cycle_lt(nram_w_low_temp, nram_loc_w,
+  __bang_cycle_lt((float *)nram_w_low_temp, (float *)nram_loc_w,
                   (float *)(nram_spatial_shapes + num_levels), num_deal_grid,
                   num_levels);
-  __bang_cycle_lt(nram_h_high_temp, nram_loc_h, (float *)(nram_spatial_shapes),
+  __bang_cycle_lt((float *)nram_h_high_temp, (float *)nram_loc_h, (float *)(nram_spatial_shapes),
                   num_deal_grid, num_levels);
 
-  __bang_and(nram_w_low_temp, nram_w_low_temp, nram_h_high_temp, num_deal_grid);
-  __bang_gt_scalar(nram_h_high_temp, nram_loc_h, -1, num_deal_grid);
-  __bang_and(nram_h_high_temp, nram_h_high_temp, nram_w_low_temp,
+  __bang_and((float *)nram_w_low_temp, (float *)nram_w_low_temp, (float *)nram_h_high_temp, num_deal_grid);
+  __bang_gt_scalar((float *)nram_h_high_temp, (float *)nram_loc_h, -1, num_deal_grid);
+  __bang_and((float *)nram_h_high_temp,(float *) nram_h_high_temp, (float *)nram_w_low_temp,
              num_deal_grid);
-  __bang_gt_scalar(nram_w_low_temp, nram_loc_w, -1, num_deal_grid);
-  __bang_and(nram_h_high_temp, nram_h_high_temp, nram_w_low_temp,
+  __bang_gt_scalar((float *)nram_w_low_temp, (float *)nram_loc_w, -1, num_deal_grid);
+  __bang_and((float *)nram_h_high_temp, (float *)nram_h_high_temp, (float *)nram_w_low_temp,
              num_deal_grid);
 
-  __bang_transpose(nram_w_low_temp, nram_h_high_temp, num_points,
+  __bang_transpose((float *)nram_w_low_temp, (float *)nram_h_high_temp, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __memcpy_async(nram_h_high_temp, nram_w_low_temp,
+  __memcpy_async((float *)nram_h_high_temp, (float *)nram_w_low_temp,
                  num_deal_grid * sizeof(float), NRAM2NRAM);
 
-  __bang_transpose(nram_grad_output_tl, nram_loc_w, num_points,
+  __bang_transpose((float *)nram_grad_output_tl,(float *)nram_loc_w, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __memcpy_async(nram_loc_w, nram_grad_output_tl, num_deal_grid * sizeof(float),
+  __memcpy_async((float *)nram_loc_w, (float *)nram_grad_output_tl, num_deal_grid * sizeof(float),
                  NRAM2NRAM);
-  __bang_transpose(nram_grad_output_tl, nram_loc_h, num_points,
+  __bang_transpose((float *)nram_grad_output_tl, (float *)nram_loc_h, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __memcpy_async(nram_loc_h, nram_grad_output_tl, num_deal_grid * sizeof(float),
+  __memcpy_async((float *)nram_loc_h, (float *)nram_grad_output_tl, num_deal_grid * sizeof(float),
                  NRAM2NRAM);
+
 
   __bang_floor(nram_w_low, nram_loc_w, num_deal_grid);
   __bang_floor(nram_h_low, nram_loc_h, num_deal_grid);
+  __bang_float2int32((int32_t*)nram_w_low,nram_w_low, num_deal_grid, 0);
+  __bang_float2int32((int32_t*)nram_h_low,nram_h_low, num_deal_grid, 0);
 
-  __bang_add_scalar(nram_h_high, nram_h_low, 1, num_deal_grid);
-  __bang_add_scalar(nram_w_high, nram_w_low, 1, num_deal_grid);
+  __bang_add_scalar((int32_t*)nram_h_high, (int32_t*)nram_h_low, 1, num_deal_grid);
+  __bang_add_scalar((int32_t*)nram_w_high, (int32_t*)nram_w_low, 1, num_deal_grid);
 
-  __bang_transpose(nram_h_low_ptr_offset, nram_h_low,
+  __bang_transpose((int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_h_low,
                    num_per_time_real * num_heads * num_levels, num_points);
-  __bang_cycle_mul(nram_h_low_ptr_offset, nram_h_low_ptr_offset, nram_h_stride,
+  __bang_cycle_mul((int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_h_low_ptr_offset, 
+  (int32_t*)nram_h_stride, num_deal_grid, num_levels);
+   for(int i = 0; i < num_deal_grid; ++i){
+         __bang_printf("112 nram_h_stride = %d \n",((int32_t*)nram_h_stride)[i]);
+       //  __bang_printf("113 nram_w_high = %d \n",((int32_t*)nram_w_high)[i]);
+     }
+  __bang_cycle_add((int32_t*)nram_h_high_ptr_offset, (int32_t*)nram_h_low_ptr_offset, 
+  (int32_t*)nram_h_stride,
                    num_deal_grid, num_levels);
 
-  __bang_cycle_add(nram_h_high_ptr_offset, nram_h_low_ptr_offset, nram_h_stride,
-                   num_deal_grid, num_levels);
 
-  __bang_transpose(nram_w_low_ptr_offset, nram_h_low_ptr_offset, num_points,
+ 
+  __bang_transpose((int32_t*)nram_w_low_ptr_offset, (int32_t*)nram_h_low_ptr_offset, num_points,
                    num_per_time_real * num_heads * num_levels);
 
-  __memcpy_async(nram_h_low_ptr_offset, nram_w_low_ptr_offset,
-                 num_deal_grid * sizeof(float), NRAM2NRAM);
-  __bang_transpose(nram_w_low_ptr_offset, nram_h_high_ptr_offset, num_points,
+  __memcpy_async((int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_w_low_ptr_offset,
+                 num_deal_grid * sizeof(int32_t), NRAM2NRAM);
+  __bang_transpose((int32_t*)nram_w_low_ptr_offset, (int32_t*)nram_h_high_ptr_offset, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __memcpy_async(nram_h_high_ptr_offset, nram_w_low_ptr_offset,
-                 num_deal_grid * sizeof(float), NRAM2NRAM);
-  __bang_mul_scalar(nram_w_low_ptr_offset, nram_w_low, qid_stride,
+  __memcpy_async((int32_t*)nram_h_high_ptr_offset, (int32_t*)nram_w_low_ptr_offset,
+                 num_deal_grid * sizeof(int32_t), NRAM2NRAM);
+  __bang_mul_scalar((int32_t*)nram_w_low_ptr_offset, (int32_t*)nram_w_low, qid_stride,
                     num_deal_grid);
-  __bang_add_scalar(nram_w_high_ptr_offset, nram_w_low_ptr_offset, qid_stride,
+  __bang_add_scalar((int32_t*)nram_w_high_ptr_offset, (int32_t*)nram_w_low_ptr_offset, qid_stride,
                     num_deal_grid);
-
-  __bang_add(nram_offset1, nram_h_low_ptr_offset, nram_w_low_ptr_offset,
+               
+  __bang_add((int32_t*)nram_offset1, (int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_w_low_ptr_offset,
              num_deal_grid);
 
-  __bang_transpose(nram_offset_temp, nram_offset1,
+  __bang_transpose((int32_t*)nram_offset_temp,(int32_t*) nram_offset1,
                    num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add(nram_offset_temp, nram_offset_temp, nram_base_ptr,
+  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, (int32_t*)nram_base_ptr,
                    num_deal_grid, num_heads);
 
-  __bang_transpose(nram_offset1, nram_offset_temp, num_levels * num_points,
+  __bang_transpose((int32_t*)nram_offset1, (int32_t*)nram_offset_temp, num_levels * num_points,
                    num_per_time_real * num_heads);
 
-  __bang_add(nram_offset2, nram_h_low_ptr_offset, nram_w_high_ptr_offset,
+  __bang_add((int32_t*)nram_offset2, (int32_t*)nram_h_low_ptr_offset,
+   (int32_t*)nram_w_high_ptr_offset,
              num_deal_grid);
-  __bang_transpose(nram_offset_temp, nram_offset2,
+  __bang_transpose((int32_t*)nram_offset_temp, (int32_t*)nram_offset2,
                    num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add(nram_offset_temp, nram_offset_temp, nram_base_ptr,
+  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, 
+  (int32_t*)nram_base_ptr,
                    num_deal_grid, num_heads);
-  __bang_transpose(nram_offset2, nram_offset_temp, num_levels * num_points,
+  __bang_transpose((int32_t*)nram_offset2, (int32_t*)nram_offset_temp, num_levels * num_points,
                    num_per_time_real * num_heads);
 
-  __bang_add(nram_offset3, nram_h_high_ptr_offset, nram_w_low_ptr_offset,
+  __bang_add((int32_t*)nram_offset3, (int32_t*)nram_h_high_ptr_offset, 
+  (int32_t*)nram_w_low_ptr_offset,
              num_deal_grid);
-  __bang_transpose(nram_offset_temp, nram_offset3,
+  __bang_transpose((int32_t*)nram_offset_temp, (int32_t*)nram_offset3,
                    num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add(nram_offset_temp, nram_offset_temp, nram_base_ptr,
+  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, (int32_t*)nram_base_ptr,
                    num_deal_grid, num_heads);
-  __bang_transpose(nram_offset3, nram_offset_temp, num_levels * num_points,
+  __bang_transpose((int32_t*)nram_offset3, (int32_t*)nram_offset_temp, num_levels * num_points,
                    num_per_time_real * num_heads);
-  __bang_add(nram_offset4, nram_h_high_ptr_offset, nram_w_high_ptr_offset,
+  __bang_add((int32_t*)nram_offset4, (int32_t*)nram_h_high_ptr_offset, (int32_t*)nram_w_high_ptr_offset,
              num_deal_grid);
-  __bang_transpose(nram_offset_temp, nram_offset4,
+  __bang_transpose((int32_t*)nram_offset_temp, (int32_t*)nram_offset4,
                    num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add(nram_offset_temp, nram_offset_temp, nram_base_ptr,
+  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, (int32_t*)nram_base_ptr,
                    num_deal_grid, num_heads);
-  __bang_transpose(nram_offset4, nram_offset_temp, num_levels * num_points,
+  __bang_transpose((int32_t*)nram_offset4, (int32_t*)nram_offset_temp, num_levels * num_points,
                    num_per_time_real * num_heads);
 
   // h_low >= 0 && w_low >= 0  mask2
@@ -168,56 +183,103 @@ void __mlu_func__ computeGridMaskAndOffset(
   float *mask2 = nram_h_high_ptr_offset;
   float *mask3 = nram_w_low_ptr_offset;
   float *mask4 = nram_w_high_ptr_offset;
-  __bang_ge_scalar(mask1, nram_h_low, 0, num_deal_grid);
-  __bang_ge_scalar(mask2, nram_w_low, 0, num_deal_grid);
-  __bang_and(mask2, mask1, mask2, num_deal_grid);
-  __bang_and(mask2, nram_h_high_temp, mask2, num_deal_grid);
+  __bang_ge_scalar((int32_t*)mask1, (int32_t*)nram_h_low, 0, num_deal_grid);
+  __bang_ge_scalar((int32_t*)mask2, (int32_t*)nram_w_low, 0, num_deal_grid);
+  __bang_and((int32_t*)mask2, (int32_t*)mask1, (int32_t*)mask2, num_deal_grid);
+  __bang_float2int32((int32_t*)nram_h_high_temp,nram_h_high_temp,num_deal_grid, 0);
+  __bang_and((int32_t*)mask2, (int32_t*)nram_h_high_temp, (int32_t*)mask2, num_deal_grid);
 
   // h_low >= 0 && w_high <= width - 1 mask1
-  __bang_transpose(mask3, nram_w_high,
+  __bang_transpose((int32_t*)mask3, (int32_t*)nram_w_high,
                    num_per_time_real * num_heads * num_levels, num_points);
+                
   __bang_sub_scalar((float *)nram_spatial_shapes, (float *)nram_spatial_shapes,
-                    1.0, num_levels * 2);
-  __bang_cycle_le(mask3, mask3, (float *)(nram_spatial_shapes + num_levels),
-                  num_deal_grid, num_levels);
-  __bang_transpose(mask4, mask3, num_points,
+                    1, num_levels * 2);
+ // __bang_int322float((float*)nram_spatial_shapes, (int32_t*)nram_spatial_shapes, num_levels * 2, 0); 
+  __bang_int322float((float *)mask3, (int32_t*)mask3, num_deal_grid, 0);  
+  //__bang_int322float(mask1, (int32_t*)mask1, num_levels, 0);               
+  __bang_cycle_le((float *)mask3, (float *)mask3, (float *)(nram_spatial_shapes + num_levels),
+                  num_deal_grid, num_levels); // 仅float
+   __bang_float2int32((int32_t*)mask3, (float *)mask3,num_deal_grid , 0);                   
+  __bang_transpose((int32_t*)mask4, (int32_t*)mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __bang_and(mask1, mask1, mask4, num_deal_grid);
-  __bang_and(mask1, nram_h_high_temp, mask1, num_deal_grid);
+  __bang_and((int32_t*)mask1, (int32_t*)mask1, (int32_t*)mask4, num_deal_grid);
+  //__bang_int322float(nram_h_high_temp,(int32_t*)nram_h_high_temp, num_deal_grid, 0);
+  __bang_and((int32_t*)mask1, (int32_t*)nram_h_high_temp, (int32_t*)mask1, num_deal_grid);
 
   // h_high <= height - 1 && w_high <= width - 1 mask3
-  __bang_transpose(mask3, nram_h_high,
+  __bang_transpose((int32_t*)mask3, (int32_t*)nram_h_high,
                    num_per_time_real * num_heads * num_levels, num_points);
-  __bang_cycle_le(mask3, mask3, (float *)(nram_spatial_shapes), num_deal_grid,
-                  num_levels);
-  __bang_transpose(nram_h_low_temp, mask3, num_points,
+   __bang_int322float((float *)mask3, (int32_t*)mask3, num_deal_grid, 0);                
+  __bang_cycle_le((float *)mask3, (float *)mask3, (float *)(nram_spatial_shapes), num_deal_grid,
+                  num_levels);// 仅float
+    __bang_float2int32((int32_t*)mask3, (float *)mask3, num_deal_grid, 0);                 
+  __bang_transpose((int32_t*)nram_h_low_temp, (int32_t*)mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __bang_and(mask4, mask4, nram_h_low_temp, num_deal_grid);
-  __bang_and(mask3, mask4, nram_h_high_temp, num_deal_grid);
+  __bang_and((int32_t*)mask4, (int32_t*)mask4, (int32_t*)nram_h_low_temp, num_deal_grid);
+  __bang_and((int32_t*)mask3, (int32_t*)mask4, (int32_t*)nram_h_high_temp, num_deal_grid);
+    //   for(int i = 0; i < num_deal_grid; ++i){
+    //     // __bang_printf("mask1 = %f \n",mask1[i]);
+    //     //  __bang_printf("mask2 = %f \n",mask2[i]);
+    //       __bang_printf("228mask3 = %d \n",((int32_t*)mask3)[i]);
+    //     //  __bang_printf("mask4 = %f \n",mask4[i]);
+    //  }
 
   // h_high <= height - 1 && w_low >= 0 mask4
-  __bang_ge_scalar(nram_w_low_temp, nram_w_low, 0, num_deal_grid);
-  __bang_and(mask4, nram_h_low_temp, nram_w_low_temp, num_deal_grid);
-  __bang_and(mask4, mask4, nram_h_high_temp, num_deal_grid);
+  __bang_ge_scalar((int32_t*)nram_w_low_temp, (int32_t*)nram_w_low, 0, num_deal_grid); // 仅float
+  __bang_and((int32_t*)mask4, (int32_t*)nram_h_low_temp, (int32_t*)nram_w_low_temp, num_deal_grid);
+  __bang_and((int32_t*)mask4, (int32_t*)mask4, (int32_t*)nram_h_high_temp, num_deal_grid);
+ __bang_int322float(nram_offset1,(int32_t*)nram_offset1, num_deal_grid , 0);
   __bang_gt_scalar(grad_temp1, nram_offset1, 0, num_deal_grid);
-  __bang_mul(nram_offset1, nram_offset1, grad_temp1, num_deal_grid);
-  __bang_mul(nram_offset1, nram_offset1, mask2, num_deal_grid);
+  __bang_float2int32((int32_t*)grad_temp1, grad_temp1, num_deal_grid, 0);
+   __bang_float2int32((int32_t*)nram_offset1,nram_offset1, num_deal_grid , 0);    
+  __bang_mul((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)mask2, num_deal_grid);
 
-  __bang_gt_scalar(grad_temp1, nram_offset2, 0, num_deal_grid);
-  __bang_mul(nram_offset2, nram_offset2, grad_temp1, num_deal_grid);
-  __bang_mul(nram_offset2, nram_offset2, mask1, num_deal_grid);
+ __bang_int322float((float *)nram_offset2,(int32_t*)nram_offset2, num_deal_grid , 0);
+  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset2, 0, num_deal_grid);
+  __bang_float2int32((int32_t*)grad_temp1, grad_temp1, num_deal_grid, 0); 
+  __bang_float2int32((int32_t*)nram_offset2,nram_offset2, num_deal_grid , 0); 
+  __bang_mul((int32_t*)nram_offset2,(int32_t*) nram_offset2, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t*)nram_offset2, (int32_t*)nram_offset2,(int32_t*) mask1, num_deal_grid);
 
-  __bang_gt_scalar(grad_temp1, nram_offset3, 0, num_deal_grid);
-  __bang_mul(nram_offset3, nram_offset3, grad_temp1, num_deal_grid);
-  __bang_mul(nram_offset3, nram_offset3, mask4, num_deal_grid);
+ __bang_int322float((float *)nram_offset3,(int32_t*)nram_offset3, num_deal_grid , 0);
+  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset3, 0, num_deal_grid);
+    __bang_float2int32((int32_t*)grad_temp1, (float *)grad_temp1, num_deal_grid, 0); 
+    __bang_float2int32((int32_t*)nram_offset3,nram_offset3, num_deal_grid , 0); 
+  __bang_mul((int32_t*)nram_offset3, (int32_t*)nram_offset3, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t*)nram_offset3, (int32_t*)nram_offset3,(int32_t*) mask4, num_deal_grid);
 
-  __bang_gt_scalar(grad_temp1, nram_offset4, 0, num_deal_grid);
-  __bang_mul(nram_offset4, nram_offset4, grad_temp1, num_deal_grid);
-  __bang_mul(nram_offset4, nram_offset4, mask3, num_deal_grid);
+ __bang_int322float((float *)nram_offset4,(int32_t*)nram_offset4, num_deal_grid , 0);
+  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset4, 0, num_deal_grid);
+  __bang_float2int32((int32_t*)grad_temp1, grad_temp1, num_deal_grid, 0); 
+  __bang_float2int32((int32_t*)nram_offset4,nram_offset4, num_deal_grid , 0); 
+  __bang_mul((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)mask3, num_deal_grid);
   __sync_io_move_compute();
-  __bang_sub(nram_lh, nram_loc_h, nram_h_low, num_deal_grid);
-  __bang_sub(nram_lw, nram_loc_w, nram_w_low, num_deal_grid);
-
+  __bang_int322float((float*)nram_h_low, (int32_t*)nram_h_low,num_deal_grid ,0);
+  __bang_int322float((float*)nram_w_low, (int32_t*)nram_w_low,num_deal_grid, 0);
+  __bang_sub((float*)nram_lh, (float*)nram_loc_h, (float*)nram_h_low, num_deal_grid);
+  __bang_sub((float*)nram_lw, (float*)nram_loc_w, (float*)nram_w_low, num_deal_grid);
+  __bang_int322float(mask1, (int32_t*)mask1, num_deal_grid, 0);
+  __bang_int322float(mask2, (int32_t*)mask2, num_deal_grid, 0);
+  __bang_int322float(mask3, (int32_t*)mask3, num_deal_grid, 0);
+  __bang_int322float(mask4, (int32_t*)mask4, num_deal_grid, 0);
+  __bang_int322float(nram_offset1, (int32_t*)nram_offset1, num_deal_grid, 0);
+  __bang_int322float(nram_offset2, (int32_t*)nram_offset2, num_deal_grid, 0);
+  __bang_int322float(nram_offset3, (int32_t*)nram_offset3, num_deal_grid, 0);
+  __bang_int322float(nram_offset4, (int32_t*)nram_offset4, num_deal_grid, 0);
+    // for(int i = 0; i < num_deal_grid; ++i){
+    //     __bang_printf("  nram_offset1 = %f \n",((float*)nram_offset1)[i]);
+    //     __bang_printf("  nram_offset2 = %f \n",((float*)nram_offset2)[i]);
+    //     __bang_printf("  nram_offset3 = %f \n",((float*)nram_offset3)[i]);
+    //     __bang_printf("  nram_offset4 = %f \n",((float*)nram_offset4)[i]);
+    //     __bang_printf("  mask1 = %f \n",((float*)mask1)[i]);
+    //     __bang_printf("  mask2 = %f \n",((float*)mask2)[i]);
+    //     __bang_printf("  mask3 = %f \n",((float*)mask3)[i]);
+    //     __bang_printf("  mask4 = %f \n",((float*)mask4)[i]);
+      
+    //  }
   __bang_fusion(FUSION_FMA, nram_hh, nram_lh, (float)(-1), 1, num_deal_grid);
   __bang_fusion(FUSION_FMA, nram_hw, nram_lw, (float)(-1), 1, num_deal_grid);
 
@@ -227,7 +289,6 @@ void __mlu_func__ computeGridMaskAndOffset(
   __bang_mul(nram_w4, nram_lh, nram_lw, num_deal_grid);
 #endif
 }
-
 void __mlu_func__ loadValue(
     float *nram_grad_output_tl, float *nram_grad_output_tr,
     float *nram_grad_output_bl, float *nram_grad_output_br,
@@ -294,13 +355,17 @@ void __mlu_func__ loadValue(
   value_offset_temp =
       b_col * spatial_size * qid_stride + level_start_id * qid_stride;
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+        __bang_printf("nram_offset1 = %d \n",value_offset_temp + ((float*)nram_offset1)[loop]);
+    //    __bang_printf("nram_offset2 = %f \n",((float*)nram_offset2)[loop]);
+    //    __bang_printf("nram_offset3 = %f \n",((float*)nram_offset3)[loop]);
+    //    __bang_printf("nram_offset4 = %f \n",((float*)nram_offset4)[loop]); 
     __memcpy_async(
         (void *)(nram_grad_output_tl + loop * deal_num_real),
         (void *)(data_value + value_offset_temp + int32_t(nram_offset1[loop])),
         deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
         (int32_t(nram_offset2[loop]) - int32_t(nram_offset1[loop])) *
             sizeof(float),
-        mask1[loop]);
+        1);
     b_col = (grid_offset + loop + 1) / num_query / num_heads / num_levels /
             num_points;
     l_col = (grid_offset + loop + 1) / num_points % num_levels;
@@ -312,11 +377,18 @@ void __mlu_func__ loadValue(
         deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
         (int32_t(nram_offset4[loop]) - int32_t(nram_offset3[loop])) *
             sizeof(float),
-        mask3[loop]);
+        1);
     value_offset_temp =
         b_col * spatial_size * qid_stride + level_start_id * qid_stride;
+        // __bang_printf("nram_grad_output_tl = %f \n",((float*)nram_grad_output_tl)[loop]);
+        // __bang_printf("nram_grad_output_tr = %f \n",((float*)nram_grad_output_tr)[loop]);
+        // __bang_printf("nram_grad_output_bl = %f \n",((float*)nram_grad_output_bl)[loop]);
+        // __bang_printf("nram_grad_output_br = %f \n",((float*)nram_grad_output_br)[loop]);
   }
-
+  for(int loop = 0; loop < num_deal_grid; ++loop){
+        __bang_printf("nram_grad_output_tl = %f \n",((float*)nram_grad_output_tl)[loop]);
+        
+  }
 #endif
   __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
   __bang_cycle_add(grad_temp1, grad_temp1, mask2, deal_num_real * num_deal_grid,
@@ -370,8 +442,12 @@ void __mlu_func__ loadValue(
   __bang_band((char *)nram_grad_output_br, (char *)nram_grad_output_br,
               (char *)grad_temp3,
               num_deal_grid * deal_num_real * sizeof(float));
+//    for(int i = 0; i < num_deal_grid; ++i){
+//        __bang_printf("nram_grad_output_br = %f \n",nram_grad_output_br[]);
+//    }           
 #endif
 }
+
 
 void __mlu_func__ computeGradValue(
     float *grad_temp1, float *grad_temp2, float *grad_temp3, float *grad_temp4,
@@ -404,53 +480,58 @@ void __mlu_func__ computeGradValue(
 
   int32_t temp_res = num_query * num_heads * num_levels * num_points;
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    nram_grid_offset1[loop] = ((loop + grid_offset) / temp_res);
+    ((int32_t*)nram_grid_offset1)[loop] = ((loop + grid_offset) / temp_res);
   }
-  __bang_mul_scalar((float *)nram_grid_offset1, (float *)nram_grid_offset1,
+  __bang_mul_scalar((int32_t*)nram_grid_offset1, (int32_t*)nram_grid_offset1,
                     spatial_size * qid_stride, num_deal_grid);
-  __bang_transpose(nram_grid_offset2, nram_grid_offset1,
+  __bang_transpose((int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset1,
                    num_per_time_real * num_heads * num_levels, num_points);
-  __bang_int322float((float *)nram_level_start_index, nram_level_start_index,
-                     num_levels, 0);
-  __bang_mul_scalar(nram_grid_offset1, (float *)nram_level_start_index,
+//   __bang_int322float((float *)nram_level_start_index, nram_level_start_index,
+//                      num_levels, 0);
+  __bang_mul_scalar((int32_t*)nram_grid_offset1, (int32_t*)nram_level_start_index,
                     qid_stride, num_levels);
-  __bang_cycle_add(nram_grid_offset2, nram_grid_offset2, nram_grid_offset1,
+  __bang_cycle_add((int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset1,
                    num_deal_grid, num_levels);
-  __bang_transpose(nram_grid_offset1, nram_grid_offset2, num_points,
+  __bang_transpose((int32_t*)nram_grid_offset1, (int32_t*)nram_grid_offset2, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __bang_add(nram_offset1, nram_offset1, nram_grid_offset1, num_deal_grid);
-  __bang_add(nram_offset2, nram_offset2, nram_grid_offset1, num_deal_grid);
-  __bang_add(nram_offset3, nram_offset3, nram_grid_offset1, num_deal_grid);
-  __bang_add(nram_offset4, nram_offset4, nram_grid_offset1, num_deal_grid);
+// __bang_float2int32((int32_t*)nram_offset1,nram_offset1,num_deal_grid, 0);  
+// __bang_float2int32((int32_t*)nram_offset2,nram_offset2,num_deal_grid, 0);
+// __bang_float2int32((int32_t*)nram_offset3,nram_offset3,num_deal_grid, 0);
+// __bang_float2int32((int32_t*)nram_offset4,nram_offset4,num_deal_grid, 0);              
+  __bang_add((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)nram_grid_offset1, num_deal_grid);
+  __bang_add((int32_t*)nram_offset2, (int32_t*)nram_offset2, (int32_t*)nram_grid_offset1, num_deal_grid);
+  __bang_add((int32_t*)nram_offset3, (int32_t*)nram_offset3, (int32_t*)nram_grid_offset1, num_deal_grid);
+  __bang_add((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)nram_grid_offset1, num_deal_grid);
 
 #if __BANG_ARCH__ >= 592
   // make sure offset not great than (batch * spatial_size * num_heads *
   // channels)
-  __bang_lt_scalar(grad_temp1, nram_offset1,
+  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset1,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul(nram_offset1, nram_offset1, grad_temp1, num_deal_grid);
-  __bang_lt_scalar(grad_temp1, nram_offset2,
+  __bang_mul((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset2,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul(nram_offset2, nram_offset2, grad_temp1, num_deal_grid);
-  __bang_lt_scalar(grad_temp1, nram_offset3,
+  __bang_mul((int32_t*)nram_offset2, (int32_t*)nram_offset2, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset3,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul(nram_offset3, nram_offset3, grad_temp1, num_deal_grid);
-  __bang_lt_scalar(grad_temp1, nram_offset4,
+  __bang_mul((int32_t*)nram_offset3, (int32_t*)nram_offset3, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset4,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul(nram_offset4, nram_offset4, grad_temp1, num_deal_grid);
+  __bang_mul((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)grad_temp1, num_deal_grid);
   __bang_mul(grad_temp3, nram_w1, mask2, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
                    num_deal_grid * deal_num_real, num_deal_grid);
   __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset1[loop])),
-        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
+        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);    
   }
 
   __bang_mul(grad_temp3, nram_w2, mask1, num_deal_grid);
@@ -462,7 +543,9 @@ void __mlu_func__ computeGradValue(
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset2[loop])),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
+   
   }
+
   __bang_mul(grad_temp3, nram_w3, mask4, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
                    num_deal_grid * deal_num_real, num_deal_grid);
@@ -473,6 +556,7 @@ void __mlu_func__ computeGradValue(
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset3[loop])),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
+    
   }
   __bang_mul(grad_temp3, nram_w4, mask3, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
@@ -483,6 +567,7 @@ void __mlu_func__ computeGradValue(
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset4[loop])),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
+              
   }
 #else
   __bang_cycle_mul(grad_temp1, grad_temp4, nram_w1,
@@ -505,6 +590,7 @@ void __mlu_func__ computeGradValue(
   __bang_transpose(nram_grad_output_bl, grad_temp1, deal_num_real,
                    num_deal_grid);
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+      
     if (mask2[loop]) {
       __bang_atomic_reduce_add(
           (float *)(grad_value + int32_t(nram_offset1[loop])),
@@ -526,6 +612,7 @@ void __mlu_func__ computeGradValue(
           (float *)(grad_value + int32_t(nram_offset4[loop])),
           (float *)(nram_grad_output_bl + loop * deal_num_real), deal_num_real);
     }
+
   }
 #endif
 #endif
@@ -840,10 +927,9 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
   int32_t num_per_time_real = num_per_time_theory;
 
   for (int32_t loop = 0; loop < num_heads; ++loop) {
-    nram_base_ptr[loop] = loop * channels;
+    ((int32_t*)nram_base_ptr)[loop] = loop * channels;
   }
   const int32_t w_stride = num_heads * channels;
-
   for (int32_t grid_loop = 0; grid_loop < repeat_times + 1; ++grid_loop) {
     int32_t grid_offset =
         (start_per_core + grid_loop * num_per_time_theory) * num_hlp;

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -352,7 +352,7 @@ void __mlu_func__ loadValue(
                    (int32_t(((int32_t *)nram_offset2)[loop]) -
                     int32_t(((int32_t *)nram_offset1)[loop])) *
                        sizeof(float),
-                   1);
+                   mask1[loop]);
     b_col = (grid_offset + loop + 1) / num_query / num_heads / num_levels /
             num_points;
     l_col = (grid_offset + loop + 1) / num_points % num_levels;
@@ -366,7 +366,7 @@ void __mlu_func__ loadValue(
                    (int32_t(((int32_t *)nram_offset4)[loop]) -
                     int32_t(((int32_t *)nram_offset3)[loop])) *
                        sizeof(float),
-                   1);
+                   mask3[loop]);
     value_offset_temp =
         b_col * spatial_size * qid_stride + level_start_id * qid_stride;
   }

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -176,8 +176,8 @@ void __mlu_func__ computeGridMaskAndOffset(
   // h_low >= 0 && w_high <= width - 1 mask1
   __bang_transpose(mask3, nram_w_high,
                    num_per_time_real * num_heads * num_levels, num_points);
-  __bang_sub_scalar(nram_spatial_shapes, nram_spatial_shapes, 1,
-                    num_levels * 2);
+  __bang_sub_scalar((float *)nram_spatial_shapes, (float *)nram_spatial_shapes,
+                    1.0, num_levels * 2);
   __bang_cycle_le(mask3, mask3, (float *)(nram_spatial_shapes + num_levels),
                   num_deal_grid, num_levels);
   __bang_transpose(mask4, mask3, num_points,
@@ -647,6 +647,8 @@ void __mlu_func__ computeGradSampingLoc(
     const int32_t &num_points, const int32_t &grid_offset,
     float *nram_h_high_temp) {
 #if __BANG_ARCH__ >= 372
+  __bang_add_scalar((float *)nram_spatial_shapes, (float *)nram_spatial_shapes,
+                    1.0, 2 * num_levels);
   __bang_transpose(nram_grad_output_tl, grad_h_weight,
                    num_per_time_real * num_heads * num_levels * deal_num_real,
                    num_points);  // pcxhl

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -107,6 +107,12 @@ void __mlu_func__ computeGridMaskAndOffset(
 
   __bang_floor(nram_w_low, nram_loc_w, num_deal_grid);
   __bang_floor(nram_h_low, nram_loc_h, num_deal_grid);
+  __bang_sub((float *)nram_lh, (float *)nram_loc_h, (float *)nram_h_low,
+             num_deal_grid);
+  __bang_sub((float *)nram_lw, (float *)nram_loc_w, (float *)nram_w_low,
+             num_deal_grid);
+  __bang_fusion(FUSION_FMA, nram_hh, nram_lh, (float)(-1), 1, num_deal_grid);
+  __bang_fusion(FUSION_FMA, nram_hw, nram_lw, (float)(-1), 1, num_deal_grid);
   __bang_float2int32((int32_t *)nram_w_low, nram_w_low, num_deal_grid, 0);
   __bang_float2int32((int32_t *)nram_h_low, nram_h_low, num_deal_grid, 0);
 
@@ -185,114 +191,84 @@ void __mlu_func__ computeGridMaskAndOffset(
   float *mask2 = nram_h_high_ptr_offset;
   float *mask3 = nram_w_low_ptr_offset;
   float *mask4 = nram_w_high_ptr_offset;
-  __bang_ge_scalar((int32_t *)mask1, (int32_t *)nram_h_low, 0, num_deal_grid);
-  __bang_ge_scalar((int32_t *)mask2, (int32_t *)nram_w_low, 0, num_deal_grid);
-  __bang_and((int32_t *)mask2, (int32_t *)mask1, (int32_t *)mask2,
-             num_deal_grid);
-  __bang_float2int32((int32_t *)nram_h_high_temp, nram_h_high_temp,
-                     num_deal_grid, 0);
-  __bang_and((int32_t *)mask2, (int32_t *)nram_h_high_temp, (int32_t *)mask2,
-             num_deal_grid);
+
+  __bang_int322float(nram_w_low, (int32_t *)nram_w_low, num_deal_grid, 0);
+  __bang_int322float(nram_h_low, (int32_t *)nram_h_low, num_deal_grid, 0);
+
+  __bang_ge_scalar(mask1, nram_h_low, 0, num_deal_grid);
+  __bang_ge_scalar(mask2, nram_w_low, 0, num_deal_grid);
+  __bang_and(mask2, mask1, mask2, num_deal_grid);
+
+  __bang_and(mask2, nram_h_high_temp, mask2, num_deal_grid);
 
   // h_low >= 0 && w_high <= width - 1 mask1
-  __bang_transpose((int32_t *)mask3, (int32_t *)nram_w_high,
+  __bang_int322float(nram_w_high, (int32_t *)nram_w_high, num_deal_grid, 0);
+
+  __bang_transpose(mask3, nram_w_high,
                    num_per_time_real * num_heads * num_levels, num_points);
 
   __bang_sub_scalar((float *)nram_spatial_shapes, (float *)nram_spatial_shapes,
                     1, num_levels * 2);
-  __bang_int322float((float *)mask3, (int32_t *)mask3, num_deal_grid, 0);
+
   __bang_cycle_le((float *)mask3, (float *)mask3,
                   (float *)(nram_spatial_shapes + num_levels), num_deal_grid,
-                  num_levels);  // 仅float
-  __bang_float2int32((int32_t *)mask3, (float *)mask3, num_deal_grid, 0);
-  __bang_transpose((int32_t *)mask4, (int32_t *)mask3, num_points,
+                  num_levels);
+  __bang_transpose(mask4, mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __bang_and((int32_t *)mask1, (int32_t *)mask1, (int32_t *)mask4,
-             num_deal_grid);
-  __bang_and((int32_t *)mask1, (int32_t *)nram_h_high_temp, (int32_t *)mask1,
-             num_deal_grid);
+  __bang_and(mask1, mask1, mask4, num_deal_grid);
+  __bang_and(mask1, nram_h_high_temp, mask1, num_deal_grid);
 
   // h_high <= height - 1 && w_high <= width - 1 mask3
-  __bang_transpose((int32_t *)mask3, (int32_t *)nram_h_high,
+  __bang_int322float(nram_h_high, (int32_t *)nram_h_high, num_deal_grid, 0);
+  __bang_transpose(mask3, nram_h_high,
                    num_per_time_real * num_heads * num_levels, num_points);
-  __bang_int322float((float *)mask3, (int32_t *)mask3, num_deal_grid, 0);
+
   __bang_cycle_le((float *)mask3, (float *)mask3,
                   (float *)(nram_spatial_shapes), num_deal_grid, num_levels);
-  __bang_float2int32((int32_t *)mask3, (float *)mask3, num_deal_grid, 0);
-  __bang_transpose((int32_t *)nram_h_low_temp, (int32_t *)mask3, num_points,
+
+  __bang_transpose(nram_h_low_temp, mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __bang_and((int32_t *)mask4, (int32_t *)mask4, (int32_t *)nram_h_low_temp,
-             num_deal_grid);
-  __bang_and((int32_t *)mask3, (int32_t *)mask4, (int32_t *)nram_h_high_temp,
-             num_deal_grid);
+  __bang_and(mask4, mask4, nram_h_low_temp, num_deal_grid);
+  __bang_and(mask3, mask4, nram_h_high_temp, num_deal_grid);
 
   // h_high <= height - 1 && w_low >= 0 mask4
-  __bang_ge_scalar((int32_t *)nram_w_low_temp, (int32_t *)nram_w_low, 0,
-                   num_deal_grid);  // 仅float
-  __bang_and((int32_t *)mask4, (int32_t *)nram_h_low_temp,
-             (int32_t *)nram_w_low_temp, num_deal_grid);
-  __bang_and((int32_t *)mask4, (int32_t *)mask4, (int32_t *)nram_h_high_temp,
-             num_deal_grid);
+  __bang_ge_scalar(nram_w_low_temp, nram_w_low, 0, num_deal_grid);
+  __bang_and(mask4, nram_h_low_temp, nram_w_low_temp, num_deal_grid);
+  __bang_and(mask4, mask4, nram_h_high_temp, num_deal_grid);
   __bang_int322float(nram_offset1, (int32_t *)nram_offset1, num_deal_grid, 0);
   __bang_gt_scalar(grad_temp1, nram_offset1, 0, num_deal_grid);
-  __bang_float2int32((int32_t *)grad_temp1, grad_temp1, num_deal_grid, 0);
+
+  __bang_mul(nram_offset1, nram_offset1, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset1, nram_offset1, mask2, num_deal_grid);
   __bang_float2int32((int32_t *)nram_offset1, nram_offset1, num_deal_grid, 0);
-  __bang_mul((int32_t *)nram_offset1, (int32_t *)nram_offset1,
-             (int32_t *)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t *)nram_offset1, (int32_t *)nram_offset1, (int32_t *)mask2,
-             num_deal_grid);
 
   __bang_int322float((float *)nram_offset2, (int32_t *)nram_offset2,
                      num_deal_grid, 0);
   __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset2, 0,
                    num_deal_grid);
-  __bang_float2int32((int32_t *)grad_temp1, grad_temp1, num_deal_grid, 0);
+
+  __bang_mul(nram_offset2, nram_offset2, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset2, nram_offset2, mask1, num_deal_grid);
   __bang_float2int32((int32_t *)nram_offset2, nram_offset2, num_deal_grid, 0);
-  __bang_mul((int32_t *)nram_offset2, (int32_t *)nram_offset2,
-             (int32_t *)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t *)nram_offset2, (int32_t *)nram_offset2, (int32_t *)mask1,
-             num_deal_grid);
 
   __bang_int322float((float *)nram_offset3, (int32_t *)nram_offset3,
                      num_deal_grid, 0);
   __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset3, 0,
                    num_deal_grid);
-  __bang_float2int32((int32_t *)grad_temp1, (float *)grad_temp1, num_deal_grid,
-                     0);
+
+  __bang_mul(nram_offset3, nram_offset3, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset3, nram_offset3, mask4, num_deal_grid);
   __bang_float2int32((int32_t *)nram_offset3, nram_offset3, num_deal_grid, 0);
-  __bang_mul((int32_t *)nram_offset3, (int32_t *)nram_offset3,
-             (int32_t *)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t *)nram_offset3, (int32_t *)nram_offset3, (int32_t *)mask4,
-             num_deal_grid);
 
   __bang_int322float((float *)nram_offset4, (int32_t *)nram_offset4,
                      num_deal_grid, 0);
   __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset4, 0,
                    num_deal_grid);
-  __bang_float2int32((int32_t *)grad_temp1, grad_temp1, num_deal_grid, 0);
-  __bang_float2int32((int32_t *)nram_offset4, nram_offset4, num_deal_grid, 0);
-  __bang_mul((int32_t *)nram_offset4, (int32_t *)nram_offset4,
-             (int32_t *)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t *)nram_offset4, (int32_t *)nram_offset4, (int32_t *)mask3,
-             num_deal_grid);
-  __sync_io_move_compute();
-  __bang_int322float((float *)nram_h_low, (int32_t *)nram_h_low, num_deal_grid,
-                     0);
-  __bang_int322float((float *)nram_w_low, (int32_t *)nram_w_low, num_deal_grid,
-                     0);
-  __bang_sub((float *)nram_lh, (float *)nram_loc_h, (float *)nram_h_low,
-             num_deal_grid);
-  __bang_sub((float *)nram_lw, (float *)nram_loc_w, (float *)nram_w_low,
-             num_deal_grid);
-  __bang_int322float(mask1, (int32_t *)mask1, num_deal_grid, 0);
-  __bang_int322float(mask2, (int32_t *)mask2, num_deal_grid, 0);
-  __bang_int322float(mask3, (int32_t *)mask3, num_deal_grid, 0);
-  __bang_int322float(mask4, (int32_t *)mask4, num_deal_grid, 0);
 
-  __bang_int322float(nram_h_high_temp, (int32_t *)nram_h_high_temp,
-                     num_deal_grid, 0);
-  __bang_fusion(FUSION_FMA, nram_hh, nram_lh, (float)(-1), 1, num_deal_grid);
-  __bang_fusion(FUSION_FMA, nram_hw, nram_lw, (float)(-1), 1, num_deal_grid);
+  __bang_mul(nram_offset4, nram_offset4, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset4, nram_offset4, mask3, num_deal_grid);
+  __bang_float2int32((int32_t *)nram_offset4, nram_offset4, num_deal_grid, 0);
+  __sync_io_move_compute();
 
   __bang_mul(nram_w1, nram_hh, nram_hw, num_deal_grid);
   __bang_mul(nram_w2, nram_hh, nram_lw, num_deal_grid);

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -53,203 +53,244 @@ void __mlu_func__ computeGridMaskAndOffset(
   __bang_transpose(nram_loc_h, nram_grad_output_tl + num_deal_grid,
                    num_per_time_real * num_heads * num_levels, num_points);
 
-  __bang_transpose((int32_t*)nram_grad_output_tr, (int32_t *)nram_spatial_shapes,
-                   num_levels, 2);
-  __bang_mul_scalar((int32_t*)nram_h_stride, (int32_t*)((int32_t*)nram_grad_output_tr + num_levels), w_stride,
-                    num_levels);
-                 
-  __memcpy_async((int32_t*)nram_spatial_shapes, (int32_t*)nram_grad_output_tr,
+  __bang_transpose((int32_t *)nram_grad_output_tr,
+                   (int32_t *)nram_spatial_shapes, num_levels, 2);
+  __bang_mul_scalar((int32_t *)nram_h_stride,
+                    (int32_t *)((int32_t *)nram_grad_output_tr + num_levels),
+                    w_stride, num_levels);
+
+  __memcpy_async((int32_t *)nram_spatial_shapes, (int32_t *)nram_grad_output_tr,
                  num_levels * 2 * sizeof(int32_t), NRAM2NRAM);
-__bang_int322float((float *)nram_spatial_shapes,
-                      (int32_t *)nram_spatial_shapes, num_levels * 2, 0);
+  __bang_int322float((float *)nram_spatial_shapes,
+                     (int32_t *)nram_spatial_shapes, num_levels * 2, 0);
   __bang_cycle_mul((float *)nram_loc_w, (float *)nram_loc_w,
                    (float *)(nram_spatial_shapes + num_levels), num_deal_grid,
                    num_levels);
-  __bang_cycle_mul((float *)nram_loc_h, (float *)nram_loc_h, (float *)(nram_spatial_shapes),
-                   num_deal_grid, num_levels);
-  __bang_sub_scalar((float *)nram_loc_w, (float *)nram_loc_w, 0.5, num_deal_grid);
-  __bang_sub_scalar((float *)nram_loc_h, (float *)nram_loc_h, 0.5, num_deal_grid);
+  __bang_cycle_mul((float *)nram_loc_h, (float *)nram_loc_h,
+                   (float *)(nram_spatial_shapes), num_deal_grid, num_levels);
+  __bang_sub_scalar((float *)nram_loc_w, (float *)nram_loc_w, 0.5,
+                    num_deal_grid);
+  __bang_sub_scalar((float *)nram_loc_h, (float *)nram_loc_h, 0.5,
+                    num_deal_grid);
 
   // get mask. (h_im > -1 && w_im > -1 && h_im < spatial_h && w_im < spatial_w)
   __bang_cycle_lt((float *)nram_w_low_temp, (float *)nram_loc_w,
                   (float *)(nram_spatial_shapes + num_levels), num_deal_grid,
                   num_levels);
-  __bang_cycle_lt((float *)nram_h_high_temp, (float *)nram_loc_h, (float *)(nram_spatial_shapes),
-                  num_deal_grid, num_levels);
+  __bang_cycle_lt((float *)nram_h_high_temp, (float *)nram_loc_h,
+                  (float *)(nram_spatial_shapes), num_deal_grid, num_levels);
 
-  __bang_and((float *)nram_w_low_temp, (float *)nram_w_low_temp, (float *)nram_h_high_temp, num_deal_grid);
-  __bang_gt_scalar((float *)nram_h_high_temp, (float *)nram_loc_h, -1, num_deal_grid);
-  __bang_and((float *)nram_h_high_temp,(float *) nram_h_high_temp, (float *)nram_w_low_temp,
-             num_deal_grid);
-  __bang_gt_scalar((float *)nram_w_low_temp, (float *)nram_loc_w, -1, num_deal_grid);
-  __bang_and((float *)nram_h_high_temp, (float *)nram_h_high_temp, (float *)nram_w_low_temp,
-             num_deal_grid);
+  __bang_and((float *)nram_w_low_temp, (float *)nram_w_low_temp,
+             (float *)nram_h_high_temp, num_deal_grid);
+  __bang_gt_scalar((float *)nram_h_high_temp, (float *)nram_loc_h, -1,
+                   num_deal_grid);
+  __bang_and((float *)nram_h_high_temp, (float *)nram_h_high_temp,
+             (float *)nram_w_low_temp, num_deal_grid);
+  __bang_gt_scalar((float *)nram_w_low_temp, (float *)nram_loc_w, -1,
+                   num_deal_grid);
+  __bang_and((float *)nram_h_high_temp, (float *)nram_h_high_temp,
+             (float *)nram_w_low_temp, num_deal_grid);
 
-  __bang_transpose((float *)nram_w_low_temp, (float *)nram_h_high_temp, num_points,
-                   num_per_time_real * num_heads * num_levels);
+  __bang_transpose((float *)nram_w_low_temp, (float *)nram_h_high_temp,
+                   num_points, num_per_time_real * num_heads * num_levels);
   __memcpy_async((float *)nram_h_high_temp, (float *)nram_w_low_temp,
                  num_deal_grid * sizeof(float), NRAM2NRAM);
 
-  __bang_transpose((float *)nram_grad_output_tl,(float *)nram_loc_w, num_points,
-                   num_per_time_real * num_heads * num_levels);
-  __memcpy_async((float *)nram_loc_w, (float *)nram_grad_output_tl, num_deal_grid * sizeof(float),
-                 NRAM2NRAM);
-  __bang_transpose((float *)nram_grad_output_tl, (float *)nram_loc_h, num_points,
-                   num_per_time_real * num_heads * num_levels);
-  __memcpy_async((float *)nram_loc_h, (float *)nram_grad_output_tl, num_deal_grid * sizeof(float),
-                 NRAM2NRAM);
-
+  __bang_transpose((float *)nram_grad_output_tl, (float *)nram_loc_w,
+                   num_points, num_per_time_real * num_heads * num_levels);
+  __memcpy_async((float *)nram_loc_w, (float *)nram_grad_output_tl,
+                 num_deal_grid * sizeof(float), NRAM2NRAM);
+  __bang_transpose((float *)nram_grad_output_tl, (float *)nram_loc_h,
+                   num_points, num_per_time_real * num_heads * num_levels);
+  __memcpy_async((float *)nram_loc_h, (float *)nram_grad_output_tl,
+                 num_deal_grid * sizeof(float), NRAM2NRAM);
 
   __bang_floor(nram_w_low, nram_loc_w, num_deal_grid);
   __bang_floor(nram_h_low, nram_loc_h, num_deal_grid);
-  __bang_float2int32((int32_t*)nram_w_low,nram_w_low, num_deal_grid, 0);
-  __bang_float2int32((int32_t*)nram_h_low,nram_h_low, num_deal_grid, 0);
+  __bang_float2int32((int32_t *)nram_w_low, nram_w_low, num_deal_grid, 0);
+  __bang_float2int32((int32_t *)nram_h_low, nram_h_low, num_deal_grid, 0);
 
-  __bang_add_scalar((int32_t*)nram_h_high, (int32_t*)nram_h_low, 1, num_deal_grid);
-  __bang_add_scalar((int32_t*)nram_w_high, (int32_t*)nram_w_low, 1, num_deal_grid);
+  __bang_add_scalar((int32_t *)nram_h_high, (int32_t *)nram_h_low, 1,
+                    num_deal_grid);
+  __bang_add_scalar((int32_t *)nram_w_high, (int32_t *)nram_w_low, 1,
+                    num_deal_grid);
 
-  __bang_transpose((int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_h_low,
+  __bang_transpose((int32_t *)nram_h_low_ptr_offset, (int32_t *)nram_h_low,
                    num_per_time_real * num_heads * num_levels, num_points);
-  __bang_cycle_mul((int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_h_low_ptr_offset, 
-  (int32_t*)nram_h_stride, num_deal_grid, num_levels);
-  __bang_cycle_add((int32_t*)nram_h_high_ptr_offset, (int32_t*)nram_h_low_ptr_offset, 
-  (int32_t*)nram_h_stride,
+  __bang_cycle_mul((int32_t *)nram_h_low_ptr_offset,
+                   (int32_t *)nram_h_low_ptr_offset, (int32_t *)nram_h_stride,
+                   num_deal_grid, num_levels);
+  __bang_cycle_add((int32_t *)nram_h_high_ptr_offset,
+                   (int32_t *)nram_h_low_ptr_offset, (int32_t *)nram_h_stride,
                    num_deal_grid, num_levels);
 
-  __bang_transpose((int32_t*)nram_w_low_ptr_offset, (int32_t*)nram_h_low_ptr_offset, num_points,
+  __bang_transpose((int32_t *)nram_w_low_ptr_offset,
+                   (int32_t *)nram_h_low_ptr_offset, num_points,
                    num_per_time_real * num_heads * num_levels);
 
-  __memcpy_async((int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_w_low_ptr_offset,
+  __memcpy_async((int32_t *)nram_h_low_ptr_offset,
+                 (int32_t *)nram_w_low_ptr_offset,
                  num_deal_grid * sizeof(int32_t), NRAM2NRAM);
-  __bang_transpose((int32_t*)nram_w_low_ptr_offset, (int32_t*)nram_h_high_ptr_offset, num_points,
+  __bang_transpose((int32_t *)nram_w_low_ptr_offset,
+                   (int32_t *)nram_h_high_ptr_offset, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __memcpy_async((int32_t*)nram_h_high_ptr_offset, (int32_t*)nram_w_low_ptr_offset,
+  __memcpy_async((int32_t *)nram_h_high_ptr_offset,
+                 (int32_t *)nram_w_low_ptr_offset,
                  num_deal_grid * sizeof(int32_t), NRAM2NRAM);
-  __bang_mul_scalar((int32_t*)nram_w_low_ptr_offset, (int32_t*)nram_w_low, qid_stride,
+  __bang_mul_scalar((int32_t *)nram_w_low_ptr_offset, (int32_t *)nram_w_low,
+                    qid_stride, num_deal_grid);
+  __bang_add_scalar((int32_t *)nram_w_high_ptr_offset,
+                    (int32_t *)nram_w_low_ptr_offset, qid_stride,
                     num_deal_grid);
-  __bang_add_scalar((int32_t*)nram_w_high_ptr_offset, (int32_t*)nram_w_low_ptr_offset, qid_stride,
-                    num_deal_grid);
-               
-  __bang_add((int32_t*)nram_offset1, (int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_w_low_ptr_offset,
-             num_deal_grid);
 
-  __bang_transpose((int32_t*)nram_offset_temp,(int32_t*) nram_offset1,
-                   num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, (int32_t*)nram_base_ptr,
-                   num_deal_grid, num_heads);
+  __bang_add((int32_t *)nram_offset1, (int32_t *)nram_h_low_ptr_offset,
+             (int32_t *)nram_w_low_ptr_offset, num_deal_grid);
 
-  __bang_transpose((int32_t*)nram_offset1, (int32_t*)nram_offset_temp, num_levels * num_points,
-                   num_per_time_real * num_heads);
+  __bang_transpose((int32_t *)nram_offset_temp, (int32_t *)nram_offset1,
+                   num_per_time_real * num_heads, num_levels * num_points);
+  __bang_cycle_add((int32_t *)nram_offset_temp, (int32_t *)nram_offset_temp,
+                   (int32_t *)nram_base_ptr, num_deal_grid, num_heads);
 
-  __bang_add((int32_t*)nram_offset2, (int32_t*)nram_h_low_ptr_offset,
-   (int32_t*)nram_w_high_ptr_offset,
-             num_deal_grid);
-  __bang_transpose((int32_t*)nram_offset_temp, (int32_t*)nram_offset2,
-                   num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, 
-  (int32_t*)nram_base_ptr,
-                   num_deal_grid, num_heads);
-  __bang_transpose((int32_t*)nram_offset2, (int32_t*)nram_offset_temp, num_levels * num_points,
-                   num_per_time_real * num_heads);
+  __bang_transpose((int32_t *)nram_offset1, (int32_t *)nram_offset_temp,
+                   num_levels * num_points, num_per_time_real * num_heads);
 
-  __bang_add((int32_t*)nram_offset3, (int32_t*)nram_h_high_ptr_offset, 
-  (int32_t*)nram_w_low_ptr_offset,
-             num_deal_grid);
-  __bang_transpose((int32_t*)nram_offset_temp, (int32_t*)nram_offset3,
+  __bang_add((int32_t *)nram_offset2, (int32_t *)nram_h_low_ptr_offset,
+             (int32_t *)nram_w_high_ptr_offset, num_deal_grid);
+  __bang_transpose((int32_t *)nram_offset_temp, (int32_t *)nram_offset2,
                    num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, (int32_t*)nram_base_ptr,
-                   num_deal_grid, num_heads);
-  __bang_transpose((int32_t*)nram_offset3, (int32_t*)nram_offset_temp, num_levels * num_points,
-                   num_per_time_real * num_heads);
-  __bang_add((int32_t*)nram_offset4, (int32_t*)nram_h_high_ptr_offset, (int32_t*)nram_w_high_ptr_offset,
-             num_deal_grid);
-  __bang_transpose((int32_t*)nram_offset_temp, (int32_t*)nram_offset4,
+  __bang_cycle_add((int32_t *)nram_offset_temp, (int32_t *)nram_offset_temp,
+                   (int32_t *)nram_base_ptr, num_deal_grid, num_heads);
+  __bang_transpose((int32_t *)nram_offset2, (int32_t *)nram_offset_temp,
+                   num_levels * num_points, num_per_time_real * num_heads);
+
+  __bang_add((int32_t *)nram_offset3, (int32_t *)nram_h_high_ptr_offset,
+             (int32_t *)nram_w_low_ptr_offset, num_deal_grid);
+  __bang_transpose((int32_t *)nram_offset_temp, (int32_t *)nram_offset3,
                    num_per_time_real * num_heads, num_levels * num_points);
-  __bang_cycle_add((int32_t*)nram_offset_temp, (int32_t*)nram_offset_temp, (int32_t*)nram_base_ptr,
-                   num_deal_grid, num_heads);
-  __bang_transpose((int32_t*)nram_offset4, (int32_t*)nram_offset_temp, num_levels * num_points,
-                   num_per_time_real * num_heads);
+  __bang_cycle_add((int32_t *)nram_offset_temp, (int32_t *)nram_offset_temp,
+                   (int32_t *)nram_base_ptr, num_deal_grid, num_heads);
+  __bang_transpose((int32_t *)nram_offset3, (int32_t *)nram_offset_temp,
+                   num_levels * num_points, num_per_time_real * num_heads);
+  __bang_add((int32_t *)nram_offset4, (int32_t *)nram_h_high_ptr_offset,
+             (int32_t *)nram_w_high_ptr_offset, num_deal_grid);
+  __bang_transpose((int32_t *)nram_offset_temp, (int32_t *)nram_offset4,
+                   num_per_time_real * num_heads, num_levels * num_points);
+  __bang_cycle_add((int32_t *)nram_offset_temp, (int32_t *)nram_offset_temp,
+                   (int32_t *)nram_base_ptr, num_deal_grid, num_heads);
+  __bang_transpose((int32_t *)nram_offset4, (int32_t *)nram_offset_temp,
+                   num_levels * num_points, num_per_time_real * num_heads);
 
   // h_low >= 0 && w_low >= 0  mask2
   float *mask1 = nram_h_low_ptr_offset;
   float *mask2 = nram_h_high_ptr_offset;
   float *mask3 = nram_w_low_ptr_offset;
   float *mask4 = nram_w_high_ptr_offset;
-  __bang_ge_scalar((int32_t*)mask1, (int32_t*)nram_h_low, 0, num_deal_grid);
-  __bang_ge_scalar((int32_t*)mask2, (int32_t*)nram_w_low, 0, num_deal_grid);
-  __bang_and((int32_t*)mask2, (int32_t*)mask1, (int32_t*)mask2, num_deal_grid);
-  __bang_float2int32((int32_t*)nram_h_high_temp,nram_h_high_temp,num_deal_grid, 0);
-  __bang_and((int32_t*)mask2, (int32_t*)nram_h_high_temp, (int32_t*)mask2, num_deal_grid);
+  __bang_ge_scalar((int32_t *)mask1, (int32_t *)nram_h_low, 0, num_deal_grid);
+  __bang_ge_scalar((int32_t *)mask2, (int32_t *)nram_w_low, 0, num_deal_grid);
+  __bang_and((int32_t *)mask2, (int32_t *)mask1, (int32_t *)mask2,
+             num_deal_grid);
+  __bang_float2int32((int32_t *)nram_h_high_temp, nram_h_high_temp,
+                     num_deal_grid, 0);
+  __bang_and((int32_t *)mask2, (int32_t *)nram_h_high_temp, (int32_t *)mask2,
+             num_deal_grid);
 
   // h_low >= 0 && w_high <= width - 1 mask1
-  __bang_transpose((int32_t*)mask3, (int32_t*)nram_w_high,
+  __bang_transpose((int32_t *)mask3, (int32_t *)nram_w_high,
                    num_per_time_real * num_heads * num_levels, num_points);
-                
+
   __bang_sub_scalar((float *)nram_spatial_shapes, (float *)nram_spatial_shapes,
                     1, num_levels * 2);
-  __bang_int322float((float *)mask3, (int32_t*)mask3, num_deal_grid, 0);            
-  __bang_cycle_le((float *)mask3, (float *)mask3, (float *)(nram_spatial_shapes + num_levels),
-                  num_deal_grid, num_levels); // 仅float
-   __bang_float2int32((int32_t*)mask3, (float *)mask3,num_deal_grid , 0);                   
-  __bang_transpose((int32_t*)mask4, (int32_t*)mask3, num_points,
+  __bang_int322float((float *)mask3, (int32_t *)mask3, num_deal_grid, 0);
+  __bang_cycle_le((float *)mask3, (float *)mask3,
+                  (float *)(nram_spatial_shapes + num_levels), num_deal_grid,
+                  num_levels);  // 仅float
+  __bang_float2int32((int32_t *)mask3, (float *)mask3, num_deal_grid, 0);
+  __bang_transpose((int32_t *)mask4, (int32_t *)mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __bang_and((int32_t*)mask1, (int32_t*)mask1, (int32_t*)mask4, num_deal_grid);
-  __bang_and((int32_t*)mask1, (int32_t*)nram_h_high_temp, (int32_t*)mask1, num_deal_grid);
+  __bang_and((int32_t *)mask1, (int32_t *)mask1, (int32_t *)mask4,
+             num_deal_grid);
+  __bang_and((int32_t *)mask1, (int32_t *)nram_h_high_temp, (int32_t *)mask1,
+             num_deal_grid);
 
   // h_high <= height - 1 && w_high <= width - 1 mask3
-  __bang_transpose((int32_t*)mask3, (int32_t*)nram_h_high,
+  __bang_transpose((int32_t *)mask3, (int32_t *)nram_h_high,
                    num_per_time_real * num_heads * num_levels, num_points);
-   __bang_int322float((float *)mask3, (int32_t*)mask3, num_deal_grid, 0);                
-  __bang_cycle_le((float *)mask3, (float *)mask3, (float *)(nram_spatial_shapes), num_deal_grid,
-                  num_levels);
-    __bang_float2int32((int32_t*)mask3, (float *)mask3, num_deal_grid, 0);                 
-  __bang_transpose((int32_t*)nram_h_low_temp, (int32_t*)mask3, num_points,
+  __bang_int322float((float *)mask3, (int32_t *)mask3, num_deal_grid, 0);
+  __bang_cycle_le((float *)mask3, (float *)mask3,
+                  (float *)(nram_spatial_shapes), num_deal_grid, num_levels);
+  __bang_float2int32((int32_t *)mask3, (float *)mask3, num_deal_grid, 0);
+  __bang_transpose((int32_t *)nram_h_low_temp, (int32_t *)mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
-  __bang_and((int32_t*)mask4, (int32_t*)mask4, (int32_t*)nram_h_low_temp, num_deal_grid);
-  __bang_and((int32_t*)mask3, (int32_t*)mask4, (int32_t*)nram_h_high_temp, num_deal_grid);
+  __bang_and((int32_t *)mask4, (int32_t *)mask4, (int32_t *)nram_h_low_temp,
+             num_deal_grid);
+  __bang_and((int32_t *)mask3, (int32_t *)mask4, (int32_t *)nram_h_high_temp,
+             num_deal_grid);
 
   // h_high <= height - 1 && w_low >= 0 mask4
-  __bang_ge_scalar((int32_t*)nram_w_low_temp, (int32_t*)nram_w_low, 0, num_deal_grid); // 仅float
-  __bang_and((int32_t*)mask4, (int32_t*)nram_h_low_temp, (int32_t*)nram_w_low_temp, num_deal_grid);
-  __bang_and((int32_t*)mask4, (int32_t*)mask4, (int32_t*)nram_h_high_temp, num_deal_grid);
- __bang_int322float(nram_offset1,(int32_t*)nram_offset1, num_deal_grid , 0);
+  __bang_ge_scalar((int32_t *)nram_w_low_temp, (int32_t *)nram_w_low, 0,
+                   num_deal_grid);  // 仅float
+  __bang_and((int32_t *)mask4, (int32_t *)nram_h_low_temp,
+             (int32_t *)nram_w_low_temp, num_deal_grid);
+  __bang_and((int32_t *)mask4, (int32_t *)mask4, (int32_t *)nram_h_high_temp,
+             num_deal_grid);
+  __bang_int322float(nram_offset1, (int32_t *)nram_offset1, num_deal_grid, 0);
   __bang_gt_scalar(grad_temp1, nram_offset1, 0, num_deal_grid);
-  __bang_float2int32((int32_t*)grad_temp1, grad_temp1, num_deal_grid, 0);
-   __bang_float2int32((int32_t*)nram_offset1,nram_offset1, num_deal_grid , 0);    
-  __bang_mul((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)mask2, num_deal_grid);
+  __bang_float2int32((int32_t *)grad_temp1, grad_temp1, num_deal_grid, 0);
+  __bang_float2int32((int32_t *)nram_offset1, nram_offset1, num_deal_grid, 0);
+  __bang_mul((int32_t *)nram_offset1, (int32_t *)nram_offset1,
+             (int32_t *)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t *)nram_offset1, (int32_t *)nram_offset1, (int32_t *)mask2,
+             num_deal_grid);
 
- __bang_int322float((float *)nram_offset2,(int32_t*)nram_offset2, num_deal_grid , 0);
-  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset2, 0, num_deal_grid);
-  __bang_float2int32((int32_t*)grad_temp1, grad_temp1, num_deal_grid, 0); 
-  __bang_float2int32((int32_t*)nram_offset2,nram_offset2, num_deal_grid , 0); 
-  __bang_mul((int32_t*)nram_offset2,(int32_t*) nram_offset2, (int32_t*)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t*)nram_offset2, (int32_t*)nram_offset2,(int32_t*) mask1, num_deal_grid);
+  __bang_int322float((float *)nram_offset2, (int32_t *)nram_offset2,
+                     num_deal_grid, 0);
+  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset2, 0,
+                   num_deal_grid);
+  __bang_float2int32((int32_t *)grad_temp1, grad_temp1, num_deal_grid, 0);
+  __bang_float2int32((int32_t *)nram_offset2, nram_offset2, num_deal_grid, 0);
+  __bang_mul((int32_t *)nram_offset2, (int32_t *)nram_offset2,
+             (int32_t *)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t *)nram_offset2, (int32_t *)nram_offset2, (int32_t *)mask1,
+             num_deal_grid);
 
- __bang_int322float((float *)nram_offset3,(int32_t*)nram_offset3, num_deal_grid , 0);
-  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset3, 0, num_deal_grid);
-    __bang_float2int32((int32_t*)grad_temp1, (float *)grad_temp1, num_deal_grid, 0); 
-    __bang_float2int32((int32_t*)nram_offset3,nram_offset3, num_deal_grid , 0); 
-  __bang_mul((int32_t*)nram_offset3, (int32_t*)nram_offset3, (int32_t*)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t*)nram_offset3, (int32_t*)nram_offset3,(int32_t*) mask4, num_deal_grid);
+  __bang_int322float((float *)nram_offset3, (int32_t *)nram_offset3,
+                     num_deal_grid, 0);
+  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset3, 0,
+                   num_deal_grid);
+  __bang_float2int32((int32_t *)grad_temp1, (float *)grad_temp1, num_deal_grid,
+                     0);
+  __bang_float2int32((int32_t *)nram_offset3, nram_offset3, num_deal_grid, 0);
+  __bang_mul((int32_t *)nram_offset3, (int32_t *)nram_offset3,
+             (int32_t *)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t *)nram_offset3, (int32_t *)nram_offset3, (int32_t *)mask4,
+             num_deal_grid);
 
- __bang_int322float((float *)nram_offset4,(int32_t*)nram_offset4, num_deal_grid , 0);
-  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset4, 0, num_deal_grid);
-  __bang_float2int32((int32_t*)grad_temp1, grad_temp1, num_deal_grid, 0); 
-  __bang_float2int32((int32_t*)nram_offset4,nram_offset4, num_deal_grid , 0); 
-  __bang_mul((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)grad_temp1, num_deal_grid);
-  __bang_mul((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)mask3, num_deal_grid);
+  __bang_int322float((float *)nram_offset4, (int32_t *)nram_offset4,
+                     num_deal_grid, 0);
+  __bang_gt_scalar((float *)grad_temp1, (float *)nram_offset4, 0,
+                   num_deal_grid);
+  __bang_float2int32((int32_t *)grad_temp1, grad_temp1, num_deal_grid, 0);
+  __bang_float2int32((int32_t *)nram_offset4, nram_offset4, num_deal_grid, 0);
+  __bang_mul((int32_t *)nram_offset4, (int32_t *)nram_offset4,
+             (int32_t *)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t *)nram_offset4, (int32_t *)nram_offset4, (int32_t *)mask3,
+             num_deal_grid);
   __sync_io_move_compute();
-  __bang_int322float((float*)nram_h_low, (int32_t*)nram_h_low,num_deal_grid ,0);
-  __bang_int322float((float*)nram_w_low, (int32_t*)nram_w_low,num_deal_grid, 0);
-  __bang_sub((float*)nram_lh, (float*)nram_loc_h, (float*)nram_h_low, num_deal_grid);
-  __bang_sub((float*)nram_lw, (float*)nram_loc_w, (float*)nram_w_low, num_deal_grid);
-  __bang_int322float(mask1, (int32_t*)mask1, num_deal_grid, 0);
-  __bang_int322float(mask2, (int32_t*)mask2, num_deal_grid, 0);
-  __bang_int322float(mask3, (int32_t*)mask3, num_deal_grid, 0);
-  __bang_int322float(mask4, (int32_t*)mask4, num_deal_grid, 0);
+  __bang_int322float((float *)nram_h_low, (int32_t *)nram_h_low, num_deal_grid,
+                     0);
+  __bang_int322float((float *)nram_w_low, (int32_t *)nram_w_low, num_deal_grid,
+                     0);
+  __bang_sub((float *)nram_lh, (float *)nram_loc_h, (float *)nram_h_low,
+             num_deal_grid);
+  __bang_sub((float *)nram_lw, (float *)nram_loc_w, (float *)nram_w_low,
+             num_deal_grid);
+  __bang_int322float(mask1, (int32_t *)mask1, num_deal_grid, 0);
+  __bang_int322float(mask2, (int32_t *)mask2, num_deal_grid, 0);
+  __bang_int322float(mask3, (int32_t *)mask3, num_deal_grid, 0);
+  __bang_int322float(mask4, (int32_t *)mask4, num_deal_grid, 0);
 
-  __bang_int322float(nram_h_high_temp, (int32_t*)nram_h_high_temp, num_deal_grid, 0);
+  __bang_int322float(nram_h_high_temp, (int32_t *)nram_h_high_temp,
+                     num_deal_grid, 0);
   __bang_fusion(FUSION_FMA, nram_hh, nram_lh, (float)(-1), 1, num_deal_grid);
   __bang_fusion(FUSION_FMA, nram_hw, nram_lw, (float)(-1), 1, num_deal_grid);
 
@@ -282,17 +323,19 @@ void __mlu_func__ loadValue(
     int32_t level_start_id = nram_level_start_index[l_col];
     value_offset_temp =
         b_col * spatial_size * qid_stride + level_start_id * qid_stride;
-    ((float *)grad_temp1)[i] = value_offset_temp;
+    ((int32_t *)grad_temp1)[i] = value_offset_temp;
   }
 
-  __bang_add(grad_temp3, grad_temp1, nram_offset1, num_deal_grid);
-  __bang_add(grad_temp3 + num_deal_grid, grad_temp1, nram_offset2,
-             num_deal_grid);
-  __bang_add(grad_temp3 + 2 * num_deal_grid, grad_temp1, nram_offset3,
-             num_deal_grid);
-  __bang_add(grad_temp3 + 3 * num_deal_grid, grad_temp1, nram_offset4,
-             num_deal_grid);
-  __bang_mul_scalar(grad_temp3, grad_temp3, sizeof(float), 4 * num_deal_grid);
+  __bang_add((int32_t *)grad_temp3, (int32_t *)grad_temp1,
+             (int32_t *)nram_offset1, num_deal_grid);
+  __bang_add((int32_t *)(grad_temp3 + num_deal_grid), (int32_t *)grad_temp1,
+             (int32_t *)nram_offset2, num_deal_grid);
+  __bang_add((int32_t *)(grad_temp3 + 2 * num_deal_grid), (int32_t *)grad_temp1,
+             (int32_t *)nram_offset3, num_deal_grid);
+  __bang_add((int32_t *)(grad_temp3 + 3 * num_deal_grid), (int32_t *)grad_temp1,
+             (int32_t *)nram_offset4, num_deal_grid);
+  __bang_mul_scalar((int32_t *)grad_temp3, (int32_t *)grad_temp3,
+                    sizeof(int32_t), 4 * num_deal_grid);
   __bang_float2int32((int32_t *)(grad_temp3), (grad_temp3), 4 * num_deal_grid,
                      0);
   __sync_io_move_compute();
@@ -325,28 +368,31 @@ void __mlu_func__ loadValue(
   value_offset_temp =
       b_col * spatial_size * qid_stride + level_start_id * qid_stride;
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    __memcpy_async(
-        (void *)(nram_grad_output_tl + loop * deal_num_real),
-        (void *)(data_value + value_offset_temp + int32_t(((int32_t*)nram_offset1)[loop])),
-        deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
-        (int32_t(((int32_t*)nram_offset2)[loop]) - int32_t(((int32_t*)nram_offset1)[loop])) *
-            sizeof(float),
-        1);
+    __memcpy_async((void *)(nram_grad_output_tl + loop * deal_num_real),
+                   (void *)(data_value + value_offset_temp +
+                            int32_t(((int32_t *)nram_offset1)[loop])),
+                   deal_num_real * sizeof(float), GDRAM2NRAM,
+                   offset_nram * sizeof(float),
+                   (int32_t(((int32_t *)nram_offset2)[loop]) -
+                    int32_t(((int32_t *)nram_offset1)[loop])) *
+                       sizeof(float),
+                   1);
     b_col = (grid_offset + loop + 1) / num_query / num_heads / num_levels /
             num_points;
     l_col = (grid_offset + loop + 1) / num_points % num_levels;
     level_start_id = nram_level_start_index[l_col];
 
-    __memcpy_async(
-        (void *)(nram_grad_output_bl + loop * deal_num_real),
-        (void *)(data_value + value_offset_temp + int32_t(((int32_t*)nram_offset3)[loop])),
-        deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
-        (int32_t(((int32_t*)nram_offset4)[loop]) - int32_t(((int32_t*)nram_offset3)[loop])) *
-            sizeof(float),
-        1);
+    __memcpy_async((void *)(nram_grad_output_bl + loop * deal_num_real),
+                   (void *)(data_value + value_offset_temp +
+                            int32_t(((int32_t *)nram_offset3)[loop])),
+                   deal_num_real * sizeof(float), GDRAM2NRAM,
+                   offset_nram * sizeof(float),
+                   (int32_t(((int32_t *)nram_offset4)[loop]) -
+                    int32_t(((int32_t *)nram_offset3)[loop])) *
+                       sizeof(float),
+                   1);
     value_offset_temp =
         b_col * spatial_size * qid_stride + level_start_id * qid_stride;
-       
   }
 #endif
   __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
@@ -400,10 +446,9 @@ void __mlu_func__ loadValue(
                  num_deal_grid * deal_num_real, 64);
   __bang_band((char *)nram_grad_output_br, (char *)nram_grad_output_br,
               (char *)grad_temp3,
-              num_deal_grid * deal_num_real * sizeof(float));         
+              num_deal_grid * deal_num_real * sizeof(float));
 #endif
 }
-
 
 void __mlu_func__ computeGradValue(
     float *grad_temp1, float *grad_temp2, float *grad_temp3, float *grad_temp4,
@@ -436,56 +481,61 @@ void __mlu_func__ computeGradValue(
 
   int32_t temp_res = num_query * num_heads * num_levels * num_points;
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    ((int32_t*)nram_grid_offset1)[loop] = ((loop + grid_offset) / temp_res);
+    ((int32_t *)nram_grid_offset1)[loop] = ((loop + grid_offset) / temp_res);
   }
-  //__bang_float2int32((int32_t*)nram_grid_offset1, nram_grid_offset1,num_deal_grid, 0 );
-  __bang_mul_scalar((int32_t*)nram_grid_offset1, (int32_t*)nram_grid_offset1,
+  __bang_mul_scalar((int32_t *)nram_grid_offset1, (int32_t *)nram_grid_offset1,
                     spatial_size * qid_stride, num_deal_grid);
-  __bang_transpose((int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset1,
+  __bang_transpose((int32_t *)nram_grid_offset2, (int32_t *)nram_grid_offset1,
                    num_per_time_real * num_heads * num_levels, num_points);
-  //  __bang_int322float((float *)nram_level_start_index, nram_level_start_index,
-  //                     num_levels, 0);
-  __bang_mul_scalar((int32_t*)nram_grid_offset1,(int32_t*)nram_level_start_index,
-                    qid_stride, num_levels);
-  __bang_cycle_add((int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset1,
-                   num_deal_grid, num_levels);
-  __bang_transpose((int32_t*)nram_grid_offset1, (int32_t*)nram_grid_offset2, num_points,
-                   num_per_time_real * num_heads * num_levels);
-                          
-   __bang_add((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)nram_grid_offset1, num_deal_grid);
-  __bang_add((int32_t*)nram_offset2, (int32_t*)nram_offset2, (int32_t*)nram_grid_offset1, num_deal_grid);
-  __bang_add((int32_t*)nram_offset3, (int32_t*)nram_offset3, (int32_t*)nram_grid_offset1, num_deal_grid);
-  __bang_add((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)nram_grid_offset1, num_deal_grid);
+
+  __bang_mul_scalar((int32_t *)nram_grid_offset1,
+                    (int32_t *)nram_level_start_index, qid_stride, num_levels);
+  __bang_cycle_add((int32_t *)nram_grid_offset2, (int32_t *)nram_grid_offset2,
+                   (int32_t *)nram_grid_offset1, num_deal_grid, num_levels);
+  __bang_transpose((int32_t *)nram_grid_offset1, (int32_t *)nram_grid_offset2,
+                   num_points, num_per_time_real * num_heads * num_levels);
+
+  __bang_add((int32_t *)nram_offset1, (int32_t *)nram_offset1,
+             (int32_t *)nram_grid_offset1, num_deal_grid);
+  __bang_add((int32_t *)nram_offset2, (int32_t *)nram_offset2,
+             (int32_t *)nram_grid_offset1, num_deal_grid);
+  __bang_add((int32_t *)nram_offset3, (int32_t *)nram_offset3,
+             (int32_t *)nram_grid_offset1, num_deal_grid);
+  __bang_add((int32_t *)nram_offset4, (int32_t *)nram_offset4,
+             (int32_t *)nram_grid_offset1, num_deal_grid);
 
 #if __BANG_ARCH__ >= 592
   // make sure offset not great than (batch * spatial_size * num_heads *
   // channels)
-  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset1,
+  __bang_lt_scalar((int32_t *)grad_temp1, (int32_t *)nram_offset1,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)grad_temp1, num_deal_grid);
-  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset2,
+  __bang_mul((int32_t *)nram_offset1, (int32_t *)nram_offset1,
+             (int32_t *)grad_temp1, num_deal_grid);
+  __bang_lt_scalar((int32_t *)grad_temp1, (int32_t *)nram_offset2,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul((int32_t*)nram_offset2, (int32_t*)nram_offset2, (int32_t*)grad_temp1, num_deal_grid);
-  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset3,
+  __bang_mul((int32_t *)nram_offset2, (int32_t *)nram_offset2,
+             (int32_t *)grad_temp1, num_deal_grid);
+  __bang_lt_scalar((int32_t *)grad_temp1, (int32_t *)nram_offset3,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul((int32_t*)nram_offset3, (int32_t*)nram_offset3, (int32_t*)grad_temp1, num_deal_grid);
-  __bang_lt_scalar((int32_t*)grad_temp1, (int32_t*)nram_offset4,
+  __bang_mul((int32_t *)nram_offset3, (int32_t *)nram_offset3,
+             (int32_t *)grad_temp1, num_deal_grid);
+  __bang_lt_scalar((int32_t *)grad_temp1, (int32_t *)nram_offset4,
                    batch * spatial_size * num_heads * deal_num_real,
                    num_deal_grid);
-  __bang_mul((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)grad_temp1, num_deal_grid);
+  __bang_mul((int32_t *)nram_offset4, (int32_t *)nram_offset4,
+             (int32_t *)grad_temp1, num_deal_grid);
   __bang_mul(grad_temp3, nram_w1, mask2, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
                    num_deal_grid * deal_num_real, num_deal_grid);
   __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset1[loop])),
-        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);    
+        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
   }
 
   __bang_mul(grad_temp3, nram_w2, mask1, num_deal_grid);
@@ -497,7 +547,6 @@ void __mlu_func__ computeGradValue(
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset2[loop])),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
-   
   }
 
   __bang_mul(grad_temp3, nram_w3, mask4, num_deal_grid);
@@ -510,7 +559,6 @@ void __mlu_func__ computeGradValue(
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset3[loop])),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
-    
   }
   __bang_mul(grad_temp3, nram_w4, mask3, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
@@ -521,7 +569,6 @@ void __mlu_func__ computeGradValue(
     __bang_atomic_reduce_add(
         (float *)(grad_value + int32_t(nram_offset4[loop])),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
-              
   }
 #else
   __bang_cycle_mul(grad_temp1, grad_temp4, nram_w1,
@@ -544,29 +591,27 @@ void __mlu_func__ computeGradValue(
   __bang_transpose(nram_grad_output_bl, grad_temp1, deal_num_real,
                    num_deal_grid);
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-      
     if (mask2[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + int32_t(((int32_t*)nram_offset1)[loop])   ),
+          (float *)(grad_value + int32_t(((int32_t *)nram_offset1)[loop])),
           (float *)(nram_grad_output_br + loop * deal_num_real), deal_num_real);
     }
     if (mask1[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + ((int32_t*)nram_offset2)[loop]   ),
+          (float *)(grad_value + ((int32_t *)nram_offset2)[loop]),
           (float *)(nram_grad_output_tl + loop * deal_num_real), deal_num_real);
     }
     if (mask4[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + ((int32_t*)nram_offset3)[loop]   ),
+          (float *)(grad_value + ((int32_t *)nram_offset3)[loop]),
           (float *)(nram_grad_output_tr + loop * deal_num_real), deal_num_real);
     }
 
     if (mask3[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + ((int32_t*)nram_offset4)[loop]   ),
+          (float *)(grad_value + ((int32_t *)nram_offset4)[loop]),
           (float *)(nram_grad_output_bl + loop * deal_num_real), deal_num_real);
     }
-
   }
 #endif
 #endif
@@ -881,7 +926,7 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
   int32_t num_per_time_real = num_per_time_theory;
 
   for (int32_t loop = 0; loop < num_heads; ++loop) {
-    ((int32_t*)nram_base_ptr)[loop] = loop * channels;
+    ((int32_t *)nram_base_ptr)[loop] = loop * channels;
   }
   const int32_t w_stride = num_heads * channels;
   for (int32_t grid_loop = 0; grid_loop < repeat_times + 1; ++grid_loop) {

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -52,8 +52,6 @@ void __mlu_func__ computeGridMaskAndOffset(
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_transpose(nram_loc_h, nram_grad_output_tl + num_deal_grid,
                    num_per_time_real * num_heads * num_levels, num_points);
-//   __bang_int322float((float *)nram_spatial_shapes,
-//                      (int32_t *)nram_spatial_shapes, num_levels * 2, 0);
 
   __bang_transpose((int32_t*)nram_grad_output_tr, (int32_t *)nram_spatial_shapes,
                    num_levels, 2);
@@ -114,16 +112,10 @@ __bang_int322float((float *)nram_spatial_shapes,
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_cycle_mul((int32_t*)nram_h_low_ptr_offset, (int32_t*)nram_h_low_ptr_offset, 
   (int32_t*)nram_h_stride, num_deal_grid, num_levels);
-   for(int i = 0; i < num_deal_grid; ++i){
-         __bang_printf("112 nram_h_stride = %d \n",((int32_t*)nram_h_stride)[i]);
-       //  __bang_printf("113 nram_w_high = %d \n",((int32_t*)nram_w_high)[i]);
-     }
   __bang_cycle_add((int32_t*)nram_h_high_ptr_offset, (int32_t*)nram_h_low_ptr_offset, 
   (int32_t*)nram_h_stride,
                    num_deal_grid, num_levels);
 
-
- 
   __bang_transpose((int32_t*)nram_w_low_ptr_offset, (int32_t*)nram_h_low_ptr_offset, num_points,
                    num_per_time_real * num_heads * num_levels);
 
@@ -195,16 +187,13 @@ __bang_int322float((float *)nram_spatial_shapes,
                 
   __bang_sub_scalar((float *)nram_spatial_shapes, (float *)nram_spatial_shapes,
                     1, num_levels * 2);
- // __bang_int322float((float*)nram_spatial_shapes, (int32_t*)nram_spatial_shapes, num_levels * 2, 0); 
-  __bang_int322float((float *)mask3, (int32_t*)mask3, num_deal_grid, 0);  
-  //__bang_int322float(mask1, (int32_t*)mask1, num_levels, 0);               
+  __bang_int322float((float *)mask3, (int32_t*)mask3, num_deal_grid, 0);            
   __bang_cycle_le((float *)mask3, (float *)mask3, (float *)(nram_spatial_shapes + num_levels),
                   num_deal_grid, num_levels); // 仅float
    __bang_float2int32((int32_t*)mask3, (float *)mask3,num_deal_grid , 0);                   
   __bang_transpose((int32_t*)mask4, (int32_t*)mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
   __bang_and((int32_t*)mask1, (int32_t*)mask1, (int32_t*)mask4, num_deal_grid);
-  //__bang_int322float(nram_h_high_temp,(int32_t*)nram_h_high_temp, num_deal_grid, 0);
   __bang_and((int32_t*)mask1, (int32_t*)nram_h_high_temp, (int32_t*)mask1, num_deal_grid);
 
   // h_high <= height - 1 && w_high <= width - 1 mask3
@@ -212,18 +201,12 @@ __bang_int322float((float *)nram_spatial_shapes,
                    num_per_time_real * num_heads * num_levels, num_points);
    __bang_int322float((float *)mask3, (int32_t*)mask3, num_deal_grid, 0);                
   __bang_cycle_le((float *)mask3, (float *)mask3, (float *)(nram_spatial_shapes), num_deal_grid,
-                  num_levels);// 仅float
+                  num_levels);
     __bang_float2int32((int32_t*)mask3, (float *)mask3, num_deal_grid, 0);                 
   __bang_transpose((int32_t*)nram_h_low_temp, (int32_t*)mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
   __bang_and((int32_t*)mask4, (int32_t*)mask4, (int32_t*)nram_h_low_temp, num_deal_grid);
   __bang_and((int32_t*)mask3, (int32_t*)mask4, (int32_t*)nram_h_high_temp, num_deal_grid);
-    //   for(int i = 0; i < num_deal_grid; ++i){
-    //     // __bang_printf("mask1 = %f \n",mask1[i]);
-    //     //  __bang_printf("mask2 = %f \n",mask2[i]);
-    //       __bang_printf("228mask3 = %d \n",((int32_t*)mask3)[i]);
-    //     //  __bang_printf("mask4 = %f \n",mask4[i]);
-    //  }
 
   // h_high <= height - 1 && w_low >= 0 mask4
   __bang_ge_scalar((int32_t*)nram_w_low_temp, (int32_t*)nram_w_low, 0, num_deal_grid); // 仅float
@@ -265,21 +248,8 @@ __bang_int322float((float *)nram_spatial_shapes,
   __bang_int322float(mask2, (int32_t*)mask2, num_deal_grid, 0);
   __bang_int322float(mask3, (int32_t*)mask3, num_deal_grid, 0);
   __bang_int322float(mask4, (int32_t*)mask4, num_deal_grid, 0);
-  __bang_int322float(nram_offset1, (int32_t*)nram_offset1, num_deal_grid, 0);
-  __bang_int322float(nram_offset2, (int32_t*)nram_offset2, num_deal_grid, 0);
-  __bang_int322float(nram_offset3, (int32_t*)nram_offset3, num_deal_grid, 0);
-  __bang_int322float(nram_offset4, (int32_t*)nram_offset4, num_deal_grid, 0);
-    // for(int i = 0; i < num_deal_grid; ++i){
-    //     __bang_printf("  nram_offset1 = %f \n",((float*)nram_offset1)[i]);
-    //     __bang_printf("  nram_offset2 = %f \n",((float*)nram_offset2)[i]);
-    //     __bang_printf("  nram_offset3 = %f \n",((float*)nram_offset3)[i]);
-    //     __bang_printf("  nram_offset4 = %f \n",((float*)nram_offset4)[i]);
-    //     __bang_printf("  mask1 = %f \n",((float*)mask1)[i]);
-    //     __bang_printf("  mask2 = %f \n",((float*)mask2)[i]);
-    //     __bang_printf("  mask3 = %f \n",((float*)mask3)[i]);
-    //     __bang_printf("  mask4 = %f \n",((float*)mask4)[i]);
-      
-    //  }
+
+  __bang_int322float(nram_h_high_temp, (int32_t*)nram_h_high_temp, num_deal_grid, 0);
   __bang_fusion(FUSION_FMA, nram_hh, nram_lh, (float)(-1), 1, num_deal_grid);
   __bang_fusion(FUSION_FMA, nram_hw, nram_lw, (float)(-1), 1, num_deal_grid);
 
@@ -355,15 +325,11 @@ void __mlu_func__ loadValue(
   value_offset_temp =
       b_col * spatial_size * qid_stride + level_start_id * qid_stride;
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-        __bang_printf("nram_offset1 = %d \n",value_offset_temp + ((float*)nram_offset1)[loop]);
-    //    __bang_printf("nram_offset2 = %f \n",((float*)nram_offset2)[loop]);
-    //    __bang_printf("nram_offset3 = %f \n",((float*)nram_offset3)[loop]);
-    //    __bang_printf("nram_offset4 = %f \n",((float*)nram_offset4)[loop]); 
     __memcpy_async(
         (void *)(nram_grad_output_tl + loop * deal_num_real),
-        (void *)(data_value + value_offset_temp + int32_t(nram_offset1[loop])),
+        (void *)(data_value + value_offset_temp + int32_t(((int32_t*)nram_offset1)[loop])),
         deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
-        (int32_t(nram_offset2[loop]) - int32_t(nram_offset1[loop])) *
+        (int32_t(((int32_t*)nram_offset2)[loop]) - int32_t(((int32_t*)nram_offset1)[loop])) *
             sizeof(float),
         1);
     b_col = (grid_offset + loop + 1) / num_query / num_heads / num_levels /
@@ -373,21 +339,14 @@ void __mlu_func__ loadValue(
 
     __memcpy_async(
         (void *)(nram_grad_output_bl + loop * deal_num_real),
-        (void *)(data_value + value_offset_temp + int32_t(nram_offset3[loop])),
+        (void *)(data_value + value_offset_temp + int32_t(((int32_t*)nram_offset3)[loop])),
         deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
-        (int32_t(nram_offset4[loop]) - int32_t(nram_offset3[loop])) *
+        (int32_t(((int32_t*)nram_offset4)[loop]) - int32_t(((int32_t*)nram_offset3)[loop])) *
             sizeof(float),
         1);
     value_offset_temp =
         b_col * spatial_size * qid_stride + level_start_id * qid_stride;
-        // __bang_printf("nram_grad_output_tl = %f \n",((float*)nram_grad_output_tl)[loop]);
-        // __bang_printf("nram_grad_output_tr = %f \n",((float*)nram_grad_output_tr)[loop]);
-        // __bang_printf("nram_grad_output_bl = %f \n",((float*)nram_grad_output_bl)[loop]);
-        // __bang_printf("nram_grad_output_br = %f \n",((float*)nram_grad_output_br)[loop]);
-  }
-  for(int loop = 0; loop < num_deal_grid; ++loop){
-        __bang_printf("nram_grad_output_tl = %f \n",((float*)nram_grad_output_tl)[loop]);
-        
+       
   }
 #endif
   __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
@@ -441,10 +400,7 @@ void __mlu_func__ loadValue(
                  num_deal_grid * deal_num_real, 64);
   __bang_band((char *)nram_grad_output_br, (char *)nram_grad_output_br,
               (char *)grad_temp3,
-              num_deal_grid * deal_num_real * sizeof(float));
-//    for(int i = 0; i < num_deal_grid; ++i){
-//        __bang_printf("nram_grad_output_br = %f \n",nram_grad_output_br[]);
-//    }           
+              num_deal_grid * deal_num_real * sizeof(float));         
 #endif
 }
 
@@ -482,23 +438,21 @@ void __mlu_func__ computeGradValue(
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
     ((int32_t*)nram_grid_offset1)[loop] = ((loop + grid_offset) / temp_res);
   }
+  //__bang_float2int32((int32_t*)nram_grid_offset1, nram_grid_offset1,num_deal_grid, 0 );
   __bang_mul_scalar((int32_t*)nram_grid_offset1, (int32_t*)nram_grid_offset1,
                     spatial_size * qid_stride, num_deal_grid);
   __bang_transpose((int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset1,
                    num_per_time_real * num_heads * num_levels, num_points);
-//   __bang_int322float((float *)nram_level_start_index, nram_level_start_index,
-//                      num_levels, 0);
-  __bang_mul_scalar((int32_t*)nram_grid_offset1, (int32_t*)nram_level_start_index,
+  //  __bang_int322float((float *)nram_level_start_index, nram_level_start_index,
+  //                     num_levels, 0);
+  __bang_mul_scalar((int32_t*)nram_grid_offset1,(int32_t*)nram_level_start_index,
                     qid_stride, num_levels);
   __bang_cycle_add((int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset2, (int32_t*)nram_grid_offset1,
                    num_deal_grid, num_levels);
   __bang_transpose((int32_t*)nram_grid_offset1, (int32_t*)nram_grid_offset2, num_points,
                    num_per_time_real * num_heads * num_levels);
-// __bang_float2int32((int32_t*)nram_offset1,nram_offset1,num_deal_grid, 0);  
-// __bang_float2int32((int32_t*)nram_offset2,nram_offset2,num_deal_grid, 0);
-// __bang_float2int32((int32_t*)nram_offset3,nram_offset3,num_deal_grid, 0);
-// __bang_float2int32((int32_t*)nram_offset4,nram_offset4,num_deal_grid, 0);              
-  __bang_add((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)nram_grid_offset1, num_deal_grid);
+                          
+   __bang_add((int32_t*)nram_offset1, (int32_t*)nram_offset1, (int32_t*)nram_grid_offset1, num_deal_grid);
   __bang_add((int32_t*)nram_offset2, (int32_t*)nram_offset2, (int32_t*)nram_grid_offset1, num_deal_grid);
   __bang_add((int32_t*)nram_offset3, (int32_t*)nram_offset3, (int32_t*)nram_grid_offset1, num_deal_grid);
   __bang_add((int32_t*)nram_offset4, (int32_t*)nram_offset4, (int32_t*)nram_grid_offset1, num_deal_grid);
@@ -593,23 +547,23 @@ void __mlu_func__ computeGradValue(
       
     if (mask2[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + int32_t(nram_offset1[loop])),
+          (float *)(grad_value + int32_t(((int32_t*)nram_offset1)[loop])   ),
           (float *)(nram_grad_output_br + loop * deal_num_real), deal_num_real);
     }
     if (mask1[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + int32_t(nram_offset2[loop])),
+          (float *)(grad_value + ((int32_t*)nram_offset2)[loop]   ),
           (float *)(nram_grad_output_tl + loop * deal_num_real), deal_num_real);
     }
     if (mask4[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + int32_t(nram_offset3[loop])),
+          (float *)(grad_value + ((int32_t*)nram_offset3)[loop]   ),
           (float *)(nram_grad_output_tr + loop * deal_num_real), deal_num_real);
     }
 
     if (mask3[loop]) {
       __bang_atomic_reduce_add(
-          (float *)(grad_value + int32_t(nram_offset4[loop])),
+          (float *)(grad_value + ((int32_t*)nram_offset4)[loop]   ),
           (float *)(nram_grad_output_bl + loop * deal_num_real), deal_num_real);
     }
 

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -276,6 +276,7 @@ void __mlu_func__ computeGridMaskAndOffset(
   __bang_mul(nram_w4, nram_lh, nram_lw, num_deal_grid);
 #endif
 }
+
 void __mlu_func__ loadValue(
     float *nram_grad_output_tl, float *nram_grad_output_tr,
     float *nram_grad_output_bl, float *nram_grad_output_br,
@@ -312,8 +313,6 @@ void __mlu_func__ loadValue(
              (int32_t *)nram_offset4, num_deal_grid);
   __bang_mul_scalar((int32_t *)grad_temp3, (int32_t *)grad_temp3,
                     sizeof(int32_t), 4 * num_deal_grid);
-  __bang_float2int32((int32_t *)(grad_temp3), (grad_temp3), 4 * num_deal_grid,
-                     0);
   __sync_io_move_compute();
 
   __gather_async((void *)nram_grad_output_tl, (void *)data_value,
@@ -346,11 +345,11 @@ void __mlu_func__ loadValue(
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
     __memcpy_async((void *)(nram_grad_output_tl + loop * deal_num_real),
                    (void *)(data_value + value_offset_temp +
-                            int32_t(((int32_t *)nram_offset1)[loop])),
+                            (((int32_t *)nram_offset1)[loop])),
                    deal_num_real * sizeof(float), GDRAM2NRAM,
                    offset_nram * sizeof(float),
-                   (int32_t(((int32_t *)nram_offset2)[loop]) -
-                    int32_t(((int32_t *)nram_offset1)[loop])) *
+                   ((((int32_t *)nram_offset2)[loop]) -
+                    (((int32_t *)nram_offset1)[loop])) *
                        sizeof(float),
                    mask1[loop]);
     b_col = (grid_offset + loop + 1) / num_query / num_heads / num_levels /
@@ -360,11 +359,11 @@ void __mlu_func__ loadValue(
 
     __memcpy_async((void *)(nram_grad_output_bl + loop * deal_num_real),
                    (void *)(data_value + value_offset_temp +
-                            int32_t(((int32_t *)nram_offset3)[loop])),
+                            (((int32_t *)nram_offset3)[loop])),
                    deal_num_real * sizeof(float), GDRAM2NRAM,
                    offset_nram * sizeof(float),
-                   (int32_t(((int32_t *)nram_offset4)[loop]) -
-                    int32_t(((int32_t *)nram_offset3)[loop])) *
+                   ((((int32_t *)nram_offset4)[loop]) -
+                    (((int32_t *)nram_offset3)[loop])) *
                        sizeof(float),
                    mask3[loop]);
     value_offset_temp =
@@ -510,7 +509,7 @@ void __mlu_func__ computeGradValue(
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
     __bang_atomic_reduce_add(
-        (float *)(grad_value + int32_t(nram_offset1[loop])),
+        (float *)(grad_value + ((int32_t *)nram_offset1)[loop]),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
   }
 
@@ -521,7 +520,7 @@ void __mlu_func__ computeGradValue(
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
     __bang_atomic_reduce_add(
-        (float *)(grad_value + int32_t(nram_offset2[loop])),
+        (float *)(grad_value + + ((int32_t *)nram_offset2)[loop]),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
   }
 
@@ -533,7 +532,7 @@ void __mlu_func__ computeGradValue(
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
     __bang_atomic_reduce_add(
-        (float *)(grad_value + int32_t(nram_offset3[loop])),
+        (float *)(grad_value + ((int32_t *)nram_offset3)[loop]),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
   }
   __bang_mul(grad_temp3, nram_w4, mask3, num_deal_grid);
@@ -543,7 +542,7 @@ void __mlu_func__ computeGradValue(
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
     __bang_atomic_reduce_add(
-        (float *)(grad_value + int32_t(nram_offset4[loop])),
+        (float *)(grad_value + ((int32_t *)nram_offset4)[loop]),
         (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
   }
 #else

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -48,7 +48,7 @@ void msDeformAttnCol2imBilinear(
   const int32_t h_high_ptr_offset = h_low_ptr_offset + h_stride;
   const int32_t w_low_ptr_offset = w_low * w_stride;
   const int32_t w_high_ptr_offset = w_low_ptr_offset + w_stride;
-  int32_t base_ptr = m * channels + c;
+  const int32_t base_ptr = m * channels + c;
 
   const float w1 = hh * hw, w2 = hh * lw, w3 = lh * hw, w4 = lh * lw;
   const float top_grad_value = top_grad * attn_weight;

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -48,7 +48,7 @@ void msDeformAttnCol2imBilinear(
   const int32_t h_high_ptr_offset = h_low_ptr_offset + h_stride;
   const int32_t w_low_ptr_offset = w_low * w_stride;
   const int32_t w_high_ptr_offset = w_low_ptr_offset + w_stride;
-  const int32_t base_ptr = m * channels + c;
+  int32_t base_ptr = m * channels + c;
 
   const float w1 = hh * hw, w2 = hh * lw, w3 = lh * hw, w4 = lh * lw;
   const float top_grad_value = top_grad * attn_weight;
@@ -173,17 +173,12 @@ void MsDeformAttnBackwardExecutor::cpuCompute() {
     temp /= num_heads;
     temp /= num_query;
     const int32_t b_col = temp;
-    const int32_t per_sample_loc_size =
-        b_col * num_query * num_heads * num_levels * num_point * 2;
-    const int32_t per_attn_weight_size =
-        b_col * num_query * num_heads * num_levels * num_point;
-
-    float *data_value = cpu_value + 0;
-    float *grad_data_value = cpu_grad_value + 0;
-    float *data_sampling_loc = cpu_sampling_loc + 0;
-    float *data_attn_weight = cpu_attn_weight + 0;
-    float *grad_sampling_loc = cpu_grad_sampling_loc + 0;
-    float *grad_attn_weight = cpu_grad_attn_weight + 0;
+    float *data_value = cpu_value;
+    float *grad_data_value = cpu_grad_value;
+    float *data_sampling_loc = cpu_sampling_loc;
+    float *data_attn_weight = cpu_attn_weight;
+    float *grad_sampling_loc = cpu_grad_sampling_loc;
+    float *grad_attn_weight = cpu_grad_attn_weight;
     int32_t grad_output_offset = b_col * num_query * num_heads * channels +
                                  i % (num_query * num_heads * channels);
     float top_grad = cpu_grad_output[grad_output_offset];

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -162,10 +162,6 @@ void MsDeformAttnBackwardExecutor::cpuCompute() {
   const int32_t qid_stride = num_heads * channels;
   const int32_t spatial_size = value_desc->dims[1];
 
-  float *cache_grad_sampling_loc =
-      static_cast<float *>(cpu_runtime_.allocate(channels * 2 * sizeof(float)));
-  float *cache_grad_attn_weight =
-      static_cast<float *>(cpu_runtime_.allocate(channels * sizeof(float)));
   const int32_t grad_weight_stride = 1;
   const int32_t grad_loc_stride = 2;
   for (int32_t i = 0; i < batch * num_query * num_heads * channels; ++i) {
@@ -182,13 +178,12 @@ void MsDeformAttnBackwardExecutor::cpuCompute() {
     const int32_t per_attn_weight_size =
         b_col * num_query * num_heads * num_levels * num_point;
 
-    float *data_value = cpu_value + b_col * spatial_size * num_heads * channels;
-    float *grad_data_value =
-        cpu_grad_value + b_col * spatial_size * num_heads * channels;
-    float *data_sampling_loc = cpu_sampling_loc + per_sample_loc_size;
-    float *data_attn_weight = cpu_attn_weight + per_attn_weight_size;
-    float *grad_sampling_loc = cpu_grad_sampling_loc + per_sample_loc_size;
-    float *grad_attn_weight = cpu_grad_attn_weight + per_attn_weight_size;
+    float *data_value = cpu_value + 0;
+    float *grad_data_value = cpu_grad_value + 0;
+    float *data_sampling_loc = cpu_sampling_loc + 0;
+    float *data_attn_weight = cpu_attn_weight + 0;
+    float *grad_sampling_loc = cpu_grad_sampling_loc + 0;
+    float *grad_attn_weight = cpu_grad_attn_weight + 0;
     int32_t grad_output_offset = b_col * num_query * num_heads * channels +
                                  i % (num_query * num_heads * channels);
     float top_grad = cpu_grad_output[grad_output_offset];


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Fix the bug of ms_deform_attn_backward op.

## 2. Modification

Converting floating point numbers to int is dangerous when the num larger than 16777215, tthis pull request is mainly change float computation to int, and fix the zero element bug.
Modification:
bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu  
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/ms_deform_attn_backward/ms_deform_attn_backward.cpp 
bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward.cpp
