### PR TITLE
[Feature](bangc-ops):add file name format check

### DIFF
--- a/tools/check_file_name.py
+++ b/tools/check_file_name.py
@@ -19,6 +19,8 @@
 # CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# pylint: disable=invalid-name, missing-class-docstring, missing-function-docstring
+# pylint: disable=attribute-defined-outside-init
 
 import os
 import sys

--- a/tools/check_file_name.py
+++ b/tools/check_file_name.py
@@ -25,7 +25,7 @@
 import os
 import sys
 
-def file_name(dir):
+def filename_check(dir):
   for root, dirs, _ in os.walk(dir):
     for dir in dirs:
       file_name = []
@@ -42,7 +42,7 @@ def file_name(dir):
 
 def main():
     dir_path = sys.argv[1]
-    file_name(dir_path)
+    filename_check(dir_path)
 
 
 if __name__ == "__main__":

--- a/tools/check_file_name.py
+++ b/tools/check_file_name.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+# Copyright (C) [2023] by Cambricon, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall self.tcp included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS self.tcp LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+import sys
+
+def file_name(dir):
+  for root, dirs, _ in os.walk(dir):
+    for dir in dirs:
+      file_name = []
+      for  _, _, files in os.walk(os.path.join(root, dir)):
+        for file in files:
+          if file.endswith(".mlu") or file.endswith(".cpp"):
+            name = file.split('.')[0]
+            if name in file_name:
+              print('-- [check_file_name error] find %s.cpp and %s.mlu in directory %s,'\
+                     %(name, name, os.path.join(root, dir)), 'the same name is forbidden.' )
+              exit(-1)
+            file_name.append(name)
+
+
+def main():
+    dir_path = sys.argv[1]
+    file_name(dir_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -6,6 +6,7 @@ bangc_check_list=${bangc_ops}
 bangpy_check_list=${bangpy_ops}
 
 bangc_mlu_op_h="bangc-ops/mlu_op.h"
+bangc_kernels_dir='bangc-ops/kernels/'
 bangc_gtest_json_file="jsoncppDist/"
 
 bangc_exclude_list=${bangc_gtest_json_file}
@@ -149,6 +150,17 @@ echo "-- [check_log_error] Using tools/check_log_error.py to check the LOG(error
 for i in $filenames; do
   python tools/check_log_error.py $i
 done
+
+echo "-- [check_file_name] Using tools/check_file_name.py to check the file_name"
+python tools/check_file_name.py ${bangc_kernels_dir}
+
+if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+  ret=1
+fi
+
+if [[ ${ret} != 0 ]]; then
+  exit ${ret}
+fi
 
 if [[ $# -eq 1 ]]; then
   bangpy_filenames=$(git diff --name-only ${1} \

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -154,12 +154,8 @@ done
 echo "-- [check_file_name] Using tools/check_file_name.py to check the file_name"
 python tools/check_file_name.py ${bangc_kernels_dir}
 
-if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
-  ret=1
-fi
-
-if [[ ${ret} != 0 ]]; then
-  exit ${ret}
+if [[ $? -ne 0 ]]; then
+  exit 1
 fi
 
 if [[ $# -eq 1 ]]; then


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

In directory bangc-ops/kernels/*/, .cpp and .mlu cannot be the same name.

## 2. Modification

- Add new file : tools/check_file_name.py
- Modify tools/pre-commit.

## 3. Test Report

If abs.cpp and abs.mlu exist in bangc-ops/kernels/abs, it will be reported while pre-commit.
-- [check_file_name] Using tools/check_file_name.py to check the file_name
-- [check_file_name error] find abs.cpp and abs.mlu in directory bangc-ops/kernels/abs, the same name is forbidden.
