### PR TITLE
[TEST](bangc-ops): add dynamic_point_to_voxel_forward api test

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -34,9 +34,8 @@
 namespace mluopapitest {
 class dynamic_point_to_voxel_forward : public testing::Test {
  public:
-  void setParam(bool handle, bool feats_desc, bool feats,
-                bool coors_desc, bool coors, 
-                bool voxel_feats_desc, bool voxel_feats,
+  void setParam(bool handle, bool feats_desc, bool feats, bool coors_desc,
+                bool coors, bool voxel_feats_desc, bool voxel_feats,
                 bool voxel_coors_desc, bool voxel_coors,
                 bool point2voxel_map_desc, bool point2voxel_map,
                 bool voxel_points_count_desc, bool voxel_points_count,
@@ -55,10 +54,10 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (feats) {
       if (feats_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&feats_,
-                               MLUOP_DTYPE_FLOAT *
-                                   mluOpGetTensorElementNum(feats_desc_)));
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&feats_, MLUOP_DTYPE_FLOAT *
+                                    mluOpGetTensorElementNum(feats_desc_)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&feats_, MLUOP_DTYPE_FLOAT * 2));
@@ -75,10 +74,10 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (coors) {
       if (coors_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&coors_,
-                               MLUOP_DTYPE_INT32 *
-                                   mluOpGetTensorElementNum(coors_desc_)));
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&coors_, MLUOP_DTYPE_INT32 *
+                                    mluOpGetTensorElementNum(coors_desc_)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&coors_, MLUOP_DTYPE_INT32 * 2));
@@ -88,17 +87,17 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     if (voxel_feats_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_feats_desc_));
       std::vector<int> voxel_feats_desc_dims{4, 3};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(voxel_feats_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, 2,
-                                           voxel_feats_desc_dims.data()));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          voxel_feats_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, 2,
+          voxel_feats_desc_dims.data()));
     }
 
     if (voxel_feats) {
       if (voxel_feats_desc) {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&voxel_feats_,
-                               MLUOP_DTYPE_FLOAT *
-                                   mluOpGetTensorElementNum(voxel_feats_desc_)));
+                               MLUOP_DTYPE_FLOAT * mluOpGetTensorElementNum(
+                                                       voxel_feats_desc_)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&voxel_feats_, MLUOP_DTYPE_FLOAT * 2));
@@ -108,17 +107,17 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     if (voxel_coors_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_coors_desc_));
       std::vector<int> voxel_coors_desc_dims{4, 3};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(voxel_coors_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_INT32, 2,
-                                           voxel_coors_desc_dims.data()));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          voxel_coors_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 2,
+          voxel_coors_desc_dims.data()));
     }
 
     if (voxel_coors) {
       if (voxel_coors_desc) {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&voxel_coors_,
-                               MLUOP_DTYPE_INT32 *
-                                   mluOpGetTensorElementNum(voxel_coors_desc_)));
+                               MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
+                                                       voxel_coors_desc_)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&voxel_coors_, MLUOP_DTYPE_INT32 * 2));
@@ -128,17 +127,17 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     if (point2voxel_map_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&point2voxel_map_desc_));
       std::vector<int> point2voxel_map_desc_dims{4};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(point2voxel_map_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_INT32, 1,
-                                           point2voxel_map_desc_dims.data()));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          point2voxel_map_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 1,
+          point2voxel_map_desc_dims.data()));
     }
 
     if (point2voxel_map) {
       if (point2voxel_map_desc) {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&point2voxel_map_,
-                               MLUOP_DTYPE_INT32 *
-                                   mluOpGetTensorElementNum(point2voxel_map_desc_)));
+                               MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
+                                                       point2voxel_map_desc_)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&point2voxel_map_, MLUOP_DTYPE_INT32 * 2));
@@ -148,17 +147,18 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     if (voxel_points_count_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_points_count_desc_));
       std::vector<int> voxel_points_count_desc_dims{4};
-      MLUOP_CHECK(mluOpSetTensorDescriptor(voxel_points_count_desc_, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_INT32, 1,
-                                           voxel_points_count_desc_dims.data()));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          voxel_points_count_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32, 1,
+          voxel_points_count_desc_dims.data()));
     }
 
     if (voxel_points_count) {
       if (voxel_points_count_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&voxel_points_count_,
-                               MLUOP_DTYPE_INT32 *
-                                   mluOpGetTensorElementNum(voxel_points_count_desc_)));
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_points_count_,
+                       MLUOP_DTYPE_INT32 *
+                           mluOpGetTensorElementNum(voxel_points_count_desc_)));
       } else {
         GTEST_CHECK(CNRT_RET_SUCCESS ==
                     cnrtMalloc(&voxel_points_count_, MLUOP_DTYPE_INT32 * 2));
@@ -186,18 +186,18 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     }
 
     if (workspace) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&workspace_, MLUOP_DTYPE_INT32 * workspace_size_));
+      GTEST_CHECK(CNRT_RET_SUCCESS ==
+                  cnrtMalloc(&workspace_, MLUOP_DTYPE_INT32 * workspace_size_));
     }
   }
 
   mluOpStatus_t compute() {
     mluOpStatus_t status = mluOpDynamicPointToVoxelForward(
-        handle_, reduce_type_, feats_desc_, feats_,
-        coors_desc_, coors_,workspace_, workspace_size_, 
-        voxel_feats_desc_,voxel_feats_, voxel_coors_desc_, 
-        voxel_coors_, point2voxel_map_desc_,point2voxel_map_, 
-        voxel_points_count_desc_, voxel_points_count_, voxel_num_desc_, voxel_num_);
+        handle_, reduce_type_, feats_desc_, feats_, coors_desc_, coors_,
+        workspace_, workspace_size_, voxel_feats_desc_, voxel_feats_,
+        voxel_coors_desc_, voxel_coors_, point2voxel_map_desc_,
+        point2voxel_map_, voxel_points_count_desc_, voxel_points_count_,
+        voxel_num_desc_, voxel_num_);
     destroy();
     return status;
   }
@@ -498,5 +498,4 @@ TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_workspace_null) {
            << " in dynamic_point_to_voxel_forward";
   }
 }
-
 }  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -1,0 +1,502 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+#include "core/context.h"
+
+namespace mluopapitest {
+class dynamic_point_to_voxel_forward : public testing::Test {
+ public:
+  void setParam(bool handle, bool feats_desc, bool feats,
+                bool coors_desc, bool coors, 
+                bool voxel_feats_desc, bool voxel_feats,
+                bool voxel_coors_desc, bool voxel_coors,
+                bool point2voxel_map_desc, bool point2voxel_map,
+                bool voxel_points_count_desc, bool voxel_points_count,
+                bool voxel_num_desc, bool voxel_num, bool workspace) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (feats_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&feats_desc_));
+      std::vector<int> feats_desc_dims{4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(feats_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           feats_desc_dims.data()));
+    }
+
+    if (feats) {
+      if (feats_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&feats_,
+                               MLUOP_DTYPE_FLOAT *
+                                   mluOpGetTensorElementNum(feats_desc_)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&feats_, MLUOP_DTYPE_FLOAT * 2));
+      }
+    }
+
+    if (coors_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&coors_desc_));
+      std::vector<int> coors_desc_dims{4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(coors_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 2,
+                                           coors_desc_dims.data()));
+    }
+
+    if (coors) {
+      if (coors_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&coors_,
+                               MLUOP_DTYPE_INT32 *
+                                   mluOpGetTensorElementNum(coors_desc_)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&coors_, MLUOP_DTYPE_INT32 * 2));
+      }
+    }
+
+    if (voxel_feats_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_feats_desc_));
+      std::vector<int> voxel_feats_desc_dims{4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(voxel_feats_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           voxel_feats_desc_dims.data()));
+    }
+
+    if (voxel_feats) {
+      if (voxel_feats_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_feats_,
+                               MLUOP_DTYPE_FLOAT *
+                                   mluOpGetTensorElementNum(voxel_feats_desc_)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_feats_, MLUOP_DTYPE_FLOAT * 2));
+      }
+    }
+
+    if (voxel_coors_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_coors_desc_));
+      std::vector<int> voxel_coors_desc_dims{4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(voxel_coors_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 2,
+                                           voxel_coors_desc_dims.data()));
+    }
+
+    if (voxel_coors) {
+      if (voxel_coors_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_coors_,
+                               MLUOP_DTYPE_INT32 *
+                                   mluOpGetTensorElementNum(voxel_coors_desc_)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_coors_, MLUOP_DTYPE_INT32 * 2));
+      }
+    }
+
+    if (point2voxel_map_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&point2voxel_map_desc_));
+      std::vector<int> point2voxel_map_desc_dims{4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(point2voxel_map_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 1,
+                                           point2voxel_map_desc_dims.data()));
+    }
+
+    if (point2voxel_map) {
+      if (point2voxel_map_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&point2voxel_map_,
+                               MLUOP_DTYPE_INT32 *
+                                   mluOpGetTensorElementNum(point2voxel_map_desc_)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&point2voxel_map_, MLUOP_DTYPE_INT32 * 2));
+      }
+    }
+
+    if (voxel_points_count_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_points_count_desc_));
+      std::vector<int> voxel_points_count_desc_dims{4};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(voxel_points_count_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 1,
+                                           voxel_points_count_desc_dims.data()));
+    }
+
+    if (voxel_points_count) {
+      if (voxel_points_count_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_points_count_,
+                               MLUOP_DTYPE_INT32 *
+                                   mluOpGetTensorElementNum(voxel_points_count_desc_)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_points_count_, MLUOP_DTYPE_INT32 * 2));
+      }
+    }
+
+    if (voxel_num_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_num_desc_));
+      std::vector<int> fvoxel_num_desc_dims{1};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(voxel_num_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 1,
+                                           fvoxel_num_desc_dims.data()));
+    }
+
+    if (voxel_num) {
+      if (voxel_num_desc) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_num_,
+                               MLUOP_DTYPE_INT32 *
+                                   mluOpGetTensorElementNum(voxel_num_desc_)));
+      } else {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&voxel_num_, MLUOP_DTYPE_INT32 * 1));
+      }
+    }
+
+    if (workspace) {
+        GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&workspace_, MLUOP_DTYPE_INT32 * workspace_size_));
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpDynamicPointToVoxelForward(
+        handle_, reduce_type_, feats_desc_, feats_,
+        coors_desc_, coors_,workspace_, workspace_size_, 
+        voxel_feats_desc_,voxel_feats_, voxel_coors_desc_, 
+        voxel_coors_, point2voxel_map_desc_,point2voxel_map_, 
+        voxel_points_count_desc_, voxel_points_count_, voxel_num_desc_, voxel_num_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (feats_desc_) {
+      VLOG(4) << "Destroy feats_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(feats_desc_));
+      feats_desc_ = nullptr;
+    }
+
+    if (feats_) {
+      VLOG(4) << "Destroy feats_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feats_));
+      feats_ = nullptr;
+    }
+
+    if (coors_desc_) {
+      VLOG(4) << "Destroy coors_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(coors_desc_));
+      coors_desc_ = nullptr;
+    }
+
+    if (coors_) {
+      VLOG(4) << "Destroy coors_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_));
+      coors_ = nullptr;
+    }
+
+    if (voxel_feats_desc_) {
+      VLOG(4) << "Destroy voxel_feats_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_feats_desc_));
+      voxel_feats_desc_ = nullptr;
+    }
+
+    if (voxel_feats_) {
+      VLOG(4) << "Destroy voxel_feats_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_feats_));
+      voxel_feats_ = nullptr;
+    }
+
+    if (voxel_coors_desc_) {
+      VLOG(4) << "Destroy voxel_coors_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_coors_desc_));
+      voxel_coors_desc_ = nullptr;
+    }
+
+    if (voxel_coors_) {
+      VLOG(4) << "Destroy voxel_coors_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_coors_));
+      voxel_coors_ = nullptr;
+    }
+
+    if (point2voxel_map_desc_) {
+      VLOG(4) << "Destroy point2voxel_map_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(point2voxel_map_desc_));
+      point2voxel_map_desc_ = nullptr;
+    }
+
+    if (point2voxel_map_) {
+      VLOG(4) << "Destroy point2voxel_map_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point2voxel_map_));
+      point2voxel_map_ = nullptr;
+    }
+
+    if (voxel_points_count_desc_) {
+      VLOG(4) << "Destroy data_col_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_points_count_desc_));
+      voxel_points_count_desc_ = nullptr;
+    }
+
+    if (voxel_points_count_) {
+      VLOG(4) << "Destroy voxel_points_count_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_points_count_));
+      voxel_points_count_ = nullptr;
+    }
+
+    if (voxel_num_desc_) {
+      VLOG(4) << "Destroy voxel_num_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_num_desc_));
+      voxel_num_desc_ = nullptr;
+    }
+
+    if (voxel_num_) {
+      VLOG(4) << "Destroy voxel_num_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      voxel_num_ = nullptr;
+    }
+
+    if (workspace_) {
+      VLOG(4) << "Destroy workspace_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      workspace_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t feats_desc_ = nullptr;
+  void *feats_ = nullptr;
+  mluOpTensorDescriptor_t coors_desc_ = nullptr;
+  void *coors_ = nullptr;
+  mluOpTensorDescriptor_t voxel_feats_desc_ = nullptr;
+  void *voxel_feats_ = nullptr;
+  mluOpTensorDescriptor_t voxel_coors_desc_ = nullptr;
+  void *voxel_coors_ = nullptr;
+  mluOpTensorDescriptor_t point2voxel_map_desc_ = nullptr;
+  void *point2voxel_map_ = nullptr;
+  mluOpTensorDescriptor_t voxel_points_count_desc_ = nullptr;
+  void *voxel_points_count_ = nullptr;
+  mluOpTensorDescriptor_t voxel_num_desc_ = nullptr;
+  void *voxel_num_ = nullptr;
+  size_t workspace_size_ = 10;
+  void *workspace_ = nullptr;
+  mluOpReduceMode_t reduce_type_ = MLUOP_REDUCE_DMEAN;
+};
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true, true, true, true, true, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_feats_desc_null) {
+  try {
+    setParam(true, false, true, true, true, true, true, true, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_feats_null) {
+  try {
+    setParam(true, true, false, true, true, true, true, true, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_coors_desc_null) {
+  try {
+    setParam(true, true, true, false, true, true, true, true, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_coors_null) {
+  try {
+    setParam(true, true, true, true, false, true, true, true, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_feats_desc_null) {
+  try {
+    setParam(true, true, true, true, true, false, true, true, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_feats_null) {
+  try {
+    setParam(true, true, true, true, true, true, false, true, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_coors_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, false, true, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_coors_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, false, true, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_point2voxel_map_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, false, true,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_point2voxel_map_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, false,
+             true, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_points_count_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             false, true, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_points_count_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             true, false, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_num_desc_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             true, true, false, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_voxel_num_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             true, true, true, false, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward, BAD_PARAM_workspace_null) {
+  try {
+    setParam(true, true, true, true, true, true, true, true, true, true, true,
+             true, true, true, true, false);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward";
+  }
+}
+
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_general.cpp
@@ -37,7 +37,8 @@ namespace mluopapitest {
 typedef std::tuple<MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
                    MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
                    MLUOpTensorParam, mluOpReduceMode_t, mluOpDevType_t,
-                   mluOpStatus_t> DynamicPointToVoxelForward;
+                   mluOpStatus_t>
+    DynamicPointToVoxelForward;
 class dynamic_point_to_voxel_forward_general
     : public testing::TestWithParam<DynamicPointToVoxelForward> {
  public:
@@ -48,9 +49,8 @@ class dynamic_point_to_voxel_forward_general
       MLUOpTensorParam feats_params = std::get<0>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&feats_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
-          feats_desc_, feats_params.get_layout(),
-          feats_params.get_dtype(), feats_params.get_dim_nb(),
-          feats_params.get_dim_size().data()));
+          feats_desc_, feats_params.get_layout(), feats_params.get_dtype(),
+          feats_params.get_dim_nb(), feats_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(feats_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
@@ -59,17 +59,15 @@ class dynamic_point_to_voxel_forward_general
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&feats_,
-                       mluOpDataTypeBytes(feats_params.get_dtype()) *
-                           mluOpGetTensorElementNum(feats_desc_)));
+            cnrtMalloc(&feats_, mluOpDataTypeBytes(feats_params.get_dtype()) *
+                                    mluOpGetTensorElementNum(feats_desc_)));
       }
 
       MLUOpTensorParam coors_params = std::get<1>(GetParam());
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&coors_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
-          coors_desc_, coors_params.get_layout(),
-          coors_params.get_dtype(), coors_params.get_dim_nb(),
-          coors_params.get_dim_size().data()));
+          coors_desc_, coors_params.get_layout(), coors_params.get_dtype(),
+          coors_params.get_dim_nb(), coors_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(coors_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
@@ -78,9 +76,8 @@ class dynamic_point_to_voxel_forward_general
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&coors_,
-                       mluOpDataTypeBytes(coors_params.get_dtype()) *
-                           mluOpGetTensorElementNum(coors_desc_)));
+            cnrtMalloc(&coors_, mluOpDataTypeBytes(coors_params.get_dtype()) *
+                                    mluOpGetTensorElementNum(coors_desc_)));
       }
 
       MLUOpTensorParam voxel_feats_params = std::get<2>(GetParam());
@@ -125,13 +122,15 @@ class dynamic_point_to_voxel_forward_general
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&point2voxel_map_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
           point2voxel_map_desc_, point2voxel_map_params.get_layout(),
-          point2voxel_map_params.get_dtype(), point2voxel_map_params.get_dim_nb(),
+          point2voxel_map_params.get_dtype(),
+          point2voxel_map_params.get_dim_nb(),
           point2voxel_map_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(point2voxel_map_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&point2voxel_map_,
-                       mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) * 2));
+            cnrtMalloc(
+                &point2voxel_map_,
+                mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
@@ -144,19 +143,23 @@ class dynamic_point_to_voxel_forward_general
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_points_count_desc_));
       MLUOP_CHECK(mluOpSetTensorDescriptor(
           voxel_points_count_desc_, voxel_points_count_params.get_layout(),
-          voxel_points_count_params.get_dtype(), voxel_points_count_params.get_dim_nb(),
+          voxel_points_count_params.get_dtype(),
+          voxel_points_count_params.get_dim_nb(),
           voxel_points_count_params.get_dim_size().data()));
-      if (mluOpGetTensorElementNum(voxel_points_count_desc_) >= LARGE_TENSOR_NUM) {
+      if (mluOpGetTensorElementNum(voxel_points_count_desc_) >=
+          LARGE_TENSOR_NUM) {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&voxel_points_count_,
-                       mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) * 2));
+            cnrtMalloc(
+                &voxel_points_count_,
+                mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
             CNRT_RET_SUCCESS ==
-            cnrtMalloc(&voxel_points_count_,
-                       mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) *
-                           mluOpGetTensorElementNum(voxel_points_count_desc_)));
+            cnrtMalloc(
+                &voxel_points_count_,
+                mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) *
+                    mluOpGetTensorElementNum(voxel_points_count_desc_)));
       }
 
       MLUOpTensorParam voxel_num_params = std::get<6>(GetParam());
@@ -183,7 +186,7 @@ class dynamic_point_to_voxel_forward_general
       expected_status_ = std::get<9>(GetParam());
 
       GTEST_CHECK(CNRT_RET_SUCCESS ==
-                    cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
+                  cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
              << " in ms_deform_attn_forward general.";
@@ -197,11 +200,11 @@ class dynamic_point_to_voxel_forward_general
       return true;
     }
     mluOpStatus_t status = mluOpDynamicPointToVoxelForward(
-        handle_, reduce_type_, feats_desc_, feats_,
-        coors_desc_, coors_,workspace_, workspace_size_, 
-        voxel_feats_desc_,voxel_feats_, voxel_coors_desc_, 
-        voxel_coors_, point2voxel_map_desc_,point2voxel_map_, 
-        voxel_points_count_desc_, voxel_points_count_, voxel_num_desc_, voxel_num_);
+        handle_, reduce_type_, feats_desc_, feats_, coors_desc_, coors_,
+        workspace_, workspace_size_, voxel_feats_desc_, voxel_feats_,
+        voxel_coors_desc_, voxel_coors_, point2voxel_map_desc_,
+        point2voxel_map_, voxel_points_count_desc_, voxel_points_count_,
+        voxel_num_desc_, voxel_num_);
     destroy();
     return expected_status_ == status;
   }
@@ -328,7 +331,9 @@ class dynamic_point_to_voxel_forward_general
   mluOpStatus_t expected_status_;
 };
 
-TEST_P(dynamic_point_to_voxel_forward_general, negative) { EXPECT_TRUE(compute()); }
+TEST_P(dynamic_point_to_voxel_forward_general, negative) {
+  EXPECT_TRUE(compute());
+}
 
 INSTANTIATE_TEST_CASE_P(
     zero_element_1, dynamic_point_to_voxel_forward_general,
@@ -347,7 +352,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
@@ -368,7 +373,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({0})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_SUCCESS)));
 
@@ -389,7 +394,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -410,7 +415,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -431,7 +436,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -452,7 +457,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -473,7 +478,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -494,7 +499,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -515,7 +520,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -536,7 +541,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -557,7 +562,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -578,7 +583,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -599,7 +604,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -620,7 +625,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -641,7 +646,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({5})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -662,7 +667,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({2})}),
-        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_REDUCE_DMEAN),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
@@ -683,7 +688,7 @@ INSTANTIATE_TEST_CASE_P(
                                          1, std::vector<int>({4})}),
         testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
                                          1, std::vector<int>({1})}),
-        testing::Values(MLUOP_REDUCE_DSUM),                                 
+        testing::Values(MLUOP_REDUCE_DSUM),
         testing::Values(MLUOP_UNKNOWN_DEVICE),
         testing::Values(MLUOP_STATUS_BAD_PARAM)));
 }  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_general.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_general.cpp
@@ -1,0 +1,689 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <iostream>
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+#include "core/context.h"
+
+namespace mluopapitest {
+
+typedef std::tuple<MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, MLUOpTensorParam, MLUOpTensorParam,
+                   MLUOpTensorParam, mluOpReduceMode_t, mluOpDevType_t,
+                   mluOpStatus_t> DynamicPointToVoxelForward;
+class dynamic_point_to_voxel_forward_general
+    : public testing::TestWithParam<DynamicPointToVoxelForward> {
+ public:
+  void SetUp() {
+    try {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+
+      MLUOpTensorParam feats_params = std::get<0>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&feats_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          feats_desc_, feats_params.get_layout(),
+          feats_params.get_dtype(), feats_params.get_dim_nb(),
+          feats_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(feats_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&feats_,
+                       mluOpDataTypeBytes(feats_params.get_dtype()) * 2));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&feats_,
+                       mluOpDataTypeBytes(feats_params.get_dtype()) *
+                           mluOpGetTensorElementNum(feats_desc_)));
+      }
+
+      MLUOpTensorParam coors_params = std::get<1>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&coors_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          coors_desc_, coors_params.get_layout(),
+          coors_params.get_dtype(), coors_params.get_dim_nb(),
+          coors_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(coors_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&coors_,
+                       mluOpDataTypeBytes(coors_params.get_dtype()) * 2));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&coors_,
+                       mluOpDataTypeBytes(coors_params.get_dtype()) *
+                           mluOpGetTensorElementNum(coors_desc_)));
+      }
+
+      MLUOpTensorParam voxel_feats_params = std::get<2>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_feats_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          voxel_feats_desc_, voxel_feats_params.get_layout(),
+          voxel_feats_params.get_dtype(), voxel_feats_params.get_dim_nb(),
+          voxel_feats_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(voxel_feats_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_feats_,
+                       mluOpDataTypeBytes(voxel_feats_params.get_dtype()) * 2));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_feats_,
+                       mluOpDataTypeBytes(voxel_feats_params.get_dtype()) *
+                           mluOpGetTensorElementNum(voxel_feats_desc_)));
+      }
+
+      MLUOpTensorParam voxel_coors_params = std::get<3>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_coors_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          voxel_coors_desc_, voxel_coors_params.get_layout(),
+          voxel_coors_params.get_dtype(), voxel_coors_params.get_dim_nb(),
+          voxel_coors_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(voxel_coors_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_coors_,
+                       mluOpDataTypeBytes(voxel_coors_params.get_dtype()) * 2));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_coors_,
+                       mluOpDataTypeBytes(voxel_coors_params.get_dtype()) *
+                           mluOpGetTensorElementNum(voxel_coors_desc_)));
+      }
+
+      MLUOpTensorParam point2voxel_map_params = std::get<4>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&point2voxel_map_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          point2voxel_map_desc_, point2voxel_map_params.get_layout(),
+          point2voxel_map_params.get_dtype(), point2voxel_map_params.get_dim_nb(),
+          point2voxel_map_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(point2voxel_map_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&point2voxel_map_,
+                       mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) * 2));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&point2voxel_map_,
+                       mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) *
+                           mluOpGetTensorElementNum(point2voxel_map_desc_)));
+      }
+
+      MLUOpTensorParam voxel_points_count_params = std::get<5>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_points_count_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          voxel_points_count_desc_, voxel_points_count_params.get_layout(),
+          voxel_points_count_params.get_dtype(), voxel_points_count_params.get_dim_nb(),
+          voxel_points_count_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(voxel_points_count_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_points_count_,
+                       mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) * 2));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_points_count_,
+                       mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) *
+                           mluOpGetTensorElementNum(voxel_points_count_desc_)));
+      }
+
+      MLUOpTensorParam voxel_num_params = std::get<6>(GetParam());
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_num_desc_));
+      MLUOP_CHECK(mluOpSetTensorDescriptor(
+          voxel_num_desc_, voxel_num_params.get_layout(),
+          voxel_num_params.get_dtype(), voxel_num_params.get_dim_nb(),
+          voxel_num_params.get_dim_size().data()));
+      if (mluOpGetTensorElementNum(voxel_num_desc_) >= LARGE_TENSOR_NUM) {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_num_,
+                       mluOpDataTypeBytes(voxel_num_params.get_dtype()) * 2));
+      } else {
+        GTEST_CHECK(
+            CNRT_RET_SUCCESS ==
+            cnrtMalloc(&voxel_num_,
+                       mluOpDataTypeBytes(voxel_num_params.get_dtype()) *
+                           mluOpGetTensorElementNum(voxel_num_desc_)));
+      }
+
+      reduce_type_ = std::get<7>(GetParam());
+      target_device_ = std::get<8>(GetParam());
+      expected_status_ = std::get<9>(GetParam());
+
+      GTEST_CHECK(CNRT_RET_SUCCESS ==
+                    cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
+    } catch (const std::exception &e) {
+      FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+             << " in ms_deform_attn_forward general.";
+    }
+  }
+
+  bool compute() {
+    if (!(target_device_ == MLUOP_UNKNOWN_DEVICE ||
+          target_device_ == handle_->arch)) {
+      destroy();
+      return true;
+    }
+    mluOpStatus_t status = mluOpDynamicPointToVoxelForward(
+        handle_, reduce_type_, feats_desc_, feats_,
+        coors_desc_, coors_,workspace_, workspace_size_, 
+        voxel_feats_desc_,voxel_feats_, voxel_coors_desc_, 
+        voxel_coors_, point2voxel_map_desc_,point2voxel_map_, 
+        voxel_points_count_desc_, voxel_points_count_, voxel_num_desc_, voxel_num_);
+    destroy();
+    return expected_status_ == status;
+  }
+
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (feats_desc_) {
+      VLOG(4) << "Destroy feats_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(feats_desc_));
+      feats_desc_ = nullptr;
+    }
+
+    if (feats_) {
+      VLOG(4) << "Destroy feats_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feats_));
+      feats_ = nullptr;
+    }
+
+    if (coors_desc_) {
+      VLOG(4) << "Destroy coors_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(coors_desc_));
+      coors_desc_ = nullptr;
+    }
+
+    if (coors_) {
+      VLOG(4) << "Destroy coors_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_));
+      coors_ = nullptr;
+    }
+
+    if (voxel_feats_desc_) {
+      VLOG(4) << "Destroy voxel_feats_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_feats_desc_));
+      voxel_feats_desc_ = nullptr;
+    }
+
+    if (voxel_feats_) {
+      VLOG(4) << "Destroy voxel_feats_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_feats_));
+      voxel_feats_ = nullptr;
+    }
+
+    if (voxel_coors_desc_) {
+      VLOG(4) << "Destroy voxel_coors_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_coors_desc_));
+      voxel_coors_desc_ = nullptr;
+    }
+
+    if (voxel_coors_) {
+      VLOG(4) << "Destroy voxel_coors_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_coors_));
+      voxel_coors_ = nullptr;
+    }
+
+    if (point2voxel_map_desc_) {
+      VLOG(4) << "Destroy point2voxel_map_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(point2voxel_map_desc_));
+      point2voxel_map_desc_ = nullptr;
+    }
+
+    if (point2voxel_map_) {
+      VLOG(4) << "Destroy point2voxel_map_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point2voxel_map_));
+      point2voxel_map_ = nullptr;
+    }
+
+    if (voxel_points_count_desc_) {
+      VLOG(4) << "Destroy data_col_desc";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_points_count_desc_));
+      voxel_points_count_desc_ = nullptr;
+    }
+
+    if (voxel_points_count_) {
+      VLOG(4) << "Destroy voxel_points_count_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_points_count_));
+      voxel_points_count_ = nullptr;
+    }
+
+    if (voxel_num_desc_) {
+      VLOG(4) << "Destroy voxel_num_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(voxel_num_desc_));
+      voxel_num_desc_ = nullptr;
+    }
+
+    if (voxel_num_) {
+      VLOG(4) << "Destroy voxel_num_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      voxel_num_ = nullptr;
+    }
+
+    if (workspace_) {
+      VLOG(4) << "Destroy workspace_";
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      workspace_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t feats_desc_ = nullptr;
+  void *feats_ = nullptr;
+  mluOpTensorDescriptor_t coors_desc_ = nullptr;
+  void *coors_ = nullptr;
+  mluOpTensorDescriptor_t voxel_feats_desc_ = nullptr;
+  void *voxel_feats_ = nullptr;
+  mluOpTensorDescriptor_t voxel_coors_desc_ = nullptr;
+  void *voxel_coors_ = nullptr;
+  mluOpTensorDescriptor_t point2voxel_map_desc_ = nullptr;
+  void *point2voxel_map_ = nullptr;
+  mluOpTensorDescriptor_t voxel_points_count_desc_ = nullptr;
+  void *voxel_points_count_ = nullptr;
+  mluOpTensorDescriptor_t voxel_num_desc_ = nullptr;
+  void *voxel_num_ = nullptr;
+  size_t workspace_size_ = 10;
+  void *workspace_ = nullptr;
+  mluOpReduceMode_t reduce_type_ = MLUOP_REDUCE_DMEAN;
+  mluOpDevType_t target_device_;
+  mluOpStatus_t expected_status_;
+};
+
+TEST_P(dynamic_point_to_voxel_forward_general, negative) { EXPECT_TRUE(compute()); }
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_1, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 0})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 0})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    zero_element_2, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({0, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({0, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({0, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({0})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({0})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_SUCCESS)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_feats_dtype, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_coors_dtype, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_voxel_feats_dtype, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_voxel_coors_dtype, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_point2voxel_map_dtype, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_voxel_points_count_dtype, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_voxel_num_dtype, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_shape1, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_shape2, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_shape3, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({5, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({5, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_shape4, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({5, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({5})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_shape5, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({3, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({3, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_shape6, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({5, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({5, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({5})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_shape7, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({2})}),
+        testing::Values(MLUOP_REDUCE_DMEAN),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+
+INSTANTIATE_TEST_CASE_P(
+    error_reduce_type, dynamic_point_to_voxel_forward_general,
+    testing::Combine(
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         2, std::vector<int>({4, 3})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({4})}),
+        testing::Values(MLUOpTensorParam{MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_INT32,
+                                         1, std::vector<int>({1})}),
+        testing::Values(MLUOP_REDUCE_DSUM),                                 
+        testing::Values(MLUOP_UNKNOWN_DEVICE),
+        testing::Values(MLUOP_STATUS_BAD_PARAM)));
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_workspace.cpp
@@ -1,0 +1,141 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <vector>
+#include <string>
+#include <tuple>
+
+#include "api_test_tools.h"
+#include "core/logging.h"
+#include "core/tensor.h"
+#include "gtest/gtest.h"
+#include "mlu_op.h"
+#include "core/context.h"
+
+namespace mluopapitest {
+class dynamic_point_to_voxel_forward_workspace : public testing::Test {
+ public:
+  void setParam(bool handle, bool feats_desc,
+                bool coors_desc, bool workspace_size) {
+    if (handle) {
+      MLUOP_CHECK(mluOpCreate(&handle_));
+    }
+
+    if (feats_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&feats_desc_));
+      std::vector<int> feats_desc_dims{4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(feats_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_FLOAT, 2,
+                                           feats_desc_dims.data()));
+    }
+
+    if (coors_desc) {
+      MLUOP_CHECK(mluOpCreateTensorDescriptor(&coors_desc_));
+      std::vector<int> coors_desc_dims{4, 3};
+      MLUOP_CHECK(mluOpSetTensorDescriptor(coors_desc_, MLUOP_LAYOUT_ARRAY,
+                                           MLUOP_DTYPE_INT32, 2,
+                                           coors_desc_dims.data()));
+    }
+
+    if (workspace_size) {
+        workspace_size_ = &workspace_size__;
+    }
+  }
+
+  mluOpStatus_t compute() {
+    mluOpStatus_t status = mluOpGetDynamicPointToVoxelForwardWorkspaceSize(
+        handle_, feats_desc_, coors_desc_, workspace_size_);
+    destroy();
+    return status;
+  }
+
+ protected:
+  void destroy() {
+    if (handle_) {
+      CNRT_CHECK(cnrtQueueSync(handle_->queue));
+      VLOG(4) << "Destroy handle";
+      MLUOP_CHECK(mluOpDestroy(handle_));
+      handle_ = nullptr;
+    }
+
+    if (feats_desc_) {
+      VLOG(4) << "Destroy feats_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(feats_desc_));
+      feats_desc_ = nullptr;
+    }
+
+    if (coors_desc_) {
+      VLOG(4) << "Destroy coors_desc_";
+      MLUOP_CHECK(mluOpDestroyTensorDescriptor(coors_desc_));
+      coors_desc_ = nullptr;
+    }
+  }
+
+ private:
+  mluOpHandle_t handle_ = nullptr;
+  mluOpTensorDescriptor_t feats_desc_ = nullptr;
+  mluOpTensorDescriptor_t coors_desc_ = nullptr;
+  size_t workspace_size__ = 10;
+  size_t *workspace_size_ = nullptr;
+};
+
+
+TEST_F(dynamic_point_to_voxel_forward_workspace, BAD_PARAM_handle_null) {
+  try {
+    setParam(false, true, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward_workspace";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward_workspace, BAD_PARAM_feats_desc_null) {
+  try {
+    setParam(true, false, true, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward_workspace";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward_workspace, BAD_PARAM_coors_desc_null) {
+  try {
+    setParam(true, true, false, true);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward_workspace";
+  }
+}
+
+TEST_F(dynamic_point_to_voxel_forward_workspace, BAD_PARAM_workspace_size_null) {
+  try {
+    setParam(true, true, true, false);
+    EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);
+  } catch (std::exception &e) {
+    FAIL() << "MLUOPAPIGTEST: catched " << e.what()
+           << " in dynamic_point_to_voxel_forward_workspace";
+  }
+}
+}  // namespace mluopapitest

--- a/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_workspace.cpp
+++ b/bangc-ops/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_workspace.cpp
@@ -34,8 +34,8 @@
 namespace mluopapitest {
 class dynamic_point_to_voxel_forward_workspace : public testing::Test {
  public:
-  void setParam(bool handle, bool feats_desc,
-                bool coors_desc, bool workspace_size) {
+  void setParam(bool handle, bool feats_desc, bool coors_desc,
+                bool workspace_size) {
     if (handle) {
       MLUOP_CHECK(mluOpCreate(&handle_));
     }
@@ -57,7 +57,7 @@ class dynamic_point_to_voxel_forward_workspace : public testing::Test {
     }
 
     if (workspace_size) {
-        workspace_size_ = &workspace_size__;
+      workspace_size_ = &workspace_size__;
     }
   }
 
@@ -98,7 +98,6 @@ class dynamic_point_to_voxel_forward_workspace : public testing::Test {
   size_t *workspace_size_ = nullptr;
 };
 
-
 TEST_F(dynamic_point_to_voxel_forward_workspace, BAD_PARAM_handle_null) {
   try {
     setParam(false, true, true, true);
@@ -129,7 +128,8 @@ TEST_F(dynamic_point_to_voxel_forward_workspace, BAD_PARAM_coors_desc_null) {
   }
 }
 
-TEST_F(dynamic_point_to_voxel_forward_workspace, BAD_PARAM_workspace_size_null) {
+TEST_F(dynamic_point_to_voxel_forward_workspace,
+       BAD_PARAM_workspace_size_null) {
   try {
     setParam(true, true, true, false);
     EXPECT_EQ(compute(), MLUOP_STATUS_BAD_PARAM);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
