### PR TITLE
[Fix](bangc-ops): fix focal_loss_sigmoid_backward gamma range precheck

### DIFF
--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
@@ -420,9 +420,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
-  if (gamma < 0) {
+  if (gamma < 0 || gamma > 10000) {
     LOG(ERROR) << interface_name
-               << "gamma should be greater than or equal to 0."
+               << "gamma should be in the range of [0, 10000]. "
                << "But now gamma is " << gamma << ".";
     return MLUOP_STATUS_NOT_SUPPORTED;
   }

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -7450,7 +7450,7 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  *   \b weight is NULL on MLU500 series. The length of C should be in the range of [0, 8864] when
  *   \b weight is not NULL on MLU500 series.
  * - \b weight does not support positive infinity and negative infinity currently.
- * - \b gamma should be in the range of [0, 10000] on MLU300 series.
+ * - \b gamma should be in the range of [0, 10000].
  *
  * @par Example
  * - None.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

 fix focal_loss_sigmoid_backward gamma range precheck

## 2. Modification

	modified:   kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
	modified:   mlu_op.h


## 3. Test Report
（1） gamma test
[2023-6-1 15:37:59] [MLUOP] [Error]:[mluOpFocalLossSigmoidBackward]: gamma should be in the range of [0, 10000]. But now gamma is 20000.
[2023-6-1 15:37:59] [MLUOP] [Error]:"MLUOP_STATUS_NOT_SUPPORTED in mluOpFocalLossSigmoidBackward( handle_, prefer, reduction, input_desc, input_mlu, target_desc, target_mlu, weight_desc, weight_mlu, alpha, gamma, grad_input_desc, grad_input_mlu)"

(2) release_temp cases test
[^      OK ] /MLU_OPS/SOFT_TRAIN/release_temp/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward_data_included_int32_float16_1682494108948.pb
[       OK ] focal_loss_sigmoid_backward/TestSuite.mluOp/1029 (42 ms)
[----------] 1030 tests from focal_loss_sigmoid_backward/TestSuite (114205 ms total)

[----------] Global test environment tear-down
[2023-6-1 15:46:15] [MLUOP] [Vlog]:TearDown CNRT environment.
[ SUMMARY  ] Total 1030 cases of 1 op(s).
ALL PASSED.
[==========] 1030 test cases from 1 test suite ran. (114730 ms total)
[  PASSED  ] 1030 test cases.

  YOU HAVE 7 DISABLED TESTS
