### PR TITLE
[Feature](bangc-ops): add mutual_information_forward op

### DIFF
--- a/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
+++ b/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
@@ -30,7 +30,7 @@ __nram__ char nram_buffer[MAX_NRAM_SIZE];
 __mlu_func__ void setNanInfToZero(float *src, float *mask, const int num) {
   __bang_sub(mask, src, src, num);
   __bang_eq_scalar(mask, mask, 0., num);
-  __bang_float2int32_rn((int *)mask, mask, num, 0);
+  __bang_float2int32_tz((int *)mask, mask, num, 0);
   __bang_mul_scalar((int *)mask, (int *)mask, int(-1), num);
   __bang_band((char *)src, (char *)src, (char *)mask, num * sizeof(float));
 }

--- a/bangc-ops/kernels/mutual_information_forward/mutual_information_forward.cpp
+++ b/bangc-ops/kernels/mutual_information_forward/mutual_information_forward.cpp
@@ -20,7 +20,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
-#include "mutual_information_backward.h"
+#include "mutual_information_forward.h"
 
 #include <algorithm>
 #include <string>
@@ -32,22 +32,21 @@
 #include "core/tensor.h"
 #include "core/type.h"
 
-#define API_NAME "[mluOpMutualInformationBackward]"
+#define API_NAME "[mluOpMutualInformationForward]"
 
-mluOpStatus_t MLUOP_WIN_API mluOpGetMutualInformationBackwardWorkspaceSize(
+mluOpStatus_t MLUOP_WIN_API mluOpGetMutualInformationForwardWorkspaceSize(
     mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc,
     const mluOpTensorDescriptor_t py_desc,
     const mluOpTensorDescriptor_t opt_boundary_desc,
     const mluOpTensorDescriptor_t p_desc,
-    const mluOpTensorDescriptor_t ans_grad_desc,
-    const bool overwrite_ans_grad, size_t *workspace_size) {
+    const mluOpTensorDescriptor_t ans_desc, size_t *workspace_size) {
   // Workspace is not required in the current implementation.
   // This interface will be used when the scale limitation is removed.
   PARAM_CHECK(API_NAME, handle != nullptr);
   PARAM_CHECK(API_NAME, px_desc != nullptr);
   PARAM_CHECK(API_NAME, py_desc != nullptr);
   PARAM_CHECK(API_NAME, p_desc != nullptr);
-  PARAM_CHECK(API_NAME, ans_grad_desc != nullptr);
+  PARAM_CHECK(API_NAME, ans_desc != nullptr);
   PARAM_CHECK(API_NAME, workspace_size != nullptr);
   *workspace_size = 0;
   return MLUOP_STATUS_SUCCESS;
@@ -58,9 +57,7 @@ static mluOpStatus_t checkTensorDim(
     const mluOpTensorDescriptor_t py_desc,
     const mluOpTensorDescriptor_t opt_boundary_desc,
     const mluOpTensorDescriptor_t p_desc,
-    const mluOpTensorDescriptor_t ans_grad_desc,
-    const mluOpTensorDescriptor_t px_grad_desc,
-    const mluOpTensorDescriptor_t py_grad_desc) {
+    const mluOpTensorDescriptor_t ans_desc) {
   if (3 != px_desc->dim) {
     LOG(ERROR) << API_NAME << " The dim of px must be 3. "
                << "But now the dim of px is " << px_desc->dim << ".";
@@ -83,20 +80,10 @@ static mluOpStatus_t checkTensorDim(
                << "But now the dim of p is " << p_desc->dim << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
-  if (1 != ans_grad_desc->dim) {
-    LOG(ERROR) << API_NAME << " The dim of ans_grad must be 1. "
-               << "But now the dim of ans_grad is "
-               << ans_grad_desc->dim << ".";
-    return MLUOP_STATUS_BAD_PARAM;
-  }
-  if (3 != px_grad_desc->dim) {
-    LOG(ERROR) << API_NAME << " The dim of px_grad must be 3. "
-               << "But now the dim of px_grad is " << px_grad_desc->dim << ".";
-    return MLUOP_STATUS_BAD_PARAM;
-  }
-  if (3 != py_grad_desc->dim) {
-    LOG(ERROR) << API_NAME << " The dim of py_grad must be 3. "
-               << "But now the dim of py_grad is " << py_grad_desc->dim << ".";
+  if (1 != ans_desc->dim) {
+    LOG(ERROR) << API_NAME << " The dim of ans must be 1. "
+               << "But now the dim of ans is "
+               << ans_desc->dim << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
 
@@ -108,24 +95,18 @@ static mluOpStatus_t checkTensorShape(
     const mluOpTensorDescriptor_t py_desc,
     const mluOpTensorDescriptor_t opt_boundary_desc,
     const mluOpTensorDescriptor_t p_desc,
-    const mluOpTensorDescriptor_t ans_grad_desc,
-    const mluOpTensorDescriptor_t px_grad_desc,
-    const mluOpTensorDescriptor_t py_grad_desc) {
+    const mluOpTensorDescriptor_t ans_desc) {
   const int B = px_desc->dims[0];
   const int S = px_desc->dims[1];
   const int T = py_desc->dims[2];
-  if (B != py_desc->dims[0] || B != p_desc->dims[0] ||
-      B != ans_grad_desc->dims[0] || B != px_grad_desc->dims[0] ||
-      B != py_grad_desc->dims[0]) {
+  if (B != py_desc->dims[0] || B != p_desc->dims[0] || B != ans_desc->dims[0]) {
     LOG(ERROR) << API_NAME
-               << " px.shape[0], py.shape[0], p.shape[0], ans_grad.shape[0], "
-               << "px_grad.shape[0] and py_grad.shape[0] must be same. But now "
+               << " px.shape[0], py.shape[0], p.shape[0], ans.shape[0], "
+               << "must be same. But now "
                << "px.shape[0] is " << px_desc->dims[0]
                << ", py.shape[0] is " << py_desc->dims[0]
                << ", p.shape[0] is " << p_desc->dims[0]
-               << ", ans_grad.shape[0] is " << ans_grad_desc->dims[0]
-               << ", px_grad.shape[0] is " << px_grad_desc->dims[0]
-               << ", py_grad.shape[0] is " << py_grad_desc->dims[0] << ".";
+               << ", ans.shape[0] is " << ans_desc->dims[0] << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
 
@@ -172,30 +153,6 @@ static mluOpStatus_t checkTensorShape(
     return MLUOP_STATUS_BAD_PARAM;
   }
 
-  // the shape of px and px_grad must be same: [B, S, T+1]
-  for (int i = 1; i < px_grad_desc->dim; ++i) {
-    if (px_grad_desc->dims[i] != px_desc->dims[i]) {
-      LOG(ERROR) << API_NAME
-                 << " The shape of px and px_grad must be same. But now "
-                 << "px.shape[" << i << "] is " << px_desc->dims[i]
-                 << ", px_grad.shape[" << i << "] is " << px_grad_desc->dims[i]
-                 << ".";
-      return MLUOP_STATUS_BAD_PARAM;
-    }
-  }
-
-  // the shape of py and py_grad must be same: [B, S+1, T]
-  for (int i = 1; i < py_grad_desc->dim; ++i) {
-    if (py_grad_desc->dims[i] != py_desc->dims[i]) {
-      LOG(ERROR) << API_NAME
-                 << " The shape of py and py_grad must be same. But now "
-                 << "py.shape[" << i << "] is " << py_desc->dims[i]
-                 << ", py_grad.shape[" << i << "] is " << py_grad_desc->dims[i]
-                 << ".";
-      return MLUOP_STATUS_BAD_PARAM;
-    }
-  }
-
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -204,9 +161,7 @@ static mluOpStatus_t checkTensorDatatype(
     const mluOpTensorDescriptor_t py_desc,
     const mluOpTensorDescriptor_t opt_boundary_desc,
     const mluOpTensorDescriptor_t p_desc,
-    const mluOpTensorDescriptor_t ans_grad_desc,
-    const mluOpTensorDescriptor_t px_grad_desc,
-    const mluOpTensorDescriptor_t py_grad_desc) {
+    const mluOpTensorDescriptor_t ans_desc) {
   if (MLUOP_DTYPE_FLOAT != px_desc->dtype) {
     LOG(ERROR) << API_NAME
                << "The data type of px currently only support float. But now "
@@ -236,25 +191,11 @@ static mluOpStatus_t checkTensorDatatype(
                << mluOpGetNameOfDataType(p_desc->dtype) << ".";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
-  if (MLUOP_DTYPE_FLOAT != ans_grad_desc->dtype) {
+  if (MLUOP_DTYPE_FLOAT != ans_desc->dtype) {
     LOG(ERROR) << API_NAME
-               << "The data type of ans_grad currently only support float. "
-               << "But now the data type of ans_grad is "
-               << mluOpGetNameOfDataType(ans_grad_desc->dtype) << ".";
-    return MLUOP_STATUS_NOT_SUPPORTED;
-  }
-  if (MLUOP_DTYPE_FLOAT != px_grad_desc->dtype) {
-    LOG(ERROR) << API_NAME
-               << "The data type of px_grad currently only support float. "
-               << "But now the data type of px_grad is "
-               << mluOpGetNameOfDataType(px_grad_desc->dtype) << ".";
-    return MLUOP_STATUS_NOT_SUPPORTED;
-  }
-  if (MLUOP_DTYPE_FLOAT != py_grad_desc->dtype) {
-    LOG(ERROR) << API_NAME
-               << "The data type of py_grad currently only support float. "
-               << "But now the data type of py_grad is "
-               << mluOpGetNameOfDataType(py_grad_desc->dtype) << ".";
+               << "The data type of ans currently only support float. "
+               << "But now the data type of ans is "
+               << mluOpGetNameOfDataType(ans_desc->dtype) << ".";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
@@ -268,39 +209,28 @@ static mluOpStatus_t checkTensorScaleLimit(
     const mluOpTensorDescriptor_t opt_boundary_desc,
     const mluOpTensorDescriptor_t p_desc) {
   // check large tensor
-  // the shape of px and px_grad are the same,
-  // the shape of py and py_grad are the same,
-  // so there is no need to check the tensor num of px_grad and py_grad
   if (mluOpGetTensorElementNum(px_desc) >= LARGE_TENSOR_NUM ||
       mluOpGetTensorElementNum(py_desc) >= LARGE_TENSOR_NUM ||
       (nullptr != opt_boundary_desc &&
-      mluOpGetTensorElementNum(opt_boundary_desc) >= LARGE_TENSOR_NUM) ||
+       mluOpGetTensorElementNum(opt_boundary_desc) >= LARGE_TENSOR_NUM) ||
       mluOpGetTensorElementNum(p_desc) >= LARGE_TENSOR_NUM) {
     LOG(ERROR) << API_NAME << " Overflow max tensor num."
                << " Current operator supports tensor num smaller than 2^31.";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
-  const int B = px_desc->dims[0];
   const int S = px_desc->dims[1];
   const int T = py_desc->dims[2];
-  // check scale limit for compute term1 and term2
-  int currnet_size = T * (S + 1) + (T + 1) * S + 5 * (T + 1);
-  if (currnet_size > handle->nram_size / sizeof(float)) {
-    LOG(ERROR) << API_NAME << " The num of px.shape[1] * px.shape[2] + "
-               << "py.shape[1] * py.shape[2] + 5 * (py.shape[2] + 1) shoule be "
-               << "less than " << handle->nram_size / sizeof(float)
-               << ". But now it is " << currnet_size << ".";
-    return MLUOP_STATUS_NOT_SUPPORTED;
-  }
 
-  // check scale limit for compute p_grad
-  currnet_size = T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) +
-                 3 * std::min(S, T) + 4;
+  // check scale limit for compute p
+  // 9: max_val, mask, temp, ping(py, px, p) and pong(py, px, p)
+  // 11: max_val, mask, temp, ping(py, px, p), pong(py, px, p) and 2*(-inf)
+  int currnet_size = T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) +
+                     9 * std::min(S, T) + 11;
   if (currnet_size > handle->nram_size / sizeof(float)) {
     LOG(ERROR) << API_NAME << " The num of px.shape[1] * px.shape[2] + "
-               << "py.shape[1] * py.shape[2] + p.shape[1] * p.shape[2] "
-               << "+ 3 * min(px.shape[1], py.shape[2]) + 4 shoule be less than "
+               << "py.shape[1] * py.shape[2] + p.shape[1] * p.shape[2] + "
+               << "9 * min(px.shape[1], py.shape[2]) + 11 shoule be less than "
                << handle->nram_size / sizeof(float)
                << ". But now it is " << currnet_size << ".";
     return MLUOP_STATUS_NOT_SUPPORTED;
@@ -310,32 +240,28 @@ static mluOpStatus_t checkTensorScaleLimit(
 }
 
 static mluOpStatus_t checkTensorPtr(
-    const void *px, const void *py, const void *p, const void *ans_grad,
+    const void *px, const void *py, const void *p, const void *ans,
     const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
-    const void *px_grad, const void *py_grad, const int S, const int T,
-    bool &has_boundary) {
+    const int S, const int T, bool &has_boundary) {
   if (S > 0) {
     PARAM_CHECK(API_NAME, px != nullptr);
-    PARAM_CHECK(API_NAME, px_grad != nullptr);
   } else {
     VLOG(5) << API_NAME << " px.shape[1] is zero.";
   }
 
   if (T > 0) {
     PARAM_CHECK(API_NAME, py != nullptr);
-    PARAM_CHECK(API_NAME, py_grad != nullptr);
   } else {
     VLOG(5) << API_NAME << " py.shape[2] is zero.";
   }
 
   PARAM_CHECK(API_NAME, p != nullptr);
-  PARAM_CHECK(API_NAME, ans_grad != nullptr);
+  PARAM_CHECK(API_NAME, ans != nullptr);
 
   if (nullptr != opt_boundary_desc && nullptr != opt_boundary) {
     has_boundary = true;
     VLOG(5) << API_NAME << " opt_boundary is not NULL.";
-
-  } else  if (nullptr == opt_boundary_desc && nullptr == opt_boundary) {
+  } else if (nullptr == opt_boundary_desc && nullptr == opt_boundary) {
     has_boundary = false;
     VLOG(5) << API_NAME << " opt_boundary is NULL.";
   } else {
@@ -348,24 +274,20 @@ static mluOpStatus_t checkTensorPtr(
   return MLUOP_STATUS_SUCCESS;
 }
 
-static mluOpStatus_t mutualInformationBackwardParamCheck(
+static mluOpStatus_t mutualInformationForwardParamCheck(
     mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
     const mluOpTensorDescriptor_t py_desc, const void *py,
     const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
     const mluOpTensorDescriptor_t p_desc, const void *p,
-    const mluOpTensorDescriptor_t ans_grad_desc, void *ans_grad,
     void *workspace, const size_t workspace_size,
-    const mluOpTensorDescriptor_t px_grad_desc, void *px_grad,
-    const mluOpTensorDescriptor_t py_grad_desc, void *py_grad,
+    const mluOpTensorDescriptor_t ans_desc, void *ans,
     bool &has_boundary, bool &zero_element) {
   // 1. check handle and tensor_desc
   PARAM_CHECK(API_NAME, handle != nullptr);
   PARAM_CHECK(API_NAME, px_desc != nullptr);
   PARAM_CHECK(API_NAME, py_desc != nullptr);
   PARAM_CHECK(API_NAME, p_desc != nullptr);
-  PARAM_CHECK(API_NAME, ans_grad_desc != nullptr);
-  PARAM_CHECK(API_NAME, px_grad_desc != nullptr);
-  PARAM_CHECK(API_NAME, py_grad_desc != nullptr);
+  PARAM_CHECK(API_NAME, ans_desc != nullptr);
 
   // since the layout of all tensor is ARRAY, so skip check tensor layout
 
@@ -379,24 +301,21 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
   // 3. check tensor dim
   mluOpStatus_t check_status = checkTensorDim(px_desc, py_desc,
                                               opt_boundary_desc,
-                                              p_desc, ans_grad_desc,
-                                              px_grad_desc, py_grad_desc);
+                                              p_desc, ans_desc);
   if (MLUOP_STATUS_SUCCESS != check_status) {
     return check_status;
   }
 
   // 4. check tensor shape
   check_status = checkTensorShape(px_desc, py_desc, opt_boundary_desc,
-                                  p_desc, ans_grad_desc, px_grad_desc,
-                                  py_grad_desc);
+                                  p_desc, ans_desc);
   if (MLUOP_STATUS_SUCCESS != check_status) {
     return check_status;
   }
 
   // 5. check tensor dtype
   check_status = checkTensorDatatype(px_desc, py_desc, opt_boundary_desc,
-                                     p_desc, ans_grad_desc, px_grad_desc,
-                                     py_grad_desc);
+                                     p_desc, ans_desc);
   if (MLUOP_STATUS_SUCCESS != check_status) {
     return check_status;
   }
@@ -413,10 +332,10 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
   const int T = py_desc->dims[2];
 
   // 7. check zero element.
-  if (0 == B || (0 == S && 0 == T)) {
+  if (0 == B) {
     zero_element = true;
-    VLOG(5) << API_NAME << " Skip zero element tensor when px.shape[0] is zero "
-                        << "or px.shape[1] and py.shape[2] are both zero.";
+    VLOG(5) << API_NAME
+            << " Skip zero element tensor when px.shape[0] is zero.";
     return MLUOP_STATUS_SUCCESS;
   }
 
@@ -426,9 +345,8 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
   }
 
   // 9. check tensor ptr
-  check_status = checkTensorPtr(px, py, p, ans_grad, opt_boundary_desc,
-                                opt_boundary, px_grad, py_grad, S, T,
-                                has_boundary);
+  check_status = checkTensorPtr(px, py, p, ans, opt_boundary_desc,
+                                opt_boundary, S, T, has_boundary);
   if (MLUOP_STATUS_SUCCESS != check_status) {
     return check_status;
   }
@@ -436,16 +354,13 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
   return MLUOP_STATUS_SUCCESS;
 }
 
-static void mutualInformationBackwardGencase(
+static void mutualInformationForwardGencase(
     mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
     const mluOpTensorDescriptor_t py_desc, const void *py,
     const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
     const mluOpTensorDescriptor_t p_desc, const void *p,
-    const mluOpTensorDescriptor_t ans_grad_desc, void *ans_grad,
-    const bool overwrite_ans_grad,
-    const mluOpTensorDescriptor_t px_grad_desc, void *px_grad,
-    const mluOpTensorDescriptor_t py_grad_desc, void *py_grad) {
-  GEN_CASE_START("mutual_information_backward");
+    const mluOpTensorDescriptor_t ans_desc, void *ans) {
+  GEN_CASE_START("mutual_information_forward");
   GEN_CASE_HANDLE(handle);
 
   GEN_CASE_DATA(true, "px", px, px_desc, -1, 1);
@@ -454,32 +369,25 @@ static void mutualInformationBackwardGencase(
     GEN_CASE_DATA_REAL(true, "opt_boundary", opt_boundary, opt_boundary_desc);
   }
   GEN_CASE_DATA(true, "p", p, p_desc, -1, 1);
-  GEN_CASE_DATA(true, "ans_grad", ans_grad, ans_grad_desc, -1, 1);
-  GEN_CASE_DATA(false, "ans_grad", ans_grad, ans_grad_desc, -1, 1);
-  GEN_CASE_DATA(false, "px_grad", px_grad, px_grad_desc, -1, 1);
-  GEN_CASE_DATA(false, "py_grad", py_grad, py_grad_desc, -1, 1);
-
-  GEN_CASE_OP_PARAM_SINGLE(0, "mutual_information_backward",
-                           "overwrite_ans_grad", overwrite_ans_grad);
+  GEN_CASE_DATA(false, "p", p, p_desc, -1, 1);
+  GEN_CASE_DATA(false, "ans", ans, ans_desc, -1, 1);
   GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
 }
 
 static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type, int batch_size) {
-  int core_num =  mluop::runtime::getClusterLimitCapability(handle) *
-                  mluop::runtime::getCoreNumOfEachUnionCapability(handle);
+  int core_num = mluop::runtime::getClusterLimitCapability(handle) *
+                 mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   *k_type = CNRT_FUNC_TYPE_BLOCK;
   k_dim->x = 1;
   k_dim->y = batch_size < core_num ? batch_size : core_num;
   k_dim->z = 1;
 }
 
-static mluOpStatus_t launchMutualInformationBackwardKernel(
+static mluOpStatus_t launchMutualInformationForwardKernel(
     mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
     const mluOpTensorDescriptor_t py_desc, const void *py,
-    const bool has_boundary, const void *opt_boundary, const void *p,
-    const bool overwrite_ans_grad, void *ans_grad, void *px_grad,
-    void *py_grad) {
+    const bool has_boundary, const void *opt_boundary, void *p, void *ans) {
   const int B = px_desc->dims[0];
   const int S = px_desc->dims[1];
   const int T = py_desc->dims[2];
@@ -487,31 +395,29 @@ static mluOpStatus_t launchMutualInformationBackwardKernel(
   cnrtDim3_t k_dim;
   cnrtFunctionType_t k_type;
   policyFunc(handle, &k_dim, &k_type, B);
-  VLOG(5) << "Launch Kernel MutualInformationBackward<<<Block "
+  VLOG(5) << "Launch Kernel MutualInformationForward<<<Block "
           << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";
-  KERNEL_CHECK(kernelMutualInformationBackward(
-      k_dim, k_type, handle->queue, B, S, T, px, py, has_boundary, opt_boundary,
-      p, overwrite_ans_grad, ans_grad, px_grad, py_grad));
+  KERNEL_CHECK(kernelMutualInformationForward(k_dim, k_type, handle->queue,
+                                              B, S, T, px, py, has_boundary,
+                                              opt_boundary, p, ans));
 
   return MLUOP_STATUS_SUCCESS;
 }
 
-mluOpStatus_t MLUOP_WIN_API mluOpMutualInformationBackward(
+mluOpStatus_t MLUOP_WIN_API mluOpMutualInformationForward(
     mluOpHandle_t handle, const mluOpTensorDescriptor_t px_desc, const void *px,
     const mluOpTensorDescriptor_t py_desc, const void *py,
     const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
-    const mluOpTensorDescriptor_t p_desc, const void *p,
-    const mluOpTensorDescriptor_t ans_grad_desc, void *ans_grad,
-    const bool overwrite_ans_grad, void *workspace, const size_t workspace_size,
-    const mluOpTensorDescriptor_t px_grad_desc, void *px_grad,
-    const mluOpTensorDescriptor_t py_grad_desc, void *py_grad) {
+    const mluOpTensorDescriptor_t p_desc, void *p,
+    void *workspace, const size_t workspace_size,
+    const mluOpTensorDescriptor_t ans_desc, void *ans) {
   // 1. paramcheck
   bool has_boundary = false;
   bool zero_element = false;
-  mluOpStatus_t check_status = mutualInformationBackwardParamCheck(
+  mluOpStatus_t check_status = mutualInformationForwardParamCheck(
       handle, px_desc, px, py_desc, py, opt_boundary_desc, opt_boundary,
-      p_desc, p, ans_grad_desc, ans_grad, workspace, workspace_size,
-      px_grad_desc, px_grad, py_grad_desc, py_grad, has_boundary, zero_element);
+      p_desc, p, workspace, workspace_size, ans_desc, ans, has_boundary,
+      zero_element);
 
   if (MLUOP_STATUS_SUCCESS != check_status || zero_element) {
     return check_status;
@@ -519,17 +425,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpMutualInformationBackward(
 
   // 2. generate case
   if (MLUOP_GEN_CASE_ON_NEW) {
-    mutualInformationBackwardGencase(handle, px_desc, px, py_desc, py,
-                                     opt_boundary_desc, opt_boundary,
-                                     p_desc, p, ans_grad_desc, ans_grad,
-                                     overwrite_ans_grad, px_grad_desc, px_grad,
-                                     py_grad_desc, py_grad);
+    mutualInformationForwardGencase(handle, px_desc, px, py_desc, py,
+                                    opt_boundary_desc, opt_boundary,
+                                    p_desc, p, ans_desc, ans);
   }
 
   // 3. launch kernel
-  mluOpStatus_t return_status = launchMutualInformationBackwardKernel(
-      handle, px_desc, px, py_desc, py, has_boundary, opt_boundary, p,
-      overwrite_ans_grad, ans_grad, px_grad, py_grad);
+  mluOpStatus_t return_status = launchMutualInformationForwardKernel(
+      handle, px_desc, px, py_desc, py, has_boundary, opt_boundary, p, ans);
 
   GEN_CASE_END();
   return return_status;

--- a/bangc-ops/kernels/mutual_information_forward/mutual_information_forward.h
+++ b/bangc-ops/kernels/mutual_information_forward/mutual_information_forward.h
@@ -1,0 +1,34 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef KERNELS_MUTUAL_INFORMATION_FORWARD_H_
+#define KERNELS_MUTUAL_INFORMATION_FORWARD_H_
+
+#include "mlu_op.h"
+
+
+void MLUOP_WIN_API kernelMutualInformationForward(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const int B, const int S, const int T, const void *px, const void *py,
+    const bool has_boundary, const void *opt_boundary, void *p, void *ans);
+
+#endif  // KERNELS_MUTUAL_INFORMATION_FORWARD_H_

--- a/bangc-ops/kernels/mutual_information_forward/mutual_information_forward_block.mlu
+++ b/bangc-ops/kernels/mutual_information_forward/mutual_information_forward_block.mlu
@@ -1,0 +1,274 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "mutual_information_forward.h"
+
+#include "kernels/kernel.h"
+#include "kernels/utils/common.h"
+
+#define MIN_LOG_DIFF_FLOAT -15.9423847198486328125f
+#define MIN_POS_NAN 0x7f800001
+
+__nram__ char nram_buffer[MAX_NRAM_SIZE];
+
+__mlu_func__ void computeLog(float *nram_dst, float *nram_src,
+                             const int32_t deal_num) {
+  int x2d = 0x3f317217;
+  float rlog2e = *(float *)&x2d;
+  __bang_log(nram_dst, nram_src, deal_num);
+  __bang_mul_scalar(nram_dst, nram_src, rlog2e, deal_num);
+}
+
+__mlu_func__ void logAddVector(float *dst, float *src1, float *src2,
+                               float *max_value, float *mask, float *temp,
+                               int data_num) {
+  __bang_nan_minimum(dst, src1, src2, data_num);
+  __bang_maximum(max_value, src1, src2, data_num);
+
+  // if src1 is nan, then max_value = src1
+  int nan_mask_i = 0x7fffffff;
+  float nan_mask_f = *(float *)&nan_mask_i;
+  __bang_band_scalar(mask, src1, nan_mask_f, data_num);
+  __bang_ge_scalar((int *)mask, (int *)mask, MIN_POS_NAN, data_num);
+  __bang_mul_scalar((int *)mask, (int *)mask, -1, data_num);
+  __bang_band((char *)temp, (char *)src1, (char *)mask,
+              data_num * sizeof(float));
+  __bang_add(max_value, max_value, temp, data_num);
+
+  // compute log sum exp
+  __bang_sub(dst, dst, max_value, data_num);
+  __bang_ge_scalar(mask, dst, MIN_LOG_DIFF_FLOAT, data_num);
+  __mluop_exp(dst, dst, nullptr, 0, data_num);
+  __bang_add_scalar(dst, dst, 1.f, data_num);
+  computeLog(dst, dst, data_num);
+  __bang_add(dst, dst, max_value, data_num);
+
+  // if min_value - max_value < MIN_LOG_DIFF_FLOAT, return the larger one
+  __bang_float2int32_tz((int *)mask, mask, data_num, 0);
+  __bang_mul_scalar((int *)mask, (int *)mask, -1, data_num);
+  __bang_band((char *)dst, (char *)dst, (char *)mask, data_num * sizeof(float));
+  __bang_add_scalar((int *)mask, (int *)mask, 1, data_num);
+  __bang_mul_scalar((int *)mask, (int *)mask, -1, data_num);
+  __bang_band((char *)max_value, (char *)max_value, (char *)mask,
+              data_num * sizeof(float));
+  __bang_add(dst, dst, max_value, data_num);
+}
+
+__mlu_func__ void pipelineLoad(float *nram_px, float *nram_py,
+                               const int T, const int s_len, const int t_len,
+                               const int max_len, const int min_len,
+                               const int s_begin, const int t_begin,
+                               const int t_end, const int diagonal_num,
+                               const int i, float *ping) {
+  int data_num = i < max_len ? __mluop_min(i + 1, min_len) : diagonal_num - i;
+  int s = i - 1 < t_len ? s_begin : i - t_len + s_begin;
+  int t = i - 1 < t_len ? i + t_begin - 1 : t_end;
+  int px_num = i < t_len ? data_num - 1 : data_num;
+  if (px_num > 0) {
+    __memcpy_async(ping + min_len + 1, nram_px + s * (T + 1) + t, sizeof(float),
+                   NRAM2NRAM, sizeof(float), T * sizeof(float), px_num - 1);
+  }
+
+  int py_num = i < s_len ? data_num - 1 : data_num;
+  if (i >= t_len) {
+    s += 1;
+    t -= 1;
+  }
+
+  if (py_num > 0) {
+    __memcpy_async(ping, nram_py + s * T + t, sizeof(float), NRAM2NRAM,
+                   sizeof(float), (T - 1) * sizeof(float), py_num - 1);
+  }
+}
+
+__mlu_func__ void pipelineCompute(const int s_len, const int t_len,
+                                  const int max_len, const int min_len,
+                                  const int diagonal_num, const int i,
+                                  float *max_value, float *mask, float *temp,
+                                  float *pong_p, float *ping) {
+  float *ping_py = ping;
+  float *ping_px = ping_py + min_len + 1;
+  float *ping_p = ping_px + min_len;
+
+  int data_num = i < max_len ? __mluop_min(i + 1, min_len) : diagonal_num - i;
+
+  int px_num = i < t_len ? data_num - 1 : data_num;
+  if (px_num > 0) {
+    __bang_add(ping_px, ping_px, pong_p, px_num);
+  }
+
+  int py_num = i < s_len ? data_num - 1 : data_num;
+  if (i >= t_len) {
+    pong_p += 1;
+  }
+  if (py_num > 0) {
+    __bang_add(ping_py, ping_py, pong_p, py_num);
+  }
+
+  ping_px = i < t_len ? ping_px - 1 : ping_px;
+  logAddVector(ping_p, ping_px, ping_py, max_value, mask, temp, data_num);
+
+  __bang_write_value(ping, 2 * min_len + 1, -INFINITY);
+}
+
+__mlu_func__ void pipelineStore(float *nram_p, const int T, const int t_len,
+                                const int max_len,
+                                const int min_len, const int s_begin,
+                                const int t_begin, const int t_end,
+                                const int diagonal_num, const int i,
+                                float *ping_p) {
+  int data_num = i < max_len ? __mluop_min(i + 1, min_len) : diagonal_num - i;
+  int s = i < t_len ? s_begin : i - t_len + 1 + s_begin;
+  int t = i < t_len ? i + t_begin : t_end;
+  __memcpy_async(nram_p + s * (T + 1) + t, ping_p, sizeof(float), NRAM2NRAM,
+                 T * sizeof(float), sizeof(float), data_num - 1);
+}
+
+__mlu_func__ void computeMutualInformation(const int b, const int S,
+                                           const int T, const bool has_boundary,
+                                           const int s_begin, const int s_end,
+                                           const int t_begin, const int t_end,
+                                           const float *px, const float *py,
+                                           float *p, float *ans) {
+  /* *********************nram space split********************** */
+  /* |--------------------------COMMON-------------------------| */
+  /* |  px   |  py   |     p     | max_val |  mask   |  temp   | */
+  /* |S*(T+1)|(S+1)*T|(S+1)*(T+1)| min_len | min_len | min_len | */
+  /* |------------PING------------|------------PONG------------| */
+  /* | cur_py|-inf|cur_px | cur_p | cur_py|-inf|cur_px | cur_p | */
+  /* |min_len| 1  |min_len|min_len|min_len| 1  |min_len|min_len| */
+  const int px_one_batch_size = S * (T + 1);
+  const int py_one_batch_size = (S + 1) * T;
+  const int p_one_batch_size = (S + 1) * (T + 1);
+
+  float *nram_px = (float *)nram_buffer;
+  float *nram_py = nram_px + px_one_batch_size;
+  float *nram_p = nram_py + py_one_batch_size;
+
+  if (S > 0) {
+    __memcpy(nram_px, px + b * px_one_batch_size,
+             px_one_batch_size * sizeof(float), GDRAM2NRAM);
+  }
+
+  if (T > 0) {
+    __memcpy(nram_py, py + b * py_one_batch_size,
+             py_one_batch_size * sizeof(float), GDRAM2NRAM);
+  }
+
+  if (has_boundary) {
+    __memcpy(nram_p, p + b * p_one_batch_size, p_one_batch_size * sizeof(float),
+             GDRAM2NRAM);
+  }
+
+  const int s_len = s_end - s_begin + 1;
+  const int t_len = t_end - t_begin + 1;
+  const int max_len = __mluop_max(s_len, t_len);
+  const int min_len = __mluop_min(s_len, t_len);
+  const int ping_pong_gap = 3 * min_len + 1;
+
+  float *nram_max_value = nram_p + p_one_batch_size;
+  float *nram_mask = nram_max_value + min_len;
+  float *nram_temp = nram_mask + min_len;
+
+  float *ping = nram_temp + min_len;
+  float *ping_p = ping + 2 * min_len + 1;
+
+  __bang_write_value(ping, ping_pong_gap * 2, -INFINITY);
+
+  nram_p[s_begin * (T + 1) + t_begin] = (float)0;
+  ping_p[ping_pong_gap] = (float)0;
+
+  __sync();
+
+  int repeat = s_len + t_len - 2;
+  for (int i = 0; i < repeat + 2; ++i) {
+    if (i < repeat) {
+      pipelineLoad(nram_px, nram_py, T, s_len, t_len, max_len, min_len, s_begin,
+                   t_begin, t_end, repeat + 1, i + 1,
+                   ping + (i % 2) * ping_pong_gap);
+    }
+
+    if (i > 0 && i <= repeat) {
+      pipelineCompute(s_len, t_len, max_len, min_len, repeat + 1, i,
+                      nram_max_value, nram_mask, nram_temp,
+                      ping_p + (i % 2) * ping_pong_gap,
+                      ping + ((i - 1) % 2) * ping_pong_gap);
+    }
+
+    if (i > 1) {
+      pipelineStore(nram_p, T, t_len, max_len, min_len, s_begin, t_begin, t_end,
+                    repeat + 1, i - 1, ping_p + (i % 2) * ping_pong_gap);
+    }
+    __sync();
+  }
+
+  __memcpy(ans + b, nram_p + s_end * (T + 1) + t_end, sizeof(float),
+           NRAM2GDRAM);
+  __memcpy(p + b * p_one_batch_size, nram_p, p_one_batch_size * sizeof(float),
+           NRAM2GDRAM);
+}
+
+__mlu_global__ void mluBlockMutualInformationForward(
+    const int B, const int S, const int T, const float *px, const float *py,
+    const bool has_boundary, const int64_t *opt_boundary, float *p,
+    float *ans) {
+  const int num_per_core = B / taskDim;
+  const int num_rem = B % taskDim;
+  const int num_cur_core = num_per_core + (taskId < num_rem);
+  const int b_offset = taskId * num_cur_core + (taskId >= num_rem) * num_rem;
+
+  int s_begin = 0;
+  int t_begin = 0;
+  int s_end = S;
+  int t_end = T;
+  if (has_boundary) {
+    int64_t *boundary = (int64_t *)nram_buffer;
+    for (int b = b_offset; b < b_offset + num_cur_core; ++b) {
+      __memcpy(boundary, opt_boundary + 4 * b, 4 * sizeof(int64_t), GDRAM2NRAM);
+      s_begin = boundary[0];
+      t_begin = boundary[1];
+      s_end = boundary[2];
+      t_end = boundary[3];
+
+      if (s_begin > s_end || t_begin > t_end) {
+        ans[b] = 0;
+        continue;
+      }
+      computeMutualInformation(b, S, T, has_boundary, s_begin, s_end, t_begin,
+                               t_end, px, py, p, ans);
+    }
+  } else {
+    for (int b = b_offset; b < b_offset + num_cur_core; ++b) {
+      computeMutualInformation(b, S, T, has_boundary, s_begin, s_end, t_begin,
+                               t_end, px, py, p, ans);
+    }
+  }
+}
+
+void MLUOP_WIN_API kernelMutualInformationForward(
+  cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+  const int B, const int S, const int T, const void *px, const void *py,
+  const bool has_boundary, const void *opt_boundary, void *p, void *ans) {
+  mluBlockMutualInformationForward<<<k_dim, k_type, queue>>>(
+      B, S, T, (float *)px, (float *)py, has_boundary, (int64_t *)opt_boundary,
+      (float *)p, (float *)ans);
+}

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -7511,26 +7511,26 @@ mluOpMsDeformAttnBackward(mluOpHandle_t handle,
 
 // Group:MutualInformationBackward
 /*!
- * @brief Returns the size of the MLU memory that is used as an extra workspace
+ * @brief Returns the size of the MLU memory as an extra workspace
  * to optimize ::mluOpMutualInformationBackward.
  *
  * @param[in] handle
- * Handle to an MLUOP context that is used to manage MLU devices and queues in
+ * Handle to an MLUOP context for MLU devices and queues management in
  * ::mluOpMutualInformationBackward. For detailed information, see ::mluOpHandle_t.
  * @param[in] px_desc
- * The descriptor of the tensor \b px, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b px containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] py_desc
- * The descriptor of the tensor \b py, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b py containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] opt_boundary_desc
- * The descriptor of the tensor \b opt_boundary, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b opt_boundary containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] p_desc
- * The descriptor of the tensor \b p, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b p containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] ans_grad_desc
- * The descriptor of the tensor \b ans_grad, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b ans_grad containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] overwrite_ans_grad
  * A boolean value indicating whether to overwrite \b ans_grad.
@@ -7550,7 +7550,7 @@ mluOpMsDeformAttnBackward(mluOpHandle_t handle,
  * - None.
  *
  * @par API Dependency
- * - The allocated extra workspace should be passed to ::mluOpMutualInformationBackward.
+ * - The allocated extra workspace must be passed to ::mluOpMutualInformationBackward.
  *
  * @par Note
  * - Currently the \b workspace_size always returns 0.
@@ -7577,47 +7577,47 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
  * @brief Computes the gradients of tensor \b px and tensor \b py.
  *
  * @param[in] handle
- * Handle to an MLUOP context that is used to manage MLU devices and queues in the
+ * Handle to an MLUOP context for MLU devices and queues management in the
  * mutual_information_backward operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] px_desc
- * The descriptor of the tensor \b px, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b px containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] px
  * Pointer to the MLU memory that stores the tensor \b px.
  * @param[in] py_desc
- * The descriptor of the tensor \b py, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b py containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] py
  * Pointer to the MLU memory that stores the tensor \b py.
  * @param[in] opt_boundary_desc
- * The descriptor of the input tensor \b opt_boundary, which contains dimension, data type, and data layout.
+ * The descriptor of the input tensor \b opt_boundary containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] opt_boundary
  * Pointer to the MLU memory that stores the \b opt_boundary tensor.
  * @param[in] p_desc
- * The descriptor of the tensor \b p, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b p containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] p
  * Pointer to the MLU memory that stores the tensor \b p.
  * @param[in] ans_grad_desc
- * The descriptor of the tensor \b ans_grad, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b ans_grad containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] ans_grad
  * Pointer to the MLU memory that stores the tensor \b ans_grad.
  * @param[in] overwrite_ans_grad
  * A boolean value indicating whether to overwrite \b ans_grad.
  * @param[in] workspace
- * Pointer to the MLU memory that is used as an extra workspace for the mutual_information_backward operation.
- * For more information about workspace, see "Cambricon BANG C OPS User Guide".
+ * Pointer to the MLU memory as an extra workspace for the mutual_information_backward operation.
+ * For more information about the workspace, see "Cambricon BANG C OPS User Guide".
  * @param[in] workspace_size
  * The size of the extra workspace in bytes.
  * @param[in] px_grad_desc
- * The descriptor of the tensor \b px_grad, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b px_grad containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] px_grad
  * Pointer to the MLU memory that stores the tensor \b px_grad.
  * @param[in] py_grad_desc
- * The descriptor of the tensor \b py_grad, which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b py_grad containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] py_grad
  * Pointer to the MLU memory that stores the tensor \b py_grad.
@@ -7630,6 +7630,7 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
  *   - tensor ``px`` : ``float``;
  *   - tensor ``py`` : ``float``;
  *   - tensor ``opt_boundary`` : ``int64``;
+ *   - tensor ``p`` : ``float``;
  *   - tensor ``ans_grad`` : ``float``;
  *   - tensor ``px_grad`` : ``float``;
  *   - tensor ``py_grad`` : ``float``;
@@ -7639,7 +7640,7 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Scale Limitation
  * - The shape of \b px is 3D([B, S, T + 1]), where B is the batch size, S is the length of symbols
- *   and T is the length of input.
+ *   and T is the length of the input sequence.
  * - The shape of \b py is 3D([B, S + 1, T]).
  * - The shape of \b opt_boundary is 2D([B, 4]), where each row contains
      [begin_symbol, begin_frame, end_symbol, end_frame] with
@@ -7654,16 +7655,16 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
  *   - On MLU370, the scale needs to meet the following restrictions:
  *
  *     - T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 163840.
- *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 163840.
+ *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * min(S, T) + 4 <= 163840.
  *
  *   - On MLU590, the scale needs to meet the following restrictions:
  *
  *     - T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 98304.
- *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 98304.
+ *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * min(S, T) + 4 <= 98304.
  *
  * @par API Dependency
  * - Before calling this function to perform ::mluOpMutualInformationBackward, you need to get
- *   the size of workspace by ::mluOpGetMutualInformationBackwardWorkspaceSize.
+ *   the size of the workspace by ::mluOpGetMutualInformationBackwardWorkspaceSize.
  *
  * @par Note
  * - This function is only supported on MLU300 series or above platforms.
@@ -7697,6 +7698,167 @@ mluOpMutualInformationBackward(mluOpHandle_t handle,
                                void *px_grad,
                                const mluOpTensorDescriptor_t py_grad_desc,
                                void *py_grad);
+
+// Group:MutualInformationForward
+/*!
+ * @brief Returns the size of the MLU memory as an extra workspace
+ * to optimize ::mluOpMutualInformationForward.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context for MLU devices and queues management in
+ * ::mluOpMutualInformationForward. For detailed information, see ::mluOpHandle_t.
+ * @param[in] px_desc
+ * The descriptor of the tensor \b px containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] py_desc
+ * The descriptor of the tensor \b py containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] opt_boundary_desc
+ * The descriptor of the tensor \b opt_boundary containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] p_desc
+ * The descriptor of the tensor \b p containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] ans_desc
+ * The descriptor of the tensor \b ans containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] workspace_size
+ * Pointer to the MLU memory that stores the returned size of the extra workspace in bytes.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par Data Type
+ * - None.
+ *
+ * @par Data Layout
+ * - None.
+ *
+ * @par Scale Limitations
+ * - None.
+ *
+ * @par API Dependency
+ * - The allocated extra workspace must be passed to ::mluOpMutualInformationForward.
+ *
+ * @par Note
+ * - Currently the \b workspace_size always returns 0.
+ *   This will be changed when the scale limitation is removed in ::mluOpMutualInformationForward.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetMutualInformationForwardWorkspaceSize(mluOpHandle_t handle,
+                                              const mluOpTensorDescriptor_t px_desc,
+                                              const mluOpTensorDescriptor_t py_desc,
+                                              const mluOpTensorDescriptor_t opt_boundary_desc,
+                                              const mluOpTensorDescriptor_t p_desc,
+                                              const mluOpTensorDescriptor_t ans_desc,
+                                              size_t *workspace_size);
+
+// Group:MutualInformationForward
+/*!
+ * @brief Computes mutual information between tensor \b px and tensor \b py.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context for MLU devices and queues management in the
+ * mutual_information_forward operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] px_desc
+ * The descriptor of the tensor \b px containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] px
+ * Pointer to the MLU memory that stores the tensor \b px.
+ * @param[in] py_desc
+ * The descriptor of the tensor \b py containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] py
+ * Pointer to the MLU memory that stores the tensor \b py.
+ * @param[in] opt_boundary_desc
+ * The descriptor of the input tensor \b opt_boundary containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] opt_boundary
+ * Pointer to the MLU memory that stores the \b opt_boundary tensor.
+ * @param[in] p_desc
+ * The descriptor of the tensor \b p containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] p
+ * Pointer to the MLU memory that stores the tensor \b p.
+ * @param[in] workspace
+ * Pointer to the MLU memory as an extra workspace for the mutual_information_forward operation.
+ * For more information about the workspace, see "Cambricon BANG C OPS User Guide".
+ * @param[in] workspace_size
+ * The size of the extra workspace in bytes.
+ * @param[in] ans_desc
+ * The descriptor of the tensor \b ans containing dimension, data type, and data layout.
+ * For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] ans
+ * Pointer to the MLU memory that stores the tensor \b ans.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
+ *
+ * @par Data Type
+ * - The supported data types of input and output tensors are as follows:
+ *   - tensor ``px`` : ``float``;
+ *   - tensor ``py`` : ``float``;
+ *   - tensor ``opt_boundary`` : ``int64``;
+ *   - tensor ``p`` : ``float``;
+ *   - tensor ``ans`` : ``float``;
+ *
+ * @par Data Layout
+ * - The supported layout of input and output tensors must be \p MLUOP_LAYOUT_ARRAY.
+ *
+ * @par Scale Limitation
+ * - The shape of \b px is 3D([B, S, T + 1]), where B is the batch size, S is the length of symbols
+ *   and T is the length of the input sequence.
+ * - The shape of \b py is 3D([B, S + 1, T]).
+ * - The shape of \b opt_boundary is 2D([B, 4]), where each row contains
+     [begin_symbol, begin_frame, end_symbol, end_frame] with
+     "0 <= begin_symbol <= end_symbol <= S" and "0 <= begin_frame <= end_frame <= T".
+     If \b opt_boundary is NULL, it will be treated as [0, 0, S, T].
+ * - The shape of \b p is 3D([B, S + 1, T + 1]).
+ * - The shape of \b ans is 1D([B]).
+ * - The size of each tensor must be in the range of [0, 2^31].
+ *
+ *   - On MLU370, the scale needs to meet the following restrictions:
+ *
+ *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 9 * min(S, T) + 11 <= 163840.
+ *
+ *   - On MLU590, the scale needs to meet the following restrictions:
+ *
+ *     - T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 9 * min(S, T) + 11 <= 98304.
+ *
+ * @par API Dependency
+ * - Before calling this function to perform ::mluOpMutualInformationForward, you need to get
+ *   the size of the workspace by ::mluOpGetMutualInformationForwardWorkspaceSize.
+ *
+ * @par Note
+ * - This function is only supported on MLU300 series or above platforms.
+ * - If B is zero, ::MLUOP_STATUS_SUCCESS is returned without any changes to tensor \b p and tensor \b ans.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://github.com/k2-fsa/k2/blob/master/k2/python/csrc/torch/mutual_information_cuda.cu
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpMutualInformationForward(mluOpHandle_t handle,
+                              const mluOpTensorDescriptor_t px_desc,
+                              const void *px,
+                              const mluOpTensorDescriptor_t py_desc,
+                              const void *py,
+                              const mluOpTensorDescriptor_t opt_boundary_desc,
+                              const void *opt_boundary,
+                              const mluOpTensorDescriptor_t p_desc,
+                              void *p,
+                              void *workspace,
+                              const size_t workspace_size,
+                              const mluOpTensorDescriptor_t ans_desc,
+                              void *ans);
 
 // Group:RoiawarePool3d
 /*!

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.cpp
@@ -1,0 +1,218 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#include "mutual_information_forward.h"
+
+namespace mluoptest {
+
+void MutualInformationForwardExecutor::initParam() {
+  px_desc_ = tensor_desc_[0].tensor;
+  py_desc_ = tensor_desc_[1].tensor;
+  float *host_p_in = nullptr;
+  if (tensor_desc_.size() == max_tensor_num_) {
+    opt_boundary_desc_ = tensor_desc_[2].tensor;
+    p_desc_ = tensor_desc_[3].tensor;
+    ans_desc_ = tensor_desc_[5].tensor;
+    host_p_in = (float *)data_vector_[3].host_ptr;
+  } else {
+    p_desc_ = tensor_desc_[2].tensor;
+    ans_desc_ = tensor_desc_[4].tensor;
+
+    host_p_in = (float *)data_vector_[2].host_ptr;
+  }
+
+  B_ = px_desc_->dims[0];
+  S_ = px_desc_->dims[1];
+  T_ = py_desc_->dims[2];
+
+  px_index_ = MutualInformationForward::Index3D(S_, T_ + 1);
+  py_index_ = MutualInformationForward::Index3D(S_ + 1, T_);
+  p_index_ = MutualInformationForward::Index3D(S_ + 1, T_ + 1);
+
+  int p_size = B_ * (S_ + 1) * (T_ + 1);
+  p_in_ = (float *)cpu_runtime_.allocate(p_size * sizeof(float));
+  memcpy(p_in_, host_p_in, p_size  * sizeof(float));
+}
+
+void MutualInformationForwardExecutor::workspaceMalloc() {
+  initParam();
+  MLUOP_CHECK(mluOpGetMutualInformationForwardWorkspaceSize(
+      handle_, px_desc_, py_desc_, opt_boundary_desc_, p_desc_, ans_desc_,
+      &workspace_size_));
+  void *dev_workspace = nullptr;
+  if (workspace_size_ != 0) {
+    dev_workspace = mlu_runtime_.allocate(workspace_size_);
+    eva_->setMluWorkspaceSize(workspace_size_);
+  }
+  workspace_.push_back(dev_workspace);
+}
+
+void MutualInformationForwardExecutor::workspaceFree() {
+  for (auto ptr : workspace_) {
+    if (ptr) {
+      mlu_runtime_.deallocate(ptr);
+    }
+  }
+}
+
+void MutualInformationForwardExecutor::paramCheck() {
+  GTEST_CHECK(parser_->getInputNum() == 4 || parser_->getInputNum() == 3,
+              "[MutualInformationForwardExecutor] Input number is wrong.");
+  GTEST_CHECK(parser_->getOutputNum() == 2,
+              "[MutualInformationForwardExecutor] Output number is wrong.");
+}
+
+void MutualInformationForwardExecutor::compute() {
+  VLOG(4) << "MutualInformationForwardExecutor compute.";
+  void *dev_px = data_vector_[0].device_ptr;
+  void *dev_py = data_vector_[1].device_ptr;
+  void *dev_opt_boundary = nullptr;
+  void *dev_p = nullptr;
+  void *dev_ans = nullptr;
+
+  if (tensor_desc_.size() == max_tensor_num_) {
+    dev_opt_boundary = data_vector_[2].device_ptr;
+    dev_p = data_vector_[3].device_ptr;
+    dev_ans = data_vector_[5].device_ptr;
+  } else {
+    dev_p = data_vector_[2].device_ptr;
+    dev_ans = data_vector_[4].device_ptr;
+  }
+
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpMutualInformationForward(
+      handle_, px_desc_, dev_px, py_desc_, dev_py, opt_boundary_desc_,
+      dev_opt_boundary, p_desc_, dev_p, workspace_[0], workspace_size_,
+      ans_desc_, dev_ans));
+  interface_timer_.stop();
+
+  if (tensor_desc_.size() == max_tensor_num_) {
+    data_vector_[3].is_output = true;
+    data_vector_[4].is_output = false;
+    data_vector_[5].is_output = true;
+  } else {
+    data_vector_[2].is_output = true;
+    data_vector_[3].is_output = false;
+    data_vector_[4].is_output = true;
+  }
+}
+
+void MutualInformationForwardExecutor::cpuCompute() {
+  float *host_px = (float *)data_vector_[0].host_ptr;
+  float *host_py = (float *)data_vector_[1].host_ptr;
+  int64_t *host_opt_boundary = nullptr;
+
+  if (tensor_desc_.size() == max_tensor_num_) {
+    host_opt_boundary = (int64_t *)data_vector_[2].host_ptr;
+  }
+
+  float *host_p_out = cpu_fp32_output_[0];
+  memcpy(host_p_out, p_in_, B_ * (S_ + 1) * (T_ + 1) * sizeof(float));
+  float *host_ans = cpu_fp32_output_[1];
+
+  int s_begin = 0;
+  int t_begin = 0;
+  int s_end = S_;
+  int t_end = T_;
+  for (int b = 0; b < B_; ++b) {
+    if (host_opt_boundary != nullptr) {
+      s_begin = (int)host_opt_boundary[b * 4];
+      t_begin = (int)host_opt_boundary[b * 4 + 1];
+      s_end = (int)host_opt_boundary[b * 4 + 2];
+      t_end = (int)host_opt_boundary[b * 4 + 3];
+    }
+    computeMutualInformation(b, s_begin, s_end, t_begin, t_end, host_px,
+                             host_py, host_p_out, host_ans);
+  }
+
+  if (p_in_) {
+    cpu_runtime_.deallocate(p_in_);
+  }
+}
+
+float MutualInformationForwardExecutor::logAdd(float x, float y) {
+  float diff;
+  if (x < y) {
+    diff = x - y;
+    x = y;
+    theory_ops_ += 2;
+  } else {
+    diff = y - x;
+    theory_ops_++;
+  }
+
+  if (diff >= min_log_diff_float) {
+    float res;
+    res = x + log1pf(expf(diff));
+    theory_ops_ += 4;
+    return res;
+  }
+
+  return x;
+}
+
+void MutualInformationForwardExecutor::computeMutualInformation(
+    const int b, const int s_begin, const int s_end, const int t_begin,
+    const int t_end, float *px, float *py, float *p, float *ans) {
+  p[p_index_(b, s_begin, t_begin)] = 0;
+  theory_ops_++;
+
+  for (int s = s_begin + 1; s <= s_end; ++s) {
+    p[p_index_(b, s, t_begin)] = logAdd(p[p_index_(b, s - 1, t_begin)] +
+                                        px[px_index_(b, s - 1, t_begin)],
+                                        -INFINITY);
+    theory_ops_++;
+  }
+
+  for (int t = t_begin + 1; t <= t_end; ++t) {
+    p[p_index_(b, s_begin, t)] = logAdd(-INFINITY,
+                                        p[p_index_(b, s_begin, t - 1)] +
+                                        py[py_index_(b, s_begin, t - 1)]);
+    theory_ops_++;
+  }
+
+  for (int s = s_begin + 1; s <= s_end; ++s) {
+    for (int t = t_begin + 1; t <= t_end; ++t) {
+      p[p_index_(b, s, t)] = logAdd(
+          p[p_index_(b, s - 1, t)] + px[px_index_(b, s - 1, t)],
+          p[p_index_(b, s, t - 1)] + py[py_index_(b, s, t - 1)]);
+      theory_ops_ += 2;
+    }
+  }
+
+  ans[b] = p[p_index_(b, s_end, t_end)];
+  theory_ops_++;
+}
+
+int64_t MutualInformationForwardExecutor::getTheoryOps() {
+  if (parser_->device() != Device::CPU) {
+    theory_ops_ = 0;
+    if (exe_config_->mlu_only) {
+      baselineOutputMalloc();
+    }
+    cpuCompute();
+  }
+  return theory_ops_;
+}
+
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.h
@@ -1,0 +1,95 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_MUTUAL_INFORMATION_FORWARD_\
+MUTUAL_INFORMATION_FORWARD_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_MUTUAL_INFORMATION_FORWARD_\
+MUTUAL_INFORMATION_FORWARD_H_
+
+#include "core/tensor.h"
+#include "executor.h"
+#include "mlu_op.h"
+
+namespace mluoptest {
+namespace MutualInformationForward {
+class Index3D {
+ private:
+  int S_ = 0;
+  int T_ = 0;
+
+ public:
+  Index3D() {}
+  explicit Index3D(int S, int T) : S_(S), T_(T) {}
+  ~Index3D() {}
+
+  int operator()(int b, int s, int t) {
+    return b * T_ * S_ + s * T_ + t;
+  }
+};
+}  // namespace MutualInformationForward
+
+class MutualInformationForwardExecutor : public Executor {
+ public:
+  MutualInformationForwardExecutor() {}
+  ~MutualInformationForwardExecutor() {}
+
+  void workspaceMalloc() override;
+  void workspaceFree() override;
+  void paramCheck() override;
+  void compute() override;
+  void cpuCompute() override;
+  int64_t getTheoryOps() override;
+
+ private:
+  void initParam();
+  void computeMutualInformation(const int b, const int s_begin, const int s_end,
+                                const int t_begin, const int t_end, float *px,
+                                float *py, float *p, float *ans);
+  float logAdd(float x, float y);
+
+  mluOpTensorDescriptor_t px_desc_ = nullptr;
+  mluOpTensorDescriptor_t py_desc_ = nullptr;
+  mluOpTensorDescriptor_t opt_boundary_desc_ = nullptr;
+  mluOpTensorDescriptor_t p_desc_ = nullptr;
+  mluOpTensorDescriptor_t ans_desc_ = nullptr;
+  size_t workspace_size_ = 0;
+
+  int B_ = 0;
+  int S_ = 0;
+  int T_ = 0;
+  int64_t theory_ops_ = 0;
+  const float min_log_diff_float = -15.9423847198486328125f;
+
+  // max intput num is 4: px, py, opt_boundary, p
+  // max output num is 2: p, ans
+  const int max_tensor_num_ = 6;
+
+  float *p_in_ = nullptr;
+
+  mluoptest::MutualInformationForward::Index3D px_index_;
+  mluoptest::MutualInformationForward::Index3D py_index_;
+  mluoptest::MutualInformationForward::Index3D p_index_;
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_MUTUAL_INFORMATION_FORWARD_\
+MUTUAL_INFORMATION_FORWARD_H_

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/test_case/mutual_information_forward.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/test_case/mutual_information_forward.prototxt
@@ -1,0 +1,87 @@
+device: CPU
+op_name: "mutual_information_forward"
+input {
+  id: "px"
+  shape {
+    dims: 1
+    dims: 178
+    dims: 180
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -2.5
+    upper_bound_double: 2.5
+  }
+}
+input {
+  id: "py"
+  shape {
+    dims: 1
+    dims: 179
+    dims: 179
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -2.5
+    upper_bound_double: 2.5
+  }
+}
+input {
+  id: "opt_boundary"
+  shape {
+    dims: 1
+    dims: 4
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_INT64
+  value_l: 1
+  value_l: 2
+  value_l: 120
+  value_l: 130
+}
+input {
+  id: "p"
+  shape {
+    dims: 1
+    dims: 179
+    dims: 180
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -2.5
+    upper_bound_double: 2.5
+  }
+}
+output {
+  id: "p"
+  shape {
+    dims: 1
+    dims: 179
+    dims: 180
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+}
+output {
+  id: "ans"
+  shape {
+    dims: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+}
+evaluation_criterion: DIFF1
+evaluation_criterion: DIFF2
+evaluation_threshold: 0.003
+evaluation_threshold: 0.003
+supported_mlu_platform: MLU370
+supported_mlu_platform: MLU590
+handle_param {
+  round_mode: ROUND_OFF_ZERO
+}

--- a/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
+++ b/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
@@ -131,7 +131,7 @@
 | ------------ | ------------------------------------------------------------ |
 | 数据类型限制 | px: float<br/>py: float<br/>opt_boundary: int64<br/>p: float<br/>ans_grad: float<br/>overwrite_ans_grad: bool<br/>px_grad: float<br/>py_grad: float |
 | 布局限制     | ARRAY                                                        |
-| 规模限制     | 不支持large tensor;<br>在MLU370中，<br>T * (S + 1) + (T + 1) * S + 5 * T <= 163840<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 1 <= 163840; <br>在MLU590中，<br>T * (S + 1) + (T + 1) * S + 5 * T <= 98304<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 1 <= 98304;|
+| 规模限制     | 不支持large tensor;<br>在MLU370中，<br>T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 163840<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 163840; <br>在MLU590中，<br>T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 98304<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 98304;|
 | 功能限制     | 仅支持!modified模式，即输入参数px的shape为 [B, S, T+1]       |
 | 数据范围限制 | opt_boundary的shape为[B, 4]其中B为batch，4的含义为[begin_symbol, begin_frame, end_symbol, end_frame]<br/>要求：（**python层已有相关防呆**）<br/>0<= begin_symbol <= end_symbol <= S<br/>0<= begin_frame <= end_frame <= T |
 | 原位限制     | 仅当overwrite_ans_grad为true时，ans_grad支持原位操作         |

--- a/docs/bangc-docs/design_docs/mutual_information_forward/mutual_information_forward.md
+++ b/docs/bangc-docs/design_docs/mutual_information_forward/mutual_information_forward.md
@@ -1,0 +1,393 @@
+# mutual_information_forward算子开发设计方案
+
+- #### 文档基本信息
+
+| 算子名称    | mutual_information_forward |
+| ---------- | -------------- |
+| 编制人/日期 | 吴奇 & 唐成达/2023-4-14 |
+| 审批人/日期 | 黄启元/2023-5-9           |
+| 审批人/日期 | 徐文明/2023-4-17           |
+| 审批人/日期 | 光昀轶/2023-4-17 |
+| 审批人/日期 | 聂文昌/2023-4-17 |
+| 审批人/日期 | 于宝印/2023-4-17 |
+
+- #### 修改记录
+
+| 版本号 | 修订人 | 修订日期   | 修订描述 |
+| ------| ------| --------- | --------|
+| V1.0  | 唐成达 | 2023-5-9 | 首次提交 |
+
+- #### 内容描述
+
+本文档为`mutual_information_forward`算子的设计文档，包括需求分析、接口设计、方案设计、性能优化记录和方案实施部分。
+
+- #### 算子需求 checklist
+
+* 算子接口描述
+* 功能描述
+* 框架版本 + 对应源码路径
+* 需求对应网络
+* 网络中用到的规模
+* 是否需要支持原位
+* 是否需要支持 stride 机制
+* 框架单元测试阈值指标（可选）
+
+## 1 需求分析
+
+### 1.1 算子需求分析
+
+该需求分析为框架原生算子实现功能的需求分析，对于框架原生支持但 MLU-OPS 当前版本不支持的功能，需要在`1.4算子限制` 章节中显式注明。未明确注明不支持的功能，默认 MLU-OPS 全部支持。
+
+
+| 算子功能简介                  | 简要填写算子功能，详细描述在 1.2 中进行说明 |
+| ------------------------------| ------------------------------------------- |
+| 需求来源                      | k2                    |
+| 应用网络                      | RNNT                                                         |
+| 输入数据类型                  | px: float<br>py : float<br>opt_boundary(可选): int64<br>p: float |
+| 输入 Shape                    | px : [B, S, T+1]<br/>py : [B, S+1, T]<br/>opt_boundary : [B, 4]<br/>p: [B, S+1, T+1] |
+| 输入 Layout                   | px : ARRAY<br/>py: ARRAY<br>opt_boundary : ARRAY |
+| 输出数据类型                  | float                              |
+| 输出 Shape                    | p : [B,S+1,T+1]<br>ans : [B]|
+| 输出 Layout                   | p : ARRAY<br>ans : ARRAY|
+| 模式(非输入, 算子内判断）           | 当前仅支持!modified模式，即rnnt_type=regular                |
+| 是否含有 dim/axis 等类似语义的参数且该参数支持负数/其他特殊处理 | 无 |
+| 是否含有 labels/index 等类似语义的参数且该参数支持负数/界外情况/其他特殊处理 | opt_boundary为标签和语音输入的边界，shape为[B, 4]其中B为batch，4的含义为[begin_symbol, begin_frame, end_symbol, end_frame]<br/>要求：（**python层已有相关防呆**）<br/>0<= begin_symbol <= end_symbol <= S<br/>0<= begin_frame <= end_frame <= T |
+| 是否需要支持原位                | 是 (输入数据p需要支持原位)                    |
+| 是否需要支持 stride 机制        | 否                                     |
+| 是否需要支持广播                | 否    |
+| 0 元素检查是否直接返回          | 是(当B为0，内部不做计算，直接返回，其余情况需要计算) |
+| 其他特殊需求(在线量化，融合，转数提前等，可选)| 无 |
+| 本次开发优先支持的规模/模式     | !modified模式 |
+
+### 1.2 mutual_information_forward 算子功能和应用场景描述
+
+1. 算子功能：mutual_information算子中的正向算子，用于计算px和py之间的互信息。mutual_information可用于rnnt网络(一种基于RNN的序列到序列方案，可以将任意长度的输入序列转换到任意长度的输出序列)。
+
+   **输入参数说明：**
+
+   `px`: 表示当前输出标签的概率(log形式)。在!modified模式下，shape为[B,S,T+1]；在modified模式下。shape为[B,S,T]。当前仅支持!modified模式。其中B为batch，S为输出标签symbol的长度，T为输入语音片段的长度
+
+   `py`: 表示当前输出终止符号(termination_symbol)的概率(log形式)，shape为[B,S+1,T]
+
+   `opt_boundary`: 输入(可选)，表示每个batch输入和输出的边界，shape为[B,4]，其中4的含义为[begin_symbol, begin_frame, end_symbol, end_frame]。当opt_boundary为空时，默认使用B*[0, 0, S, T]进行计算
+
+   `p`: 默认输入是一个空tensor。在计算过程中会被复写，作为反向算子的输入。表示输入T个序列时，输出S个标签的概率，shape为[B,S+1,T+1]
+
+   **输出参数说明：**
+
+   `ans`: 表示每对序列之间的互信息，可从p中直接得到
+
+2. !modified模式的计算公式如下：
+
+   ```math
+   \begin{array}{lcl}
+      p(b,s,t) = ln(e^{p(b,s-1,t) + px(b,s-1,t)} + e^{p(b,s,t-1) + py(b,s,t-1)}) \\
+      ans(b) = p(b,s\_end,t\_end)
+   \end{array}
+   ```
+   
+   * 当opt_boundary为空时，s_end=S，t_end=T
+   * 当opt_boundary不为空时，s_end=opt_boundary[:, 2]，t_end=opt_boundary[:, 3]
+
+3. nan/inf行为
+
+   mlu实现需与参考接口对齐。参考接口代码的LogAdd函数对nan有特殊处理，如下所示：
+   
+   * 当输入x=nan, y=1时，返回nan
+   * 当输入x=nan, y=nan时，返回nan
+   * 当输入x=1, y=nan时，返回1
+   
+   当输入包含nan/inf时，参考接口cpu输出和cuda输出结果不一致，mlu实现与参考接口cuda输出对齐
+
+
+### 1.3 算子输入输出参数要求
+
+|参数|语义|类型(输入/输出)|支持类型|物理布局|规模说明|
+|---|----|-------------|-------|------|-------|
+|handle| MLU-OPS上下文指针                                            |输入|mluOpHandle_t | / |无|
+|px_desc | 输入数据px的描述符号，包含px的数据类型、数据维度和布局等信息 | 输入  |         	mluOpTensorDescriptor_t   |	/     |  	无    |
+| px  | 指向px数据的mlu地址指针                                      |  输入  | float |  ARRAY  | 见1.4	|
+|py_desc | 输入数据py的描述符号，包含py的数据类型、数据维度和布局等信息 | 输入 |          	mluOpTensorDescriptor_t   |	/ |      	无       	|
+|py| 指向py数据的mlu地址指针                                      |  输入 |  float | ARRAY   |	见1.4	|
+|opt_boundary_desc | 输入数据opt_boundary的描述符号，包含opt_boundary的数据类型、数据维度和布局等信息 |      	输入  |         	mluOpTensorDescriptor_t   |	/  |     	无      |
+| opt_boundary | 指向opt_boundary数据的mlu地址指针                            |   输入 | int64 | ARRAY   |	见1.4 |
+| p_desc | 输入数据p的描述符号，包含p的数据类型、数据维度和布局等信息   | 输入 | mluOpTensorDescriptor_t | / |	见1.4 |
+| p | 指向p数据的mlu地址指针 | 输入 | float | ARRAY |	无 |
+|ans_desc | 输出数据ans的描述符号，包含ans的数据类型、数据维度和布局等信息 | 输入 | mluOpTensorDescriptor_t|	/     |  	无    |
+|ans| 指向ans数据的mlu地址指针                                     |  输出 | 	float|  ARRAY   |	见1.4 |
+
+
+### 1.4 算子限制
+
+|限制类型     |详细说明                                                     	|
+|------------|------------------------------------------------------------|
+|数据类型限制	|px: float<br/>py: float<br/>opt_boundary: int64<br/>p: float<br/>ans: float |
+|布局限制    | 仅支持 layout 为 ARRAY                                       |
+|	规模限制    | 不支持large tensor;<br/>在MLU370中，<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 4 * std::min(S, T) + 4 <= 163840;<br/>在MLU590中，<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 4 * std::min(S, T) + 4 <= 98304;	|
+|功能限制     | 仅支持!modified模式，即输入参数px的shape为 [B, S, T+1]       |
+| 数据范围限制 |opt_boundary的shape为[B, 4]，其中B为batch，4的含义为[begin_symbol, begin_frame, end_symbol, end_frame]<br/>要求： （**python层已有相关防呆**）<br/>0<= begin_symbol <= end_symbol <= S<br/>0<= begin_frame <= end_frame <= T|
+|功能限制     |	不支持stride机制|
+|功能限制     |	不支持广播|
+
+### 1.5 验收标准
+
+#### 1.5.1 精度验收标准
+本算子包含动态规划和指数运算，属于复合类算子，验收标准采用动态阈值为diff1, diff2
+
+#### 1.5.2 性能验收标准
+
+本次优先交付功能，后续视情况再优化性能；
+
+## 2 算子接口设计
+
+### 2.1 参考接口
+
+* K2 (release v1.23.4)
+
+```C++
+torch::Tensor MutualInformationCuda(torch::Tensor px, torch::Tensor py,
+                                    torch::optional<torch::Tensor> opt_boundary,
+                                    torch::Tensor p)
+```
+
+### 2.2 接口设计
+
+```c++
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetMutualInformationForwardWorkspaceSize(mluOpHandle_t handle,
+                                              const mluOpTensorDescriptor_t px_desc,
+                                              const mluOpTensorDescriptor_t py_desc,
+                                              const mluOpTensorDescriptor_t opt_boundary_desc,
+                                              const mluOpTensorDescriptor_t p_desc,
+                                              const mluOpTensorDescriptor_t ans_desc,
+                                              size_t *workspace_size)
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpMutualInformationForward(mluOpHandle_t handle,
+                              const mluOpTensorDescriptor_t px_desc,
+                              const void *px,
+                              const mluOpTensorDescriptor_t py_desc,
+                              const void *py,
+                              const mluOpTensorDescriptor_t opt_boundary_desc,
+                              const void *opt_boundary,
+                              const mluOpTensorDescriptor_t p_desc,
+                              void *p,
+                              void *workspace,
+                              const size_t workspace_size,
+                              const mluOpTensorDescriptor_t ans_desc, 
+                              void *ans)
+```
+
+备注：mluOpGetMutualInformationForwardWorkspaceSize接口：workspace_size固定返回0。预留此接口，当解除规模限制后，算子需要用到workspace
+
+## 3 实现方案设计
+
+当前方案存在规模限制，即nram空间一次可处理一个batch的数据
+
+### 3.1 实现方案
+
+由于p计算为动态规划算法，并且当opt_boundary不为空时，每个batch的boundary不一样。因此下在core间拆分batch，core内对一个batch的数据循环计算。
+
+* step1：将当前batch的px和py全都加载到NRAM上
+
+* step2：计算p
+
+  p的计算公式：
+
+  ```math
+  p(b,s,t) = ln(e^{p(b,s-1,t) + px(b,s-1,t)} + e^{p(b,s,t-1) + py(b,s,t-1)})
+  ```
+
+  从p计算公式可分析出，p(b,s,t) 依赖 p(b,s-1,t) 和p(b,s,t-1) ，因此p计算可在对角线方向进行并行计算。
+
+  以B=1, T=2，S=2举例，在batch=0时，p的计算过程如下：
+
+  - 第一步: 计算p(0, 0, 0)
+  - 第二步: 计算p(0, 0, 1)，p(0, 1, 0)
+  - 第三步: 计算p(0, 0, 2)，p(0, 1, 1)，p(0, 2, 0)
+  - 第四步: 计算p(0, 1, 2)，p(0, 2, 1)
+  - 第五步: 计算p(0, 2, 2)
+
+  如下表所示，上述每一步计算的位置都是在对角线方向
+
+  | S\T  | t0         | t1         | t2         |
+  | ---- | ---------- | ---------- | ---------- |
+  | s0   | p(0, 0, 0) | p(0, 0, 1) | p(0, 0, 2) |
+  | s1   | p(0, 1, 0) | p(0, 1, 1) | p(0, 1, 2) |
+  | s2   | p(0, 2, 0) | p(0, 2, 1) | p(0, 2, 2) |
+
+  在nram从对角线方向读取px和py，逐行计算p
+
+* step3: 将p的结果存回gdram，并将p(b,s_end,t_end)存回到ans中
+
+
+
+### 3.2 伪代码实现
+
+以下伪代码，以opt_boundary=nullptr举例
+
+```c++
+#define MIN_LOG_DIFF_FLOAT -15.9423847198486328125f 
+__mlu_func__ void logAddVector(float *dst, float *src1, float *src2, float *max_value, float *mask, float *temp, int data_num) {
+    __bang_nan_minimum(dst, src1, src2, data_num);
+    __bang_maximum(max_value, src1, src2, data_num);
+
+    // if src1 is nan, then max_value = src1
+    int nan_mask_i = 0x7fffffff;
+    float nan_mask_f = *(float *)&nan_mask_i;
+    __bang_band_scalar(mask, src1, nan_mask_f, data_num);
+    __bang_ge_scalar((int *)mask, (int *)mask, MIN_POS_NAN, data_num);
+    __bang_mul_scalar((int *)mask, (int *)mask, -1, data_num);
+    __bang_band((char *)temp, (char *)src1, (char *)mask,
+                data_num * sizeof(float));
+    __bang_add(max_value, max_value, temp, data_num);
+
+    // compute log sum exp
+    __bang_sub(dst, dst, max_value, data_num);
+    __bang_ge_scalar(mask, dst, MIN_LOG_DIFF_FLOAT, data_num);
+    __mluop_exp(dst, dst, nullptr, 0, data_num);
+    __bang_add_scalar(dst, dst, 1.f, data_num);
+    computeLog(dst, dst, data_num);
+    __bang_add(dst, dst, max_value, data_num);
+
+    // if min_value - max_value < MIN_POS_NAN, return the larger one
+    __bang_float2int32_rn((int *)mask, mask, data_num, 0);
+    __bang_mul_scalar((int *)mask, (int *)mask, -1, data_num);
+    __bang_band((char *)dst, (char *)dst, (char *)mask, data_num * sizeof(float));
+    __bang_add_scalar((int *)mask, (int *)mask, 1, data_num);
+    __bang_mul_scalar((int *)mask, (int *)mask, -1, data_num);
+    __bang_band((char *)max_value, (char *)max_value, (char *)mask,
+                data_num * sizeof(float));
+    __bang_add(dst, dst, max_value, data_num);
+}
+
+
+__mlu_func__ void computeMutualInformation() {
+    /* ***************************************nram space split**************************************** */
+    /* |    px   |   py    |      p      |   cur_px   |   cur_py   |   cur_p    | max_value/mask/temp |*/
+    /* | S*(T+1) | (S+1)*T | (S+1)*(T+1) | min(S,T)+1 | min(S,T)+1 | min(S,T)+1 |    3*min(S,T)+3     |*/
+    float *px = (float *)buffer;
+    float *py = px + S*(T+1);
+    float *p = py + (S+1)*T;
+    float *cur_px = p + (S+1)*(T+1);
+    float *cur_py = cur_px + min(S,T)+1;
+    float *cur_p = cur_py + min(S,T)+1;
+    float *max_value = cur_p + min(S,T)+1;
+    float *mask = max_value + min(S,T)+1;
+    float *temp = mask + min(S,T)+1;
+    for (int i = 1; i < S + T + 1; ++i) {
+        int data_num = 1;
+        if (i < T) {
+            data_num = std::min(i + 1, S);
+        } else {
+            data_num = T + S - i;
+        }
+        __memcpy(); // load cur_px
+        __memcpy(); // load cur_py
+        __memcpy(); // load cur_p
+        __bang_add(cur_px, cur_px, cur_p, data_num);
+        __bang_add(cur_py, cur_py, cur_p, data_num);
+        logAddVector(cur_p, cur_px, cur_py, max_value, mask, temp, data_num);
+        __memcpy(); // store cur_p
+    }
+}
+
+__mlu_global__ void MLUKernelMutualInformationForward(void *px,
+                                                      void *py,
+                                                      void *opt_boundary,
+                                                      void *p,
+                                                      void *ans) {
+    int num_per_core = batches / taskDim;
+    int num_rem = batches % taskDim;
+    int num_cur_core = num_per_core + (taskId < num_rem);
+    int b_offset = taskId * num_cur_core + (taskId >= num_rem) * num_rem;
+
+    for (int i = b_offset; i < b_offset + num_cur_core; ++i) {
+        computeMutualInformation();
+    }
+}
+```
+
+### 3.3 拆分（任务拆分，多核拆分）
+
+基本任务类型为Block任务，core间按照对batch维度进行拆分，core内在S-T矩阵的对角线方向进行循环计算
+
+### 3.4 性能优化设计
+
+1、资源分配
+
+NRAM空间划分参考3.2 伪代码实现中的描述
+
+2、流水设计
+
+bang_maximum等指令在370上无法异步执行，因此暂不排流水。
+
+### 3.5 可维护性设计
+
+1、bangc 代码中加入必要的 log 信息，比如输入的规模、数据类型、layout 这些，以及如果出错会导致程序 core dump 的变量，比如 IO 指令的 data_size、dim xyz 的值等，这些信息都是有利于快速定位问题；
+
+2、对每一个函数命名变量命名都有充分的注释；
+
+3、避免魔鬼数字，对于确定的数字尽量使用公共宏来替代，或添加注释。
+
+### 3.6 测试用例设计
+
+- 算子在网络中用到的规模：
+
+  未提供
+
+
+- 边界 case：
+  - T=0; S=0; T= 1; S= 1
+  - opt_boundary中存在begin_symbol = end_symbol
+  - opt_boundary中存在begin_frame = end_frame
+
+
+其他可根据需要进行补充。算子开发完毕后，补充测试报告链接。
+
+### 3.7 算子防呆检查
+
+1、检查handle/px_desc/py_desc/p_desc/ans_desc是否为空
+
+2、检查输入输出空间指针px/py/p/ans是否为空
+
+3、检查opt_boundary_desc和opt_boundary是否同时为空，或者同时不为空
+
+3、检查0元素，如果batch_size为=0，直接返回MLUOP_STATUS_SUCCESS
+
+3、涉及 workspace 算子对于 workspace_size 的检查防呆；
+
+4、检查px的维度为[B, S,T+1]；py的维度为[B, S+1,T]；p的维度为[B, S+1,T+1]；ans的维度为[B]；如果opt_boundary不为空，opt_boundary为维度为[B，4]
+
+5、检查px/py/p/ans的数据类型为float；如果opt_boundary不为空，opt_boundary的数据类型为int64
+
+6、检查输入输出是否包含large tensor，或者输入规模是否超出限制
+
+
+## 4 算子性能/精度问题 & 优化记录
+
+### 4.1 当前存在问题的规模说明
+
+暂无
+
+### 4.2 已经过优化的规模说明
+
+暂无
+
+## 5 方案实施
+
+### 5.1 开发测试计划
+
+- 2023.03.30 算法原理调研与参考接口分析
+- 2023.04.10 设计方案：算子功能+接口设计
+- 2023.05.09 generator开发
+- 2023.05.10 host端开发
+- 2023.05.11 正向算子gtest、device端开发
+- 2023.05.18 功能调试与优化
+- 2023.05.22 批量测试与撰写测试报告
+- 2023.05.24 提交PR与代码review
+- 2023.05.26 算子入库
+
+
+### 5.2 风险分析
+* LogAdd函数中nan/inf状态对齐会影响算子性能

--- a/docs/bangc-docs/user_guide/9_operators/index.rst
+++ b/docs/bangc-docs/user_guide/9_operators/index.rst
@@ -363,6 +363,20 @@ mluOpMutualInformationBackward
    py\_grad(b,s,t) = p\_grad(b,s,t+1) * term2(b,s,t)
   \end{array}
 
+.. _mutual_information_forward:
+
+mluOpMutualInformationforward
+--------------------------------
+该算子是计算输入 ``px`` 和 ``py`` 之间的互信息。
+
+公式如下：
+.. math::
+
+  \begin{array}{lcl}
+      p(b,s,t) = ln(e^{p(b,s-1,t) + px(b,s-1,t)} + e^{p(b,s,t-1) + py(b,s,t-1)}) \\
+      ans(b) = p(b,s\_end,t\_end)
+  \end{array}
+
 .. _nms:
 
 mluOpNms


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

add new_op, mutual_information_forward

## 2. Modification

```
new file:   bangc-ops/kernels/mutual_information_forward/mutual_information_forward.cpp
new file:   bangc-ops/kernels/mutual_information_forward/mutual_information_forward.h
new file:   bangc-ops/kernels/mutual_information_forward/mutual_information_forward_block.mlu
new file:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.cpp
new file:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.h
new file:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/test_case/mutual_information_forward.prototxt
new file:   docs/bangc-docs/design_docs/mutual_information_forward/mutual_information_forward.md
modified:   bangc-ops/kernels/mutual_information_backward/mutual_information_backward.cpp
modified:   bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
modified:   bangc-ops/mlu_op.h
modified:   docs/bangc-docs/user_guide/9_operators/index.rst
```

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block     |
|        3       |Layouts                               |          ARRAY      |
|        4       |Whether multi-dimensions are supported|             no              |
|        5       |Whether element zero is supported     |                 yes                |
|        6       |Data type(half/float)                 |           float           |
|        7       |Whether there is size limit           |       The shape of “py” is  [B, S + 1, T]<br>On MLU370:<br>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 9 * std::min(S, T) + 11 <= 163840.<br>On MLU590:<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 9 * std::min(S, T) + 11 <= 98304.        |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |      pass           |
| Whether illegal parameters are passed           |     Normal error    |        pass           |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

| Test Point          | Description                        | Quantity | Comment                                                      |
| ------------------- | ---------------------------------- | -------- | ------------------------------------------------------------ |
| Data type test      | float                              | pass     | [       OK ] mutual_information_forward/TestSuite.mluOp/27 (22 ms)<br/>[----------] 28 tests from mutual_information_forward/TestSuite (1084 ms total)<br/><br/>[----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 28 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 28 test cases from 1 test suite ran. (1434 ms total)<br/>[  PASSED  ] 28 test cases. |
| Zero element test   | Whether to support this test       | pass     | [2023-5-18 14:37:50] [MLUOP] [Vlog]:MutualInformationForwardExecutor compute.<br/>[2023-5-18 14:37:50] [MLUOP] [Vlog]:[mluOpMutualInformationForward] Skip zero element tensor when px.shape[0] is zero.<br/>[2023-5-18 14:37:50] [MLUOP] [Vlog]:Device free (for workspace). |
| Stability test      | --gtest_repeat=100<br>--thread=100 | pass     | ./mluop_gtest --gtest_filter=*mutual_information_forward* --cases_dir=/projs/cnnl/tangchengda/test_cases  --gtest_repeat=100 --thread=100<br>[----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 2800 cases of 100 op(s).<br/>ALL PASSED.<br/>[==========] 1 test case from 1 test suite ran. (466 ms total)<br/>[  PASSED  ] 1 test case. |
| Mult-platform test  | MLU370/MLU590                      | pass     | MLU370X4:<br>[       OK ] mutual_information_forward/TestSuite.mluOp/27 (22 ms)<br/>[----------] 28 tests from mutual_information_forward/TestSuite (1084 ms total)<br/><br/>[----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 28 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 28 test cases from 1 test suite ran. (1434 ms total)<br/>[  PASSED  ] 28 test cases.<br>MLU590:<br/>[       OK ] mutual_information_forward/TestSuite.mluOp/27 (19 ms)<br/>[----------] 28 tests from mutual_information_forward/TestSuite (1049 ms total)<br/><br/>[----------] Global test environment tear-down<br/>[ SUMMARY  ] Total 28 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 28 test cases from 1 test suite ran. (1541 ms total)<br/>[  PASSED  ] 28 test cases. |
| Nan/INF test        | Whether to support this test       | pass     | [ SUMMARY  ] Total 50 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 50 test cases from 1 test suite ran. (2910 ms total)<br/>[  PASSED  ] 50 test cases. |
| Memory leak check   | Test result                        | pass     | [ SUMMARY  ] Total 28 cases of 1 op(s).<br/>ALL PASSED.<br/>[==========] 28 test cases from 1 test suite ran. (1434 ms total)<br/>[  PASSED  ] 28 test cases. |
| Code coverage check | Test result                        | pass     | File - Line Coverage - Functions<br>mutual_information_forward_block.mlu - [98.8% 242 / 245] - [100.0% 8 / 8] |


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|mutual_information_forward| 138 | 64.126 | 0.00249094 | 0.000272899 | -1 | float | px:[4, 15, 105], py:[4, 16, 104], p:[4, 16, 105] |


Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|mutual_information_forward| 126 | 18.804 | 0.000303131 | 0.000161898 | -1 | float | px:[4, 15, 105], py:[4, 16, 104], p:[4, 16, 105] |


### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.