### PR TITLE
[Feature](bangc-ops): change the type of opt_boundary to int32  in mutual_information_forward and mutual_information_backward op

### DIFF
--- a/bangc-ops/kernels/mutual_information_backward/mutual_information_backward.cpp
+++ b/bangc-ops/kernels/mutual_information_backward/mutual_information_backward.cpp
@@ -222,9 +222,9 @@ static mluOpStatus_t checkTensorDatatype(
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
   if (nullptr != opt_boundary_desc &&
-      MLUOP_DTYPE_INT64 != opt_boundary_desc->dtype) {
+      MLUOP_DTYPE_INT32 != opt_boundary_desc->dtype) {
     LOG(ERROR) << API_NAME
-               << "The data type of opt_boundary currently only support int64."
+               << "The data type of opt_boundary currently only support int32."
                << " But now the data type of opt_boundary is "
                << mluOpGetNameOfDataType(opt_boundary_desc->dtype) << ".";
     return MLUOP_STATUS_NOT_SUPPORTED;

--- a/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
+++ b/bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
@@ -241,7 +241,7 @@ __mlu_func__ void computePxGradAndPyGrad(const int b, const int S, const int T,
 
 __mlu_global__ void mluBlockMutualInformationBackward(
     const int B, const int S, const int T, const float *px, const float *py,
-    const bool has_boundary, const int64_t *opt_boundary, const float *p,
+    const bool has_boundary, const int *opt_boundary, const float *p,
     const bool overwrite_ans_grad, float *ans_grad, float *px_grad,
     float *py_grad) {
   const int num_per_core = B / taskDim;
@@ -254,9 +254,9 @@ __mlu_global__ void mluBlockMutualInformationBackward(
   int s_end = S;
   int t_end = T;
   if (has_boundary) {
-    int64_t *boundary = (int64_t *)nram_buffer;
+    int *boundary = (int *)nram_buffer;
     for (int b = b_offset; b < b_offset + num_cur_core; ++b) {
-      __memcpy(boundary, opt_boundary + 4 * b, 4 * sizeof(int64_t), GDRAM2NRAM);
+      __memcpy(boundary, opt_boundary + 4 * b, 4 * sizeof(int), GDRAM2NRAM);
       s_begin = boundary[0];
       t_begin = boundary[1];
       s_end = boundary[2];
@@ -299,7 +299,7 @@ void MLUOP_WIN_API kernelMutualInformationBackward(
     const bool overwrite_ans_grad, void *ans_grad, void *px_grad,
     void *py_grad) {
   mluBlockMutualInformationBackward<<<k_dim, k_type, queue>>>(
-      B, S, T, (float *)px, (float *)py, has_boundary, (int64_t *)opt_boundary,
+      B, S, T, (float *)px, (float *)py, has_boundary, (int *)opt_boundary,
       (float *)p, overwrite_ans_grad, (float *)ans_grad, (float *)px_grad,
       (float *)py_grad);
 }

--- a/bangc-ops/kernels/mutual_information_forward/mutual_information_forward.cpp
+++ b/bangc-ops/kernels/mutual_information_forward/mutual_information_forward.cpp
@@ -177,9 +177,9 @@ static mluOpStatus_t checkTensorDatatype(
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
   if (nullptr != opt_boundary_desc &&
-      MLUOP_DTYPE_INT64 != opt_boundary_desc->dtype) {
+      MLUOP_DTYPE_INT32 != opt_boundary_desc->dtype) {
     LOG(ERROR) << API_NAME
-               << "The data type of opt_boundary currently only support int64."
+               << "The data type of opt_boundary currently only support int32."
                << " But now the data type of opt_boundary is "
                << mluOpGetNameOfDataType(opt_boundary_desc->dtype) << ".";
     return MLUOP_STATUS_NOT_SUPPORTED;

--- a/bangc-ops/kernels/mutual_information_forward/mutual_information_forward_block.mlu
+++ b/bangc-ops/kernels/mutual_information_forward/mutual_information_forward_block.mlu
@@ -229,7 +229,7 @@ __mlu_func__ void computeMutualInformation(const int b, const int S,
 
 __mlu_global__ void mluBlockMutualInformationForward(
     const int B, const int S, const int T, const float *px, const float *py,
-    const bool has_boundary, const int64_t *opt_boundary, float *p,
+    const bool has_boundary, const int *opt_boundary, float *p,
     float *ans) {
   const int num_per_core = B / taskDim;
   const int num_rem = B % taskDim;
@@ -241,9 +241,9 @@ __mlu_global__ void mluBlockMutualInformationForward(
   int s_end = S;
   int t_end = T;
   if (has_boundary) {
-    int64_t *boundary = (int64_t *)nram_buffer;
+    int *boundary = (int *)nram_buffer;
     for (int b = b_offset; b < b_offset + num_cur_core; ++b) {
-      __memcpy(boundary, opt_boundary + 4 * b, 4 * sizeof(int64_t), GDRAM2NRAM);
+      __memcpy(boundary, opt_boundary + 4 * b, 4 * sizeof(int), GDRAM2NRAM);
       s_begin = boundary[0];
       t_begin = boundary[1];
       s_end = boundary[2];
@@ -269,6 +269,6 @@ void MLUOP_WIN_API kernelMutualInformationForward(
   const int B, const int S, const int T, const void *px, const void *py,
   const bool has_boundary, const void *opt_boundary, void *p, void *ans) {
   mluBlockMutualInformationForward<<<k_dim, k_type, queue>>>(
-      B, S, T, (float *)px, (float *)py, has_boundary, (int64_t *)opt_boundary,
+      B, S, T, (float *)px, (float *)py, has_boundary, (int *)opt_boundary,
       (float *)p, (float *)ans);
 }

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.cpp
@@ -138,12 +138,12 @@ void MutualInformationBackwardExecutor::compute() {
 void MutualInformationBackwardExecutor::cpuCompute() {
   float *host_px = (float *)data_vector_[0].host_ptr;
   float *host_py = (float *)data_vector_[1].host_ptr;
-  int64_t *host_opt_boundary = nullptr;
+  int *host_opt_boundary = nullptr;
   float *host_p = nullptr;
 
   float *host_ans_grad_in = nullptr;
   if (tensor_desc_.size() == max_tensor_num_) {
-    host_opt_boundary = (int64_t *)data_vector_[2].host_ptr;
+    host_opt_boundary = (int *)data_vector_[2].host_ptr;
     host_p = (float *)data_vector_[3].host_ptr;
     host_ans_grad_in = (float *)data_vector_[4].host_ptr;
   } else {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/test_case/mutual_information_backward.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/test_case/mutual_information_backward.prototxt
@@ -37,7 +37,7 @@ input {
     dims: 4
   }
   layout: LAYOUT_ARRAY
-  dtype: DTYPE_INT64
+  dtype: DTYPE_INT32
   value_l: 0
   value_l: 0
   value_l: 10

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.cpp
@@ -120,10 +120,10 @@ void MutualInformationForwardExecutor::compute() {
 void MutualInformationForwardExecutor::cpuCompute() {
   float *host_px = (float *)data_vector_[0].host_ptr;
   float *host_py = (float *)data_vector_[1].host_ptr;
-  int64_t *host_opt_boundary = nullptr;
+  int *host_opt_boundary = nullptr;
 
   if (tensor_desc_.size() == max_tensor_num_) {
-    host_opt_boundary = (int64_t *)data_vector_[2].host_ptr;
+    host_opt_boundary = (int *)data_vector_[2].host_ptr;
   }
 
   float *host_p_out = cpu_fp32_output_[0];

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/test_case/mutual_information_forward.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/test_case/mutual_information_forward.prototxt
@@ -37,7 +37,7 @@ input {
     dims: 4
   }
   layout: LAYOUT_ARRAY
-  dtype: DTYPE_INT64
+  dtype: DTYPE_INT32
   value_l: 1
   value_l: 2
   value_l: 120

--- a/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
+++ b/docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
@@ -41,7 +41,7 @@
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | 需求来源                                                     | K2                                                           |
 | 应用网络                                                     | rnnt                                                         |
-| 输入数据类型                                                 | px: float<br/>py: float<br/>opt_boundary(可选): int64<br/>p: float<br/>ans_grad: float |
+| 输入数据类型                                                 | px: float<br/>py: float<br/>opt_boundary(可选): int<br/>p: float<br/>ans_grad: float |
 | 输入标量参数                                                 | overwrite_ans_grad: bool                                     |
 | 输入 Shape                                                   | px: [B, S, T+1]<br/>py: [B, S+1, T]<br/>opt_boundary: [B, 4] or None<br/>p: [B, S+1, T+1]<br/>ans_grad: [B] |
 | 输入 Layout                                                  | ARRAY                                                        |
@@ -114,7 +114,7 @@
 | py_desc            | 输入数据py的描述符号，包含py的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
 | py                 | 指向py数据的mlu地址指针                                      | 输入              | float                   | ARRAY    | 无       |
 | opt_boundary_desc  | 输入数据opt_boundary的描述符号，包含opt_boundary的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
-| opt_boundary       | 指向opt_boundary数据的mlu地址指针                            | 输入              | int64                   | ARRAY    | 无       |
+| opt_boundary       | 指向opt_boundary数据的mlu地址指针                            | 输入              | int                   | ARRAY    | 无       |
 | p_desc             | 输入数据p的描述符号，包含p的数据类型、数据维度和布局等信息   | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
 | p                  | 指向p数据的mlu地址指针                                       | 输入              | float                   | ARRAY    | 无       |
 | ans_grad_desc      | 输入数据ans_grad的描述符号，包含ans_grad的数据类型、数据维度和布局等信息 | 输入              | mluOpTensorDescriptor_t | /        | 见1.4    |
@@ -129,7 +129,7 @@
 
 | 限制类型     | 详细说明                                                     |
 | ------------ | ------------------------------------------------------------ |
-| 数据类型限制 | px: float<br/>py: float<br/>opt_boundary: int64<br/>p: float<br/>ans_grad: float<br/>overwrite_ans_grad: bool<br/>px_grad: float<br/>py_grad: float |
+| 数据类型限制 | px: float<br/>py: float<br/>opt_boundary: int<br/>p: float<br/>ans_grad: float<br/>overwrite_ans_grad: bool<br/>px_grad: float<br/>py_grad: float |
 | 布局限制     | ARRAY                                                        |
 | 规模限制     | 不支持large tensor;<br>在MLU370中，<br>T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 163840<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 163840; <br>在MLU590中，<br>T * (S + 1) + (T + 1) * S + 5 * (T + 1) <= 98304<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 3 * std::min(S, T) + 4 <= 98304;|
 | 功能限制     | 仅支持!modified模式，即输入参数px的shape为 [B, S, T+1]       |
@@ -435,7 +435,7 @@ NRAW空间划分参考3.2 伪代码实现中的描述
 
 4、检查px的维度为[B, S,T+1]；py的维度为[B, S+1,T]；p的维度为[B, S+1,T+1]；ans_grad的维度为[B]；px_grad的维度为[B, S,T+1]；py_grad的维度为[B, S+1,T]；如果opt_boundary不为空，opt_boundary为维度为[B，4]
 
-5、检查px/py/p/ans_grad/px_grad/py_grad的数据类型为float；如果opt_boundary不为空，opt_boundary的数据类型为int64
+5、检查px/py/p/ans_grad/px_grad/py_grad的数据类型为float；如果opt_boundary不为空，opt_boundary的数据类型为int
 
 6、检查输入输出是否包含large tensor，或者输入规模是否超出限制
 

--- a/docs/bangc-docs/design_docs/mutual_information_forward/mutual_information_forward.md
+++ b/docs/bangc-docs/design_docs/mutual_information_forward/mutual_information_forward.md
@@ -43,7 +43,7 @@
 | ------------------------------| ------------------------------------------- |
 | 需求来源                      | k2                    |
 | 应用网络                      | RNNT                                                         |
-| 输入数据类型                  | px: float<br>py : float<br>opt_boundary(可选): int64<br>p: float |
+| 输入数据类型                  | px: float<br>py : float<br>opt_boundary(可选): int<br>p: float |
 | 输入 Shape                    | px : [B, S, T+1]<br/>py : [B, S+1, T]<br/>opt_boundary : [B, 4]<br/>p: [B, S+1, T+1] |
 | 输入 Layout                   | px : ARRAY<br/>py: ARRAY<br>opt_boundary : ARRAY |
 | 输出数据类型                  | float                              |
@@ -110,7 +110,7 @@
 |py_desc | 输入数据py的描述符号，包含py的数据类型、数据维度和布局等信息 | 输入 |          	mluOpTensorDescriptor_t   |	/ |      	无       	|
 |py| 指向py数据的mlu地址指针                                      |  输入 |  float | ARRAY   |	见1.4	|
 |opt_boundary_desc | 输入数据opt_boundary的描述符号，包含opt_boundary的数据类型、数据维度和布局等信息 |      	输入  |         	mluOpTensorDescriptor_t   |	/  |     	无      |
-| opt_boundary | 指向opt_boundary数据的mlu地址指针                            |   输入 | int64 | ARRAY   |	见1.4 |
+| opt_boundary | 指向opt_boundary数据的mlu地址指针                            |   输入 | int | ARRAY   |	见1.4 |
 | p_desc | 输入数据p的描述符号，包含p的数据类型、数据维度和布局等信息   | 输入 | mluOpTensorDescriptor_t | / |	见1.4 |
 | p | 指向p数据的mlu地址指针 | 输入 | float | ARRAY |	无 |
 |ans_desc | 输出数据ans的描述符号，包含ans的数据类型、数据维度和布局等信息 | 输入 | mluOpTensorDescriptor_t|	/     |  	无    |
@@ -121,7 +121,7 @@
 
 |限制类型     |详细说明                                                     	|
 |------------|------------------------------------------------------------|
-|数据类型限制	|px: float<br/>py: float<br/>opt_boundary: int64<br/>p: float<br/>ans: float |
+|数据类型限制	|px: float<br/>py: float<br/>opt_boundary: int<br/>p: float<br/>ans: float |
 |布局限制    | 仅支持 layout 为 ARRAY                                       |
 |	规模限制    | 不支持large tensor;<br/>在MLU370中，<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 4 * std::min(S, T) + 4 <= 163840;<br/>在MLU590中，<br/>T * (S + 1) + (T + 1) * S + (T + 1) * (S + 1) + 4 * std::min(S, T) + 4 <= 98304;	|
 |功能限制     | 仅支持!modified模式，即输入参数px的shape为 [B, S, T+1]       |
@@ -359,7 +359,7 @@ bang_maximum等指令在370上无法异步执行，因此暂不排流水。
 
 4、检查px的维度为[B, S,T+1]；py的维度为[B, S+1,T]；p的维度为[B, S+1,T+1]；ans的维度为[B]；如果opt_boundary不为空，opt_boundary为维度为[B，4]
 
-5、检查px/py/p/ans的数据类型为float；如果opt_boundary不为空，opt_boundary的数据类型为int64
+5、检查px/py/p/ans的数据类型为float；如果opt_boundary不为空，opt_boundary的数据类型为int
 
 6、检查输入输出是否包含large tensor，或者输入规模是否超出限制
 


### PR DESCRIPTION
## 1. Motivation

change the type of opt_boundary to int32  in mutual_information_forward and mutual_information_backward op

## 2. Modification

modified: bangc-ops/kernels/mutual_information_backward/mutual_information_backward.cpp
	       bangc-ops/kernels/mutual_information_backward/mutual_information_backward_block.mlu
	       bangc-ops/kernels/mutual_information_forward/mutual_information_forward.cpp
	       bangc-ops/kernels/mutual_information_forward/mutual_information_forward_block.mlu
	       bangc-ops/test/mlu_op_gtest/pb_gtest/mlu_op_test_proto
	       bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/mutual_information_backward.cpp
	       bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_backward/test_case/mutual_information_backward.prototxt
	       bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/mutual_information_forward.cpp
	       bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/mutual_information_forward/test_case/mutual_information_forward.prototxt
	       docs/bangc-docs/design_docs/mutual_information_backward/mutual_information_backward.md
	       docs/bangc-docs/design_docs/mutual_information_forward/mutual_information_forward.md
## 3. Test Report
--enable-bang-memcheck: no warning or error

Platform : MLU370
[==========] 24 test cases from 1 test suite ran. (2700 ms total)
[  PASSED  ] 12 test cases.
[  FAILED  ] 12 test cases, listed below:
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/1, where GetParam() = ("mutual_information_backward", 1)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/3, where GetParam() = ("mutual_information_backward", 3)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/4, where GetParam() = ("mutual_information_backward", 4)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/5, where GetParam() = ("mutual_information_backward", 5)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/8, where GetParam() = ("mutual_information_backward", 8)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/9, where GetParam() = ("mutual_information_backward", 9)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/12, where GetParam() = ("mutual_information_backward", 12)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/14, where GetParam() = ("mutual_information_backward", 14)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/15, where GetParam() = ("mutual_information_backward", 15)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/17, where GetParam() = ("mutual_information_backward", 17)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/21, where GetParam() = ("mutual_information_backward", 21)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/22, where GetParam() = ("mutual_information_backward", 22)
12 FAILED TESTS

Platform : MLU590
[==========] 24 test cases from 1 test suite ran. (2700 ms total)
[  PASSED  ] 12 test cases.
[  FAILED  ] 12 test cases, listed below:
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/1, where GetParam() = ("mutual_information_backward", 1)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/3, where GetParam() = ("mutual_information_backward", 3)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/4, where GetParam() = ("mutual_information_backward", 4)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/5, where GetParam() = ("mutual_information_backward", 5)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/8, where GetParam() = ("mutual_information_backward", 8)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/9, where GetParam() = ("mutual_information_backward", 9)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/12, where GetParam() = ("mutual_information_backward", 12)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/14, where GetParam() = ("mutual_information_backward", 14)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/15, where GetParam() = ("mutual_information_backward", 15)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/17, where GetParam() = ("mutual_information_backward", 17)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/21, where GetParam() = ("mutual_information_backward", 21)
[  FAILED  ] mutual_information_backward/TestSuite.mluOp/22, where GetParam() = ("mutual_information_backward", 22)
12 FAILED TESTS


### 3.4 Summary Analysis
上述失败的case中，opt_boundary都是int64，导致防呆报错。后续需要同时兼容itn32和int64