### PR TITLE
[Fix](bangc-ops): fix focalLossSigmoidBackward buffer overflow

### DIFF
--- a/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -257,7 +257,7 @@ __mlu_func__ void focalLossSigmoidBackwardBlock(
   int32_t compute_num = 0;
   int32_t compute_size = 0;
   int32_t compute_align_size = NFU_ALIGN_SIZE;
-  const int32_t nfu_align_num = NFU_ALIGN_SIZE / sizeof(T);
+  const int32_t nfu_align_num = NFU_ALIGN_SIZE / sizeof(float);
   if (sizeof(T) == sizeof(half)) {
     compute_align_size += NFU_ALIGN_SIZE;
   }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation
 对于half类型测例，在片上转为float计算，nram偏移大小有误，存在内存越界风险。
## 2. Modification

modified: bangc-ops/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu

## 3. Test Report

精度流水：http://jenkins.svc.cambricon.com/dist/job/MLUOPS/view/Pipelines-Adaptable/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/158/
性能流水： http://jenkins.svc.cambricon.com/dist/job/MLUOPS/view/Pipelines-Adaptable/job/MLU_ALL_PLATFORMS/job/mluops_build_perf_adaptable_mlu/113/

开启--enable-bang-memcheck编译，运行测例无Buffer Overflow Detected报错

