### PR TITLE
[Fix](bangc-ops):Fix 500 series platform max_num_priors exceed the limit problem.

### DIFF
--- a/bangc-ops/kernels/prior_box/prior_box.cpp
+++ b/bangc-ops/kernels/prior_box/prior_box.cpp
@@ -28,7 +28,7 @@
 #include "core/runtime/device.h"
 
 #define api "mluOpPriorBox"
-#define MLU200SERIERS_MAX_SUPPORT 2100
+#define MLU200_500SERIERS_MAX_SUPPORT 2100
 #define MLU300SERIERS_MAX_SUPPORT 2900
 
 // policy function
@@ -117,8 +117,8 @@ mluOpStatus_t mluOpPriorBoxParamCheck(
   const int num_priors =
       getNumPriors(min_sizes_desc, aspect_ratios_desc, max_sizes_desc);
   // check num_priors limit
-  const int max_support_num_priors = handle->arch < 300
-                                         ? MLU200SERIERS_MAX_SUPPORT
+  const int max_support_num_priors = (handle->arch < 300 || handle->arch > 500)
+                                         ? MLU200_500SERIERS_MAX_SUPPORT
                                          : MLU300SERIERS_MAX_SUPPORT;
   if (num_priors > max_support_num_priors) {
     LOG(ERROR) << api << " Support max num_priors is " << max_support_num_priors


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Fix 500 series platform max_num_priors exceed the limit problem.

## 2. Modification

bangc-ops/kernels/prior_box/prior_box.cpp
