### PR TITLE
[Feature](bangc-ops): replace math.h by cmath

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/kl_test.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/kl_test.cpp
@@ -22,7 +22,7 @@
  *************************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 #include <vector>
 #include "gtest/gtest.h"


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

include <math.h> + 低版本gcc编译下，abs(double(a))会报错abs函数二义性，这是由于math.h中的abs()仅适用于整数类型，如果想要获取double，则应使用fabs，由于仓库是C++标准，更改为cmath更合适一些.
