### PR TITLE
[Fix](bangc-ops): fix check_log_error space error.

### DIFF
--- a/tools/check_log_error.py
+++ b/tools/check_log_error.py
@@ -169,7 +169,7 @@ def check():
 
 def main():
     if sys.argv[1].endswith(".mlu") or sys.argv[1].endswith(".cpp"):
-	getFile(sys.argv[1])
+        getFile(sys.argv[1])
         print('check filename: %s.'%(sys.argv[1]))
         check()
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

fix space error in tools/check_log_error.
## 2. Modification

tools/check_log_error.py
## 3. Test Report