### PR TITLE
[Fix](bangc-ops): fix dynamic_point_to_voxel_forward bug

### DIFF
--- a/bangc-ops/kernels/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/bangc-ops/kernels/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -68,8 +68,9 @@ static void policyFuncDynamicPointToVoxelForward(const mluOpHandle_t handle,
 }
 
 static mluOpStatus_t DynamicPointToVoxelForwardParamCheck(
-    const std::string &api, const mluOpHandle_t handle, const void *feats,
-    const void *coors, const void *voxel_feats, const void *voxel_coors,
+    const std::string &api, const mluOpHandle_t handle,
+    const mluOpReduceMode_t reduce_type, const void *feats, const void *coors,
+    const void *voxel_feats, const void *voxel_coors,
     const void *point2voxel_map, const void *voxel_points_count,
     const void *voxel_num, void *workspace, const size_t workspace_size,
     const mluOpTensorDescriptor_t feats_desc,
@@ -123,6 +124,12 @@ static mluOpStatus_t DynamicPointToVoxelForwardParamCheck(
   PARAM_CHECK(api,
               voxel_points_count_desc->dtype == point2voxel_map_desc->dtype);
   PARAM_CHECK(api, voxel_num_desc->dtype == point2voxel_map_desc->dtype);
+
+  if (reduce_type != MLUOP_REDUCE_DMAX || reduce_type != MLUOP_REDUCE_DMEAN) {
+    LOG(ERROR) << api << "Only support max and mean. "
+               << "Please check reduce_type!";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
 
   // check dim
   PARAM_CHECK(api, feats_desc->dims[0] == coors_desc->dims[0]);
@@ -210,10 +217,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelForward(
   bool zero_element = false;
 
   mluOpStatus_t ret = DynamicPointToVoxelForwardParamCheck(
-      api, handle, feats, coors, voxel_feats, voxel_coors, point2voxel_map,
-      voxel_points_count, voxel_num, workspace, workspace_size, feats_desc,
-      coors_desc, voxel_feats_desc, voxel_coors_desc, point2voxel_map_desc,
-      voxel_points_count_desc, voxel_num_desc, &zero_element);
+      api, handle, reduce_type, feats, coors, voxel_feats, voxel_coors,
+      point2voxel_map, voxel_points_count, voxel_num, workspace, workspace_size,
+      feats_desc, coors_desc, voxel_feats_desc, voxel_coors_desc,
+      point2voxel_map_desc, voxel_points_count_desc, voxel_num_desc,
+      &zero_element);
 
   if (ret != MLUOP_STATUS_SUCCESS) {
     LOG(ERROR) << api

--- a/bangc-ops/kernels/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/bangc-ops/kernels/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -124,9 +124,7 @@ static mluOpStatus_t DynamicPointToVoxelForwardParamCheck(
   PARAM_CHECK(api,
               voxel_points_count_desc->dtype == point2voxel_map_desc->dtype);
   PARAM_CHECK(api, voxel_num_desc->dtype == point2voxel_map_desc->dtype);
-  printf("reduce_type:%d\n", reduce_type);
-  printf("reduce_type1:%d\n", MLUOP_REDUCE_DMAX);
-  printf("reduce_type2:%d\n", MLUOP_REDUCE_DMEAN);
+
   if (reduce_type != MLUOP_REDUCE_DMAX && reduce_type != MLUOP_REDUCE_DMEAN) {
     LOG(ERROR) << api << "Only support max and mean. "
                << "Please check reduce_type!";

--- a/bangc-ops/kernels/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/bangc-ops/kernels/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -124,8 +124,10 @@ static mluOpStatus_t DynamicPointToVoxelForwardParamCheck(
   PARAM_CHECK(api,
               voxel_points_count_desc->dtype == point2voxel_map_desc->dtype);
   PARAM_CHECK(api, voxel_num_desc->dtype == point2voxel_map_desc->dtype);
-
-  if (reduce_type != MLUOP_REDUCE_DMAX || reduce_type != MLUOP_REDUCE_DMEAN) {
+  printf("reduce_type:%d\n", reduce_type);
+  printf("reduce_type1:%d\n", MLUOP_REDUCE_DMAX);
+  printf("reduce_type2:%d\n", MLUOP_REDUCE_DMEAN);
+  if (reduce_type != MLUOP_REDUCE_DMAX && reduce_type != MLUOP_REDUCE_DMEAN) {
     LOG(ERROR) << api << "Only support max and mean. "
                << "Please check reduce_type!";
     return MLUOP_STATUS_BAD_PARAM;

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -3558,7 +3558,7 @@ mluOpGetDynamicPointToVoxelForwardWorkspaceSize(mluOpHandle_t handle,
  * Handle to an MLUOP context that is used to manage MLU devices and queues in
  * the DynamicPointToVoxelForward operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] reduce_type
- * Reduce op. support 'max', 'sum' and 'mean'. Default: 'max'.
+ * Reduce op. support 'max' and 'mean'. Default: 'max'.
  * @param[in] feats_desc
  * The descriptor of the tensor \b feats. For detailed information, see
  * ::mluOpTensorDescriptor_t.

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -62,8 +62,10 @@ void DynamicPointToVoxelForwardExecutor::compute() {
                                .reduce_type();
   if (reduce_mode == REDUCE_MODE_MAX) {
     reduce_type = MLUOP_REDUCE_DMAX;
-  } else {
+  } else if (reduce_mode == REDUCE_MODE_MEAN) {
     reduce_type = MLUOP_REDUCE_DMEAN;
+  } else {
+    reduce_type = MLUOP_REDUCE_DSUM;
   }
   auto feats_desc = tensor_desc_[0].tensor;
   auto coors_desc = tensor_desc_[1].tensor;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

 修复算子 reduce_type 防呆问题

## 2. Modification

1）modified:   bangc-ops/kernels/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
2）modified:   bangc-ops/mlu_op.h
3）modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.

## 3. Test Report

[2023-5-16 17:35:35] [MLUOP] [Error]:[mluOpDynamicPointToVoxelForward]Only support max and mean. Please check reduce_type!