### PR TITLE
[Fix](bangc-ops): delete unused api return message on indice_convolution_backward_data api

### DIFF
--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -11964,7 +11964,7 @@ mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_INTERNAL_ERROR
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

delete unused api return message MLUOP_STATUS_INTERNAL_ERROR on indice_convolution_backward_data api

## 2. Modification

modified:   bangc-ops/mlu_op.h

## 3. Test Report

No test
