### PR TITLE
[Feature](bangc-ops): nms_rotated boxes support naninf

### DIFF
--- a/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -53,10 +53,9 @@ __mlu_func__ void nms_detection(
   const IN_DT *input_dy_ptr = input_dx_ptr + input_box_num;
   const IN_DT *input_angle_ptr = input_dy_ptr + input_box_num;
 
-  // memory for max_box, dst of __bang_max() and saved index
-  // |-- nram_save(OUT_DT) --|--score(IN_DT)--|--
-  // temp(IN_DT)--|--max_box(IN_DT)--| | nram_save_limit_count | max_seg_pad |
-  // NFU_ALIGN_SIZE | NFU_ALIGN_SIZE   |
+  // memory for max_box, dst of max and saved index
+  // |--nram_save(OUT_DT)--|-score(IN_DT)-|--temp(IN_DT)-|-max_box(IN_DT)-|
+  // |nram_save_limit_count| max_seg_pad  |NFU_ALIGN_SIZE| NFU_ALIGN_SIZE |
   int32_t limit = (SIZE_NRAM_BUF - 2 * NFU_ALIGN_SIZE * sizeof(IN_DT) -
                    nram_save_limit_count * sizeof(OUT_DT)) /
                   sizeof(IN_DT);
@@ -86,10 +85,10 @@ __mlu_func__ void nms_detection(
    * | nram_save_limit_count | max_seg_iou_pad             |
    *
    * |-- copies_of_nram: 244 copies of ram --|
-   * | score | valid_box | temp_1~8 | intersect_pts_x/y |
+   * | score | valid_box | temp_1~10 | intersect_pts_x/y |
    *   & ordered_pts+x/y | temp_long_1~3 | dist_ram | valid_pts | nums_in_ram |
    *   & box1 | box2 | box1_buffer |
-   * | 1     | 1         | 10       | 24x2              |
+   * | 1     | 1         | 10        | 24x2              |
    *     24x2            | 24x3          | 24       | 24        | 1           |
    *     5    | 5          | 5          |
    *
@@ -119,6 +118,8 @@ __mlu_func__ void nms_detection(
   void *temp6_ram = (float *)temp5_ram + max_seg_iou_pad;
   void *temp7_ram = (float *)temp6_ram + max_seg_iou_pad;
   void *temp8_ram = (float *)temp7_ram + max_seg_iou_pad;
+  void *temp9_ram = (float *)temp8_ram + max_seg_iou_pad;
+  void *temp10_ram = (float *)temp9_ram + max_seg_iou_pad;
   void *intersect_pts_x = (float *)temp1_ram + 10 * max_seg_iou_pad;
   void *intersect_pts_y = (float *)intersect_pts_x + 24 * max_seg_iou_pad;
   void *ordered_pts_x = (float *)intersect_pts_y + 24 * max_seg_iou_pad;
@@ -193,9 +194,6 @@ __mlu_func__ void nms_detection(
     // save result
     nram_save[nram_save_count++] = global_max_index;
     output_box_num++;
-    if (!__is_mpu()) {
-      input_data_score[global_max_index] = IN_DT(-INFINITY);
-    }
 
     if (nram_save_count == nram_save_limit_count) {
       if (taskId == 0) {
@@ -206,6 +204,11 @@ __mlu_func__ void nms_detection(
       }
       output_data += nram_save_count;
       nram_save_count = 0;
+    }
+
+    // suppress max_box's score as -inf
+    if (!__is_mpu()) {
+      input_data_score[global_max_index] = IN_DT(-INFINITY);
     }
 
     // prepare box1, also is the max_box
@@ -254,6 +257,34 @@ __mlu_func__ void nms_detection(
                           seg_len * SINGLE_BOX_DIM);
       }
 
+      // Initialize valid_box, set actual_box_num boxes to 1, else set to 0
+      __bang_write_value(((float *)valid_box), seg_len, 1.0f);
+      if (cpy_len < seg_len) {
+        for (uint32_t i = cpy_len; i < seg_len; i++) {
+          ((float *)valid_box)[i] = 0;
+        }
+      }
+
+      // Each box data: x, y, w, h, a
+      // area1 = box1.h * box1.w; (max_area)
+      // area2 = box2.h * box2.w;
+      __bang_mul((float *)temp10_ram, (float *)box2 + seg_len * 2,
+                 (float *)box2 + seg_len * 3, seg_len);
+
+      // Where area < 1e-14(@float), valid_box set to 0
+      if (max_area < (float)1e-14) {
+        __bang_write_value((float *)valid_box, seg_len, 0.0f);
+      }
+
+      __bang_lt_scalar((float *)temp2_ram, (float *)temp10_ram, (float)1e-14,
+                       seg_len);
+      __bang_not((float *)temp2_ram, (float *)temp2_ram, seg_len);
+
+      __bang_and((float *)valid_box, (float *)valid_box, (float *)temp2_ram,
+                 seg_len);
+
+      __bang_move((void *)temp9_ram, (void *)valid_box,
+                  seg_len * sizeof(float));
       // 1. Calculate new points
       // center_shift_x = (box1_raw.x_ctr + box2_raw.x_ctr) / 2.0;  ----temp1
       // center_shift_y = (box1_raw.y_ctr + box2_raw.y_ctr) / 2.0;  ----temp2
@@ -301,7 +332,6 @@ __mlu_func__ void nms_detection(
           (float *)temp8_ram, seg_len);
 
       // Where nums_in <= 2, set valid_box to false
-      __bang_write_value(((float *)valid_box), seg_len, 1.0f);
       __bang_le_scalar((float *)temp1_ram, (float *)nums_in_ram, (float)2,
                        seg_len);
       __bang_not((float *)temp1_ram, (float *)temp1_ram, seg_len);
@@ -328,61 +358,50 @@ __mlu_func__ void nms_detection(
                   (float *)temp4_ram, (float *)temp5_ram, (float *)temp6_ram,
                   (float *)temp7_ram, (float *)temp8_ram, seg_len);
 
-      // Each box data: x, y, w, h, a
-      // area1 = box1.h * box1.w = max_area;
-      // area2 = box2.h * box2.w;
-      // set area1 to 0 when area1 < 1e-14(@float)
-      if (max_area < (float)1e-14) {
-        __bang_write_value((float *)temp1_ram, seg_len, 0.0f);
-      } else {
-        __bang_mul((float *)temp5_ram, (float *)box2 + seg_len * 2,
-                   (float *)box2 + seg_len * 3, seg_len);
-        __bang_le_scalar((float *)temp5_ram, (float *)temp5_ram, (float)1e-14,
-                         seg_len);
-        __bang_not((float *)temp5_ram, (float *)temp5_ram, seg_len);
-        __bang_mul((float *)temp1_ram, (float *)temp1_ram, (float *)temp5_ram,
-                   seg_len);
+      if (iou_threshold == IN_DT(-INFINITY)) {
+        // suppress boxes whose iou is 0, for 0 > -inf is always true
+        __bang_not((float *)temp8_ram, (float *)temp9_ram, seg_len);
       }
+      __nram__ int table[2] = {0, FIILED_ONES};
+      __bang_float2int32((int32_t *)temp9_ram, (float *)temp9_ram, seg_len, 0);
+      __bang_lut_s32((int32_t *)temp9_ram, (int32_t *)temp9_ram,
+                     (int32_t *)table, seg_len, TABLE_LENGTH);
+      // temp1: area_I
+      __bang_band((char *)temp1_ram, (char *)temp1_ram, (char *)temp9_ram,
+                  seg_len * sizeof(float));
 
-      // area2
-      __bang_mul((float *)temp2_ram, (float *)box2 + seg_len * 2,
-                 (float *)box2 + seg_len * 3, seg_len);
-      // get the area_U: area2 + area1 - area_I
-      __bang_add_scalar((float *)temp2_ram, (float *)temp2_ram, float(max_area),
-                        seg_len);
+      // get the area_U(temp2): area2(temp10) + area1(max_area) - area_I(temp1)
+      __bang_add_scalar((float *)temp2_ram, (float *)temp10_ram,
+                        float(max_area), seg_len);
       __bang_sub((float *)temp2_ram, (float *)temp2_ram, (float *)temp1_ram,
                  seg_len);  // area_U
-      // set negative area_U to positive
-      __bang_write_zero((float *)temp3_ram, seg_len);
-      __bang_gt((float *)temp3_ram, (float *)temp2_ram, (float *)temp3_ram,
-                seg_len);
-      __bang_mul((float *)temp5_ram, (float *)temp2_ram, (float *)temp3_ram,
-                 seg_len);
-      __bang_not((float *)temp4_ram, (float *)temp3_ram, seg_len);
-      __bang_add((float *)temp2_ram, (float *)temp5_ram, (float *)temp4_ram,
-                 seg_len);
-      // temp1: area_I
+
       // temp2: area_U
-      // area_I < iou_threshold * area_U
+      __bang_band((char *)temp2_ram, (char *)temp2_ram, (char *)temp9_ram,
+                  seg_len * sizeof(float));
+
+      // temp2: iou_threshold * area_U
       __bang_mul_scalar((float *)temp2_ram, (float *)temp2_ram, iou_threshold,
                         seg_len);
-      if (iou_threshold == 0.0f) {
-        __bang_ge((float *)temp1_ram, (float *)temp2_ram, (float *)temp1_ram,
-                  seg_len);
-      } else {
-        __bang_gt((float *)temp1_ram, (float *)temp2_ram, (float *)temp1_ram,
+      // temp1: 1 = area_I > iou_threshold * area_U, 0 = else
+      __bang_gt((float *)temp1_ram, (float *)temp1_ram, (float *)temp2_ram,
+                seg_len);
+      if (iou_threshold == IN_DT(-INFINITY)) {
+        __bang_or((float *)temp1_ram, (float *)temp1_ram, (float *)temp8_ram,
                   seg_len);
       }
       if (std::is_same<IN_DT, half>::value) {
         __bang_float2half_dn((half *)temp1_ram, (float *)temp1_ram, seg_len);
       }
 
+      // temp1: 1->1, 0->-1
       __bang_mul_scalar((IN_DT *)temp1_ram, (IN_DT *)temp1_ram, IN_DT(2),
                         seg_len);
       __bang_sub_scalar((IN_DT *)temp1_ram, (IN_DT *)temp1_ram, IN_DT(1),
                         seg_len);
-      __bang_mul_scalar((IN_DT *)temp1_ram, (IN_DT *)temp1_ram, IN_DT(INFINITY),
-                        seg_len);
+      __bang_mul_scalar((IN_DT *)temp1_ram, (IN_DT *)temp1_ram,
+                        IN_DT(-INFINITY), seg_len);
+      // score: keep value if inf, suppressed if -inf
       __bang_minequal((IN_DT *)score, (IN_DT *)score, (IN_DT *)temp1_ram,
                       seg_len);
 

--- a/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -54,6 +54,9 @@ __mlu_func__ void nms_detection(
   const IN_DT *input_angle_ptr = input_dy_ptr + input_box_num;
 
   // memory for max_box, dst of __bang_max() and saved index
+  // |-- nram_save(OUT_DT) --|--score(IN_DT)--|--
+  // temp(IN_DT)--|--max_box(IN_DT)--| | nram_save_limit_count | max_seg_pad |
+  // NFU_ALIGN_SIZE | NFU_ALIGN_SIZE   |
   int32_t limit = (SIZE_NRAM_BUF - 2 * NFU_ALIGN_SIZE * sizeof(IN_DT) -
                    nram_save_limit_count * sizeof(OUT_DT)) /
                   sizeof(IN_DT);
@@ -77,17 +80,46 @@ __mlu_func__ void nms_detection(
   // memory layout for compute iou
   // every box require 244 * sizeof(float) space in nram;
   int32_t copies_of_nram = 244 * sizeof(float);
+  /* NRAM buffer
+   *
+   * |-- nram_save(OUT_DT) --|--copies_of_nram(244*float)--|
+   * | nram_save_limit_count | max_seg_iou_pad             |
+   *
+   * |-- copies_of_nram: 244 copies of ram --|
+   * | score | valid_box | temp_1~8 | intersect_pts_x/y |
+   *   & ordered_pts+x/y | temp_long_1~3 | dist_ram | valid_pts | nums_in_ram |
+   *   & box1 | box2 | box1_buffer |
+   * | 1     | 1         | 10       | 24x2              |
+   *     24x2            | 24x3          | 24       | 24        | 1           |
+   *     5    | 5          | 5          |
+   *
+   * |-- reuse memory from dist_ram: 16 copies of ram --|
+   * | rotated_pts1/2_x/y                               |
+   * | 4x4                                              |
+   *
+   * |-- reuse memory from temp_long_1 + 5 : 16 copies of ram --|
+   * | vec1/2_x/y                                               |
+   * | 4x4                                                      |
+   *
+   */
   limit =
-      (MAX_NRAM_SIZE - nram_save_limit_count * sizeof(OUT_DT)) / copies_of_nram;
+      (SIZE_NRAM_BUF - nram_save_limit_count * sizeof(OUT_DT)) / copies_of_nram;
 
   int32_t max_seg_iou_pad = NMS_DOWN(limit, NMS_SIZE);
   int32_t repeat_iou_compute = len_core / max_seg_iou_pad;
   int32_t remain_iou_compute = len_core % max_seg_iou_pad;
 
   // basic consistent memory layout
-  void *valid_box = (float *)score + 1 * max_seg_iou_pad;
-  void *temp_buffer = (float *)valid_box + 1 * max_seg_iou_pad;
-  void *intersect_pts_x = (float *)temp_buffer + 10 * max_seg_iou_pad;
+  void *valid_box = (float *)score + max_seg_iou_pad;
+  void *temp1_ram = (float *)valid_box + max_seg_iou_pad;
+  void *temp2_ram = (float *)temp1_ram + max_seg_iou_pad;
+  void *temp3_ram = (float *)temp2_ram + max_seg_iou_pad;
+  void *temp4_ram = (float *)temp3_ram + max_seg_iou_pad;
+  void *temp5_ram = (float *)temp4_ram + max_seg_iou_pad;
+  void *temp6_ram = (float *)temp5_ram + max_seg_iou_pad;
+  void *temp7_ram = (float *)temp6_ram + max_seg_iou_pad;
+  void *temp8_ram = (float *)temp7_ram + max_seg_iou_pad;
+  void *intersect_pts_x = (float *)temp1_ram + 10 * max_seg_iou_pad;
   void *intersect_pts_y = (float *)intersect_pts_x + 24 * max_seg_iou_pad;
   void *ordered_pts_x = (float *)intersect_pts_y + 24 * max_seg_iou_pad;
   void *ordered_pts_y = (float *)ordered_pts_x + 24 * max_seg_iou_pad;
@@ -97,17 +129,21 @@ __mlu_func__ void nms_detection(
   void *dist_ram = (float *)temp_long_3 + 24 * max_seg_iou_pad;
   void *valid_pts = (float *)dist_ram + 24 * max_seg_iou_pad;
   void *nums_in_ram = (float *)valid_pts + 24 * max_seg_iou_pad;
-  IN_DT *box1 = (IN_DT *)((float *)nums_in_ram + 1 * max_seg_iou_pad);
-  IN_DT *box2 = (IN_DT *)((float *)box1 + 5 * max_seg_iou_pad);
-  IN_DT *box1_buffer = (IN_DT *)((float *)box2 + 5 * max_seg_iou_pad);
+  IN_DT *box1 = (IN_DT *)((float *)nums_in_ram + max_seg_iou_pad);
+  IN_DT *box2 = (IN_DT *)((float *)box1 + SINGLE_BOX_DIM * max_seg_iou_pad);
+  IN_DT *box1_buffer =
+      (IN_DT *)((float *)box2 + SINGLE_BOX_DIM * max_seg_iou_pad);
 
-  // reuse memeory
-  void *rotated_pts1_x = ((char *)dist_ram);
-  void *rotated_pts1_y = ((float *)rotated_pts1_x) + 4 * max_seg_iou_pad;
-  void *rotated_pts2_x = ((float *)rotated_pts1_y) + 4 * max_seg_iou_pad;
-  void *rotated_pts2_y = ((float *)rotated_pts2_x) + 4 * max_seg_iou_pad;
-  void *vec_buffer = ((float *)temp_long_1) + 5 * max_seg_iou_pad;
-  // vec_buffer ~ 16 * max_seg_pad * sizeof(float)
+  // reuse memory from dist_ram
+  void *rotated_pts1_x = (char *)dist_ram;
+  void *rotated_pts1_y = (float *)rotated_pts1_x + 4 * max_seg_iou_pad;
+  void *rotated_pts2_x = (float *)rotated_pts1_y + 4 * max_seg_iou_pad;
+  void *rotated_pts2_y = (float *)rotated_pts2_x + 4 * max_seg_iou_pad;
+  // reuse memory from temp_long_1 + 5
+  void *vec1_x = (float *)temp_long_1 + 5 * max_seg_iou_pad;
+  void *vec1_y = (float *)vec1_x + 4 * max_seg_iou_pad;
+  void *vec2_x = (float *)vec1_y + 4 * max_seg_iou_pad;
+  void *vec2_y = (float *)vec2_x + 4 * max_seg_iou_pad;
 
   // First, initialize ram with all 0, or could cause nan/inf unexcepted results
   __bang_write_zero((unsigned char *)score, copies_of_nram * max_seg_iou_pad);
@@ -190,7 +226,9 @@ __mlu_func__ void nms_detection(
                          float(input_angle_ptr[global_max_index]));
     }
 
-    __memcpy(box1_buffer, box1, max_seg_iou_pad * 5 * sizeof(float), NRAM2NRAM);
+    // box1 5xN
+    __memcpy(box1_buffer, box1,
+             max_seg_iou_pad * SINGLE_BOX_DIM * sizeof(float), NRAM2NRAM);
 
     // update score
     for (int i = 0; i <= repeat_iou_compute; i++) {
@@ -209,19 +247,14 @@ __mlu_func__ void nms_detection(
       __memcpy(box2 + half_offset,
                input_x_ptr + input_offset + i * max_seg_iou_pad,
                cpy_len * sizeof(IN_DT), boxes_load_dir, seg_len * sizeof(IN_DT),
-               input_box_num * sizeof(IN_DT), 4);
+               input_box_num * sizeof(IN_DT), SINGLE_BOX_DIM - 1);
 
       if (std::is_same<IN_DT, half>::value) {
         __bang_half2float((float *)box2, (half *)(box2 + half_offset),
-                          seg_len * 5);
+                          seg_len * SINGLE_BOX_DIM);
       }
 
-      // Calculate rotated vertices
-      void *temp1_ram = ((char *)temp_buffer);
-      void *temp2_ram = ((char *)temp_buffer) + seg_len * sizeof(float);
-      void *temp3_ram = ((char *)temp_buffer) + 2 * seg_len * sizeof(float);
-      void *temp4_ram = ((char *)temp_buffer) + 3 * seg_len * sizeof(float);
-
+      // 1. Calculate new points
       // center_shift_x = (box1_raw.x_ctr + box2_raw.x_ctr) / 2.0;  ----temp1
       // center_shift_y = (box1_raw.y_ctr + box2_raw.y_ctr) / 2.0;  ----temp2
       __bang_add((float *)temp1_ram, (float *)box1_buffer, (float *)box2,
@@ -244,6 +277,7 @@ __mlu_func__ void nms_detection(
       __bang_sub((float *)box2 + seg_len, (float *)box2 + seg_len,
                  (float *)temp2_ram, seg_len);
 
+      // 2. Calculate rotated vertices
       getRotatedVertices((float *)rotated_pts1_x, (float *)rotated_pts1_y,
                          (float *)box1, (float *)temp1_ram, (float *)temp2_ram,
                          (float *)temp3_ram, (float *)temp4_ram, seg_len);
@@ -251,21 +285,12 @@ __mlu_func__ void nms_detection(
                          (float *)box2, (float *)temp1_ram, (float *)temp2_ram,
                          (float *)temp3_ram, (float *)temp4_ram, seg_len);
 
+      // initialize valid_pts, nums_in
       __bang_write_zero((float *)valid_pts, 24 * seg_len);
       __bang_write_zero((float *)nums_in_ram, seg_len);
-      void *vec1_x = ((char *)vec_buffer);
-      void *vec1_y = ((char *)vec1_x) + 4 * seg_len * sizeof(float);
-      void *vec2_x = ((char *)vec1_y) + 4 * seg_len * sizeof(float);
-      void *vec2_y = ((char *)vec2_x) + 4 * seg_len * sizeof(float);
-      void *temp5_ram = ((char *)temp_buffer) + 4 * seg_len * sizeof(float);
-      void *temp6_ram = ((char *)temp_buffer) + 5 * seg_len * sizeof(float);
-      void *temp7_ram = ((char *)temp_buffer) + 6 * seg_len * sizeof(float);
-      void *temp8_ram = ((char *)temp_buffer) + 7 * seg_len * sizeof(float);
-      void *temp9_ram = ((char *)temp_buffer) + 8 * seg_len * sizeof(float);
-      void *temp10_ram = ((char *)temp_buffer) + 9 * seg_len * sizeof(float);
 
-      // Get all intersection points
-      getIntersectPts(
+      // 3. Get all intersection points
+      getIntersectionPoints(
           (float *)rotated_pts1_x, (float *)rotated_pts1_y,
           (float *)rotated_pts2_x, (float *)rotated_pts2_y, (float *)vec1_x,
           (float *)vec1_y, (float *)vec2_x, (float *)vec2_y,
@@ -273,57 +298,56 @@ __mlu_func__ void nms_detection(
           (float *)valid_pts, (float *)nums_in_ram, (float *)temp1_ram,
           (float *)temp2_ram, (float *)temp3_ram, (float *)temp4_ram,
           (float *)temp5_ram, (float *)temp6_ram, (float *)temp7_ram,
-          (float *)temp8_ram, (float *)temp9_ram, (float *)temp10_ram, seg_len);
+          (float *)temp8_ram, seg_len);
 
       // Where nums_in <= 2, set valid_box to false
       __bang_write_value(((float *)valid_box), seg_len, 1.0f);
-      __bang_write_value((float *)temp9_ram, NMS_SIZE, (float)2);
-      __bang_cycle_gt((float *)temp1_ram, (float *)nums_in_ram,
-                      (float *)temp9_ram, seg_len, NMS_SIZE);
+      __bang_le_scalar((float *)temp1_ram, (float *)nums_in_ram, (float)2,
+                       seg_len);
+      __bang_not((float *)temp1_ram, (float *)temp1_ram, seg_len);
       __bang_and((float *)valid_box, (float *)valid_box, (float *)temp1_ram,
                  seg_len);
       __bang_cycle_and((float *)valid_pts, (float *)valid_pts,
                        (float *)valid_box, 24 * seg_len, seg_len);
 
-      // Convex-hull-graham to order the intersection points in clockwise order
-      // and find the contour area
+      // 4. Convex-hull-graham to order the intersection points in clockwise
+      // order and find the contour area
 
       convexHullGraham(
           (float *)intersect_pts_x, (float *)intersect_pts_y,
           (float *)ordered_pts_x, (float *)ordered_pts_y, (float *)dist_ram,
           (float *)valid_box, (float *)valid_pts, (float *)nums_in_ram,
-          (float *)temp7_ram, (float *)temp8_ram, (float *)temp9_ram,
+          (float *)temp1_ram, (float *)temp2_ram, (float *)temp3_ram,
           (float *)temp_long_1, (float *)temp_long_2, (float *)temp_long_3,
           seg_len, seg_len);
-      // Calculate polygon area
+      // 5. Calculate polygon area
       // set temp1 = intersection part area
       polygonArea((float *)ordered_pts_x, (float *)ordered_pts_y,
                   (float *)valid_box, (float *)valid_pts, (float *)nums_in_ram,
                   (float *)temp1_ram, (float *)temp2_ram, (float *)temp3_ram,
                   (float *)temp4_ram, (float *)temp5_ram, (float *)temp6_ram,
-                  (float *)temp7_ram, (float *)temp8_ram, (float *)temp9_ram,
-                  seg_len);
+                  (float *)temp7_ram, (float *)temp8_ram, seg_len);
 
       // Each box data: x, y, w, h, a
-      // area1 = max_area
+      // area1 = box1.h * box1.w = max_area;
       // area2 = box2.h * box2.w;
-      // set areaI to 0 when area < 1e-14(@float)
+      // set area1 to 0 when area1 < 1e-14(@float)
       if (max_area < (float)1e-14) {
         __bang_write_value((float *)temp1_ram, seg_len, 0.0f);
       } else {
         __bang_mul((float *)temp5_ram, (float *)box2 + seg_len * 2,
                    (float *)box2 + seg_len * 3, seg_len);
-        __bang_write_value((float *)temp6_ram, NMS_SIZE, (float)1e-14);
-        __bang_cycle_gt((float *)temp5_ram, (float *)temp5_ram,
-                        (float *)temp6_ram, seg_len, NMS_SIZE);
+        __bang_le_scalar((float *)temp5_ram, (float *)temp5_ram, (float)1e-14,
+                         seg_len);
+        __bang_not((float *)temp5_ram, (float *)temp5_ram, seg_len);
         __bang_mul((float *)temp1_ram, (float *)temp1_ram, (float *)temp5_ram,
                    seg_len);
       }
 
-      // area
+      // area2
       __bang_mul((float *)temp2_ram, (float *)box2 + seg_len * 2,
                  (float *)box2 + seg_len * 3, seg_len);
-      // get the area_U: area + max_area - area_I
+      // get the area_U: area2 + area1 - area_I
       __bang_add_scalar((float *)temp2_ram, (float *)temp2_ram, float(max_area),
                         seg_len);
       __bang_sub((float *)temp2_ram, (float *)temp2_ram, (float *)temp1_ram,

--- a/bangc-ops/kernels/nms_rotated/nms_utils.h
+++ b/bangc-ops/kernels/nms_rotated/nms_utils.h
@@ -75,7 +75,7 @@ __mlu_func__ void findCoreMaxBox(
 
     /******NMS LOAD END******/
 
-    __bang_max(temp, score, seg_len);
+    __bang_argmax(temp, score, seg_len);
     if (temp[0] > max_box[0]) {
       max_box[0] = temp[0];
       if (std::is_same<IN_DT, half>::value) {
@@ -109,7 +109,7 @@ __mlu_func__ void findClusterMaxBox(IN_DT *sram, IN_DT *max_box, IN_DT *temp,
   __bang_write_value(temp, 64, IN_DT(-INFINITY));
   __memcpy(temp, sram, sizeof(IN_DT), SRAM2NRAM, sizeof(IN_DT),
            REDUCE_NUM * sizeof(IN_DT), coreDim - 1);
-  __bang_max(max_box, temp, 64);
+  __bang_argmax(max_box, temp, 64);
   int max_core = (std::is_same<IN_DT, half>::value) ? ((uint16_t *)max_box)[1]
                                                     : ((uint32_t *)max_box)[1];
   // copy the max box to max_box

--- a/bangc-ops/kernels/nms_rotated/nms_utils.h
+++ b/bangc-ops/kernels/nms_rotated/nms_utils.h
@@ -34,6 +34,11 @@
 #define SIZE_SRAM_BUF (MAX_SRAM_SIZE)
 // score, x1, y1, x2, y2, max_index (reserve 2 num for half-type input)
 #define REDUCE_NUM (7)
+
+#define FIILED_ONES (int)0xffffffff
+#define HALF_FILLED_ONES (int16_t)0xffff
+#define TABLE_LENGTH 64
+
 // each box data contains 5 number: x, y, w, h, a
 #define SINGLE_BOX_DIM 5
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
@@ -66,7 +71,7 @@ __mlu_func__ void findCoreMaxBox(
     /******NMS LOAD START******/
     __bang_write_value(score, seg_len, IN_DT(-INFINITY));
     __memcpy(score, input_score_ptr + input_offset + i * max_seg_pad,
-              cpy_len * sizeof(IN_DT), load_dir);
+             cpy_len * sizeof(IN_DT), load_dir);
 
     /******NMS LOAD END******/
 
@@ -203,20 +208,14 @@ template <typename T>
 __mlu_func__ void getRotatedVertices(T *pts_x, T *pts_y, T *box, T *temp1,
                                      T *temp2, T *temp3, T *temp4,
                                      const uint32_t &actual_compute_box_num) {
-// T cosTheta2 = (T)cos(theta) * 0.5f; -- temp1
-// T sinTheta2 = (T)sin(theta) * 0.5f; -- temp2
-// theta is the box's 5th data: a, rotated radian;
-#if __BANG_ARCH__ >= 300
+  // T cosTheta2 = (T)cos(theta) * 0.5f; -- temp1
+  // T sinTheta2 = (T)sin(theta) * 0.5f; -- temp2
+  // theta is the box's 5th data: a, rotated radian;
   __bang_cos((float *)temp1, ((float *)box) + 4 * actual_compute_box_num,
              actual_compute_box_num);
   __bang_sin((float *)temp2, ((float *)box) + 4 * actual_compute_box_num,
              actual_compute_box_num);
-#else
-  __bang_taylor4_cos((T *)temp1, ((T *)box) + 4 * actual_compute_box_num,
-                     (T *)temp3, (T *)temp4, actual_compute_box_num);
-  __bang_taylor4_sin((T *)temp2, ((T *)box) + 4 * actual_compute_box_num,
-                     (T *)temp3, (T *)temp4, actual_compute_box_num);
-#endif
+
   __bang_mul_scalar((T *)temp1, (T *)temp1, (T)0.5, actual_compute_box_num);
   __bang_mul_scalar((T *)temp2, (T *)temp2, (T)0.5, actual_compute_box_num);
 
@@ -254,56 +253,39 @@ __mlu_func__ void getRotatedVertices(T *pts_x, T *pts_y, T *box, T *temp1,
              actual_compute_box_num);
   // pts[2].x = 2 * box.x_ctr - pts[0].x;
   // pts[3].x = 2 * box.x_ctr - pts[1].x;
-  __bang_add((T *)pts_x + 2 * actual_compute_box_num, (T *)box, (T *)box,
-             actual_compute_box_num);
+  __bang_mul_scalar((T *)pts_x + 2 * actual_compute_box_num, (T *)box, (T)2,
+                    actual_compute_box_num);
   __bang_sub((T *)pts_x + 2 * actual_compute_box_num,
              (T *)pts_x + 2 * actual_compute_box_num, (T *)pts_x,
              actual_compute_box_num);
-  __bang_add((T *)pts_x + 3 * actual_compute_box_num, (T *)box, (T *)box,
-             actual_compute_box_num);
+  __bang_mul_scalar((T *)pts_x + 3 * actual_compute_box_num, (T *)box, (T)2,
+                    actual_compute_box_num);
   __bang_sub((T *)pts_x + 3 * actual_compute_box_num,
              (T *)pts_x + 3 * actual_compute_box_num,
              (T *)pts_x + 1 * actual_compute_box_num, actual_compute_box_num);
   // pts[2].y = 2 * box.y_ctr - pts[0].y;
   // pts[3].y = 2 * box.y_ctr - pts[1].y;
-  __bang_add((T *)pts_y + 2 * actual_compute_box_num,
-             (T *)box + 1 * actual_compute_box_num,
-             (T *)box + 1 * actual_compute_box_num, actual_compute_box_num);
+  __bang_mul_scalar((T *)pts_y + 2 * actual_compute_box_num,
+                    (T *)box + 1 * actual_compute_box_num, (T)2,
+                    actual_compute_box_num);
   __bang_sub((T *)pts_y + 2 * actual_compute_box_num,
              (T *)pts_y + 2 * actual_compute_box_num, (T *)pts_y,
              actual_compute_box_num);
-  __bang_add((T *)pts_y + 3 * actual_compute_box_num,
-             (T *)box + 1 * actual_compute_box_num,
-             (T *)box + 1 * actual_compute_box_num, actual_compute_box_num);
+  __bang_mul_scalar((T *)pts_y + 3 * actual_compute_box_num,
+                    (T *)box + 1 * actual_compute_box_num, (T)2,
+                    actual_compute_box_num);
   __bang_sub((T *)pts_y + 3 * actual_compute_box_num,
              (T *)pts_y + 3 * actual_compute_box_num,
              (T *)pts_y + 1 * actual_compute_box_num, actual_compute_box_num);
 }
 
 template <typename T>
-__mlu_func__ void getIntersectPts(T *rotated_pts1_x, T *rotated_pts1_y,
-                                  T *rotated_pts2_x, T *rotated_pts2_y,
-                                  T *vec1_x, T *vec1_y, T *vec2_x, T *vec2_y,
-                                  T *intersect_pts_x, T *intersect_pts_y,
-                                  T *valid_pts, T *nums_in_ram, T *temp1_ram,
-                                  T *temp2_ram, T *temp3_ram, T *temp4_ram,
-                                  T *temp5_ram, T *temp6_ram, T *temp7_ram,
-                                  T *temp8_ram, T *temp9_ram, T *temp10_ram,
-                                  const uint32_t &actual_compute_box_num) {
-// Initialize const data to ram
-// temp3 = const 1e-14(@float), lenth = COMPUTE_COUNT_ALIGN
-#if __BANG_ARCH__ >= 300
-  __bang_write_value((T *)temp3_ram, COMPUTE_COUNT_ALIGN, (T)1e-14);
-#else
-  // NOTE: Since active_reciphp function has strict value range,
-  //       [2.2205e-16, 2e6]@float, [0.00391, 65504]@half
-  __bang_write_value((T *)temp3_ram, COMPUTE_COUNT_ALIGN, (float)1e-14);
-#endif
-  // temp4 = const T(0), lenth = COMPUTE_COUNT_ALIGN
-  __bang_write_value((T *)temp4_ram, COMPUTE_COUNT_ALIGN, (T)0);
-  // temp5 = const T(1), lenth = COMPUTE_COUNT_ALIGN
-  __bang_write_value((T *)temp5_ram, COMPUTE_COUNT_ALIGN, (T)1);
-
+__mlu_func__ void getIntersectionPoints(
+    T *rotated_pts1_x, T *rotated_pts1_y, T *rotated_pts2_x, T *rotated_pts2_y,
+    T *vec1_x, T *vec1_y, T *vec2_x, T *vec2_y, T *intersect_pts_x,
+    T *intersect_pts_y, T *valid_pts, T *nums_in_ram, T *temp1_ram,
+    T *temp2_ram, T *temp3_ram, T *temp4_ram, T *temp5_ram, T *temp6_ram,
+    T *temp7_ram, T *temp8_ram, const uint32_t &actual_compute_box_num) {
   // Line vector, from p1 to p2 is: p1+(p2-p1)*t, t=[0,1]
   // for i = 0~3, vec[i] = pts[(i+1)%4] - pts[i]
   __bang_sub((T *)vec1_x, (T *)rotated_pts1_x + actual_compute_box_num,
@@ -337,95 +319,110 @@ __mlu_func__ void getIntersectPts(T *rotated_pts1_x, T *rotated_pts1_y,
                  (T *)vec1_x + i * actual_compute_box_num,
                  (T *)vec1_y + i * actual_compute_box_num,
                  actual_compute_box_num, (T *)temp1_ram);
-      // temp8 = sign(det), since active_reciphp only receive positive values
-      __bang_active_sign((T *)temp8_ram, (T *)temp2_ram,
-                         actual_compute_box_num);
-      // deal with parallel lines, temp2 = fabs(det), temp1 = temp2 > 1e-14
-      __bang_active_abs((T *)temp2_ram, (T *)temp2_ram, actual_compute_box_num);
-      __bang_cycle_gt((T *)temp1_ram, (T *)temp2_ram, (T *)temp3_ram,
-                      actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-      // Where temp1 = false, set recip input to 1, avoiding recip(0), cause inf
-      __bang_not((T *)temp9_ram, (T *)temp1_ram, actual_compute_box_num);
-      __bang_mul((T *)temp2_ram, (T *)temp2_ram, (T *)temp1_ram,
-                 actual_compute_box_num);
-      __bang_add((T *)temp2_ram, (T *)temp2_ram, (T *)temp9_ram,
-                 actual_compute_box_num);
-// temp2 = 1/temp2, use mult (1/temp2) instead of div temp2
-#if __BANG_ARCH__ >= 300
-      __bang_recip((float *)temp2_ram, (float *)temp2_ram,
-                   actual_compute_box_num);
-#else
-      // NOTE: active_reciphp function has strict value range:
-      //       [2.2205e-16, 2e6]@float, [0.00391, 65504]@half
-      __bang_active_reciphp((T *)temp2_ram, (T *)temp2_ram,
-                            actual_compute_box_num);
-#endif
-      // Restore temp2 invalid box value 1 and sign-bit
-      __bang_mul((T *)temp2_ram, (T *)temp2_ram, (T *)temp1_ram,
-                 actual_compute_box_num);
-      __bang_mul((T *)temp2_ram, (T *)temp2_ram, (T *)temp8_ram,
-                 actual_compute_box_num);
+      // deal with parallel lines, temp2 = fabs(det), temp1 = temp2 <= 1e-14
+      __bang_abs((T *)temp3_ram, (T *)temp2_ram, actual_compute_box_num);
+      __bang_le_scalar((T *)temp1_ram, (T *)temp3_ram, (T)1e-14,
+                       actual_compute_box_num);
+      __bang_not((T *)temp1_ram, (T *)temp1_ram, actual_compute_box_num);
 
-      // auto vec12 = pts2[j] - pts1[i], (temp6, temp7) = (x, y)
-      __bang_sub((T *)temp6_ram,
+      // auto vec12 = pts2[j] - pts1[i], (temp4, temp5) = (vec12.x, vec12.y)
+      __bang_sub((T *)temp4_ram,
                  (T *)rotated_pts2_x + j * actual_compute_box_num,
                  (T *)rotated_pts1_x + i * actual_compute_box_num,
                  actual_compute_box_num);
-      __bang_sub((T *)temp7_ram,
+      __bang_sub((T *)temp5_ram,
                  (T *)rotated_pts2_y + j * actual_compute_box_num,
                  (T *)rotated_pts1_y + i * actual_compute_box_num,
                  actual_compute_box_num);
 
-      // T t1 = cross2d<T>(vec2[j], vec12) mult (1/det)  -- temp8
-      cross2d<T>((T *)temp8_ram, (T *)vec2_x + j * actual_compute_box_num,
-                 (T *)vec2_y + j * actual_compute_box_num, (T *)temp6_ram,
-                 (T *)temp7_ram, actual_compute_box_num, (T *)temp9_ram);
-      __bang_mul((T *)temp8_ram, (T *)temp8_ram, (T *)temp2_ram,
+      // T t1 = cross2d<T>(vec2[j], vec12) / det  -- temp6
+      cross2d<T>((T *)temp6_ram, (T *)vec2_x + j * actual_compute_box_num,
+                 (T *)vec2_y + j * actual_compute_box_num, (T *)temp4_ram,
+                 (T *)temp5_ram, actual_compute_box_num, (T *)temp7_ram);
+      // T t2 = cross2d<T>(vec1[i], vec12) / det  -- temp7
+      // NOTE: temp6(t1) is used after, reuse temp5(p2_y) as cross2d temp ram
+      cross2d<T>((T *)temp7_ram, (T *)vec1_x + i * actual_compute_box_num,
+                 (T *)vec1_y + i * actual_compute_box_num, (T *)temp4_ram,
+                 (T *)temp5_ram, actual_compute_box_num, (T *)temp8_ram);
+
+#if __BANG_ARCH__ == 372
+      // Where temp1 = false, set recip input to 1, avoiding recip(0), cause inf
+      __bang_not((T *)temp4_ram, (T *)temp1_ram, actual_compute_box_num);
+      __bang_mul((T *)temp2_ram, (T *)temp2_ram, (T *)temp1_ram,
+                 actual_compute_box_num);
+      __bang_add((T *)temp2_ram, (T *)temp2_ram, (T *)temp4_ram,
+                 actual_compute_box_num);
+      // bang_recip only support float data type, others should use cast to
+      // float first
+      __bang_recip((float *)temp2_ram, (float *)temp2_ram,
+                   actual_compute_box_num);
+      __bang_mul((T *)temp6_ram, (T *)temp6_ram, (T *)temp2_ram,
+                 actual_compute_box_num);
+      __bang_mul((T *)temp7_ram, (T *)temp7_ram, (T *)temp2_ram,
+                 actual_compute_box_num);
+#else
+      __bang_div((T *)temp6_ram, (T *)temp6_ram, (T *)temp2_ram,
+                 actual_compute_box_num);
+      __bang_div((T *)temp7_ram, (T *)temp7_ram, (T *)temp2_ram,
+                 actual_compute_box_num);
+#endif
+      // temp1 &= (t1 >= 0.0f && t1 <= 1.0f)  -- temp7
+      __bang_ge_scalar((T *)temp5_ram, (T *)temp6_ram, (T)0,
+                       actual_compute_box_num);
+      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp5_ram,
+                 actual_compute_box_num);
+      __bang_le_scalar((T *)temp5_ram, (T *)temp6_ram, (T)1,
+                       actual_compute_box_num);
+      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp5_ram,
                  actual_compute_box_num);
 
-      // temp1 &= (t1 >= 0.0f && t1 <= 1.0f)  -- temp9
-      __bang_cycle_ge((T *)temp9_ram, (T *)temp8_ram, (T *)temp4_ram,
-                      actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp9_ram,
+      // temp1 &= (t2 >= 0.0f && t2 <= 1.0f)  -- temp7
+      __bang_ge_scalar((T *)temp5_ram, (T *)temp7_ram, (T)0,
+                       actual_compute_box_num);
+      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp5_ram,
                  actual_compute_box_num);
-      __bang_cycle_le((T *)temp9_ram, (T *)temp8_ram, (T *)temp5_ram,
-                      actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp9_ram,
-                 actual_compute_box_num);
-
-      // T t2 = cross2d<T>(vec1[i], vec12) mult temp2  -- temp9
-      // NOTE: temp8(t1) is used after, reuse temp7(p2_y) as cross2d temp ram
-      cross2d<T>((T *)temp9_ram, (T *)vec1_x + i * actual_compute_box_num,
-                 (T *)vec1_y + i * actual_compute_box_num, (T *)temp6_ram,
-                 (T *)temp7_ram, actual_compute_box_num, (T *)temp7_ram);
-      __bang_mul((T *)temp9_ram, (T *)temp9_ram, (T *)temp2_ram,
+      __bang_le_scalar((T *)temp5_ram, (T *)temp7_ram, (T)1,
+                       actual_compute_box_num);
+      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp5_ram,
                  actual_compute_box_num);
 
-      // temp1 &= (t2 >= 0.0f && t2 <= 1.0f)  -- temp9
-      __bang_cycle_ge((T *)temp7_ram, (T *)temp9_ram, (T *)temp4_ram,
-                      actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp7_ram,
-                 actual_compute_box_num);
-      __bang_cycle_le((T *)temp7_ram, (T *)temp9_ram, (T *)temp5_ram,
-                      actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-      __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp7_ram,
-                 actual_compute_box_num);
+      // NOTE: after there temp2 temp4 temp5 temp7 can be reused as temp ram
 
       // intersections = (pts1[i] + vec1[i] * t1) * temp1
-      __bang_mul((T *)temp9_ram, (T *)vec1_x + i * actual_compute_box_num,
-                 (T *)temp8_ram, actual_compute_box_num);
-      __bang_add((T *)temp9_ram,
+      __bang_mul((T *)temp7_ram, (T *)vec1_x + i * actual_compute_box_num,
+                 (T *)temp6_ram, actual_compute_box_num);
+      __bang_add((T *)temp7_ram,
                  (T *)rotated_pts1_x + i * actual_compute_box_num,
-                 (T *)temp9_ram, actual_compute_box_num);
-      __bang_mul((T *)intersect_pts_x + (4 * i + j) * actual_compute_box_num,
-                 (T *)temp9_ram, (T *)temp1_ram, actual_compute_box_num);
-      __bang_mul((T *)temp9_ram, (T *)vec1_y + i * actual_compute_box_num,
-                 (T *)temp8_ram, actual_compute_box_num);
-      __bang_add((T *)temp9_ram,
+                 (T *)temp7_ram, actual_compute_box_num);
+
+      if (sizeof(T) == sizeof(float)) {
+        __nram__ int table[2] = {0, FIILED_ONES};
+        __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
+                           actual_compute_box_num, 0);
+        __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
+                       (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      } else {
+        __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+        __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp2_ram,
+                             actual_compute_box_num, 0);
+        __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
+                       (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      }
+      __bang_band(
+          (char *)((T *)intersect_pts_x + (4 * i + j) * actual_compute_box_num),
+          (char *)temp7_ram, (char *)temp2_ram,
+          actual_compute_box_num * sizeof(T));
+
+      __bang_mul((T *)temp7_ram, (T *)vec1_y + i * actual_compute_box_num,
+                 (T *)temp6_ram, actual_compute_box_num);
+      __bang_add((T *)temp7_ram,
                  (T *)rotated_pts1_y + i * actual_compute_box_num,
-                 (T *)temp9_ram, actual_compute_box_num);
-      __bang_mul((T *)intersect_pts_y + (4 * i + j) * actual_compute_box_num,
-                 (T *)temp9_ram, (T *)temp1_ram, actual_compute_box_num);
+                 (T *)temp7_ram, actual_compute_box_num);
+
+      __bang_band(
+          (char *)((T *)intersect_pts_y + (4 * i + j) * actual_compute_box_num),
+          (char *)temp7_ram, (char *)temp2_ram,
+          actual_compute_box_num * sizeof(T));
 
       // Assign `valid_pts` bit and accumulate `nums_in` of valid points of each
       // box pair
@@ -438,60 +435,75 @@ __mlu_func__ void getIntersectPts(T *rotated_pts1_x, T *rotated_pts1_y,
   }
 
   // Check for vertices of rect1 inside rect2
-  // temp5 = ABdotAB
-  dot2d<T>((T *)temp5_ram, (T *)vec2_x, (T *)vec2_y, (T *)vec2_x, (T *)vec2_y,
-           actual_compute_box_num, (T *)temp9_ram);
-  // temp6 = ADdotAD
-  dot2d<T>((T *)temp6_ram, (T *)vec2_x + 3 * actual_compute_box_num,
+  // temp3 = ABdotAB
+  dot2d<T>((T *)temp3_ram, (T *)vec2_x, (T *)vec2_y, (T *)vec2_x, (T *)vec2_y,
+           actual_compute_box_num, (T *)temp7_ram);
+  // temp4 = ADdotAD
+  dot2d<T>((T *)temp4_ram, (T *)vec2_x + 3 * actual_compute_box_num,
            (T *)vec2_y + 3 * actual_compute_box_num,
            (T *)vec2_x + 3 * actual_compute_box_num,
            (T *)vec2_y + 3 * actual_compute_box_num, actual_compute_box_num,
-           (T *)temp9_ram);
+           (T *)temp7_ram);
   // assume ABCD is the rectangle, and P is the point to be judged
   // P is inside ABCD iff. P's projection on AB lines within AB
   // and P's projection on AD lies within AD
   for (int i = 0; i < 4; i++) {
-    // AP = pts1[i] - pts2[0] = (temp7, temp8)
-    __bang_sub((T *)temp7_ram, (T *)rotated_pts1_x + i * actual_compute_box_num,
+    // AP = pts1[i] - pts2[0] = (temp5, temp6)
+    __bang_sub((T *)temp5_ram, (T *)rotated_pts1_x + i * actual_compute_box_num,
                (T *)rotated_pts2_x, actual_compute_box_num);
-    __bang_sub((T *)temp8_ram, (T *)rotated_pts1_y + i * actual_compute_box_num,
+    __bang_sub((T *)temp6_ram, (T *)rotated_pts1_y + i * actual_compute_box_num,
                (T *)rotated_pts2_y, actual_compute_box_num);
 
-    // temp9 = APdotAB = dot2d<T>(AP, AB)
-    dot2d<T>((T *)temp9_ram, (T *)temp7_ram, (T *)temp8_ram, (T *)vec2_x,
+    // temp7 = APdotAB = dot2d<T>(AP, AB)
+    dot2d<T>((T *)temp7_ram, (T *)temp5_ram, (T *)temp6_ram, (T *)vec2_x,
              (T *)vec2_y, actual_compute_box_num, (T *)temp2_ram);
-    // temp10 = APdotAD = -dot2d<T>(AP, DA)
-    dot2d<T>((T *)temp10_ram, (T *)temp7_ram, (T *)temp8_ram,
+    // temp8 = APdotAD = -dot2d<T>(AP, DA)
+    dot2d<T>((T *)temp8_ram, (T *)temp5_ram, (T *)temp6_ram,
              (T *)vec2_x + 3 * actual_compute_box_num,
              (T *)vec2_y + 3 * actual_compute_box_num, actual_compute_box_num,
              (T *)temp2_ram);
-    __bang_mul_scalar((T *)temp10_ram, (T *)temp10_ram, (T)-1,
+    __bang_mul_scalar((T *)temp8_ram, (T *)temp8_ram, (T)-1,
                       actual_compute_box_num);
 
     // ((APdotAB >= 0) && (APdotAD >= 0) && (APdotAB <= ABdotAB) && (APdotAD <=
     // ADdotAD))
-    __bang_cycle_ge((T *)temp1_ram, (T *)temp9_ram, (T *)temp4_ram,
-                    actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-    __bang_cycle_ge((T *)temp2_ram, (T *)temp10_ram, (T *)temp4_ram,
-                    actual_compute_box_num, COMPUTE_COUNT_ALIGN);
+    __bang_ge_scalar((T *)temp1_ram, (T *)temp7_ram, (T)0,
+                     actual_compute_box_num);
+    __bang_ge_scalar((T *)temp2_ram, (T *)temp8_ram, (T)0,
+                     actual_compute_box_num);
     __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp2_ram,
                actual_compute_box_num);
-    __bang_le((T *)temp2_ram, (T *)temp9_ram, (T *)temp5_ram,
+    __bang_le((T *)temp2_ram, (T *)temp7_ram, (T *)temp3_ram,
               actual_compute_box_num);
     __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp2_ram,
                actual_compute_box_num);
-    __bang_le((T *)temp2_ram, (T *)temp10_ram, (T *)temp6_ram,
+    __bang_le((T *)temp2_ram, (T *)temp8_ram, (T *)temp4_ram,
               actual_compute_box_num);
     __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp2_ram,
                actual_compute_box_num);
 
     // 16 means the 4x4 possible intersection points above
-    __bang_mul((T *)intersect_pts_x + (16 + i) * actual_compute_box_num,
-               (T *)temp1_ram, (T *)rotated_pts1_x + i * actual_compute_box_num,
-               actual_compute_box_num);
-    __bang_mul((T *)intersect_pts_y + (16 + i) * actual_compute_box_num,
-               (T *)temp1_ram, (T *)rotated_pts1_y + i * actual_compute_box_num,
-               actual_compute_box_num);
+    if (sizeof(T) == sizeof(float)) {
+      __nram__ int table[2] = {0, FIILED_ONES};
+      __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
+                         actual_compute_box_num, 0);
+      __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
+                     (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
+    } else {
+      __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+      __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
+                           actual_compute_box_num, 0);
+      __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
+                     (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
+    }
+    __bang_band(
+        (char *)((T *)intersect_pts_x + (16 + i) * actual_compute_box_num),
+        (char *)((T *)rotated_pts1_x + i * actual_compute_box_num),
+        (char *)temp2_ram, actual_compute_box_num * sizeof(T));
+    __bang_band(
+        (char *)((T *)intersect_pts_y + (16 + i) * actual_compute_box_num),
+        (char *)((T *)rotated_pts1_y + i * actual_compute_box_num),
+        (char *)temp2_ram, actual_compute_box_num * sizeof(T));
 
     // assign valid_pts bit and accumulate nums of valid points of each box pair
     __bang_or((T *)valid_pts + (16 + i) * actual_compute_box_num,
@@ -502,57 +514,72 @@ __mlu_func__ void getIntersectPts(T *rotated_pts1_x, T *rotated_pts1_y,
   }
 
   // Reverse the check - check for vertices of rect2 inside rect1
-  // temp5 = ABdotAB
-  dot2d<T>((T *)temp5_ram, (T *)vec1_x, (T *)vec1_y, (T *)vec1_x, (T *)vec1_y,
-           actual_compute_box_num, (T *)temp9_ram);
-  // temp6 = ADdotAD
-  dot2d<T>((T *)temp6_ram, (T *)vec1_x + 3 * actual_compute_box_num,
+  // temp3 = ABdotAB
+  dot2d<T>((T *)temp3_ram, (T *)vec1_x, (T *)vec1_y, (T *)vec1_x, (T *)vec1_y,
+           actual_compute_box_num, (T *)temp7_ram);
+  // temp4 = ADdotAD
+  dot2d<T>((T *)temp4_ram, (T *)vec1_x + 3 * actual_compute_box_num,
            (T *)vec1_y + 3 * actual_compute_box_num,
            (T *)vec1_x + 3 * actual_compute_box_num,
            (T *)vec1_y + 3 * actual_compute_box_num, actual_compute_box_num,
-           (T *)temp9_ram);
+           (T *)temp7_ram);
   for (int i = 0; i < 4; i++) {
-    // AP = pts2[i] - pts1[0] = (temp7, temp8)
-    __bang_sub((T *)temp7_ram, (T *)rotated_pts2_x + i * actual_compute_box_num,
+    // AP = pts2[i] - pts1[0] = (temp5, temp6)
+    __bang_sub((T *)temp5_ram, (T *)rotated_pts2_x + i * actual_compute_box_num,
                (T *)rotated_pts1_x, actual_compute_box_num);
-    __bang_sub((T *)temp8_ram, (T *)rotated_pts2_y + i * actual_compute_box_num,
+    __bang_sub((T *)temp6_ram, (T *)rotated_pts2_y + i * actual_compute_box_num,
                (T *)rotated_pts1_y, actual_compute_box_num);
 
-    // temp9 = APdotAB = dot2d<T>(AP, AB)
-    dot2d<T>((T *)temp9_ram, (T *)temp7_ram, (T *)temp8_ram, (T *)vec1_x,
+    // temp7 = APdotAB = dot2d<T>(AP, AB)
+    dot2d<T>((T *)temp7_ram, (T *)temp5_ram, (T *)temp6_ram, (T *)vec1_x,
              (T *)vec1_y, actual_compute_box_num, (T *)temp2_ram);
-    // temp10 = APdotAD = -dot2d<T>(AP, DA)
-    dot2d<T>((T *)temp10_ram, (T *)temp7_ram, (T *)temp8_ram,
+    // temp8 = APdotAD = -dot2d<T>(AP, DA)
+    dot2d<T>((T *)temp8_ram, (T *)temp5_ram, (T *)temp6_ram,
              (T *)vec1_x + 3 * actual_compute_box_num,
              (T *)vec1_y + 3 * actual_compute_box_num, actual_compute_box_num,
              (T *)temp2_ram);
-    __bang_mul_scalar((T *)temp10_ram, (T *)temp10_ram, (T)-1,
+    __bang_mul_scalar((T *)temp8_ram, (T *)temp8_ram, (T)-1,
                       actual_compute_box_num);
 
     // ((APdotAB >= 0) && (APdotAD >= 0) && (APdotAB <= ABdotAB) && (APdotAD <=
     // ADdotAD))
-    __bang_cycle_ge((T *)temp1_ram, (T *)temp9_ram, (T *)temp4_ram,
-                    actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-    __bang_cycle_ge((T *)temp2_ram, (T *)temp10_ram, (T *)temp4_ram,
-                    actual_compute_box_num, COMPUTE_COUNT_ALIGN);
+    __bang_ge_scalar((T *)temp1_ram, (T *)temp7_ram, (T)0,
+                     actual_compute_box_num);
+    __bang_ge_scalar((T *)temp2_ram, (T *)temp8_ram, (T)0,
+                     actual_compute_box_num);
     __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp2_ram,
                actual_compute_box_num);
-    __bang_le((T *)temp2_ram, (T *)temp9_ram, (T *)temp5_ram,
+    __bang_le((T *)temp2_ram, (T *)temp7_ram, (T *)temp3_ram,
               actual_compute_box_num);
     __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp2_ram,
                actual_compute_box_num);
-    __bang_le((T *)temp2_ram, (T *)temp10_ram, (T *)temp6_ram,
+    __bang_le((T *)temp2_ram, (T *)temp8_ram, (T *)temp4_ram,
               actual_compute_box_num);
     __bang_and((T *)temp1_ram, (T *)temp1_ram, (T *)temp2_ram,
                actual_compute_box_num);
 
     // 20 means the (4x4+4) possible intersection points above
-    __bang_mul((T *)intersect_pts_x + (20 + i) * actual_compute_box_num,
-               (T *)temp1_ram, (T *)rotated_pts2_x + i * actual_compute_box_num,
-               actual_compute_box_num);
-    __bang_mul((T *)intersect_pts_y + (20 + i) * actual_compute_box_num,
-               (T *)temp1_ram, (T *)rotated_pts2_y + i * actual_compute_box_num,
-               actual_compute_box_num);
+    if (sizeof(T) == sizeof(float)) {
+      __nram__ int table[2] = {0, FIILED_ONES};
+      __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
+                         actual_compute_box_num, 0);
+      __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
+                     (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
+    } else {
+      __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+      __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
+                           actual_compute_box_num, 0);
+      __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
+                     (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
+    }
+    __bang_band(
+        (char *)((T *)intersect_pts_x + (20 + i) * actual_compute_box_num),
+        (char *)((T *)rotated_pts2_x + i * actual_compute_box_num),
+        (char *)temp2_ram, actual_compute_box_num * sizeof(T));
+    __bang_band(
+        (char *)((T *)intersect_pts_y + (20 + i) * actual_compute_box_num),
+        (char *)((T *)rotated_pts2_y + i * actual_compute_box_num),
+        (char *)temp2_ram, actual_compute_box_num * sizeof(T));
 
     // assign valid_pts bit and accumulate nums of valid points of each box pair
     __bang_or((T *)valid_pts + (20 + i) * actual_compute_box_num,
@@ -570,15 +597,14 @@ __mlu_func__ void convexHullGraham(
     T *temp2_ram, T *temp3_ram, T *temp_long_1, T *temp_long_2, T *temp_long_3,
     const uint32_t &actual_box_num, const uint32_t &actual_compute_box_num) {
   // Step1. Find the point with minimum y, if more than 1 points have the same
-  // minimum y,
-  //        pick the one with the minimum x.
-  // set p[i].y to max_y_value if not valid_pts, to avoid invalid result
-  // 24 means all possible intersection points
-  __bang_max((T *)temp2_ram, (T *)intersect_pts_y, 24 * actual_compute_box_num);
-  __bang_write_value((T *)temp3_ram, COMPUTE_COUNT_ALIGN, ((T *)temp2_ram)[0]);
+  // minimum y, pick the one with the minimum x. set p[i].y to max_y_value if
+  // not valid_pts, to avoid invalid result 24 means all possible intersection
+  // points
+  __bang_argmax((T *)temp2_ram, (T *)intersect_pts_y,
+                24 * actual_compute_box_num);
   __bang_not((T *)temp_long_1, (T *)valid_pts, 24 * actual_compute_box_num);
-  __bang_cycle_mul((T *)temp_long_1, (T *)temp_long_1, (T *)temp3_ram,
-                   24 * actual_compute_box_num, COMPUTE_COUNT_ALIGN);
+  __bang_mul_scalar((T *)temp_long_1, (T *)temp_long_1,
+                    (T)(((T *)temp2_ram)[0]), 24 * actual_compute_box_num);
   __bang_mul((T *)temp_long_2, (T *)intersect_pts_y, (T *)valid_pts,
              24 * actual_compute_box_num);
   __bang_add((T *)temp_long_2, (T *)temp_long_2, (T *)temp_long_1,
@@ -586,19 +612,20 @@ __mlu_func__ void convexHullGraham(
   // temp2 = min_y_value(temp_long_2), use min_pool, channel=box_num, h=1, w=24
   __bang_minpool((T *)temp2_ram, (T *)temp_long_2, actual_compute_box_num, 1,
                  24, 1, 24, 1, 24);
+
   __bang_mul((T *)temp2_ram, (T *)temp2_ram, (T *)valid_box,
              actual_compute_box_num);
 
   // set p[i].x to max_x_value if not min_y point
-  __bang_max((T *)temp1_ram, (T *)intersect_pts_x, 24 * actual_compute_box_num);
-  __bang_write_value((T *)temp3_ram, COMPUTE_COUNT_ALIGN, ((T *)temp1_ram)[0]);
+  __bang_argmax((T *)temp1_ram, (T *)intersect_pts_x,
+                24 * actual_compute_box_num);
   __bang_cycle_eq((T *)temp_long_1, (T *)temp_long_2, (T *)temp2_ram,
                   24 * actual_compute_box_num, actual_compute_box_num);
   __bang_and((T *)temp_long_1, (T *)temp_long_1, (T *)valid_pts,
              24 * actual_compute_box_num);
   __bang_not((T *)temp_long_3, (T *)temp_long_1, 24 * actual_compute_box_num);
-  __bang_cycle_mul((T *)temp_long_3, (T *)temp_long_3, (T *)temp3_ram,
-                   24 * actual_compute_box_num, COMPUTE_COUNT_ALIGN);
+  __bang_mul_scalar((T *)temp_long_3, (T *)temp_long_3, (T)((T *)temp1_ram)[0],
+                    24 * actual_compute_box_num);
   __bang_mul((T *)temp_long_1, (T *)intersect_pts_x, (T *)temp_long_1,
              24 * actual_compute_box_num);
   __bang_add((T *)temp_long_1, (T *)temp_long_1, (T *)temp_long_3,
@@ -606,6 +633,7 @@ __mlu_func__ void convexHullGraham(
   // temp3 = min_x_value(temp_long_1), use min_pool, channel=box_num, h=1, w=24
   __bang_minpool((T *)temp3_ram, (T *)temp_long_1, actual_compute_box_num, 1,
                  24, 1, 24, 1, 24);
+
   __bang_mul((T *)temp3_ram, (T *)temp3_ram, (T *)valid_box,
              actual_compute_box_num);
 
@@ -771,55 +799,55 @@ __mlu_func__ void polygonArea(T *ordered_pts_x, T *ordered_pts_y, T *valid_box,
                               T *valid_pts, T *nums_in_ram, T *temp1_ram,
                               T *temp2_ram, T *temp3_ram, T *temp4_ram,
                               T *temp5_ram, T *temp6_ram, T *temp7_ram,
-                              T *temp8_ram, T *temp9_ram,
+                              T *temp8_ram,
                               const uint32_t &actual_compute_box_num) {
   // Set where nums_in <= 2, valid_box = false
-  __bang_write_value((T *)temp9_ram, COMPUTE_COUNT_ALIGN, (T)2);
-  __bang_cycle_gt((T *)temp1_ram, (T *)nums_in_ram, (T *)temp9_ram,
-                  actual_compute_box_num, COMPUTE_COUNT_ALIGN);
+  __bang_le_scalar((T *)temp1_ram, (T *)nums_in_ram, (T)2,
+                   actual_compute_box_num);
+  __bang_not((T *)temp1_ram, (T *)temp1_ram, actual_compute_box_num);
   __bang_and((T *)valid_box, (T *)valid_box, (T *)temp1_ram,
              actual_compute_box_num);
 
   // temp1 = area, initialize with all 0
   __bang_write_zero((T *)temp1_ram, actual_compute_box_num);
-  __bang_max((T *)temp7_ram, (T *)nums_in_ram, actual_compute_box_num);
+  __bang_argmax((T *)temp6_ram, (T *)nums_in_ram, actual_compute_box_num);
 
   // temp_nums_in = max(nums_in)
-  T temp_nums_in = ((T *)temp7_ram)[0];
+  T temp_nums_in = ((T *)temp6_ram)[0];
   for (int i = 1; i < temp_nums_in - 1; i++) {
-    // q[i] - q[0]: (temp6, temp7)
-    __bang_sub((T *)temp6_ram, (T *)ordered_pts_x + i * actual_compute_box_num,
+    // q[i] - q[0]: (temp5, temp6)
+    __bang_sub((T *)temp5_ram, (T *)ordered_pts_x + i * actual_compute_box_num,
                (T *)ordered_pts_x, actual_compute_box_num);
-    __bang_sub((T *)temp7_ram, (T *)ordered_pts_y + i * actual_compute_box_num,
+    __bang_sub((T *)temp6_ram, (T *)ordered_pts_y + i * actual_compute_box_num,
                (T *)ordered_pts_y, actual_compute_box_num);
+    __bang_mul((T *)temp5_ram, (T *)temp5_ram,
+               (T *)valid_pts + (i + 1) * actual_compute_box_num,
+               actual_compute_box_num);
     __bang_mul((T *)temp6_ram, (T *)temp6_ram,
                (T *)valid_pts + (i + 1) * actual_compute_box_num,
                actual_compute_box_num);
+    // q[i + 1] - q[0]: (temp7, temp8)
+    __bang_sub((T *)temp7_ram,
+               (T *)ordered_pts_x + (i + 1) * actual_compute_box_num,
+               (T *)ordered_pts_x, actual_compute_box_num);
+    __bang_sub((T *)temp8_ram,
+               (T *)ordered_pts_y + (i + 1) * actual_compute_box_num,
+               (T *)ordered_pts_y, actual_compute_box_num);
     __bang_mul((T *)temp7_ram, (T *)temp7_ram,
                (T *)valid_pts + (i + 1) * actual_compute_box_num,
                actual_compute_box_num);
-    // q[i + 1] - q[0]: (temp8, temp9)
-    __bang_sub((T *)temp8_ram,
-               (T *)ordered_pts_x + (i + 1) * actual_compute_box_num,
-               (T *)ordered_pts_x, actual_compute_box_num);
-    __bang_sub((T *)temp9_ram,
-               (T *)ordered_pts_y + (i + 1) * actual_compute_box_num,
-               (T *)ordered_pts_y, actual_compute_box_num);
     __bang_mul((T *)temp8_ram, (T *)temp8_ram,
                (T *)valid_pts + (i + 1) * actual_compute_box_num,
                actual_compute_box_num);
-    __bang_mul((T *)temp9_ram, (T *)temp9_ram,
-               (T *)valid_pts + (i + 1) * actual_compute_box_num,
-               actual_compute_box_num);
     // area += fabs(cross2d<T>(q[i] - q[0], q[i + 1] - q[0]));
-    __bang_mul((T *)temp4_ram, (T *)temp6_ram, (T *)temp9_ram,
+    __bang_mul((T *)temp3_ram, (T *)temp5_ram, (T *)temp8_ram,
                actual_compute_box_num);
-    __bang_mul((T *)temp5_ram, (T *)temp7_ram, (T *)temp8_ram,
+    __bang_mul((T *)temp4_ram, (T *)temp6_ram, (T *)temp7_ram,
                actual_compute_box_num);
-    __bang_sub((T *)temp3_ram, (T *)temp4_ram, (T *)temp5_ram,
+    __bang_sub((T *)temp2_ram, (T *)temp3_ram, (T *)temp4_ram,
                actual_compute_box_num);
-    __bang_active_abs((T *)temp3_ram, (T *)temp3_ram, actual_compute_box_num);
-    __bang_add((T *)temp1_ram, (T *)temp1_ram, (T *)temp3_ram,
+    __bang_abs((T *)temp2_ram, (T *)temp2_ram, actual_compute_box_num);
+    __bang_add((T *)temp1_ram, (T *)temp1_ram, (T *)temp2_ram,
                actual_compute_box_num);
   }
   //  Set where valid_box = false, intersection = 0
@@ -833,7 +861,7 @@ __mlu_func__ void polygonArea(T *ordered_pts_x, T *ordered_pts_y, T *valid_box,
 template <typename T>
 __mlu_func__ void calIntersectIou(T *ious_ram, T *area1_ram, T *area2_ram,
                                   T *intersect_area_ram, T *temp1_ram,
-                                  T *temp2_ram, const int &mode,
+                                  const int &mode,
                                   const uint32_t &actual_compute_box_num) {
   if (mode == 0) {
     // Iou = intersection / (area1 + area2 - intersection)
@@ -845,23 +873,22 @@ __mlu_func__ void calIntersectIou(T *ious_ram, T *area1_ram, T *area2_ram,
     // Iof = intersection / (area1)
   }
 
+#if __BANG_ARCH__ == 372
   // where area1 = 0, set recip input to 1, to avoid recip(0), which will cause
   // inf and its valid_box = 0, intersection_area = 0, ious = 0
-  __bang_write_value((T *)temp1_ram, COMPUTE_COUNT_ALIGN, (T)0);
-  __bang_cycle_eq((T *)temp2_ram, (T *)area1_ram, (T *)temp1_ram,
-                  actual_compute_box_num, COMPUTE_COUNT_ALIGN);
-  __bang_add((T *)area1_ram, (T *)area1_ram, (T *)temp2_ram,
+  __bang_eq_scalar((T *)temp1_ram, (T *)area1_ram, (T)0,
+                   actual_compute_box_num);
+  __bang_add((T *)area1_ram, (T *)area1_ram, (T *)temp1_ram,
              actual_compute_box_num);
-
-#if __BANG_ARCH__ >= 300
   // bang_recip only support float data type, others should use cast to float
   // first
   __bang_recip((float *)area1_ram, (float *)area1_ram, actual_compute_box_num);
-#else
-  __bang_active_reciphp((T *)area1_ram, (T *)area1_ram, actual_compute_box_num);
-#endif
   __bang_mul((T *)ious_ram, (T *)intersect_area_ram, (T *)area1_ram,
              actual_compute_box_num);
+#else
+  __bang_div((T *)ious_ram, (T *)intersect_area_ram, (T *)area1_ram,
+             actual_compute_box_num);
+#endif
 }
 
 #endif  // KERNELS_NMS_ROTATED_NMS_UTILS_H_

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/nms_rotated/nms_rotated.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/nms_rotated/nms_rotated.cpp
@@ -171,14 +171,8 @@ void NmsRotatedExecutor::cpuNmsRotated(const T *boxes,
       }
       auto ovr = singleBoxIouRotated(boxes + i * box_dim,
                                     boxes + j * box_dim, 0);
-      if (iou_threshold == 0) {
-        if (ovr > iou_threshold) {
-          suppressed[j] = 1;
-        }
-      } else {
-        if (ovr >= iou_threshold) {
-          suppressed[j] = 1;
-        }
+      if (ovr > iou_threshold) {
+        suppressed[j] = 1;
       }
     }
   }

--- a/docs/bangc-docs/design_docs/nms_rotated/nms_rotated.md
+++ b/docs/bangc-docs/design_docs/nms_rotated/nms_rotated.md
@@ -94,8 +94,7 @@ NmsRotated 算子有 2 个输入 Tensor，分别为 `boxes`[N,5] or [N,6], `scor
 限制说明：
 
 - 不支持`scores`中存在相同score的情况。参考接口和mlu所选择框的index不一致。
-- `scores`不支持nan/inf。出现多个inf时不满足上述说明。不支持nan，因为参考接口nan score等同于inf，会被选择。mlu中`__bang_max` 选择正常数据，不选择nan。
-- `boxes`不支持nan/inf。sin/cos和参考接口的bit级无法保持一致。
+- `scores`不支持nan/inf。出现多个inf(即相同score)时不满足上述说明。不支持nan，因为参考接口nan score等同于inf，会被选择。
 
 ### 1.5 验收标准
 

--- a/docs/bangc-docs/design_docs/nms_rotated/nms_rotated.md
+++ b/docs/bangc-docs/design_docs/nms_rotated/nms_rotated.md
@@ -4,14 +4,15 @@
 
 | 算子名称    | `nms_rotated`          |
 | ----------- | --------------------- |
-| 编制人/日期 | liuyuan1/2022-02-06     |
-| 审批人/日期 | 袁梦，张双林/2022-02-17   |
+| 编制人/日期 | liuyuan1/2023-02-06     |
+| 审批人/日期 | 袁梦，张双林/2023-02-17   |
 
 - #### 修改记录
 
 | 版本号 | 修订人  | 修订日期  | 修订描述 |
 | ------ | ------- | --------- | -------- |
-| V1.0   | liuyuan1 | 2022-2-6 | 首次提交 |
+| V1.0   | liuyuan1 | 2023-2-6 | 首次提交 |
+| V1.1   | xuminjie | 2023-6-9 | boxes支持nan/inf |
 
 - #### 内容描述
 
@@ -37,9 +38,9 @@
 | 需求来源                  | mmcv                                                           |
 | 应用网络                  | fcos3d/pointpillar                                             |
 | 输入数据类型               | float                                                          |
-| 输入 Shape                | boxes:[N,5]; scores:[N]; iou_threshold:float;                  |
+| 输入 Shape                | boxes:[N,5]; scores:[N]; iou_threshold: scalar;                |
 | 输出数据类型               | int32                                                          |
-| 输出 Shape                | output:[N]; result_num: int32, 表示输出box的个数                 |
+| 输出 Shape                | output:[N]; result_num: scalar, 表示ouput前result_num个数有效     |
 | 是否需要支持原位            | 否                                                              |
 | 是否需要支持 stride 机制    | 否                                                              |
 | 是否需要支持广播            | 否                                                              |
@@ -74,7 +75,7 @@ NmsRotated 算子有 2 个输入 Tensor，分别为 `boxes`[N,5] or [N,6], `scor
 | iou_threshold | 输入数据，IOU 的阈值          | 输入            | float                   | scalar        | /        |
 | output_desc   | 输入数据，输出 index 的描述符  | 输入            | mluOpTensorDescriptor_t | /             | /        |
 | output        | 输出数据，输出 index 的数据    | 输出            | int32 \*                | [N]           | /        |
-| result_num    | 输出数据，输出 box 的个数      | 输出            | int32 \*                | /             | /        |
+| result_num    | 输出数据，输出 box 的个数      | 输出            | int32 \*                | scalar        | /        |
 
 ### 1.4 算子限制
 
@@ -199,8 +200,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpNmsRotated(mluOpHandle_t handle,
 2、0 元素检查防呆，VLOG(5)打印信息，是否返回与框架沟通；
 
 3、对输入输出支持的 dtype 以及 shape 进行防呆；
-
-4、算子自身的`iou_threshold`参数防呆。
 
 ## 4 算子性能优化记录
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

boxes tensor support naninf

## 2. Modification

1. modified:   bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
2. modified:   bangc-ops/kernels/bangc-ops/kernels/nms_rotated/nms_utils.h
3. modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/nms_rotated/nms_rotated.cpp
4. modified:   docs/bangc-docs/design_docs/nms_rotated/nms_rotated.md


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff3: diff3 <= 0

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1       |
|        3       |Layouts                               |          ARRAY      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |         支持                             |
|        6       |Data type(half/float)                 |           float           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [x] Multi-dimensional tensor test
- [ ] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |        本次无修改                     |
| Whether illegal parameters are passed           |     Normal error    |        本次无修改                     |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Mult-platform test   |MLU370/MLU590                     |     通过     |   已入库测例+新增测例       |
|Nan/INF test         |Whether to support this test      |   通过    |     boxes tensor，iou_threshold支持naninf<br>  [ SUMMARY  ] Total 92 cases of 1 op(s).<br>ALL PASSED.<br>[==========] 92 test cases from 1 test suite ran. (40616 ms total)<br>[  PASSED  ] 92 test cases.       |
|Memory leak check    |Test result                       |    通过      |    MLUOP_BUILD_ASAN_CHECK=ON ./build.sh --filter=nms_rotated      |
|Code coverage check  |Test result                       |     通过     |  ./build.sh --filter=nms_rotated -c<br>run docker<br>NEUWARE_HOME=xxx ../../../tools/coverage.sh "././mluop_gtest --cases_dir=xxx"<br>nms_rotated_union1.mlu<br>Line Coverage 95.8% 295 / 308	Functions 100.0 %	3 / 3 <br>nms_utils.h<br>Line Coverage 94.2% 556 / 590	Functions 100.0 %	9 / 9     |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|nms_rotated| 51266   |  23.89  |  1.38676e-07   |  0  |  1872  | float   |   [78,5]  |
|nms_rotated|  16440  | 12.85   |   1.88501e-07  |  207.213  |  816  |  float  |  [34,5]   |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|nms_rotated|  20310  | 17.405   | 5.25065e-08   |  0  |  1872  |  float  |   [78,5]  |
|nms_rotated|  6520  |  5.184  |  7.12951e-08  |  0  |  816  |  float  |  [34,5]   |

### 3.4 Summary Analysis

1. boxes tensor支持naninf
2. iou_threshold param支持naninf
3. scores tensor由于不支持相同score，因此不支持naninf
4. 功能测试通过，性能测试无下降
