### PR TITLE
[Feature](bangc-ops):voxelization support nan/inf.

### DIFF
--- a/bangc-ops/kernels/voxelization/voxelization.cpp
+++ b/bangc-ops/kernels/voxelization/voxelization.cpp
@@ -258,7 +258,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpVoxelization(
     GEN_CASE_DATA(false, "voxel_num", voxel_num, voxel_num_desc, 0, 0);
     GEN_CASE_OP_PARAM_SINGLE(0, "voxelization", "max_points", max_points);
     GEN_CASE_OP_PARAM_SINGLE(1, "voxelization", "max_voxels", max_voxels);
-    GEN_CASE_OP_PARAM_SINGLE(2, "voxelization", "NDim", NDim);
+    GEN_CASE_OP_PARAM_SINGLE(2, "voxelization", "ndim", NDim);
     GEN_CASE_OP_PARAM_SINGLE(3, "voxelization", "deterministic", deterministic);
     GEN_CASE_TEST_PARAM_NEW(false, false, true, 0, 0, 0);
   }

--- a/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
+++ b/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
@@ -23,11 +23,20 @@
 #include "voxelization.h"
 
 #include <cmath>
-
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
 
+#define INT_MIN -2147483648
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
+
+template <typename T>
+__mlu_func__ bool containNanInf(const T pos1, const T pos2) {
+  if (std::isnan(pos1) || std::isnan(pos2) || std::isinf(pos1) ||
+      std::isinf(pos2)) {
+    return true;
+  }
+  return false;
+}
 
 #if __BANG_ARCH__ >= 322
 __mlu_func__ void computeDynamicVoxelize(
@@ -172,9 +181,24 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
   const float coors_x_max = coors_range[3];
   const float coors_y_max = coors_range[4];
   const float coors_z_max = coors_range[5];
-  const int32_t grid_x = round((coors_x_max - coors_x_min) / voxel_x);
-  const int32_t grid_y = round((coors_y_max - coors_y_min) / voxel_y);
-  const int32_t grid_z = round((coors_z_max - coors_z_min) / voxel_z);
+
+  int32_t grid_x = round((coors_x_max - coors_x_min) / voxel_x);
+  int32_t grid_y = round((coors_y_max - coors_y_min) / voxel_y);
+  int32_t grid_z = round((coors_z_max - coors_z_min) / voxel_z);
+
+  bool contain_nan_inf = false;
+  contain_nan_inf = containNanInf(coors_x_max, coors_x_min);
+  if (contain_nan_inf) {
+    grid_x = INT_MIN;
+  }
+  contain_nan_inf = containNanInf(coors_y_max, coors_y_min);
+  if (contain_nan_inf) {
+    grid_y = INT_MIN;
+  }
+  contain_nan_inf = containNanInf(coors_z_max, coors_z_min);
+  if (contain_nan_inf) {
+    grid_z = INT_MIN;
+  }
 
   const int32_t split_num = 9;
   const int32_t deal_num =

--- a/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
+++ b/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
@@ -184,11 +184,14 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
 
   bool contain_nan_inf = false;
   contain_nan_inf = containNanInf(coors_x_max, coors_x_min);
-  const int32_t grid_x = contain_nan_inf ? INT_MIN : round((coors_x_max - coors_x_min) / voxel_x);
+  const int32_t grid_x =
+      contain_nan_inf ? INT_MIN : round((coors_x_max - coors_x_min) / voxel_x);
   contain_nan_inf = containNanInf(coors_y_max, coors_y_min);
-  const int32_t grid_y = contain_nan_inf ? INT_MIN : round((coors_y_max - coors_y_min) / voxel_y);
+  const int32_t grid_y =
+      contain_nan_inf ? INT_MIN : round((coors_y_max - coors_y_min) / voxel_y);
   contain_nan_inf = containNanInf(coors_z_max, coors_z_min);
-  const int32_t grid_z = contain_nan_inf ? INT_MIN : round((coors_z_max - coors_z_min) / voxel_z);
+  const int32_t grid_z =
+      contain_nan_inf ? INT_MIN : round((coors_z_max - coors_z_min) / voxel_z);
 
   const int32_t split_num = 9;
   const int32_t deal_num =

--- a/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
+++ b/bangc-ops/kernels/voxelization/voxelization_kernel.mlu
@@ -23,10 +23,10 @@
 #include "voxelization.h"
 
 #include <cmath>
+#include <climits>
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
 
-#define INT_MIN -2147483648
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
 
 template <typename T>
@@ -182,23 +182,13 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
   const float coors_y_max = coors_range[4];
   const float coors_z_max = coors_range[5];
 
-  int32_t grid_x = round((coors_x_max - coors_x_min) / voxel_x);
-  int32_t grid_y = round((coors_y_max - coors_y_min) / voxel_y);
-  int32_t grid_z = round((coors_z_max - coors_z_min) / voxel_z);
-
   bool contain_nan_inf = false;
   contain_nan_inf = containNanInf(coors_x_max, coors_x_min);
-  if (contain_nan_inf) {
-    grid_x = INT_MIN;
-  }
+  const int32_t grid_x = contain_nan_inf ? INT_MIN : round((coors_x_max - coors_x_min) / voxel_x);
   contain_nan_inf = containNanInf(coors_y_max, coors_y_min);
-  if (contain_nan_inf) {
-    grid_y = INT_MIN;
-  }
+  const int32_t grid_y = contain_nan_inf ? INT_MIN : round((coors_y_max - coors_y_min) / voxel_y);
   contain_nan_inf = containNanInf(coors_z_max, coors_z_min);
-  if (contain_nan_inf) {
-    grid_z = INT_MIN;
-  }
+  const int32_t grid_z = contain_nan_inf ? INT_MIN : round((coors_z_max - coors_z_min) / voxel_z);
 
   const int32_t split_num = 9;
   const int32_t deal_num =


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

support nan/inf case.

## 2. Modification
bangc-ops/kernels/voxelization/voxelization.cpp
bangc-ops/kernels/voxelization/voxelization_kernel.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [x] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|mlu-only mode test   |--mlu-only,see [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
