### PR TITLE
[Fix](bangc-ops): Delete masked_col2im_forward docs information

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
@@ -10,7 +10,6 @@ get_indice_pairs
 indice_convolution_backward_data
 indice_convolution_backward_filter
 indice_convolution_forward
-masked_col2im_forward
 moe_dispatch_backward_data
 moe_dispatch_forward
 mutual_information_backward

--- a/docs/bangc-docs/api_guide/update.rst
+++ b/docs/bangc-docs/api_guide/update.rst
@@ -15,7 +15,6 @@ This section lists contents that were made for each product release.
     - dynamic_point_to_voxel_forward
     - focal_loss_sigmoid_backward
     - focal_loss_sigmoid_forward
-    - masked_col2im_forward
     - mutual_information_backward
     - mutual_information_forward
 

--- a/docs/bangc-docs/release_notes/bangc_ops.rst
+++ b/docs/bangc-docs/release_notes/bangc_ops.rst
@@ -78,8 +78,6 @@ v0.7.0
 
    * ``focal_loss_sigmoid_forward``
 
-   * ``masked_col2im_forward``
-
    * ``mutual_information_backward``
 
    * ``mutual_information_forward``

--- a/docs/bangc-docs/user_guide/2_update_history/index.rst
+++ b/docs/bangc-docs/user_guide/2_update_history/index.rst
@@ -12,7 +12,6 @@
      + :ref:`dynamic_point_to_voxel_forward`
      + :ref:`focal_loss_sigmoid_backward`
      + :ref:`focal_loss_sigmoid_forward`
-     + :ref:`masked_col2im_forward`
      + :ref:`mutual_information_backward`
      + :ref:`mutual_information_forward`
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Delete masked_col2im_forward docs information

## 2. Modification

	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
	modified:   docs/bangc-docs/api_guide/update.rst
	modified:   docs/bangc-docs/release_notes/bangc_ops.rst
	modified:   docs/bangc-docs/user_guide/2_update_history/index.rst

## 3. Test Report

None
