### PR TITLE
[Feature](bangc-ops):bbox_overlaps opt

### DIFF
--- a/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
+++ b/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
@@ -30,320 +30,464 @@
 
 #define ALIGN_SIZE NFU_ALIGN_SIZE
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+#define BBOX_SIZE 32
 #define COORD_NUM 4
 
 __nram__ char nmem_buf[MAX_NRAM_SIZE];
+__nram__ char bbox_nram[BBOX_SIZE];
 
 template <typename T>
-__mlu_device__ void bbox_overlaps_workflow(
+__mlu_func__ void bboxOverlapsAlignModeImpl(
     T *vec_b1_x1, T *vec_b1_y1, T *vec_b1_x2, T *vec_b1_y2, T *vec_b2_x1,
     T *vec_b2_y1, T *vec_b2_x2, T *vec_b2_y2, T *vec_left, T *vec_right,
     T *vec_top, T *vec_bottom, const T *bbox1, const T *bbox2, void *ious,
     const int32_t offset, const int32_t mode, const int32_t batches_stride,
-    const int32_t num_bbox1, const int32_t num_bbox2, const bool aligned) {
+    const int32_t num_bbox1, const int32_t num_bbox2) {
   int32_t task_batch_stride = (num_bbox1 + taskDim - 1) / taskDim;
   int32_t batch_start = taskId * task_batch_stride;
   int32_t batch_per_task = batch_start + task_batch_stride < num_bbox1
                                ? task_batch_stride
                                : num_bbox1 - batch_start;
   batch_per_task = MAX(batch_per_task, 0);
-  const int32_t is_high_precision = 1;
-  if (aligned) {
-    int32_t num_loop_cpy = batch_per_task / batches_stride;
-    int32_t num_rem_cpy_batches = batch_per_task % batches_stride;
-    num_loop_cpy = num_rem_cpy_batches > 0 ? num_loop_cpy + 1 : num_loop_cpy;
-    for (int32_t i = 0; i < num_loop_cpy; i++) {
-      int32_t index = batch_start + i * batches_stride;
-      int32_t handle_batches = index + batches_stride > num_bbox1
-                                   ? num_rem_cpy_batches
-                                   : batches_stride;
-      int32_t b1 = index;
-      int32_t b2 = index;
 
-      int32_t base1 = b1 * COORD_NUM;
-      __memcpy_async(vec_b1_x1, &bbox1[base1], sizeof(T), GDRAM2NRAM, sizeof(T),
-                     COORD_NUM * sizeof(T), handle_batches - 1);
-      __memcpy_async(vec_b1_y1, &bbox1[base1 + 1], sizeof(T), GDRAM2NRAM,
-                     sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
-      __memcpy_async(vec_b1_x2, &bbox1[base1 + 2], sizeof(T), GDRAM2NRAM,
-                     sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
-      __memcpy_async(vec_b1_y2, &bbox1[base1 + 3], sizeof(T), GDRAM2NRAM,
-                     sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
+  int32_t num_loop_cpy = batch_per_task / batches_stride;
+  int32_t num_rem_cpy_batches = batch_per_task % batches_stride;
+  num_loop_cpy = num_rem_cpy_batches > 0 ? num_loop_cpy + 1 : num_loop_cpy;
+  for (int32_t i = 0; i < num_loop_cpy; i++) {
+    int32_t index = batch_start + i * batches_stride;
+    int32_t handle_batches = index + batches_stride > num_bbox1
+                                 ? num_rem_cpy_batches
+                                 : batches_stride;
+    int32_t b1 = index;
+    int32_t b2 = index;
 
-      int32_t base2 = b2 * COORD_NUM;
-      __memcpy_async(vec_b2_x1, &bbox2[base2], sizeof(T), GDRAM2NRAM, sizeof(T),
-                     COORD_NUM * sizeof(T), handle_batches - 1);
-      __memcpy_async(vec_b2_y1, &bbox2[base2 + 1], sizeof(T), GDRAM2NRAM,
-                     sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
-      __memcpy_async(vec_b2_x2, &bbox2[base2 + 2], sizeof(T), GDRAM2NRAM,
-                     sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
-      __memcpy(vec_b2_y2, &bbox2[base2 + 3], sizeof(T), GDRAM2NRAM, sizeof(T),
-               COORD_NUM * sizeof(T), handle_batches - 1);
+    int32_t base1 = b1 * COORD_NUM;
+    __memcpy_async(vec_b1_x1, &bbox1[base1], sizeof(T), GDRAM2NRAM, sizeof(T),
+                   COORD_NUM * sizeof(T), handle_batches - 1);
+    __memcpy_async(vec_b1_y1, &bbox1[base1 + 1], sizeof(T), GDRAM2NRAM,
+                   sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
+    __memcpy_async(vec_b1_x2, &bbox1[base1 + 2], sizeof(T), GDRAM2NRAM,
+                   sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
+    __memcpy_async(vec_b1_y2, &bbox1[base1 + 3], sizeof(T), GDRAM2NRAM,
+                   sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
 
-      // get the width and height
-#if __BANG_ARCH__ >= 520
-      __bang_maximum(vec_left, vec_b1_x1, vec_b2_x1, batches_stride);
-      __bang_minimum(vec_right, vec_b1_x2, vec_b2_x2, batches_stride);
-      __bang_maximum(vec_top, vec_b1_y1, vec_b2_y1, batches_stride);
-      __bang_minimum(vec_bottom, vec_b1_y2, vec_b2_y2, batches_stride);
-      // right - left + offset ---> left
-      __bang_sub(vec_left, vec_right, vec_left, batches_stride);
-      __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
+    int32_t base2 = b2 * COORD_NUM;
+    __memcpy_async(vec_b2_x1, &bbox2[base2], sizeof(T), GDRAM2NRAM, sizeof(T),
+                   COORD_NUM * sizeof(T), handle_batches - 1);
+    __memcpy_async(vec_b2_y1, &bbox2[base2 + 1], sizeof(T), GDRAM2NRAM,
+                   sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
+    __memcpy_async(vec_b2_x2, &bbox2[base2 + 2], sizeof(T), GDRAM2NRAM,
+                   sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
+    __memcpy(vec_b2_y2, &bbox2[base2 + 3], sizeof(T), GDRAM2NRAM, sizeof(T),
+             COORD_NUM * sizeof(T), handle_batches - 1);
+
+    // get the width and height
+#if __BANG_ARCH__ >= 592
+    __bang_maximum(vec_left, vec_b1_x1, vec_b2_x1, batches_stride);
+    __bang_minimum(vec_right, vec_b1_x2, vec_b2_x2, batches_stride);
+    __bang_maximum(vec_top, vec_b1_y1, vec_b2_y1, batches_stride);
+    __bang_minimum(vec_bottom, vec_b1_y2, vec_b2_y2, batches_stride);
+    // right - left + offset ---> left
+    __bang_sub(vec_left, vec_right, vec_left, batches_stride);
+    __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
 #else
-      // vec_b1_x1[0] = NAN; vec_b2_x1[0] = 10;
-      __memcpy_async(vec_left, vec_b1_x1, batches_stride * sizeof(T),
+    __memcpy_async(vec_left, vec_b1_x1, batches_stride * sizeof(T), NRAM2NRAM);
+    __memcpy_async(vec_bottom, vec_b2_x1, batches_stride * sizeof(T),
+                   NRAM2NRAM);
+    __sync_compute();
+    __bang_maximum(vec_left, vec_left, vec_bottom, batches_stride);
+
+    __memcpy_async(vec_right, vec_b1_x2, batches_stride * sizeof(T), NRAM2NRAM);
+    __memcpy_async(vec_bottom, vec_b2_x2, batches_stride * sizeof(T),
+                   NRAM2NRAM);
+    __sync_compute();
+    __bang_minimum(vec_right, vec_right, vec_bottom, batches_stride);
+    // right - left + offset ---> left
+    __bang_sub(vec_left, vec_right, vec_left, batches_stride);
+    __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
+
+    __memcpy_async(vec_top, vec_b1_y1, batches_stride * sizeof(T), NRAM2NRAM);
+    __memcpy_async(vec_bottom, vec_b2_y1, batches_stride * sizeof(T),
+                   NRAM2NRAM);
+    __sync_compute();
+    __bang_maximum(vec_top, vec_top, vec_bottom, batches_stride);
+
+    __memcpy_async(vec_bottom, vec_b1_y2, batches_stride * sizeof(T),
+                   NRAM2NRAM);
+    __memcpy_async(vec_right, vec_b2_y2, batches_stride * sizeof(T), NRAM2NRAM);
+    __sync_compute();
+    __bang_minimum(vec_bottom, vec_bottom, vec_right, batches_stride);
+
+#endif
+
+    // bottom - top + offset ---> right
+    __bang_sub(vec_right, vec_bottom, vec_top, batches_stride);
+    __bang_add_scalar(vec_right, vec_right, (T)offset, batches_stride);
+
+    // zero vector ---> bottom
+    __bang_write_value(vec_bottom, batches_stride, (T)0);
+
+    // width --> vec_left
+#if __BANG_ARCH__ >= 592
+    __bang_maximum(vec_left, vec_bottom, vec_left, batches_stride);
+#else
+    __bang_maximum(vec_left, vec_left, vec_bottom, batches_stride);
+
+#endif
+    T *width = vec_left;
+    // height --> vec_right
+
+#if __BANG_ARCH__ >= 592
+    __bang_maximum(vec_right, vec_bottom, vec_right, batches_stride);
+#else
+    __bang_write_value(vec_bottom, batches_stride, (T)0);
+    __bang_maximum(vec_right, vec_right, vec_bottom, batches_stride);
+#endif
+    T *height = vec_right;
+
+    // get the b1_area
+    // (b1_x2 - b1_x1 + offset)  --->  vec_top
+    __bang_sub(vec_top, vec_b1_x2, vec_b1_x1, batches_stride);
+    __bang_add_scalar(vec_top, vec_top, (T)offset, batches_stride);
+
+    // (b1_y2 - b1_y1 + offset)  --->  vec_bottom
+    __bang_sub(vec_bottom, vec_b1_y2, vec_b1_y1, batches_stride);
+    __bang_add_scalar(vec_bottom, vec_bottom, (T)offset, batches_stride);
+
+    // b1_area = (b1_x2 - b1_x1 + offset) * (b1_y2 - b1_y1 + offset) --->
+    // vec_top;
+    __bang_mul(vec_top, vec_top, vec_bottom, batches_stride);
+    T *b1_area = vec_top;
+
+    // get the b2_area
+    // (b2_x2 - b2_x1 + offset)  --->  b2_x1
+    __bang_sub(vec_b2_x1, vec_b2_x2, vec_b2_x1, batches_stride);
+    __bang_add_scalar(vec_b2_x1, vec_b2_x1, (T)offset, batches_stride);
+
+    // (b2_y2 - b2_y1 + offset)  --->  b2_y1
+    __bang_sub(vec_b2_y1, vec_b2_y2, vec_b2_y1, batches_stride);
+    __bang_add_scalar(vec_b2_y1, vec_b2_y1, (T)offset, batches_stride);
+
+    // b2_area = (b2_x2 - b2_x1 + offset) * (b2_y2 - b2_y1 + offset) --->
+    // b2_x1;
+    __bang_mul(vec_b2_x1, vec_b2_x1, vec_b2_y1, batches_stride);
+    T *b2_area = vec_b2_x1;
+
+    // inter_s = width * height
+    __bang_mul(height, width, height, batches_stride);
+    T *inter_s = height;
+
+    // offset vector ---> vec_b2_y1
+    __bang_write_value(vec_b2_y1, batches_stride, T(offset));
+    T *vec_offset = vec_b2_y1;
+
+    if (mode == 0) {
+      __bang_add(b1_area, b1_area, b2_area, batches_stride);
+      __bang_sub(b1_area, b1_area, inter_s, batches_stride);
+#if __BANG_ARCH__ >= 592
+      __bang_maximum(b1_area, vec_offset, b1_area, batches_stride);
+#else
+
+      __memcpy_async(vec_bottom, vec_offset, batches_stride * sizeof(T),
                      NRAM2NRAM);
-      __memcpy(vec_bottom, vec_b2_x1, batches_stride * sizeof(T), NRAM2NRAM);
-      __bang_maximum(vec_left, vec_left, vec_bottom, batches_stride);
+      __sync_compute();
+      __bang_maximum(b1_area, b1_area, vec_bottom, batches_stride);
 
-      __memcpy_async(vec_right, vec_b1_x2, batches_stride * sizeof(T),
+#endif
+    } else {
+#if __BANG_ARCH__ >= 592
+      __bang_maximum(b1_area, vec_offset, b1_area, batches_stride);
+#else
+      __memcpy_async(vec_bottom, vec_offset, batches_stride * sizeof(T),
                      NRAM2NRAM);
-      __memcpy(vec_bottom, vec_b2_x2, batches_stride * sizeof(T), NRAM2NRAM);
-      __bang_minimum(vec_right, vec_right, vec_bottom, batches_stride);
-      // right - left + offset ---> left
-      __bang_sub(vec_left, vec_right, vec_left, batches_stride);
-      __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
-
-      __memcpy_async(vec_top, vec_b1_y1, batches_stride * sizeof(T), NRAM2NRAM);
-      __memcpy(vec_bottom, vec_b2_y1, batches_stride * sizeof(T), NRAM2NRAM);
-      __bang_maximum(vec_top, vec_top, vec_bottom, batches_stride);
-
-      __memcpy_async(vec_bottom, vec_b1_y2, batches_stride * sizeof(T),
-                     NRAM2NRAM);
-      __memcpy(vec_right, vec_b2_y2, batches_stride * sizeof(T), NRAM2NRAM);
-      __bang_minimum(vec_bottom, vec_bottom, vec_right, batches_stride);
-
+      __sync_compute();
+      __bang_maximum(b1_area, b1_area, vec_bottom, batches_stride);
 #endif
-
-      // bottom - top + offset ---> right
-      __bang_sub(vec_right, vec_bottom, vec_top, batches_stride);
-      __bang_add_scalar(vec_right, vec_right, (T)offset, batches_stride);
-
-      // zero vector ---> bottom
-      __bang_write_value(vec_bottom, batches_stride, (T)0);
-
-      // width --> vec_left
-      __bang_maximum(vec_left, vec_left, vec_bottom, batches_stride);
-
-      T *width = vec_left;
-      // height --> vec_right
-
-#if __BANG_ARCH__ >= 520
-      __bang_maximum(vec_right, vec_bottom, vec_right, batches_stride);
-#else
-      __bang_write_value(vec_bottom, batches_stride, (T)0);
-      __bang_maximum(vec_right, vec_right, vec_bottom, batches_stride);
-#endif
-      T *height = vec_right;
-
-      // get the b1_area
-      // (b1_x2 - b1_x1 + offset)  --->  vec_top
-      __bang_sub(vec_top, vec_b1_x2, vec_b1_x1, batches_stride);
-      __bang_add_scalar(vec_top, vec_top, (T)offset, batches_stride);
-
-      // (b1_y2 - b1_y1 + offset)  --->  vec_bottom
-      __bang_sub(vec_bottom, vec_b1_y2, vec_b1_y1, batches_stride);
-      __bang_add_scalar(vec_bottom, vec_bottom, (T)offset, batches_stride);
-
-      // b1_area = (b1_x2 - b1_x1 + offset) * (b1_y2 - b1_y1 + offset) --->
-      // vec_top;
-      __bang_mul(vec_top, vec_top, vec_bottom, batches_stride);
-      T *b1_area = vec_top;
-
-      // get the b2_area
-      // (b2_x2 - b2_x1 + offset)  --->  b2_x1
-      __bang_sub(vec_b2_x1, vec_b2_x2, vec_b2_x1, batches_stride);
-      __bang_add_scalar(vec_b2_x1, vec_b2_x1, (T)offset, batches_stride);
-
-      // (b2_y2 - b2_y1 + offset)  --->  b2_y1
-      __bang_sub(vec_b2_y1, vec_b2_y2, vec_b2_y1, batches_stride);
-      __bang_add_scalar(vec_b2_y1, vec_b2_y1, (T)offset, batches_stride);
-
-      // b2_area = (b2_x2 - b2_x1 + offset) * (b2_y2 - b2_y1 + offset) --->
-      // b2_x1;
-      __bang_mul(vec_b2_x1, vec_b2_x1, vec_b2_y1, batches_stride);
-      T *b2_area = vec_b2_x1;
-
-      // inter_s = width * height
-      __bang_mul(height, width, height, batches_stride);
-      T *inter_s = height;
-
-      // offset vector ---> vec_b2_y1
-      __bang_write_value(vec_b2_y1, batches_stride, T(offset));
-      T *vec_offset = vec_b2_y1;
-
-      if (mode == 0) {
-        __bang_add(b1_area, b1_area, b2_area, batches_stride);
-        __bang_sub(b1_area, b1_area, inter_s, batches_stride);
-#if __BANG_ARCH__ >= 520
-        __bang_maximum(b1_area, vec_offset, b1_area, batches_stride);
-#else
-
-        __memcpy(vec_bottom, vec_offset, batches_stride * sizeof(T), NRAM2NRAM);
-        __bang_maximum(b1_area, b1_area, vec_bottom, batches_stride);
-
-#endif
-      } else {
-#if __BANG_ARCH__ >= 520
-        __bang_maximum(b1_area, vec_offset, b1_area, batches_stride);
-#else
-        __memcpy(vec_bottom, vec_offset, batches_stride * sizeof(T), NRAM2NRAM);
-        __bang_maximum(b1_area, b1_area, vec_bottom, batches_stride);
-#endif
-      }
-      T *base_s = b1_area;
-      __mluop_div(width, inter_s, base_s, vec_b2_x2, is_high_precision,
-                 batches_stride);
-      __memcpy((T *)ious + index, width, handle_batches * sizeof(T),
-               NRAM2GDRAM);
     }
+    T *base_s = b1_area;
+    const int32_t is_high_precision = 1;
+    __mluop_div(width, inter_s, base_s, vec_b2_x2, is_high_precision,
+                batches_stride);
+    __memcpy((T *)ious + index, width, handle_batches * sizeof(T), NRAM2GDRAM);
+  }
+}
+
+template <typename T>
+__mlu_func__ void load(T *vec_b2_x1, const T *bbox2,
+                       const int32_t handle_batches, const int32_t num_bbox2,
+                       const int32_t base2) {
+  __memcpy_async(vec_b2_x1, bbox2 + base2, 4 * handle_batches * sizeof(T),
+                 GDRAM2NRAM);
+}
+template <typename T>
+__mlu_func__ void compute(T *vec_b2_x1, T *vec_b2_y1, T *vec_b2_x2,
+                          T *vec_b2_y2, T *vec_left, T *vec_right, T *vec_top,
+                          T *vec_bottom, const int32_t offset,
+                          const int32_t mode, const int32_t batches_stride,
+                          const int32_t num_bbox1, const int32_t num_bbox2,
+                          int32_t handle_batches, T vec_b1_x1_value,
+                          T vec_b1_x2_value, T vec_b1_y1_value,
+                          T vec_b1_y2_value) {
+  __bang_transpose(vec_left, vec_b2_x1, handle_batches, 4);
+  __memcpy_async(vec_b2_x1, vec_left, handle_batches * sizeof(T), NRAM2NRAM);
+  __memcpy_async(vec_b2_y1, vec_left + handle_batches,
+                 handle_batches * sizeof(T), NRAM2NRAM);
+  __memcpy_async(vec_b2_x2, vec_left + 2 * handle_batches,
+                 handle_batches * sizeof(T), NRAM2NRAM);
+  __memcpy(vec_b2_y2, vec_left + 3 * handle_batches, handle_batches * sizeof(T),
+           NRAM2NRAM);
+
+  // get the width and height
+#if __BANG_ARCH__ >= 592
+  __bang_maximum_scalar(vec_left, vec_b2_x1, vec_b1_x1_value, handle_batches);
+  __bang_minimum_scalar(vec_right, vec_b2_x2, vec_b1_x2_value, handle_batches);
+  __bang_maximum_scalar(vec_top, vec_b2_y1, vec_b1_y1_value, handle_batches);
+  __bang_minimum_scalar(vec_bottom, vec_b2_y2, vec_b1_y2_value, handle_batches);
+  // right - left + offset ---> left
+  __bang_sub(vec_left, vec_right, vec_left, handle_batches);
+  __bang_add_scalar(vec_left, vec_left, (T)offset, handle_batches);
+#else
+  __bang_write_value(vec_bottom, handle_batches, vec_b1_x1_value);
+  __memcpy_async(vec_left, vec_b2_x1, handle_batches * sizeof(T), NRAM2NRAM);
+  __sync_compute();
+  __bang_maximum(vec_left, vec_left, vec_bottom, handle_batches);
+
+  __bang_write_value(vec_bottom, handle_batches, vec_b1_x2_value);
+  __memcpy_async(vec_right, vec_b2_x2, handle_batches * sizeof(T), NRAM2NRAM);
+  __sync_compute();
+  __bang_minimum(vec_right, vec_right, vec_bottom, handle_batches);
+  // right - left + offset ---> left
+  __bang_sub(vec_left, vec_right, vec_left, handle_batches);
+  __bang_add_scalar(vec_left, vec_left, (T)offset, handle_batches);
+
+  __bang_write_value(vec_bottom, handle_batches, vec_b1_y1_value);
+  __memcpy_async(vec_top, vec_b2_y1, handle_batches * sizeof(T), NRAM2NRAM);
+  __sync_compute();
+  __bang_maximum(vec_top, vec_top, vec_bottom, handle_batches);
+
+  __bang_write_value(vec_right, handle_batches, vec_b1_y2_value);
+  __memcpy_async(vec_bottom, vec_b2_y2, handle_batches * sizeof(T), NRAM2NRAM);
+  __sync_compute();
+  __bang_minimum(vec_bottom, vec_bottom, vec_right, handle_batches);
+
+#endif
+  // bottom - top + offset ---> right
+  __bang_sub(vec_right, vec_bottom, vec_top, handle_batches);
+  __bang_add_scalar(vec_right, vec_right, (T)offset, handle_batches);
+
+  // zero vector ---> bottom
+  __bang_write_value(vec_bottom, handle_batches, (T)0);
+
+  // width --> vec_left
+  __bang_maximum(vec_left, vec_left, vec_bottom, handle_batches);
+  T *width = vec_left;
+  // height --> vec_right
+#if __BANG_ARCH__ >= 592
+  __bang_maximum(vec_right, vec_bottom, vec_right, handle_batches);
+#else
+  __memcpy_async(vec_top, vec_bottom, handle_batches * sizeof(T), NRAM2NRAM);
+  __sync_compute();
+  __bang_maximum(vec_right, vec_right, vec_top, handle_batches);
+#endif
+  T *height = vec_right;
+
+  // get the b1_area
+  // (b1_x2 - b1_x1 + offset)  --->  vec_top
+  T vec_top_value = vec_b1_x2_value - vec_b1_x1_value + offset;
+  T vec_bottom_value = vec_b1_y2_value - vec_b1_y1_value + offset;
+  T b1_area_value = vec_top_value * vec_bottom_value;
+
+  // get the b2_area
+  // (b2_x2 - b2_x1 + offset)  --->  b2_x1
+  __bang_sub(vec_b2_x1, vec_b2_x2, vec_b2_x1, handle_batches);
+  __bang_add_scalar(vec_b2_x1, vec_b2_x1, (T)offset, handle_batches);
+  // (b2_y2 - b2_y1 + offset)  --->  b2_y1
+  __bang_sub(vec_b2_y1, vec_b2_y2, vec_b2_y1, handle_batches);
+  __bang_add_scalar(vec_b2_y1, vec_b2_y1, (T)offset, handle_batches);
+  // b2_area = (b2_x2 - b2_x1 + offset) * (b2_y2 - b2_y1 + offset) --->
+  // b2_x1;
+  __bang_mul(vec_b2_x1, vec_b2_x1, vec_b2_y1, handle_batches);
+  T *b2_area = vec_b2_x1;
+
+  // inter_s = width * height
+  __bang_mul(height, width, height, handle_batches);
+  T *inter_s = height;
+
+  // offset vector ---> vec_b2_y1
+  __bang_write_value(vec_b2_y1, handle_batches, T(offset));
+  T *vec_offset = vec_b2_y1;
+
+  if (mode == 0) {
+    __bang_add_scalar(b2_area, b2_area, b1_area_value, handle_batches);
+    __bang_sub(b2_area, b2_area, inter_s, handle_batches);
+#if __BANG_ARCH__ >= 592
+    __bang_maximum(b2_area, vec_offset, b2_area, handle_batches);
+#else
+    __memcpy_async(vec_bottom, vec_offset, handle_batches * sizeof(T),
+                   NRAM2NRAM);
+    __sync_compute();
+    __bang_maximum(b2_area, b2_area, vec_bottom, handle_batches);
+
+#endif
   } else {
-    int32_t num_loop_cpy = num_bbox2 / batches_stride;
-    int32_t num_rem_cpy_batches = num_bbox2 % batches_stride;
-    num_loop_cpy = num_rem_cpy_batches > 0 ? num_loop_cpy + 1 : num_loop_cpy;
-    for (int32_t i = 0; i < batch_per_task; i++) {
-      int32_t index1 = batch_start + i;
-      int32_t b1 = index1;
-      int32_t base1 = b1 * COORD_NUM;
-
-      // set bbox1 and bbox2 to nram
-      __bang_write_value(vec_b1_x1, batches_stride, bbox1[base1]);
-      __bang_write_value(vec_b1_y1, batches_stride, bbox1[base1 + 1]);
-      __bang_write_value(vec_b1_x2, batches_stride, bbox1[base1 + 2]);
-      __bang_write_value(vec_b1_y2, batches_stride, bbox1[base1 + 3]);
-
-      for (int32_t j = 0; j < num_loop_cpy; j++) {
-        int32_t index2 = j * batches_stride;
-        int32_t handle_batches = index2 + batches_stride > num_bbox2
-                                     ? num_rem_cpy_batches
-                                     : batches_stride;
-        int32_t b2 = index2;
-        int32_t base2 = b2 * COORD_NUM;
-
-        // copy bbox2 to nram
-        __memcpy_async(vec_b2_x1, &bbox2[base2], sizeof(T), GDRAM2NRAM,
-                       sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
-        __memcpy_async(vec_b2_y1, &bbox2[base2 + 1], sizeof(T), GDRAM2NRAM,
-                       sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
-        __memcpy_async(vec_b2_x2, &bbox2[base2 + 2], sizeof(T), GDRAM2NRAM,
-                       sizeof(T), COORD_NUM * sizeof(T), handle_batches - 1);
-        __memcpy(vec_b2_y2, &bbox2[base2 + 3], sizeof(T), GDRAM2NRAM, sizeof(T),
-                 COORD_NUM * sizeof(T), handle_batches - 1);
-
-        // get the width and height
-#if __BANG_ARCH__ >= 520
-        __bang_maximum(vec_left, vec_b1_x1, vec_b2_x1, batches_stride);
-        __bang_minimum(vec_right, vec_b1_x2, vec_b2_x2, batches_stride);
-        __bang_maximum(vec_top, vec_b1_y1, vec_b2_y1, batches_stride);
-        __bang_minimum(vec_bottom, vec_b1_y2, vec_b2_y2, batches_stride);
-        // right - left + offset ---> left
-        __bang_sub(vec_left, vec_right, vec_left, batches_stride);
-        __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
+#if __BANG_ARCH__ >= 592
+    __bang_maximum_scalar(b2_area, vec_offset, b1_area_value, handle_batches);
 #else
-        __memcpy_async(vec_left, vec_b1_x1, batches_stride * sizeof(T),
-                       NRAM2NRAM);
-        __memcpy(vec_bottom, vec_b2_x1, batches_stride * sizeof(T), NRAM2NRAM);
-        __bang_maximum(vec_left, vec_left, vec_bottom, batches_stride);
-
-        __memcpy_async(vec_right, vec_b1_x2, batches_stride * sizeof(T),
-                       NRAM2NRAM);
-        __memcpy(vec_bottom, vec_b2_x2, batches_stride * sizeof(T), NRAM2NRAM);
-        __bang_minimum(vec_right, vec_right, vec_bottom, batches_stride);
-        // right - left + offset ---> left
-        __bang_sub(vec_left, vec_right, vec_left, batches_stride);
-        __bang_add_scalar(vec_left, vec_left, (T)offset, batches_stride);
-
-        __memcpy_async(vec_top, vec_b1_y1, batches_stride * sizeof(T),
-                       NRAM2NRAM);
-        __memcpy(vec_bottom, vec_b2_y1, batches_stride * sizeof(T), NRAM2NRAM);
-        __bang_maximum(vec_top, vec_top, vec_bottom, batches_stride);
-
-        __memcpy_async(vec_bottom, vec_b1_y2, batches_stride * sizeof(T),
-                       NRAM2NRAM);
-        __memcpy(vec_right, vec_b2_y2, batches_stride * sizeof(T), NRAM2NRAM);
-        __bang_minimum(vec_bottom, vec_bottom, vec_right, batches_stride);
-
+    __memcpy_async(b2_area, vec_offset, handle_batches * sizeof(T), NRAM2NRAM);
+    __sync_compute();
+    __bang_write_value(vec_bottom, handle_batches, T(b1_area_value));
+    __bang_maximum(b2_area, b2_area, vec_bottom, handle_batches);
 #endif
-        // bottom - top + offset ---> right
-        __bang_sub(vec_right, vec_bottom, vec_top, batches_stride);
-        __bang_add_scalar(vec_right, vec_right, (T)offset, batches_stride);
+  }
+  T *base_s = b2_area;
 
-        // zero vector ---> bottom
-        __bang_write_value(vec_bottom, batches_stride, (T)0);
+  // ious = inter_s / base_s
+  const int32_t is_high_precision = 1;
+  __mluop_div(width, inter_s, base_s, vec_b2_x2, is_high_precision,
+              handle_batches);
+}
 
-        // width --> vec_left
-        __bang_maximum(vec_left, vec_left, vec_bottom, batches_stride);
-        T *width = vec_left;
-        // height --> vec_right
-#if __BANG_ARCH__ >= 520
-        __bang_maximum(vec_right, vec_bottom, vec_right, batches_stride);
-#else
-        __bang_write_value(vec_bottom, batches_stride, (T)0);
-        __bang_maximum(vec_right, vec_right, vec_bottom, batches_stride);
-#endif
-        T *height = vec_right;
+template <typename T>
+__mlu_func__ void store(void *ious, T *vec_left, const int32_t handle_batches,
+                        const int32_t index1, const int32_t index2,
+                        const int32_t num_bbox2) {
+  __memcpy_async((T *)ious + (index1 * num_bbox2 + index2), (T *)vec_left,
+                 handle_batches * sizeof(T), NRAM2GDRAM);
+}
 
-        // get the b1_area
-        // (b1_x2 - b1_x1 + offset)  --->  vec_top
-        __bang_sub(vec_top, vec_b1_x2, vec_b1_x1, batches_stride);
-        __bang_add_scalar(vec_top, vec_top, (T)offset, batches_stride);
-        // (b1_y2 - b1_y1 + offset)  --->  vec_bottom
-        __bang_sub(vec_bottom, vec_b1_y2, vec_b1_y1, batches_stride);
-        __bang_add_scalar(vec_bottom, vec_bottom, (T)offset, batches_stride);
-        // b1_area = (b1_x2 - b1_x1 + offset) * (b1_y2 - b1_y1 + offset) --->
-        // vec_top;
-        __bang_mul(vec_top, vec_top, vec_bottom, batches_stride);
-        T *b1_area = vec_top;
+template <typename T>
+__mlu_func__ void bboxOverlapsNotAlignModeImpl(
+    T *vec_b2_x1, T *vec_b2_y1, T *vec_b2_x2, T *vec_b2_y2, T *vec_left,
+    T *vec_right, T *vec_top, T *vec_bottom, T *bbox1, T *bbox2, void *ious,
+    const int32_t offset, const int32_t mode, const int32_t batches_stride,
+    const int32_t num_bbox1, const int32_t num_bbox2,
+    const int32_t ping_pong_gap) {
+  const int32_t task_batch_stride = (num_bbox1 + taskDim - 1) / taskDim;
+  const int32_t batch_start = taskId * task_batch_stride;
+  int32_t batch_per_task = batch_start + task_batch_stride < num_bbox1
+                               ? task_batch_stride
+                               : num_bbox1 - batch_start;
+  batch_per_task = MAX(batch_per_task, 0);
+  if (batch_per_task == 0) {
+    return;
+  }
 
-        // get the b2_area
-        // (b2_x2 - b2_x1 + offset)  --->  b2_x1
-        __bang_sub(vec_b2_x1, vec_b2_x2, vec_b2_x1, batches_stride);
-        __bang_add_scalar(vec_b2_x1, vec_b2_x1, (T)offset, batches_stride);
-        // (b2_y2 - b2_y1 + offset)  --->  b2_y1
-        __bang_sub(vec_b2_y1, vec_b2_y2, vec_b2_y1, batches_stride);
-        __bang_add_scalar(vec_b2_y1, vec_b2_y1, (T)offset, batches_stride);
-        // b2_area = (b2_x2 - b2_x1 + offset) * (b2_y2 - b2_y1 + offset) --->
-        // b2_x1;
-        __bang_mul(vec_b2_x1, vec_b2_x1, vec_b2_y1, batches_stride);
-        T *b2_area = vec_b2_x1;
+  const int32_t num_loop_cpy = num_bbox2 / batches_stride;
 
-        // inter_s = width * height
-        __bang_mul(height, width, height, batches_stride);
-        T *inter_s = height;
+  const int32_t num_rem_cpy_batches = num_bbox2 % batches_stride;
+  for (int32_t i = 0; i < batch_per_task; i++) {
+    const int32_t index1 = batch_start + i;
+    const int32_t b1 = index1;
+    const int32_t base1 = b1 * COORD_NUM;
 
-        // offset vector ---> vec_b2_y1
-        __bang_write_value(vec_b2_y1, batches_stride, T(offset));
-        T *vec_offset = vec_b2_y1;
+    // set bbox1 and bbox2 to nram
+    __memcpy((T *)bbox_nram, (T *)bbox1 + base1, 4 * sizeof(T), GDRAM2NRAM);
+    T vec_b1_x1_value = ((T *)bbox_nram)[0];
+    T vec_b1_y1_value = ((T *)bbox_nram)[1];
+    T vec_b1_x2_value = ((T *)bbox_nram)[2];
+    T vec_b1_y2_value = ((T *)bbox_nram)[3];
 
-        if (mode == 0) {
-          __bang_add(b1_area, b1_area, b2_area, batches_stride);
-          __bang_sub(b1_area, b1_area, inter_s, batches_stride);
-#if __BANG_ARCH__ >= 520
-          __bang_maximum(b1_area, vec_offset, b1_area, batches_stride);
-#else
-          __memcpy(vec_bottom, vec_offset, batches_stride * sizeof(T),
-                   NRAM2NRAM);
-          __bang_maximum(b1_area, b1_area, vec_bottom, batches_stride);
+    int32_t index2 = 0;
+    int32_t handle_batches = index2 + batches_stride > num_bbox2
+                                 ? num_rem_cpy_batches
+                                 : batches_stride;
 
-#endif
-        } else {
-#if __BANG_ARCH__ >= 520
-          __bang_maximum(b1_area, vec_offset, b1_area, batches_stride);
-#else
-          __memcpy(vec_bottom, vec_offset, batches_stride * sizeof(T),
-                   NRAM2NRAM);
-          __bang_maximum(b1_area, b1_area, vec_bottom, batches_stride);
-#endif
-        }
-        T *base_s = b1_area;
+    int32_t index2_1 = 0;
+    int32_t handle_batches_1 = 0;
 
-        // ious = inter_s / base_s
-        __mluop_div(width, inter_s, base_s, vec_b2_x2, is_high_precision,
-                   batches_stride);
-        int32_t gdram_offset = index1 * num_bbox2 + index2;
-        __memcpy((T *)ious + gdram_offset, width, handle_batches * sizeof(T),
-                 NRAM2GDRAM);
-      }
+    int32_t base2_1 = 0;
+    if (num_loop_cpy > 0) {
+      load(vec_b2_x1, bbox2, handle_batches, num_bbox2, 0);
+      __sync();
+    }
+
+    if (num_loop_cpy > 1) {
+      index2_1 = batches_stride;
+      handle_batches_1 = index2_1 + batches_stride > num_bbox2
+                             ? num_rem_cpy_batches
+                             : batches_stride;
+      base2_1 = index2_1 * COORD_NUM;
+      load(vec_b2_x1 + ping_pong_gap, bbox2, handle_batches_1, num_bbox2,
+           base2_1);
+      compute(vec_b2_x1, vec_b2_y1, vec_b2_x2, vec_b2_y2, vec_left, vec_right,
+              vec_top, vec_bottom, offset, mode, batches_stride, num_bbox1,
+              num_bbox2, handle_batches, vec_b1_x1_value, vec_b1_x2_value,
+              vec_b1_y1_value, vec_b1_y2_value);
+      __sync();
+    }
+
+    for (int32_t i = 0; i < num_loop_cpy - 2; i++) {
+      store(ious, vec_left + ((i + 2) % 2) * ping_pong_gap, handle_batches,
+            index1, i * batches_stride, num_bbox2);
+
+      load(vec_b2_x1 + (i % 2) * ping_pong_gap, bbox2, handle_batches,
+           num_bbox2, (i + 2) * batches_stride * COORD_NUM);
+
+      compute(vec_b2_x1 + ((i + 1) % 2) * ping_pong_gap,
+              vec_b2_y1 + ((i + 1) % 2) * ping_pong_gap,
+              vec_b2_x2 + ((i + 1) % 2) * ping_pong_gap,
+              vec_b2_y2 + ((i + 1) % 2) * ping_pong_gap,
+              vec_left + ((i + 1) % 2) * ping_pong_gap,
+              vec_right + ((i + 1) % 2) * ping_pong_gap,
+              vec_top + ((i + 1) % 2) * ping_pong_gap,
+              vec_bottom + ((i + 1) % 2) * ping_pong_gap, offset, mode,
+              batches_stride, num_bbox1, num_bbox2, handle_batches,
+              vec_b1_x1_value, vec_b1_x2_value, vec_b1_y1_value,
+              vec_b1_y2_value);
+      __sync();
+    }
+
+    if (num_loop_cpy > 1) {
+      store(ious, vec_left + ((num_loop_cpy - 2) % 2) * ping_pong_gap,
+            handle_batches, index1, (num_loop_cpy - 2) * batches_stride,
+            num_bbox2);
+    }
+    if (num_rem_cpy_batches > 0) {
+      index2_1 = num_loop_cpy * batches_stride;
+      handle_batches_1 = index2_1 + batches_stride > num_bbox2
+                             ? num_rem_cpy_batches
+                             : batches_stride;
+
+      base2_1 = index2_1 * COORD_NUM;
+      load(vec_b2_x1 + (num_loop_cpy % 2) * ping_pong_gap, bbox2,
+           handle_batches_1, num_bbox2, base2_1);
+    }
+
+    if (num_loop_cpy > 0) {
+      compute(vec_b2_x1 + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+              vec_b2_y1 + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+              vec_b2_x2 + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+              vec_b2_y2 + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+              vec_left + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+              vec_right + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+              vec_top + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+              vec_bottom + ((num_loop_cpy - 1) % 2) * ping_pong_gap, offset,
+              mode, batches_stride, num_bbox1, num_bbox2, handle_batches,
+              vec_b1_x1_value, vec_b1_x2_value, vec_b1_y1_value,
+              vec_b1_y2_value);
+    }
+    __sync();
+    if (num_loop_cpy > 0) {
+      store(ious, vec_left + ((num_loop_cpy - 1) % 2) * ping_pong_gap,
+            handle_batches, index1, (num_loop_cpy - 1) * batches_stride,
+            num_bbox2);
+    }
+    if (num_rem_cpy_batches > 0) {
+      compute(vec_b2_x1 + ((num_loop_cpy) % 2) * ping_pong_gap,
+              vec_b2_y1 + ((num_loop_cpy) % 2) * ping_pong_gap,
+              vec_b2_x2 + ((num_loop_cpy) % 2) * ping_pong_gap,
+              vec_b2_y2 + ((num_loop_cpy) % 2) * ping_pong_gap,
+              vec_left + ((num_loop_cpy) % 2) * ping_pong_gap,
+              vec_right + ((num_loop_cpy) % 2) * ping_pong_gap,
+              vec_top + ((num_loop_cpy) % 2) * ping_pong_gap,
+              vec_bottom + ((num_loop_cpy) % 2) * ping_pong_gap, offset, mode,
+              batches_stride, num_bbox1, num_bbox2, handle_batches_1,
+              vec_b1_x1_value, vec_b1_x2_value, vec_b1_y1_value,
+              vec_b1_y2_value);
+      __sync();
+      store(ious, vec_left + ((num_loop_cpy) % 2) * ping_pong_gap,
+            handle_batches_1, index1, index2_1, num_bbox2);
     }
   }
 }
@@ -353,31 +497,55 @@ __mlu_global__ void MLUUnion1BboxOverlapsKernel(
     const T *bbox1, const T *bbox2, T *ious, const int32_t num_bboxl,
     const int32_t num_bbox2, const int32_t mode, const bool aligned,
     const int32_t offset) {
-  int32_t align_bytes = PAD_DOWN(MAX_NRAM_SIZE, ALIGN_SIZE);
-  int32_t nram_stride = align_bytes / ALIGN_SIZE / 12 * ALIGN_SIZE;
+  if (__is_mpu()) {
+    return;
+  }
+  if (aligned) {
+    int32_t align_bytes = PAD_DOWN(MAX_NRAM_SIZE, ALIGN_SIZE);
+    int32_t nram_stride = align_bytes / ALIGN_SIZE / 12 * ALIGN_SIZE;
+    void *vec_b1_x1 = nmem_buf;
+    void *vec_b1_y1 = nmem_buf + nram_stride;
+    void *vec_b1_x2 = nmem_buf + 2 * nram_stride;
+    void *vec_b1_y2 = nmem_buf + 3 * nram_stride;
 
-  void *vec_b1_x1 = nmem_buf;
-  void *vec_b1_y1 = nmem_buf + nram_stride;
-  void *vec_b1_x2 = nmem_buf + 2 * nram_stride;
-  void *vec_b1_y2 = nmem_buf + 3 * nram_stride;
+    void *vec_b2_x1 = nmem_buf + 4 * nram_stride;
+    void *vec_b2_y1 = nmem_buf + 5 * nram_stride;
+    void *vec_b2_x2 = nmem_buf + 6 * nram_stride;
+    void *vec_b2_y2 = nmem_buf + 7 * nram_stride;
 
-  void *vec_b2_x1 = nmem_buf + 4 * nram_stride;
-  void *vec_b2_y1 = nmem_buf + 5 * nram_stride;
-  void *vec_b2_x2 = nmem_buf + 6 * nram_stride;
-  void *vec_b2_y2 = nmem_buf + 7 * nram_stride;
+    void *vec_left = nmem_buf + 8 * nram_stride;
+    void *vec_right = nmem_buf + 9 * nram_stride;
+    void *vec_top = nmem_buf + 10 * nram_stride;
+    void *vec_bottom = nmem_buf + 11 * nram_stride;
+    const int32_t vec_length = nram_stride / sizeof(T);
+    bboxOverlapsAlignModeImpl((T *)vec_b1_x1, (T *)vec_b1_y1, (T *)vec_b1_x2,
+                              (T *)vec_b1_y2, (T *)vec_b2_x1, (T *)vec_b2_y1,
+                              (T *)vec_b2_x2, (T *)vec_b2_y2, (T *)vec_left,
+                              (T *)vec_right, (T *)vec_top, (T *)vec_bottom,
+                              (T *)bbox1, (T *)bbox2, (T *)ious, offset, mode,
+                              vec_length, num_bboxl, num_bbox2);
+  } else {
+    int32_t align_bytes = PAD_DOWN(MAX_NRAM_SIZE - BBOX_SIZE, ALIGN_SIZE);
+    const int32_t nram_split_num = 16;
+    const int32_t nram_stride =
+        align_bytes / ALIGN_SIZE / nram_split_num * ALIGN_SIZE / sizeof(T);
+    T *vec_left = (T *)nmem_buf;
+    T *vec_right = (T *)nmem_buf + 1 * nram_stride;
+    T *vec_top = (T *)nmem_buf + 2 * nram_stride;
+    T *vec_bottom = (T *)nmem_buf + 3 * nram_stride;
+    T *vec_b2_x1 = (T *)nmem_buf + 4 * nram_stride;
+    T *vec_b2_y1 = (T *)nmem_buf + 5 * nram_stride;
+    T *vec_b2_x2 = (T *)nmem_buf + 6 * nram_stride;
+    T *vec_b2_y2 = (T *)nmem_buf + 7 * nram_stride;
 
-  void *vec_left = nmem_buf + 8 * nram_stride;
-  void *vec_right = nmem_buf + 9 * nram_stride;
-  void *vec_top = nmem_buf + 10 * nram_stride;
-  void *vec_bottom = nmem_buf + 11 * nram_stride;
-
-  int32_t vec_length = nram_stride / sizeof(T);
-  bbox_overlaps_workflow((T *)vec_b1_x1, (T *)vec_b1_y1, (T *)vec_b1_x2,
-                         (T *)vec_b1_y2, (T *)vec_b2_x1, (T *)vec_b2_y1,
-                         (T *)vec_b2_x2, (T *)vec_b2_y2, (T *)vec_left,
-                         (T *)vec_right, (T *)vec_top, (T *)vec_bottom,
-                         (T *)bbox1, (T *)bbox2, (T *)ious, offset, mode,
-                         vec_length, num_bboxl, num_bbox2, aligned);
+    const int32_t vec_length = nram_stride;
+    const int32_t ping_pong_gap = 8 * nram_stride;
+    bboxOverlapsNotAlignModeImpl(
+        (T *)vec_b2_x1, (T *)vec_b2_y1, (T *)vec_b2_x2, (T *)vec_b2_y2,
+        (T *)vec_left, (T *)vec_right, (T *)vec_top, (T *)vec_bottom,
+        (T *)bbox1, (T *)bbox2, (T *)ious, offset, mode, vec_length, num_bboxl,
+        num_bbox2, ping_pong_gap);
+  }
 }
 
 void MLUOP_WIN_API KernelBboxOverlaps(

--- a/docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
+++ b/docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
@@ -334,7 +334,7 @@ for (int32_t i = 0; i < num_loop_cpy; i++) {
    若aligned = False，输出ious的维度总数为2且维度0为bounding-box1的行数，维度1为bounding-bo21的行数
 
 ## 4 算子性能优化记录
-本次优化主要针对非aligned模式。
+本次（V1.1）优化主要针对非aligned模式。
 优化方案：
 1、原有方案中在aligned模式下或者非aligned模式下，在做数据拷贝时，都是通过4条带stride的memcpy指令实现的，这样会导致IO离散，
 整个IO时间占比较大（IO时间占比总时间约50%），可以通过连续的memcpy把数据拷贝到片上，在通过transpose操作将对应坐标的排列成连

--- a/docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
+++ b/docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
@@ -15,6 +15,7 @@
 | 版本号| 修订人 | 修订日期 | 修订描述 |
 | ----- | ------ | -------  | -------  |
 | V1.0  | 郭子滨 | 2021-06-21 | 首次提交 |
+| V1.1  | 郑斌 | 2023-06-27 | 通过排流水以及合并访存的方式对非aligned模式做性能优化。|
 
 * #### 内容描述
 
@@ -282,7 +283,7 @@ void *vec_right = nmem_buf + 9 * nram_stride;
 void *vec_top = nmem_buf + 10 * nram_stride;
 void *vec_bottom = nmem_buf + 11 * nram_stride;
 
-// ....
+// .... 
 for (int32_t i = 0; i < num_loop_cpy; i++) {
     int32_t index = batch_start + i * batches_stride;
     int32_t handle_batches =
@@ -333,7 +334,14 @@ for (int32_t i = 0; i < num_loop_cpy; i++) {
    若aligned = False，输出ious的维度总数为2且维度0为bounding-box1的行数，维度1为bounding-bo21的行数
 
 ## 4 算子性能优化记录
-无
+本次优化主要针对非aligned模式。
+优化方案：
+1、原有方案中在aligned模式下或者非aligned模式下，在做数据拷贝时，都是通过4条带stride的memcpy指令实现的，这样会导致IO离散，
+整个IO时间占比较大（IO时间占比总时间约50%），可以通过连续的memcpy把数据拷贝到片上，在通过transpose操作将对应坐标的排列成连
+续的摆放位置。
+2、排流水，通过IO时间和计算时间的相互掩盖来提升算子性能。算子在开发之初，考虑到内存划分太碎，排流水的收益不大，但是
+对于大多数规模较小的case而言，片上的空间是无法充分利用的，会有相当大的一部分内存处于空闲状态，造成空间浪费，可以
+通过排流水的方式将这部分空间利用起来。
 
 ### 4.1 当前存在问题的规模说明
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

bbox_overlaps supports  large tensor test.

## 2. Modification

docs/bangc-docs/design_docs/bbox_overlaps/bbox_overlaps.md
bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff1: diff1 <= 3e-3
- [x] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          ARRAY      |
|        4       |Whether multi-dimensions are supported|         no                             |
|        5       |Whether element zero is supported     |                 no                    |
|        6       |Data type(half/float)                 |           half / float           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [x] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/                  |     ALL PASSED     |          |
|Mult-tensor test     |Supports 1-8 dims                 |    no       |          |
|Layout test          |Supports NCHW/NHWC                |     no     |          |
|Zero element test    |Whether to support this test      |     no     |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|      ALL PASSED     |          |
|mlu-only mode test   |--mlu-only,see [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)|       ALL PASSED    |          |
|Mult-platform test   |MLU590                     |       ALL PASSED    |          |
|Nan/INF test         |Whether to support this test      |     ALL PASSED      |          |
|Memory leak check    |Test result                       |       ALL PASSED    |          |
|Code coverage check  |Test result                       |        ALL PASSED   |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

NONE.

### 3.4 Summary Analysis
NONE.