### PR TITLE
[Fix](bangc-ops): Fix focal_loss_sigmoid_backward mpu read overflow

### DIFF
--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -238,6 +238,7 @@ __mlu_func__ void coreCompute(char *nram_input, const T *nram_weight,
       }
       int32_t align_c = PAD_UP(total_c, c_align_num);
       int32_t target_value = ((int32_t *)nram_target)[n];
+      if (target_value >= total_c || target_value < 0) continue;
       T weight_value = nram_weight[target_value];
       __bang_mul_scalar((T *)nram_output + n * align_c,
                         (T *)nram_output + n * align_c, weight_value, align_c);
@@ -498,6 +499,7 @@ __mlu_global__ void MLUUnion1KernelFocalLossSigmoidBackward(
     const void *input, const void *target, const void *weight,
     const float gamma, const float alpha, const int32_t total_n,
     const int32_t deal_n, const int32_t total_c, void *output) {
+  if (coreId == 0x80) return;
   focalLossSigmoidBackwardBlock((T *)input, (int32_t *)target, (T *)weight,
                                 gamma, alpha, total_n, deal_n, total_c,
                                 (T *)output);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Fix focal_loss_sigmoid_backward mpu read overflow

## 2. Modification

modified: bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu

## 3. Test Report

(1) Accuracy pipeline:  http://jenkins.svc.cambricon.com/dist/job/MLUOPS/view/Pipelines-Adaptable/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/84/
(2) Performance pipeline:  http://jenkins.svc.cambricon.com/dist/job/MLUOPS/view/Pipelines-Adaptable/job/MLU_ALL_PLATFORMS/job/mluops_build_perf_adaptable_mlu/64/

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3