### PR TITLE
[Feature](bangc-ops): format func in common.h

### DIFF
--- a/bangc-ops/kernels/ball_query/ball_query_union1.mlu
+++ b/bangc-ops/kernels/ball_query/ball_query_union1.mlu
@@ -70,8 +70,8 @@ __mlu_func__ void convertFloat2Int(int32_t *dst, float *dst_addtion,
   float *src = (float *)src_origin + start_index;
   __bang_add_scalar((float *)src, (float *)src, (float)(offset),
                     CEIL_ALIGN(elem_count, ALIGN_NUM));
-  __float2int32((int32_t *)dst, (float *)dst_addtion, (float *)src,
-                (float *)src_addtion, CEIL_ALIGN(elem_count, ALIGN_NUM));
+  __mluop_float2int32((int32_t *)dst, (float *)dst_addtion, (float *)src,
+                      (float *)src_addtion, CEIL_ALIGN(elem_count, ALIGN_NUM));
 #endif
 }
 

--- a/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
+++ b/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
@@ -150,8 +150,8 @@ __mlu_device__ void bbox_overlaps_workflow(
       T *base_s = b1_area;
 
       // ious = inter_s / base_s
-      computeDiv(width, inter_s, base_s, vec_b2_x2, is_high_precision,
-                 batches_stride);
+      __mluop_div(width, inter_s, base_s, vec_b2_x2, is_high_precision,
+                  batches_stride);
       __memcpy((T *)ious + index, width, handle_batches * sizeof(T),
                NRAM2GDRAM);
     }
@@ -253,8 +253,8 @@ __mlu_device__ void bbox_overlaps_workflow(
         T *base_s = b1_area;
 
         // ious = inter_s / base_s
-        computeDiv(width, inter_s, base_s, vec_b2_x2, is_high_precision,
-                   batches_stride);
+        __mluop_div(width, inter_s, base_s, vec_b2_x2, is_high_precision,
+                    batches_stride);
         int32_t gdram_offset = index1 * num_bbox2 + index2;
         __memcpy((T *)ious + gdram_offset, width, handle_batches * sizeof(T),
                  NRAM2GDRAM);

--- a/bangc-ops/kernels/carafe/carafe_block.mlu
+++ b/bangc-ops/kernels/carafe/carafe_block.mlu
@@ -144,9 +144,9 @@ __mlu_global__ void MLUKernelCarafeForward(
     int src_offset = INDEX3(isample, ho_0, wo_0, g_0 * kernel_size_sq,
                             mask_stride_n, mask_stride_h, mask_stride_w);
     T *src = mask + src_offset;
-    loadStr3D(mask_nram, src, block_G * kernel_size_sq, block_Wo, block_Ho,
-              mask_nram_stride_w, mask_nram_stride_h, mask_stride_w,
-              mask_stride_h);
+    __mluop_load_str_3D(mask_nram, src, block_G * kernel_size_sq, block_Wo,
+                        block_Ho, mask_nram_stride_w, mask_nram_stride_h,
+                        mask_stride_w, mask_stride_h);
 
     /* ===== load input block from gdram2nram
      *
@@ -211,8 +211,9 @@ __mlu_global__ void MLUKernelCarafeForward(
                         input_stride_h, input_stride_w);
     src = input + src_offset;
     for (int i = 0; i < input_seg_num_h; ++i) {
-      loadStr3D(dst, src, block_C, block_G, input_seg_num_w, block_c_stride,
-                input_nram_stride_w, block_C, input_stride_w);
+      __mluop_load_str_3D(dst, src, block_C, block_G, input_seg_num_w,
+                          block_c_stride, input_nram_stride_w, block_C,
+                          input_stride_w);
       dst += input_nram_stride_h;
       src += input_stride_h;
     }
@@ -290,8 +291,9 @@ __mlu_global__ void MLUKernelCarafeForward(
     dst = output + dst_offset;
     src = output_nram;
     for (int i = 0; i < block_Ho; ++i) {
-      storeStr3D(dst, src, block_C, block_G, block_Wo, block_C, output_stride_w,
-                 block_c_stride, output_nram_stride_w);
+      __mluop_store_str_3D(dst, src, block_C, block_G, block_Wo, block_C,
+                           output_stride_w, block_c_stride,
+                           output_nram_stride_w);
       dst += output_stride_h;
       src += output_nram_stride_h;
     }

--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -57,8 +57,8 @@ __mlu_func__ void computeLogE(float *nram_dst, float *nram_src,
   int x2d = 0x3f317217;
   float rlog2e = *(float *)&x2d;
   __bang_log((float *)nram_dst, (float *)nram_src, deal_num);
-  __bang_mul_scalar((float *)nram_dst, (float *)nram_src,
-                    (float)rlog2e, deal_num);
+  __bang_mul_scalar((float *)nram_dst, (float *)nram_src, (float)rlog2e,
+                    deal_num);
 #else
   __bang_active_loghp((float *)nram_dst, (float *)nram_src, deal_num);
 #endif
@@ -160,7 +160,7 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
 
   // 1. pt = 1 - sigmoid(x)
 #if __BANG_ARCH__ >= 372
-  computeSigmoid((float *)nram_pt, (float *)nram_input, NULL, 0, compute_num);
+  __mluop_sigmoid((float *)nram_pt, (float *)nram_input, NULL, 0, compute_num);
 #else
   sigmoid((float *)nram_pt, (float *)nram_input, compute_num);
 #endif
@@ -199,7 +199,7 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
   computeLogE((float *)nram_temp, (float *)nram_temp, compute_num);
   __bang_cycle_mul((float *)nram_temp, (float *)nram_temp, (float *)nram_gamma,
                    compute_num, nfu_align_num);
-  computeExp((float *)nram_temp, (float *)nram_temp, NULL, 0, compute_num);
+  __mluop_exp((float *)nram_temp, (float *)nram_temp, NULL, 0, compute_num);
   __bang_mul((float *)nram_temp, (float *)nram_temp, (float *)nram_alpha_t,
              compute_num);
   __bang_mul_scalar((float *)nram_temp, (float *)nram_temp, (float)(-1),

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -683,8 +683,8 @@ void __mlu_func__ computeGradAttnWeight(
   __bang_transpose((float *)nram_grad_output_tr, (float *)nram_grad_output_br,
                    num_deal_grid, deal_num_real);
 
-  recursiveSumPool(nram_grad_output_tr, num_deal_grid, deal_num_real,
-                   ALIGN_NUM);
+  __mluop_recursive_sum_pool(nram_grad_output_tr, num_deal_grid, deal_num_real,
+                             ALIGN_NUM);
 
   __bang_float2int32((int32_t *)nram_h_high_temp, nram_h_high_temp,
                      num_deal_grid, 0);
@@ -741,7 +741,8 @@ void __mlu_func__ computeGradSampingLoc(
                    deal_num_real);
   __memcpy_async(grad_h_weight, nram_grad_output_tl,
                  num_deal_grid * deal_num_real * sizeof(float), NRAM2NRAM);
-  recursiveSumPool(grad_h_weight, num_deal_grid, deal_num_real, ALIGN_NUM);
+  __mluop_recursive_sum_pool(grad_h_weight, num_deal_grid, deal_num_real,
+                             ALIGN_NUM);
 
   __nram__ int32_t table[2] = {0, (int32_t)0xffffffff};
   __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
@@ -765,7 +766,8 @@ void __mlu_func__ computeGradSampingLoc(
                    deal_num_real);
   __memcpy_async(grad_w_weight, nram_grad_output_tl,
                  num_deal_grid * deal_num_real * sizeof(float), NRAM2NRAM);
-  recursiveSumPool(grad_w_weight, num_deal_grid, deal_num_real, ALIGN_NUM);
+  __mluop_recursive_sum_pool(grad_w_weight, num_deal_grid, deal_num_real,
+                             ALIGN_NUM);
   __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
                  (int32_t *)table, num_deal_grid, 64);
   __bang_band((char *)grad_w_weight, (char *)grad_w_weight,

--- a/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_union1.mlu
+++ b/bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_union1.mlu
@@ -121,17 +121,20 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
                              deal_num_real);
   }
   __bang_mul(grad_output_nram, grad_output_nram, top_grad, deal_num_real);
-  recursiveSumPool(grad_output_nram, 1, deal_num_real, ALIGN_NUM_FOR_REDUCE);
+  __mluop_recursive_sum_pool(grad_output_nram, 1, deal_num_real,
+                             ALIGN_NUM_FOR_REDUCE);
   __bang_atomic_reduce_add((T *)grad_attn_weight, (T *)grad_output_nram, 1);
   __bang_mul_scalar(grad_w_weight, grad_w_weight, width, deal_num_real);
   __bang_mul_scalar(top_grad_temp, top_grad, data_attn_weight, deal_num_real);
   __bang_mul(grad_w_weight, grad_w_weight, top_grad_temp, deal_num_real);
-  recursiveSumPool(grad_w_weight, 1, deal_num_real, ALIGN_NUM_FOR_REDUCE);
+  __mluop_recursive_sum_pool(grad_w_weight, 1, deal_num_real,
+                             ALIGN_NUM_FOR_REDUCE);
   __bang_atomic_reduce_add((T *)(grad_sampling_loc), (T *)grad_w_weight, 1);
 
   __bang_mul_scalar(grad_h_weight, grad_h_weight, height, deal_num_real);
   __bang_mul(grad_h_weight, grad_h_weight, top_grad_temp, deal_num_real);
-  recursiveSumPool(grad_h_weight, 1, deal_num_real, ALIGN_NUM_FOR_REDUCE);
+  __mluop_recursive_sum_pool(grad_h_weight, 1, deal_num_real,
+                             ALIGN_NUM_FOR_REDUCE);
   __bang_atomic_reduce_add((T *)(grad_sampling_loc + 1), (T *)grad_h_weight, 1);
 #endif
 }

--- a/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
+++ b/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
@@ -37,7 +37,7 @@ __mlu_func__ void setNanInfToZero(float *src, float *mask, const int num) {
 
 __mlu_func__ void safeExp(float *dst, float *src, float *mask, const int num) {
   setNanInfToZero(src, mask, num);
-  computeExp(dst, src, NULL, 0, num);
+  __mluop_exp(dst, src, NULL, 0, num);
   __bang_band((char *)dst, (char *)dst, (char *)mask, num * sizeof(float));
   setNanInfToZero(dst, mask, num);
 }
@@ -154,40 +154,40 @@ __mlu_func__ void computePGrad(const int b, const int S, const int T,
 
   int loop_time = s_len + t_len - 1;
   for (int i = 1; i < loop_time; ++i) {
-      data_num = i < max_len ? __mluop_min(i + 1, min_len) : loop_time - i;
-      s = i < s_len ? s_end - i : s_begin;
-      t = i < s_len ? t_end : t_end + s_len - i - 1;
+    data_num = i < max_len ? __mluop_min(i + 1, min_len) : loop_time - i;
+    s = i < s_len ? s_end - i : s_begin;
+    t = i < s_len ? t_end : t_end + s_len - i - 1;
 
-      term1_num = i < t_len ? data_num - 1 : data_num;
-      if (term1_num > 0) {
-        __memcpy(nram_cur_term1, nram_term1 + s * (T + 1) + t, sizeof(float),
-                 NRAM2NRAM, sizeof(float), T * sizeof(float), term1_num - 1);
-        nram_p_grad_for_compute_term1 = i >= s_len ? nram_cur_p_grad + 1 :
-                                        nram_cur_p_grad;
-        __bang_mul(nram_cur_term1, nram_cur_term1,
-                   nram_p_grad_for_compute_term1, term1_num);
-      }
+    term1_num = i < t_len ? data_num - 1 : data_num;
+    if (term1_num > 0) {
+      __memcpy(nram_cur_term1, nram_term1 + s * (T + 1) + t, sizeof(float),
+               NRAM2NRAM, sizeof(float), T * sizeof(float), term1_num - 1);
+      nram_p_grad_for_compute_term1 =
+          i >= s_len ? nram_cur_p_grad + 1 : nram_cur_p_grad;
+      __bang_mul(nram_cur_term1, nram_cur_term1, nram_p_grad_for_compute_term1,
+                 term1_num);
+    }
 
-      term2_num = data_num;
-      nram_compute_term2 = nram_cur_term2;
-      term2_s = s;
-      term2_t = t;
-      if (i < s_len) {
-        term2_num -= 1;
-        nram_compute_term2 -= 1;
-        term2_s += 1;
-        term2_t -= 1;
-      }
-      if (term2_num > 0) {
-        __memcpy(nram_cur_term2, nram_term2 + term2_s * T + term2_t,
-                 sizeof(float), NRAM2NRAM, sizeof(float),
-                 (T - 1) * sizeof(float), term2_num - 1);
-        __bang_mul(nram_cur_term2, nram_cur_term2, nram_cur_p_grad, term2_num);
-      }
+    term2_num = data_num;
+    nram_compute_term2 = nram_cur_term2;
+    term2_s = s;
+    term2_t = t;
+    if (i < s_len) {
+      term2_num -= 1;
+      nram_compute_term2 -= 1;
+      term2_s += 1;
+      term2_t -= 1;
+    }
+    if (term2_num > 0) {
+      __memcpy(nram_cur_term2, nram_term2 + term2_s * T + term2_t,
+               sizeof(float), NRAM2NRAM, sizeof(float), (T - 1) * sizeof(float),
+               term2_num - 1);
+      __bang_mul(nram_cur_term2, nram_cur_term2, nram_cur_p_grad, term2_num);
+    }
 
-      __bang_add(nram_cur_p_grad, nram_cur_term1, nram_compute_term2, data_num);
-      __memcpy(nram_p_grad + s * (T + 1) + t, nram_cur_p_grad, sizeof(float),
-               NRAM2NRAM, T * sizeof(float), sizeof(float), data_num - 1);
+    __bang_add(nram_cur_p_grad, nram_cur_term1, nram_compute_term2, data_num);
+    __memcpy(nram_p_grad + s * (T + 1) + t, nram_cur_p_grad, sizeof(float),
+             NRAM2NRAM, T * sizeof(float), sizeof(float), data_num - 1);
   }
 
   if (overwrite_ans_grad) {
@@ -217,8 +217,7 @@ __mlu_func__ void computePxGradAndPyGrad(const int b, const int S, const int T,
 
     if (t_len > 1) {
       // compute term2
-      __bang_mul(nram_term2 + i * T + t_begin,
-                 nram_term2 + i * T + t_begin,
+      __bang_mul(nram_term2 + i * T + t_begin, nram_term2 + i * T + t_begin,
                  nram_p_grad + i * (T + 1) + t_begin + 1, t_len - 1);
     }
   }
@@ -294,8 +293,8 @@ __mlu_global__ void mluBlockMutualInformationBackward(
 }
 
 void MLUOP_WIN_API kernelMutualInformationBackward(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    const int B, const int S, const int T, const void *px, const void *py,
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue, const int B,
+    const int S, const int T, const void *px, const void *py,
     const bool has_boundary, const void *opt_boundary, const void *p,
     const bool overwrite_ans_grad, void *ans_grad, void *px_grad,
     void *py_grad) {

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
@@ -587,9 +587,9 @@ __mlu_entry__ void MLUMultiKernelRoiawareAvgPool3dBackward(
         __bang_mul_scalar((float *)nram_grad_out_cur_loop,
                           (float *)nram_grad_out_cur_loop, (float)cur_grad,
                           align_actual_channels_num);
-        __float2half((half *)nram_grad_out_cur_loop,
-                     (float *)nram_grad_out_cur_loop,
-                     align_actual_channels_num);
+        __mluop_float2half((half *)nram_grad_out_cur_loop,
+                           (float *)nram_grad_out_cur_loop,
+                           align_actual_channels_num);
       } else {
         __bang_mul_scalar((float *)nram_grad_out_cur_loop,
                           (float *)nram_grad_in_cur_loop, (float)cur_grad,

--- a/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
+++ b/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
@@ -131,10 +131,10 @@ __mlu_func__ void selectIndicesBetweenMinAndMax(
     const uint32_t n_limit, const uint32_t c_limit,
     const uint32_t m_limit_org) {
   // convert indices from int32_t to float for 270
-  __int322float(nram_indices_transpose_float,
-                nram_indices_transpose_float_addition,
-                nram_indices_transpose + index * n_limit,
-                nram_indices_transpose_addition, n_limit);
+  __mluop_int322float(nram_indices_transpose_float,
+                      nram_indices_transpose_float_addition,
+                      nram_indices_transpose + index * n_limit,
+                      nram_indices_transpose_addition, n_limit);
   // select the offset between the m_min and m_max
   // judge if less than m_max
   __bang_ge_scalar(nram_indices_transpose_float_addition,
@@ -194,9 +194,9 @@ __mlu_func__ void selectIndicesBetweenMinAndMax(
   __bang_mul_scalar(nram_indices_transpose_float, nram_indices_transpose_float,
                     c_limit, n_limit);
   // convert the indices from float type back to int for 270
-  __float2int32(nram_indices, nram_indices_transpose_addition,
-                nram_indices_transpose_float,
-                nram_indices_transpose_float_addition, n_limit);
+  __mluop_float2int32(nram_indices, nram_indices_transpose_addition,
+                      nram_indices_transpose_float,
+                      nram_indices_transpose_float_addition, n_limit);
 }
 
 template <typename T>
@@ -245,11 +245,11 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
   /*
    * NRAM partition
    *  |-----------------------------------------------------------------------------------|
-   *  |           nram_features                  |        nram_features_transpose         |
+   *  |           nram_features                  | nram_features_transpose |
    *  |-----------------------------------------------------------------------------------|
-   *  |           nram_features_selected         |                    nram_output         |
+   *  |           nram_features_selected         | nram_output         |
    *  |-----------------------------------------------------------------------------------|
-   *  |      nram_weights         |   nram_weights_transpose  |      nram_indices         |
+   *  |      nram_weights         |   nram_weights_transpose  | nram_indices |
    *  |-----------------------------------------------------------------------------------|
    *  | nram_indices_transpose(addition/float/float_addition) |
    *  |-----------------------------------------------------------------------------------|
@@ -359,8 +359,8 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
         if (src_stride <= INT32_MAX_NUM) {
           __memcpy(nram_features,
                    base_addr_features + (j * m * c_limit + k * m_limit),
-                   m_slice * sizeof(T), GDRAM2NRAM, dst_stride,
-                   src_stride, c_slice - 1);
+                   m_slice * sizeof(T), GDRAM2NRAM, dst_stride, src_stride,
+                   c_slice - 1);
         } else {
           // src_stride in __memcpy is int type, here handles src_stride
           // overflow int32 max
@@ -492,11 +492,14 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
   /*
    * NRAM partition
    *  |-------------------------------------------------------------------------------------------|
-   *  |           nram_grad_output                  |        nram_grad_output_transpose           |
+   *  |           nram_grad_output                  | nram_grad_output_transpose
+   * |
    *  |-------------------------------------------------------------------------------------------|
-   *  |           nram_grad_features                |        nram_grad_features_transpose         |
+   *  |           nram_grad_features                |
+   * nram_grad_features_transpose         |
    *  |-------------------------------------------------------------------------------------------|
-   *  |      nram_weights            |   nram_weights_transpose     |      nram_indices           |
+   *  |      nram_weights            |   nram_weights_transpose     |
+   * nram_indices           |
    *  |-------------------------------------------------------------------------------------------|
    *  |      nram_indices_transpose(addition/float/float_addition)  |
    *  |-------------------------------------------------------------------------------------------|
@@ -587,8 +590,8 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
         if (src_stride <= INT32_MAX_NUM) {
           __memcpy(nram_grad_output,
                    base_addr_grad_output + (j * n * c_limit + k * n_limit),
-                   n_slice * sizeof(T), GDRAM2NRAM, dst_stride,
-                   src_stride, c_slice - 1);
+                   n_slice * sizeof(T), GDRAM2NRAM, dst_stride, src_stride,
+                   c_slice - 1);
         } else {
           // src_stride in __memcpy is int type, here handles src_stride
           // overflow int32 max

--- a/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
+++ b/bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
@@ -245,11 +245,11 @@ __mlu_global__ void MLUKernelThreeInterpolateForward(
   /*
    * NRAM partition
    *  |-----------------------------------------------------------------------------------|
-   *  |           nram_features                  | nram_features_transpose |
+   *  |           nram_features                  |        nram_features_transpose         |
    *  |-----------------------------------------------------------------------------------|
-   *  |           nram_features_selected         | nram_output         |
+   *  |           nram_features_selected         |                    nram_output         |
    *  |-----------------------------------------------------------------------------------|
-   *  |      nram_weights         |   nram_weights_transpose  | nram_indices |
+   *  |      nram_weights         |   nram_weights_transpose  |      nram_indices         |
    *  |-----------------------------------------------------------------------------------|
    *  | nram_indices_transpose(addition/float/float_addition) |
    *  |-----------------------------------------------------------------------------------|
@@ -492,14 +492,11 @@ __mlu_global__ void MLUKernelThreeInterpolateBackward(
   /*
    * NRAM partition
    *  |-------------------------------------------------------------------------------------------|
-   *  |           nram_grad_output                  | nram_grad_output_transpose
-   * |
+   *  |           nram_grad_output                  |        nram_grad_output_transpose           |
    *  |-------------------------------------------------------------------------------------------|
-   *  |           nram_grad_features                |
-   * nram_grad_features_transpose         |
+   *  |           nram_grad_features                |        nram_grad_features_transpose         |
    *  |-------------------------------------------------------------------------------------------|
-   *  |      nram_weights            |   nram_weights_transpose     |
-   * nram_indices           |
+   *  |      nram_weights            |   nram_weights_transpose     |      nram_indices           |
    *  |-------------------------------------------------------------------------------------------|
    *  |      nram_indices_transpose(addition/float/float_addition)  |
    *  |-------------------------------------------------------------------------------------------|

--- a/bangc-ops/kernels/utils/common.h
+++ b/bangc-ops/kernels/utils/common.h
@@ -67,24 +67,28 @@ __mlu_func__ inline half __mluop_float2half(float a) {
 }
 
 /******************************************************************************
- * MLUOP FUNC: computeDiv
+ * MLUOP FUNC: __mluop_div
  * param 'nram_dst' is the nram destination address, which supports half or
-float data type.  * param 'nram_src0' is the nram source address, which has the
-same data type as nram_dst.  * param 'nram_src1' is the nram source address,
-which has the same data type as nram_dst.  * param 'nram_addition' is the nram
-addition address. Pass NULL if the data type of nram_src  *   is float and
-architecture >= 300, otherwise the space size is at least twice as much as
- *nram_src.
+ * float data type.  
+ * param 'nram_src0' is the nram source address, which has the same data
+ * type as nram_dst.  
+ * param 'nram_src1' is the nram source address, which has the same data
+ * type as nram_dst.  
+ * param 'nram_addition' is the nram addition address.
+ * Pass NULL if the data type of nram_src is float and architecture >= 300,
+ * otherwise the space size is at least twice as much as nram_src.
  * param 'deal_num' is the num of input data.
- * remarks:
- *   1. nram_dst and nram_src can not be homologous operand if architecture <
-300.  *   2. On MLU2XX, nram_src1(dividend) must be positive due to limitations
-of bang_active_reciphp.
+ *
+ * remarks:
+ * 1. nram_dst and nram_src can not be homologous operand if architecture <
+ * 300.  
+ * 2. On MLU2XX, nram_src1(dividend) must be positive due to limitations
+ * of bang_active_reciphp.
 *******************************************************************************/
 template <typename T>
-static __mlu_func__ void computeDiv(T *nram_dst, T *nram_src0, T *nram_src1,
-                                    T *nram_addition, int is_high_precision,
-                                    int deal_num) {
+__mlu_func__ void __mluop_div(T *nram_dst, T *nram_src0, T *nram_src1,
+                              T *nram_addition, int is_high_precision,
+                              int deal_num) {
   if (sizeof(T) == sizeof(float)) {
 #if (__BANG_ARCH__ >= 300) && (__BANG_ARCH__ != 372)
     __bang_div((float *)nram_dst, (float *)nram_src0, (float *)nram_src1,
@@ -125,7 +129,7 @@ static __mlu_func__ void computeDiv(T *nram_dst, T *nram_src0, T *nram_src1,
 }
 
 /*******************************************************************************
- * MLUOPS FUNC: computeRecip
+ * MLUOPS FUNC: __mluop_recip
  * param 'nram_dst' is the nram destination address, which supports half or
  * float data type. param 'nram_src' is the nram source address, which has the
  * same data type as nram_dst. param 'nram_addition' is the nram addition
@@ -138,10 +142,9 @@ static __mlu_func__ void computeDiv(T *nram_dst, T *nram_src0, T *nram_src1,
  * information.
  ******************************************************************************/
 template <typename T>
-static __mlu_func__ void computeRecip(T *nram_dst, T *nram_src,
-                                      void *nram_addition,
-                                      const bool is_high_precision,
-                                      const uint32_t deal_num) {
+__mlu_func__ void __mluop_recip(T *nram_dst, T *nram_src, void *nram_addition,
+                                const bool is_high_precision,
+                                const uint32_t deal_num) {
   if (sizeof(T) == sizeof(float)) {
 #if __BANG_ARCH__ >= 300
     __bang_recip((float *)nram_dst, (float *)nram_src, deal_num);
@@ -169,7 +172,7 @@ static __mlu_func__ void computeRecip(T *nram_dst, T *nram_src,
 }
 
 /******************************************************************************
- * MLUOPS FUNC: computeExp
+ * MLUOPS FUNC: __mluop_exp
  * param 'nram_dst' is the nram destination address, which supports half or
  * float data type. param 'nram_src' is the nram source address, which has the
  * same data type as nram_dst. param 'nram_addition' is the nram addition
@@ -179,10 +182,8 @@ static __mlu_func__ void computeRecip(T *nram_dst, T *nram_src,
  * and nram_src can be homologous operand.
  ******************************************************************************/
 template <typename T>
-static __mlu_func__ void computeExp(T *nram_dst, T *nram_src,
-                                    void *nram_addition,
-                                    const int is_high_precision,
-                                    const int deal_num) {
+__mlu_func__ void __mluop_exp(T *nram_dst, T *nram_src, void *nram_addition,
+                              const int is_high_precision, const int deal_num) {
   if (sizeof(T) == sizeof(float)) {
 #if __BANG_ARCH__ >= 300
     int x2d = 0x3fb8aa3b;
@@ -218,7 +219,7 @@ static __mlu_func__ void computeExp(T *nram_dst, T *nram_src,
 }
 
 /******************************************************************************
- * MLUOPS FUNC: computeSigmoid
+ * MLUOPS FUNC: __mluop_sigmoid
  * param 'nram_dst' is the nram destination address, which supports half or
  * float data type. param 'nram_src' is the nram source address, which has the
  * same data type as nram_dst. param 'nram_addition' is the nram addition
@@ -228,18 +229,17 @@ static __mlu_func__ void computeExp(T *nram_dst, T *nram_src,
  * and nram_src can be homologous operand.
  ******************************************************************************/
 template <typename T>
-static __mlu_func__ void computeSigmoid(T *nram_dst, T *nram_src,
-                                        void *nram_addition,
-                                        const int is_high_precision,
-                                        const int deal_num) {
+__mlu_func__ void __mluop_sigmoid(T *nram_dst, T *nram_src, void *nram_addition,
+                                  const int is_high_precision,
+                                  const int deal_num) {
   if (sizeof(T) == sizeof(float)) {
 #if __BANG_ARCH__ >= 300
     __bang_mul_scalar((float *)nram_src, (float *)nram_src, (float)-1.0,
                       deal_num);
-    computeExp((float *)nram_src, (float *)nram_src, NULL, 0, deal_num);
+    __mluop_exp((float *)nram_src, (float *)nram_src, NULL, 0, deal_num);
     __bang_add_scalar((float *)nram_src, (float *)nram_src, (float)1.0,
                       deal_num);
-    computeRecip((float *)nram_dst, (float *)nram_src, NULL, 0, deal_num);
+    __mluop_recip((float *)nram_dst, (float *)nram_src, NULL, 0, deal_num);
 #else
     __bang_active_sigmoid((float *)nram_dst, (float *)nram_src, deal_num);
 #endif
@@ -248,11 +248,11 @@ static __mlu_func__ void computeSigmoid(T *nram_dst, T *nram_src,
     __bang_half2float((float *)nram_addition, (half *)nram_src, deal_num);
     __bang_mul_scalar((float *)nram_addition, (float *)nram_addition,
                       (float)-1.0, deal_num);
-    computeExp((float *)nram_addition, (float *)nram_addition, NULL, 0,
-               deal_num);
+    __mluop_exp((float *)nram_addition, (float *)nram_addition, NULL, 0,
+                deal_num);
     __bang_add_scalar((float *)nram_addition, (float *)nram_addition,
                       (float)1.0, deal_num);
-    computeRecip((float *)nram_dst, (float *)nram_addition, NULL, 0, deal_num);
+    __mluop_recip((float *)nram_dst, (float *)nram_addition, NULL, 0, deal_num);
     __bang_float2half_rn((half *)nram_dst, (float *)nram_dst, deal_num);
 #else
     if (is_high_precision) {
@@ -270,15 +270,15 @@ static __mlu_func__ void computeSigmoid(T *nram_dst, T *nram_src,
 }
 
 /******************************************************************************
- * MLUOPS FUNC: recursiveSumPool
+ * MLUOPS FUNC: __mluop_recursive_sum_pool
  * param 'dst' is the src and dst nram addr
  * param 'low_dim' is the number of low dim
  * param 'high_dim' is the number of high dim
  * param 'kernel_limit' is the high_dim of sumpool per time
  ******************************************************************************/
 template <typename T>
-__mlu_func__ void recursiveSumPool(T *dst, int low_dim, int high_dim,
-                                 int kernel_limit) {
+__mlu_func__ void __mluop_recursive_sum_pool(T *dst, int low_dim, int high_dim,
+                                             int kernel_limit) {
   for (; high_dim > 1;) {
     int repeat_s = high_dim / kernel_limit;
     int remain_s = high_dim % kernel_limit;
@@ -298,7 +298,7 @@ __mlu_func__ void recursiveSumPool(T *dst, int low_dim, int high_dim,
 }
 
 /*****************************************************************************
- * MLUOPS FUNC: __int322float
+ * MLUOPS FUNC: __mluop_int322float
  * param 'dst' is the destination pointer in NRAM, same memory space as src
  * required in NRAM
  * param 'dst_addition' is the addition workspace of dst, requiring the same
@@ -312,8 +312,9 @@ __mlu_func__ void recursiveSumPool(T *dst, int low_dim, int high_dim,
  *   src_count*sizeof(float) should be divisible by 128
  *   src input must be in range of [-2^23, 2^23-1] for MLU270 and MLU290
  *****************************************************************************/
-__mlu_func__ void __int322float(float *dst, float *dst_addition, int32_t *src,
-                                float *src_addition, int32_t src_count) {
+__mlu_func__ void __mluop_int322float(float *dst, float *dst_addition,
+                                      int32_t *src, float *src_addition,
+                                      int32_t src_count) {
 #if __BANG_ARCH__ >= 300
   __bang_int322float((float *)dst, (int32_t *)src, src_count, 0);
 #else
@@ -377,7 +378,7 @@ __mlu_func__ void __int322float(float *dst, float *dst_addition, int32_t *src,
 }
 
 /*****************************************************************************
- * MLUOPS FUNC: __float2int32
+ * MLUOPS FUNC: __mluop_float2int32
  * param 'dst' is the destination pointer in NRAM, same memory space as src
  * required in NRAM
  * param 'dst_addition' is the addition workspace of dst, requiring the same
@@ -391,8 +392,9 @@ __mlu_func__ void __int322float(float *dst, float *dst_addition, int32_t *src,
  *   src_count*sizeof(float) should be divisible by 128
  *   src input must be in range of [-2^23, 2^23-1] for MLU270 and MLU290
  *****************************************************************************/
-__mlu_func__ void __float2int32(int32_t *dst, float *dst_addition, float *src,
-                                float *src_addition, int32_t src_count) {
+__mlu_func__ void __mluop_float2int32(int32_t *dst, float *dst_addition,
+                                      float *src, float *src_addition,
+                                      int32_t src_count) {
 #if __BANG_ARCH__ >= 322
   __bang_float2int32_tz((int32_t *)dst, (float *)src, src_count, 0);
 #else
@@ -449,22 +451,6 @@ __mlu_func__ void __float2int32(int32_t *dst, float *dst_addition, float *src,
 #endif
 }
 
-/******************************************************************************
- * MLUOPS FUNC: __float2half
- * param 'dst' is the destination pointer in NRAM.
- * param 'src' is the source pointer in NRAM.
- * param 'src_count' is the src element count.
- * Note:
- *      The rounding mode on MLU200 is rd, on MLU300 is rn.
- ******************************************************************************/
-__mlu_func__ inline void __float2half(half *dst, float *src, int src_count) {
-#if __BANG_ARCH__ >= 300
-  __bang_float2half_rn(dst, src, src_count);
-#else
-  __bang_float2half_rd(dst, src, src_count);
-#endif
-}
-
 __mlu_func__ void pvLock() {
 #if __BANG_ARCH__ == 270
   if (__is_ipu()) {
@@ -482,7 +468,7 @@ __mlu_func__ void pvUnlock() {
 }
 
 /******************************************************************************
- * MLUOPS FUNC: loadStr2D
+ * MLUOPS FUNC: __mluop_load_str_2D
  * param 'size' is the getC size.
  * param 'seg_num' is the loop times.
  * param 'dst_str' is nram stride, c_align on onchip.
@@ -492,8 +478,8 @@ __mlu_func__ void pvUnlock() {
  *      may be contaminated.
  ******************************************************************************/
 template <typename T>
-__mlu_func__ void loadStr2D(T *dst, T *src, int size, int dst_str, int src_str,
-                            int seg_num) {
+__mlu_func__ void __mluop_load_str_2D(T *dst, T *src, int size, int dst_str,
+                                      int src_str, int seg_num) {
   if (dst_str == src_str && size == src_str) {
     __memcpy(dst, src, src_str * seg_num * sizeof(T), GDRAM2NRAM);
   } else if ((size == src_str || src_str <= dst_str) &&
@@ -511,7 +497,7 @@ __mlu_func__ void loadStr2D(T *dst, T *src, int size, int dst_str, int src_str,
 }
 
 /******************************************************************************
- * MLUOPS FUNC: loadStr3D
+ * MLUOPS FUNC: __mluop_load_str_3D
  * param 'size' is the getC size.
  * param 'seg_num_in' is the in loop times.
  * param 'seg_num_out' is the out loop times.
@@ -521,20 +507,22 @@ __mlu_func__ void loadStr2D(T *dst, T *src, int size, int dst_str, int src_str,
  * param 'src_str_out' is gdram out stride.
  ******************************************************************************/
 template <typename T>
-__mlu_func__ void loadStr3D(T *dst, T *src, int size, int seg_num_in,
-                            int seg_num_out, int dst_str_in, int dst_str_out,
-                            int src_str_in, int src_str_out) {
+__mlu_func__ void __mluop_load_str_3D(T *dst, T *src, int size, int seg_num_in,
+                                      int seg_num_out, int dst_str_in,
+                                      int dst_str_out, int src_str_in,
+                                      int src_str_out) {
   T *tmp_dst = dst;
   T *tmp_src = src;
   for (int i = 0; i < seg_num_out; ++i) {
-    loadStr2D(tmp_dst, tmp_src, size, dst_str_in, src_str_in, seg_num_in);
+    __mluop_load_str_2D(tmp_dst, tmp_src, size, dst_str_in, src_str_in,
+                        seg_num_in);
     tmp_src = (T *)tmp_src + src_str_out;
     tmp_dst = (T *)tmp_dst + dst_str_out;
   }
 }
 
 /******************************************************************************
- * MLUOPS FUNC: storeStr2D
+ * MLUOPS FUNC: __mluop_store_str_2D
  * param 'size' is the getC size.
  * param 'seg_num' is the loop times.
  * param 'dst_str' is gdram stride, c_align on onchip.
@@ -544,8 +532,8 @@ __mlu_func__ void loadStr3D(T *dst, T *src, int size, int seg_num_in,
  *      don't use this function, use MEMCPY instead.
  ******************************************************************************/
 template <typename T>
-__mlu_func__ void storeStr2D(T *dst, T *src, int size, int seg_num, int dst_str,
-                             int src_str) {
+__mlu_func__ void __mluop_store_str_2D(T *dst, T *src, int size, int seg_num,
+                                       int dst_str, int src_str) {
   if ((size == dst_str && dst_str <= src_str) &&
       dst_str * sizeof(T) <=
           512) {  // IO efficiency is best when datasize gather than 512bytes
@@ -561,7 +549,7 @@ __mlu_func__ void storeStr2D(T *dst, T *src, int size, int seg_num, int dst_str,
 }
 
 /******************************************************************************
- * MLUOPS FUNC: storeStr3D
+ * MLUOPS FUNC: __mluop_store_str_3D
  * param 'size' is the getC size.
  * param 'seg_num_in' is the in loop times.
  * param 'seg_num_out' is the out loop times.
@@ -574,13 +562,15 @@ __mlu_func__ void storeStr2D(T *dst, T *src, int size, int seg_num, int dst_str,
  *      don't use this function, use MEMCPY instead.
  ******************************************************************************/
 template <typename T>
-__mlu_func__ void storeStr3D(T *dst, T *src, int size, int seg_num_in,
-                             int seg_num_out, int dst_str_in, int dst_str_out,
-                             int src_str_in, int src_str_out) {
+__mlu_func__ void __mluop_store_str_3D(T *dst, T *src, int size, int seg_num_in,
+                                       int seg_num_out, int dst_str_in,
+                                       int dst_str_out, int src_str_in,
+                                       int src_str_out) {
   T *tmp_dst = dst;
   T *tmp_src = src;
   for (int i = 0; i < seg_num_out; ++i) {
-    storeStr2D(tmp_dst, tmp_src, size, seg_num_in, dst_str_in, src_str_in);
+    __mluop_store_str_2D(tmp_dst, tmp_src, size, seg_num_in, dst_str_in,
+                         src_str_in);
     tmp_src = (T *)tmp_src + src_str_out;
     tmp_dst = (T *)tmp_dst + dst_str_out;
   }

--- a/bangc-ops/kernels/yolo_box/yolo_box_block.mlu
+++ b/bangc-ops/kernels/yolo_box/yolo_box_block.mlu
@@ -146,9 +146,9 @@ static __mlu_func__ void compute(
 
 #if __BANG_ARCH__ >= 322
   // compute mask
-  computeSigmoid(nram_conf_p, nram_conf_p, NULL, 0, deal_num);
+  __mluop_sigmoid(nram_conf_p, nram_conf_p, NULL, 0, deal_num);
   if (iou_aware == true) {
-    computeSigmoid(nram_iou_p, nram_iou_p, NULL, 0, deal_num);
+    __mluop_sigmoid(nram_iou_p, nram_iou_p, NULL, 0, deal_num);
     if ((T)iou_aware_factor == (T)0.0) {
       __bang_write_value(nram_iou_p, deal_num, (T)1.0);
     } else if ((T)iou_aware_factor == (T)1.0) {
@@ -173,7 +173,7 @@ static __mlu_func__ void compute(
   __bang_add(nram_iou_p, nram_iou_p, nram_conf_p, deal_num);
 
   // bx0
-  computeSigmoid(nram_x_p, nram_x_p, NULL, 0, deal_num);
+  __mluop_sigmoid(nram_x_p, nram_x_p, NULL, 0, deal_num);
   __bang_mul_scalar(nram_x_p, nram_x_p, (T)scale, deal_num);
   __bang_add_scalar(nram_x_p, nram_x_p, bias, deal_num);
   __bang_add(nram_x_p, nram_x_p, nram_cx, deal_num);
@@ -181,7 +181,7 @@ static __mlu_func__ void compute(
   __bang_mul_scalar(nram_x_p, nram_x_p, (T)1.0 / gridw, deal_num);
 
   // by0
-  computeSigmoid(nram_y_p, nram_y_p, NULL, 0, deal_num);
+  __mluop_sigmoid(nram_y_p, nram_y_p, NULL, 0, deal_num);
   __bang_mul_scalar(nram_y_p, nram_y_p, (T)scale, deal_num);
   __bang_add_scalar(nram_y_p, nram_y_p, bias, deal_num);
   __bang_add(nram_y_p, nram_y_p, nram_cy, deal_num);
@@ -189,13 +189,13 @@ static __mlu_func__ void compute(
   __bang_mul_scalar(nram_y_p, nram_y_p, (T)1.0 / gridh, deal_num);
 
   // bw
-  computeExp(nram_w_p, nram_w_p, NULL, 0, deal_num);
+  __mluop_exp(nram_w_p, nram_w_p, NULL, 0, deal_num);
   __bang_mul(nram_w_p, nram_w_p, anchors_w, deal_num);
   __bang_mul(nram_w_p, nram_w_p, nram_imgw, deal_num);
   __bang_mul_scalar(nram_w_p, nram_w_p, (T)1.0 / inputw, deal_num);
 
   // bh
-  computeExp(nram_h_p, nram_h_p, NULL, 0, deal_num);
+  __mluop_exp(nram_h_p, nram_h_p, NULL, 0, deal_num);
   __bang_mul(nram_h_p, nram_h_p, anchors_h, deal_num);
   __bang_mul(nram_h_p, nram_h_p, nram_imgh, deal_num);
   __bang_mul_scalar(nram_h_p, nram_h_p, (T)1.0 / inputh, deal_num);
@@ -1129,9 +1129,9 @@ static __mlu_func__ void computeScore(T *nram_iou, T *nram_conf, T *nram_cls,
 
 #if __BANG_ARCH__ >= 322
   // compute mask
-  computeSigmoid(nram_conf_p, nram_conf_p, NULL, 0, deal_num);
+  __mluop_sigmoid(nram_conf_p, nram_conf_p, NULL, 0, deal_num);
   if (iou_aware == true) {
-    computeSigmoid(nram_iou_p, nram_iou_p, NULL, 0, deal_num);
+    __mluop_sigmoid(nram_iou_p, nram_iou_p, NULL, 0, deal_num);
     if ((T)iou_aware_factor == (T)0.0) {
       __bang_write_value(nram_iou_p, deal_num, (T)1.0);
     } else if ((T)iou_aware_factor == (T)1.0) {
@@ -1150,7 +1150,7 @@ static __mlu_func__ void computeScore(T *nram_iou, T *nram_conf, T *nram_cls,
     __bang_mul(nram_conf_p, nram_conf_p, nram_iou_p, deal_num);
   }
 
-  computeSigmoid(nram_cls_p, nram_cls_p, NULL, 0, class_num * deal_num);
+  __mluop_sigmoid(nram_cls_p, nram_cls_p, NULL, 0, class_num * deal_num);
   __bang_cycle_mul(nram_cls_p, nram_cls_p, nram_conf_p, class_num * deal_num,
                    deal_num);
 

--- a/docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
+++ b/docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
@@ -257,7 +257,7 @@ for (int32_t i = 0; i < batch_per_task; i++) {
       baseS = b1_area;
     }
     // ious = interS / baseS
-    computeDiv(width, interS, baseS, vec_b2_x2, batches_stride);
+    __mluop_div(width, interS, baseS, vec_b2_x2, batches_stride);
     int32_t gdram_offset = index1 * num_bbox2 + index2;
     __memcpy((T *)ious + gdram_offset, width, handle_batches * sizeof(T), NRAM2GDRAM);
   }

--- a/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
+++ b/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
@@ -297,7 +297,7 @@ __mlu_func__ void computeTerm1AndTerm2() {
 
 __mlu_func__ void safeExp(float *dst, float *src, float *mask, const int num) {
     setNanInfToZero(src, mask, num);
-    computeExp(dst, src, NULL, 0, num);
+    __mluop_exp(dst, src, NULL, 0, num);
       __bang_band((char *)dst, (char *)dst, (char *)mask, num * sizeof(float));
     setNanInfToZero(dst, mask, num);
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

[Feature](bangc-ops): format func in common.h

## 2. Modification

	modified:   bangc-ops/kernels/ball_query/ball_query_union1.mlu
	modified:   bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
	modified:   bangc-ops/kernels/carafe/carafe_block.mlu
	modified:   bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
	modified:   bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
	modified:   bangc-ops/kernels/ms_deform_attn_backward/ms_deform_attn_backward_union1.mlu
	modified:   bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
	modified:   bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
	modified:   bangc-ops/kernels/three_interpolate/three_interpolate_union1.mlu
	modified:   bangc-ops/kernels/utils/common.h
	modified:   bangc-ops/kernels/yolo_box/yolo_box_block.mlu
	modified:   docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
	modified:   docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.m

## 3. Test Report

370 & 590 all 
relase_temp/relase_test all pass 

