### PR TITLE
[Fix](bangc-ops): correct dynamic_point_to_voxel_backward call scatte…

### DIFF
--- a/bangc-ops/kernels/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
+++ b/bangc-ops/kernels/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
@@ -252,12 +252,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelBackward(
       k_dim, k_type, handle->queue, feats, voxel_feats, grad_feats, workspace,
       point2voxel_map, voxel_num, N, C)));
   // 2. scatter
+  const auto grad_voxel_feats_element_num =
+      mluOpGetTensorElementNum(grad_voxel_feats_desc);
+  const auto grad_feats_element_num = mluOpGetTensorElementNum(grad_feats_desc);
   mluOpScatterNdMode_t scatter_mode = MLUOP_SCATTERND_ADD;
   mluOpTensorDescriptor_t indices_desc;
   INTERNAL_CHECK(
       interface_name,
       MLUOP_STATUS_SUCCESS == mluOpCreateTensorDescriptor(&indices_desc));
-  int indices_dims[2] = {N * C, 1};
+  int indices_dims[2] = {(int)grad_voxel_feats_element_num, 1};
   INTERNAL_CHECK(interface_name, MLUOP_STATUS_SUCCESS ==
                                      mluOpSetTensorDescriptor(
                                          indices_desc, MLUOP_LAYOUT_ARRAY,
@@ -266,7 +269,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelBackward(
   INTERNAL_CHECK(
       interface_name,
       MLUOP_STATUS_SUCCESS == mluOpCreateTensorDescriptor(&updates_desc));
-  int updates_dims[1] = {N * C};
+  int updates_dims[1] = {(int)grad_voxel_feats_element_num};
   INTERNAL_CHECK(interface_name, MLUOP_STATUS_SUCCESS ==
                                      mluOpSetTensorDescriptor(
                                          updates_desc, MLUOP_LAYOUT_ARRAY,
@@ -274,7 +277,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelBackward(
   mluOpTensorDescriptor_t output_desc;
   INTERNAL_CHECK(interface_name, MLUOP_STATUS_SUCCESS ==
                                      mluOpCreateTensorDescriptor(&output_desc));
-  int output_dims[1] = {N * C};
+  int output_dims[1] = {(int)grad_feats_element_num};
   INTERNAL_CHECK(interface_name, MLUOP_STATUS_SUCCESS ==
                                      mluOpSetTensorDescriptor(
                                          output_desc, MLUOP_LAYOUT_ARRAY,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

兼容grad_voxel_feats[M, C]规模小于feats[N, C]的情况

## 2. Modification

1. modified:   bangc-ops/kernels/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff3: diff3 <= 0

#### 3.1.2 Operator Scheme checklist

|     No.      |                 Details              |            Check Results          |
|--------------|-----------------------------------|--------------------------------------|
|        1       |Supported hardware|             MLU370<br>MLU590         |
|        2       |Job types|          U1、U2、U4、U8（看空闲资源）       |
|        3       |Layouts|          ARRAY     |
|        4       |Whether multi-dimensions are supported|                    no                   |
|        5       |Whether element zero is supported|                  yes                    |
|        6       |Data type(half/float)|           float           |
|        7       |Whether there is size limit| grad_voxel_feats、voxel_feats、voxel_points_count的第一维度 dims[0] 都相等，且<= feats的第一维度 dims[0]；feats、point2voxel_map、grad_feats的第一维度 dims[0] 都相等；<br>  voxel_num 的维度为 1；<br> grad_voxel_feats、feats、voxel_feats、grad_feats的第二维度 dims[1] 都相等；<br> 5 * feats_desc->dims[0]+20 * feats_desc->dims[1]+sizeof(int) <= 640KB(MLU370) 或 384KB(MLU590)                     |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |            通过                 |
| Whether illegal parameters are passed           |     Normal error    |                   通过          |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |float                   |     通过     |[----------] Global test environment tear-down<br>[ SUMMARY  ] Total 200 cases of 1 op(s).<br>ALL PASSED.<br>[==========] 200 test cases from 1 test suite ran. (77973 ms total)<br>[  PASSED  ] 200 test cases.|
|Zero element test    |Whether to support this test      |    通过      |[2023-5-24 16:6:57] [MLUOP] [Vlog]:[DynamicPointToVoxelBackwardExecutor] call compute() Begin.<br>[2023-5-24 16:6:57] [MLUOP] [Vlog]:[mluOpDynamicPointToVoxelBackward] Skip zero element tensor.<br>[2023-5-24 16:6:57] [MLUOP] [Vlog]:[DynamicPointToVoxelBackwardExecutor] call compute() End.|
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|    通过      |./mluop_gtest --cases_dir=xxxx --gtest_repeat=100 --thread=100<br>[----------] Global test environment tear-down<br>[ SUMMARY  ] Total 20000 cases of 600 op(s).<br>ALL PASSED.<br>[==========] 6 test cases from 6 test suites ran. (2932 ms total)<br>[  PASSED  ] 6 test cases.|
|Mult-platform test   |MLU370/MLU590                     |    通过      |MLU370:<br>[----------] Global test environment tear-down<br>[ SUMMARY  ] Total 200 cases of 1 op(s).<br>ALL PASSED.<br>[==========] 200 test cases from 1 test suite ran. (19708 ms total)<br>[  PASSED  ] 200 test cases.<br>MLU590:<br>[----------] Global test environment tear-down<br>[ SUMMARY  ] Total 200 cases of 1 op(s).<br>ALL PASSED.<br>[==========] 200 test cases from 1 test suite ran. (21528 ms total)<br>[  PASSED  ] 200 test cases.|
|Nan/INF test         |Whether to support this test      |    通过      |[----------] Global test environment tear-down<br>[ SUMMARY  ] Total 18 cases of 1 op(s).<br>ALL PASSED.<br>[==========] 18 test cases from 1 test suite ran. (636 ms total)<br>[  PASSED  ] 18 test cases.|
|Memory leak check    |Test result                       |    通过      |          |
|Code coverage check  |Test result                       |    通过      |dynamic_point_to_voxel_backward.mlu<br>Line Coverage 98.7% 148 / 150	Functions 100.0 %	5 / 5|

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
| dynamic_point_to_voxel_backward   |  10191  |  209.829   |  0.0076793  |  0.000208799  |  8.71576e+06  |  float  |  grad_feats:[17157, 127]  |
| dynamic_point_to_voxel_backward   |  128  |   147.71  |  0.00499349  |  0.000178711  |  93696  |  float  |  grad_feats:[183, 128]  |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|  dynamic_point_to_voxel_backward  |  2230  |  138.001  |  0.00526411  |  0.00042409  |  8.71576e+06  |  float  |  grad_feats:[17157, 127]   |
|  dynamic_point_to_voxel_backward  |  26  |  91.098  |  0.0036875  |  0.000391026  |  93696  |  float  |  grad_feats:[183, 128]   |

### 3.4 Summary Analysis

1）MLU370上性能与真值相关
2）特征类tensor支持nan/inf，坐标类tensor是整型不支持nan/inf
