### PR TITLE
[Feature](bangc-ops): ms_deform_attn_backward support NaN/INF on MLU500

### DIFF
--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -284,6 +284,7 @@ void __mlu_func__ loadValue(
                  (unsigned int *)(grad_temp3 + 3 * num_deal_grid),
                  deal_num_real * sizeof(float), GDRAM2NRAM,
                  deal_num_real * sizeof(float), num_deal_grid);
+
   __sync_io_move_compute();
 
 #else
@@ -445,6 +446,14 @@ void __mlu_func__ computeGradValue(
   __bang_mul(grad_temp3, nram_w1, mask2, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
                    num_deal_grid * deal_num_real, num_deal_grid);
+  __nram__ int32_t table[2] = {0, (int32_t)0xffffffff};
+  __bang_float2int32((int32_t *)grad_temp3, mask2, num_deal_grid, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid, 64);
+  __bang_cycle_band((char *)grad_temp1, (char *)grad_temp1, (char *)grad_temp3,
+                    deal_num_real * num_deal_grid * sizeof(float),
+                    num_deal_grid * sizeof(float));
+
   __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
@@ -456,6 +465,12 @@ void __mlu_func__ computeGradValue(
   __bang_mul(grad_temp3, nram_w2, mask1, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
                    num_deal_grid * deal_num_real, num_deal_grid);
+  __bang_float2int32((int32_t *)grad_temp3, mask1, num_deal_grid, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid, 64);
+  __bang_cycle_band((char *)grad_temp1, (char *)grad_temp1, (char *)grad_temp3,
+                    deal_num_real * num_deal_grid * sizeof(float),
+                    num_deal_grid * sizeof(float));
   __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
@@ -466,7 +481,12 @@ void __mlu_func__ computeGradValue(
   __bang_mul(grad_temp3, nram_w3, mask4, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
                    num_deal_grid * deal_num_real, num_deal_grid);
-
+  __bang_float2int32((int32_t *)grad_temp3, mask4, num_deal_grid, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid, 64);
+  __bang_cycle_band((char *)grad_temp1, (char *)grad_temp1, (char *)grad_temp3,
+                    deal_num_real * num_deal_grid * sizeof(float),
+                    num_deal_grid * sizeof(float));
   __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
@@ -477,6 +497,12 @@ void __mlu_func__ computeGradValue(
   __bang_mul(grad_temp3, nram_w4, mask3, num_deal_grid);
   __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
                    num_deal_grid * deal_num_real, num_deal_grid);
+  __bang_float2int32((int32_t *)grad_temp3, mask3, num_deal_grid, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid, 64);
+  __bang_cycle_band((char *)grad_temp1, (char *)grad_temp1, (char *)grad_temp3,
+                    deal_num_real * num_deal_grid * sizeof(float),
+                    num_deal_grid * sizeof(float));
   __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
 
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
