### PR TITLE
[Fix](bangc-ops): fix device memory leak of box_iou_rotated.

### DIFF
--- a/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_aligned.h
+++ b/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_aligned.h
@@ -265,13 +265,13 @@ __mlu_func__ void MLUUnion1BoxIouRotatedAligned(const T *box1, const T *box2,
                     actual_compute_box_num);
 
     if (sizeof(T) == sizeof(float)) {
-      __nram__ int table[2] = {0, FIILED_ONES};
+      __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
       __bang_float2int32((int32_t *)temp9_ram, (float *)temp9_ram,
                          actual_compute_box_num, 0);
       __bang_lut_s32((int32_t *)temp9_ram, (int32_t *)temp9_ram,
                      (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
     } else {
-      __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+      __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
       __bang_half2int16_rd((int16_t *)temp9_ram, (half *)temp9_ram,
                            actual_compute_box_num, 0);
       __bang_lut_s16((int16_t *)temp9_ram, (int16_t *)temp9_ram,

--- a/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_nonaligned.h
+++ b/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_nonaligned.h
@@ -356,14 +356,14 @@ __mlu_func__ void MLUUnion1BoxIouRotatedNonAligned(const T *box1, const T *box2,
                         actual_compute_box_num);
 
         if (sizeof(T) == sizeof(float)) {
-          __nram__ int table[2] = {0, FIILED_ONES};
+          __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
           __bang_float2int32((int32_t *)temp9_ram, (float *)temp9_ram,
                              actual_compute_box_num, 0);
           __bang_lut_s32((int32_t *)temp9_ram, (int32_t *)temp9_ram,
                          (int32_t *)table, actual_compute_box_num,
                          TABLE_LENGTH);
         } else {
-          __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+          __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
           __bang_half2int16_rd((int16_t *)temp9_ram, (half *)temp9_ram,
                                actual_compute_box_num, 0);
           __bang_lut_s16((int16_t *)temp9_ram, (int16_t *)temp9_ram,

--- a/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_utils.h
+++ b/bangc-ops/kernels/box_iou_rotated/box_iou_rotated_utils.h
@@ -245,14 +245,14 @@ __mlu_func__ void getIntersectionPoints(
                  (T *)temp7_ram, actual_compute_box_num);
 
       if (sizeof(T) == sizeof(float)) {
-        __nram__ int table[2] = {0, FIILED_ONES};
+        __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
         __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                            actual_compute_box_num, 0);
         __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
                         (int32_t *)table, actual_compute_box_num,
                         TABLE_LENGTH);
       } else {
-        __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+        __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
         __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp2_ram,
                              actual_compute_box_num, 0);
         __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
@@ -334,13 +334,13 @@ __mlu_func__ void getIntersectionPoints(
 
     // 16 means the 4x4 possible intersection points above
     if (sizeof(T) == sizeof(float)) {
-      __nram__ int table[2] = {0, FIILED_ONES};
+      __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
       __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                          actual_compute_box_num, 0);
       __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
                      (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
     } else {
-      __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+      __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
       __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
                            actual_compute_box_num, 0);
       __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
@@ -410,14 +410,14 @@ __mlu_func__ void getIntersectionPoints(
 
     // 20 means the (4x4+4) possible intersection points above
     if (sizeof(T) == sizeof(float)) {
-      __nram__ int table[2] = {0, FIILED_ONES};
+      __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
       __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                          actual_compute_box_num, 0);
           __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
                          (int32_t *)table, actual_compute_box_num,
                          TABLE_LENGTH);
     } else {
-            __nram__ int16_t table[2] = {0, HALF_FILLED_ONES};
+            __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
       __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
                            actual_compute_box_num, 0);
       __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Fix device memory leak.

## 2. Modification

modified:   bangc-ops/kernels/box_iou_rotated/box_iou_rotated_aligned.h
modified:   bangc-ops/kernels/box_iou_rotated/box_iou_rotated_nonaligned.h
modified:   bangc-ops/kernels/box_iou_rotated/box_iou_rotated_utils.h

## 3. Test Report

--enable-bang-memcheck: no warning or  error

Platform：MLU370
release_temp: 108 cases passed.
release_test: 21 cases passed.
nan_inf case: 80 cases passed.

Platform：MLU590
release_temp: 108 cases passed.
release_test: 21 cases passed.
nan_inf case: 80 cases passed.

### 3.4 Summary Analysis
 jenkins job 执行结果:
 build status: SUCCESS

All test passed.