### PR TITLE
[Feature](bangc-ops): add fool-check for tensor size

### DIFF
--- a/bangc-ops/core/logging.h
+++ b/bangc-ops/core/logging.h
@@ -34,6 +34,12 @@
 #define LARGE_TENSOR_NUM ((uint64_t)2147483648)
 #define LARGE_TENSOR_SIZE ((uint64_t)2147483648)
 
+
+// This marco is determined by specific experiment on 40g device in market.
+// Cases with indices exceeded this number may raise OOM error when generating
+// test cases.
+#define INDICE_IN_LARGE_TENSOR_NUM  1000000
+
 #define LOG(severity) mluop::logging::CLOG(MLUOP, severity)
 
 #define TOKENPASTE(x, y, z) x##y##z

--- a/bangc-ops/kernels/get_indice_pairs/get_indice_pairs.cpp
+++ b/bangc-ops/kernels/get_indice_pairs/get_indice_pairs.cpp
@@ -142,6 +142,8 @@ static mluOpStatus_t internalGetIndicePairs(
   PARAM_CHECK_LE(interface_name, out_indices_desc->dims[0], output_spaces);
 
   // large tensor
+  PARAM_CHECK_LE(interface_name, indices_desc->dims[0],
+                INDICE_IN_LARGE_TENSOR_NUM);
   if (mluOpGetTensorElementNum(indices_desc) >= LARGE_TENSOR_NUM ||
       mluOpGetTensorElementNum(out_indices_desc) >= LARGE_TENSOR_NUM ||
       mluOpGetTensorElementNum(indice_pairs_desc) >= LARGE_TENSOR_NUM ||

--- a/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/bangc-ops/kernels/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -229,6 +229,8 @@ static mluOpStatus_t baseParamCheck(
       kd * kh * kw != indice_pairs_desc->dims[0]) {
     shape_check = false;  // interdependent dimension check failed!
   }
+  PARAM_CHECK_LE(api_name, indice_pairs_desc->dims[2],
+                  INDICE_IN_LARGE_TENSOR_NUM);
 
   if (!shape_check) {
     LOG(ERROR) << api_name << " Shape check failed! "


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

添加large tensor 防呆

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|mlu-only mode test   |--mlu-only,see [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

[MLU Hardware Time      ]: 21872 (us)
[MLU Interface Time     ]: 12612.7 (us)
[MLU IO Efficiency      ]: 0.0207424
[MLU Compute Efficiency ]: 0.0140644
[MLU Workspace Size     ]: 2.26066e+09 (Bytes)
[MLU TheoryOps          ]: 7.56e+08 (Ops)
[MLU TheoryIOs          ]: 1.25433e+09 (Bytes)
[MLU ComputeForce       ]: 2.4576e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] /home/large_tensor/case1/get_indice_pairs/get_indice_pairs_data_included_int32_1685594467561.pb
[       OK ] get_indice_pairs/TestSuite.mluOp/0 (2443143 ms)
-------- 1 test from get_indice_pairs/TestSuite (2443143 ms total)
-------- Global test environment tear-down

[MLU Hardware Time      ]: 29698 (us)
[MLU Interface Time     ]: 698.834 (us)
[MLU IO Efficiency      ]: 0.373581
[MLU Compute Efficiency ]: 3.01304
[MLU Workspace Size     ]: 3.84393e+08 (Bytes)
[MLU TheoryOps          ]: 2.19909e+11 (Ops)
[MLU TheoryIOs          ]: 3.06743e+10 (Bytes)
[MLU ComputeForce       ]: 2.4576e+12 (op/s)
[MLU IoBandWidth        ]: 2764.8 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF1: 3.023727e-04
DIFF2: 3.027446e-04
[^      OK ] /home/large_tensor/case5_convbpf/indice_convolution_backward_filter/indice_convolution_backward_filter_data_split_input_float32_int32_1685521466661.pb
[       OK ] indice_convolution_backward_filter/TestSuite.mluOp/0 (83106 ms)
-------- 1 test from indice_convolution_backward_filter/TestSuite (83106 ms total)
-------- Global test environment tear-down


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
