### PR TITLE
[Fix](bangc-ops): fix memory leak of dynamic_point_to_voxel_backward

### DIFF
--- a/bangc-ops/kernels/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward_union1.mlu
+++ b/bangc-ops/kernels/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward_union1.mlu
@@ -167,7 +167,7 @@ __mlu_global__ void MLUKernelMaxReduceTracebackScatterIdx(
   // broadcast point2voxel_map to nram
   __memcpy(point2voxel_map_nram, point2voxel_map, size_input, GDRAM2NRAM);
   // initialze voxel_from_flag to false
-  __memset_nram(voxel_from_flag_nram, M, false);
+  __memset_nram(voxel_from_flag_nram, M, (char)false);
   for (int i = 0; i < C; i++) {
     index_col_nram[i] = i;
   }


### PR DESCRIPTION
## 1. Motivation

fix memory leak of dynamic_point_to_voxel_backward caused by Implicit conversion

## 2. Modification

modified: bangc-ops/kernels/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward_union1.mlu

## 3. Test Report
--enable-bang-memcheck: no warning or error

Platform : MLU370
[----------] 53 tests from dynamic_point_to_voxel_backward/TestSuite (171181 ms total)
[----------] Global test environment tear-down
[ SUMMARY  ] Total 53 cases of 1 op(s).
ALL PASSED.
[==========] 53 test cases from 1 test suite ran. (171675 ms total)
[  PASSED  ] 53 test cases.

Platform : MLU590
[----------] 51 tests from dynamic_point_to_voxel_backward/TestSuite (7879 ms total)
[----------] Global test environment tear-down
[ SUMMARY  ] Total 51 cases of 1 op(s).
ALL PASSED.
[==========] 51 test cases from 1 test suite ran. (8240 ms total)
[  PASSED  ] 51 test cases.

### 3.4 Summary Analysis
jenkins job : [#161](http://jenkins.svc.cambricon.com/dist/job/MLUOPS/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/161/) SUCCESS

All test passed.