### PR TITLE
[Feature](bangc-ops): Add bang memcheck

### DIFF
--- a/bangc-ops/CMakeLists.txt
+++ b/bangc-ops/CMakeLists.txt
@@ -43,6 +43,14 @@ if(${MLUOP_BUILD_ASAN_CHECK} MATCHES "ON")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_ASAN_FLAGS}")
 endif()
 
+# -- BANG memcheck
+if(${MLUOP_BUILD_BANG_MEMCHECK} MATCHES "ON")
+  message("-- BANG memcheck enabled")
+  set(BANG_CNCC_FLAGS "${BANG_CNCC_FLAGS} -mllvm -enable-mlisa-sanitizer")
+  set(BANG_CNCC_FLAGS "${BANG_CNCC_FLAGS} -Xbang-cnas -O0") # XXX to reduce cnas compilation time
+  set(BANG_CNCC_FLAGS "${BANG_CNCC_FLAGS} -g") # to show file line number
+endif()
+
 # check `NEUWARE_HOME` env
 message("-- NEUWARE_HOME=${NEUWARE_HOME}")
 if(EXISTS ${NEUWARE_HOME})

--- a/docs/GTest-User-Guide-zh.md
+++ b/docs/GTest-User-Guide-zh.md
@@ -180,7 +180,17 @@ test_param: {
 
 ### 6. 内存泄漏检测
 
-打开环境变量 export MLUOP_BUILD_ASAN_CHECK=ON, 执行测试，./mluop_gtest --gtest_filter=\*div\* 程序没有内存泄漏可正常测试，存在内存泄漏会有提示。  
+#### 6.1 HOST 内存检测
+
+打开环境变量 export MLUOP_BUILD_ASAN_CHECK=ON, 执行测试，./mluop_gtest --gtest_filter=\*div\* 程序没有内存泄漏可正常测试，存在内存泄漏会有提示。
+
+#### 6.2 DEVICE 内存检测
+
+```bash
+./independent_build.sh --filter="div" --enable-bang-memcheck
+cd mlu-ops/bangc-ops/build/test
+./mluop_gtest --gtest_filter=\*div\*  # 存在 DEVICE 内存泄漏会输出内存溢出提示
+```
 
 ### 7. 代码覆盖率
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Add BANG memcheck to check device memory.

## 2. Modification

- bangc-ops/CMakeLists.txt
- bangc-ops/independent_build.sh
- docs/GTest-User-Guide-zh.md

### 3 Summary Analysis

Will detect the Buffer Overflow on device
