### PR TITLE
[Feature](bangc-ops): add large tensor check

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward.cpp
@@ -220,7 +220,7 @@ void FocalLossSigmoidForwardExecutor::cpuCompute() {
   auto output_num = parser_->getOutputDataCount(0);
 
   VLOG(5)
-      << "[FOCAL_LOSS_SIGMOID_FORWARD] call focalLossSigmoidForwardCpu....2017";
+      << "[FOCAL_LOSS_SIGMOID_FORWARD] call focalLossSigmoidForwardCpu.";
   {
     switch (prefer) {
       case ComputationPreference::COMPUTATION_FAST: {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

add large tensor check

## 2. Modification

	modified:   bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward.cpp

## 3. Test Report

tensor's element num near 2G 
 370X4 & 590all

[^ OK ] /MLU_OPS/DEV_SOFT_TRAIN/wangyuan/wy_generator/mlu-ops-generator/generated_testcases/370_590/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward_data_split_int32_float16_1684137306623.pb
[ OK ] focal_loss_sigmoid_forward/TestSuite.mluOp/7 (78606 ms)
[----------] 6 tests from focal_loss_sigmoid_forward/TestSuite (816940 ms total)

[----------] Global test environment tear-down
[2023-5-15 16:15:23] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY ] Total 8 cases of 1 op(s).
ALL PASSED.
[==========] 6 test cases from 1 test suite ran. (817394 ms total)
[ PASSED ] 8 test cases. 


release_temp
370X4 & 590 M9 & 580

[^ OK ] /MLU_OPS/SOFT_TRAIN/release_temp/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward_data_included_int32_float16_1683690544337.pb
[ OK ] focal_loss_sigmoid_forward/TestSuite.mluOp/856 (11 ms)
[----------] 857 tests from focal_loss_sigmoid_forward/TestSuite (26146 ms total)

[----------] Global test environment tear-down
[2023-5-15 18:12:59] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY ] Total 857 cases of 1 op(s).
ALL PASSED.
[==========] 857 test cases from 1 test suite ran. (26624 ms total)
[ PASSED ] 857 test cases.

