### PR TITLE
[Fix](bangc-ops): update clang version for coverage test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/case_list.cpp
 bangc-ops/test/mlu_op_gtest/pb_gtest/src/gtest/op_register.h
+bangc-ops/daily.software.cambricon.com/
+bangc-ops/dep_libs_extract
+dependency.txt
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 if(${MLUOP_BUILD_COVERAGE_TEST} MATCHES "ON")
   message("-- MLU_OP_COVERAGE_TEST=${MLUOP_BUILD_COVERAGE_TEST}")
-  set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-u__llvm_profile_runtime ${NEUWARE_HOME}/lib/clang/11.0.0/lib/linux/libclang_rt.profile-x86_64.a")
+  set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "-u__llvm_profile_runtime ${NEUWARE_HOME}/lib/clang/11.1.0/lib/linux/libclang_rt.profile-x86_64.a")
   set(CNRT_DUMP_PGO 1)
   set(CNRT_PGO_OUTPUT_DIR=output)
   set(BANG_CNCC_FLAGS "${BANG_CNCC_FLAGS} -fprofile-instr-generate -fcoverage-mapping -D COVERAGE")


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Update clang version.

## 2. Modification

bangc-ops/CMakelist.txt
.gitignore

## 3. Test Report
three_nn_forward test

filename [Sort by name]     Line Coverage [Sort_by_line     Functions [Sort_by
                            coverage]                       function_coverage]
three_nn_forward_union1.mlu [100.0%] 100.0 %314 /314  100.0 %22 / 22

Generated by: LCOV_version_1.14
