### PR TITLE
[Fix](bangc-ops): correct release docs for v0.7.0

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
@@ -14,7 +14,6 @@ masked_col2im_forward
 moe_dispatch_backward_data
 moe_dispatch_forward
 mutual_information_backward
-mutual_information_forwardward
 mutual_information_forward
 nms
 nms_rotated

--- a/docs/bangc-docs/api_guide/update.rst
+++ b/docs/bangc-docs/api_guide/update.rst
@@ -17,7 +17,6 @@ This section lists contents that were made for each product release.
     - focal_loss_sigmoid_forward
     - masked_col2im_forward
     - mutual_information_backward
-    - mutual_information_forwardward
     - mutual_information_forward
 
 * V0.6.0

--- a/docs/bangc-docs/release_notes/bangc_ops.rst
+++ b/docs/bangc-docs/release_notes/bangc_ops.rst
@@ -82,8 +82,6 @@ v0.7.0
 
    * ``mutual_information_backward``
 
-   * ``mutual_information_forwardward``
-
    * ``mutual_information_forward``
 
 v0.6.0

--- a/docs/bangc-docs/user_guide/2_update_history/index.rst
+++ b/docs/bangc-docs/user_guide/2_update_history/index.rst
@@ -14,7 +14,6 @@
      + :ref:`focal_loss_sigmoid_forward`
      + :ref:`masked_col2im_forward`
      + :ref:`mutual_information_backward`
-     + :ref:`mutual_information_forwardward`
      + :ref:`mutual_information_forward`
 
 * **V0.6.0**


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

correct release docs for v0.7.0

## 2. Modification

bangc-ops/test/mlu_op_gtest/pb_gtest/gtest_config/test_list b/bangc-ops/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
docs/bangc-docs/api_guide/update.rst b/docs/bangc-docs/api_guide/update.rst
docs/bangc-docs/release_notes/bangc_ops.rst b/docs/bangc-docs/release_notes/bangc_ops.rst
docs/bangc-docs/user_guide/2_update_history/index.rst b/docs/bangc-docs/user_guide/2_update_history/index.rst

## 3. Test Report

None.