### PR TITLE
[Feature](bangc-ops): Redefine sizeof in mlu file

### DIFF
--- a/bangc-ops/kernels/abs/abs_block.mlu
+++ b/bangc-ops/kernels/abs/abs_block.mlu
@@ -24,6 +24,7 @@
 
 #include "core/logging.h"
 #include "kernels/debug.h"
+#include "kernels/kernel.h"
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
 

--- a/bangc-ops/kernels/abs/abs_block.mlu
+++ b/bangc-ops/kernels/abs/abs_block.mlu
@@ -81,7 +81,8 @@ Kernel3StagePipelineAbs(const cnrtDim3_t k_dim, const cnrtFunctionType_t k_type,
     KERNEL_CHECK(
         MLUBlockKernel3StagePipelineAbsfloatFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, 0.0));
-  } else if (d_type == MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     KERNEL_CHECK(
         MLUBlockKernel3StagePipelineAbshalfFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, 0.0));
@@ -97,7 +98,8 @@ Kernel5StagePipelineAbs(const cnrtDim3_t k_dim, const cnrtFunctionType_t k_type,
     KERNEL_CHECK(
         MLUBlockKernel5StagePipelineAbsfloatFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, 0.0));
-  } else if (d_type == MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     KERNEL_CHECK(
         MLUBlockKernel5StagePipelineAbshalfFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, 0.0));

--- a/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
+++ b/bangc-ops/kernels/bbox_overlaps/bbox_overlaps_union1.mlu
@@ -549,7 +549,7 @@ mluOpStatus_t MLUOP_WIN_API KernelBboxOverlaps(
     KERNEL_CHECK(MLUUnion1BboxOverlapsKernel<<<k_dim, k_type, queue>>>(
         (half *)bbox1, (half *)bbox2, (half *)ious, num_bboxl, num_bbox2, mode,
         aligned, offset));
-  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_FLOAT) {
+  } else {
     KERNEL_CHECK(MLUUnion1BboxOverlapsKernel<<<k_dim, k_type, queue>>>(
         (float *)bbox1, (float *)bbox2, (float *)ious, num_bboxl, num_bbox2,
         mode, aligned, offset));

--- a/bangc-ops/kernels/border_align_backward/border_align_backward_union1.mlu
+++ b/bangc-ops/kernels/border_align_backward/border_align_backward_union1.mlu
@@ -256,7 +256,7 @@ __mlu_global__ void MLUKernelBorderAlignBackward(
 
     /* load boxes:
      *     boxes[n,k,0:4] indicates the information on the bottom left
-     *     and top right points: [lb_x, lb_y, rt_x, rt_y]  
+     *     and top right points: [lb_x, lb_y, rt_x, rt_y]
      */
     __memcpy(nram_boxes, (T *)boxes + n * origin_k * coord_num + k * coord_num,
              coord_num * sizeof(T), GDRAM2NRAM);
@@ -294,7 +294,8 @@ mluOpStatus_t MLUOP_WIN_API KernelBorderAlignBackward(
         (float *)grad_output, (float *)boxes, (int32_t *)argmax_idx, pool_size,
         origin_n, origin_h, origin_w, origin_c, origin_k, (float *)grad_input));
 
-  } else if (data_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     KERNEL_CHECK(MLUKernelBorderAlignBackward<<<k_dim, k_type, queue>>>(
         (half *)grad_output, (half *)boxes, (int32_t *)argmax_idx, pool_size,
         origin_n, origin_h, origin_w, origin_c, origin_k, (half *)grad_input));

--- a/bangc-ops/kernels/border_align_forward/border_align_forward_union1.mlu
+++ b/bangc-ops/kernels/border_align_forward/border_align_forward_union1.mlu
@@ -401,7 +401,8 @@ mluOpStatus_t MLUOP_WIN_API KernelBorderAlignForward(
     KERNEL_CHECK(MLUKernelBorderAlignForward<<<k_dim, k_type, queue>>>(
         (float *)input, (float *)boxes, pool_size, origin_n, origin_h, origin_w,
         origin_c, origin_k, (float *)output, (int32_t *)argmax_idx_nram));
-  } else if (data_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     KERNEL_CHECK(MLUKernelBorderAlignForward<<<k_dim, k_type, queue>>>(
         (half *)input, (half *)boxes, pool_size, origin_n, origin_h, origin_w,
         origin_c, origin_k, (half *)output, (int32_t *)argmax_idx_nram));

--- a/bangc-ops/kernels/kernel.h
+++ b/bangc-ops/kernels/kernel.h
@@ -88,6 +88,11 @@
 #endif  // __BANG_ARCH__
 
 
+#if __BANG_ARCH__ == 372
+#define sizeof(T) (uint32_t(sizeof(T)))
+#endif  // __BANG_ARCH__ == 372
+
+
 #ifndef PAD_UP
 #define PAD_UP(x, y) (((x) / (y) + (int)((x) % (y) > 0)) * (y))
 #endif

--- a/bangc-ops/kernels/log/log.cpp
+++ b/bangc-ops/kernels/log/log.cpp
@@ -76,14 +76,14 @@ mluOpLog(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
   int element_num = mluOpGetTensorElementNum(x_desc);
   if (handle->arch == MLUOP_MLU270) {
     VLOG(5) << "kernel Kernel5StagePipelineLog.";
-    KERNEL_CHECK(
-        (Kernel5StagePipelineLog(k_dim, k_type, handle->queue, x_desc->dtype,
-                                 prefer, x, y, element_num, coef)));
+    CHECK_RETURN("[mluOpLog] ", (Kernel5StagePipelineLog(
+                                    k_dim, k_type, handle->queue, x_desc->dtype,
+                                    prefer, x, y, element_num, coef)));
   } else {
     VLOG(5) << "kernel Kernel3StagePipelineLog.";
-    KERNEL_CHECK(
-        (Kernel3StagePipelineLog(k_dim, k_type, handle->queue, x_desc->dtype,
-                                 prefer, x, y, element_num, coef)));
+    CHECK_RETURN("[mluOpLog] ", (Kernel3StagePipelineLog(
+                                    k_dim, k_type, handle->queue, x_desc->dtype,
+                                    prefer, x, y, element_num, coef)));
   }
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;

--- a/bangc-ops/kernels/log/log.h
+++ b/bangc-ops/kernels/log/log.h
@@ -25,12 +25,12 @@
 
 #include "mlu_op.h"
 
-void MLUOP_WIN_API Kernel3StagePipelineLog(
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLog(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num, float coef);
 
-void MLUOP_WIN_API Kernel5StagePipelineLog(
+mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineLog(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num, float coef);

--- a/bangc-ops/kernels/log/log_block.mlu
+++ b/bangc-ops/kernels/log/log_block.mlu
@@ -175,7 +175,8 @@ mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLog(
     KERNEL_CHECK(
         MLUBlockKernel3StagePipelineLogfloatFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, coef));
-  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     if (prefer == MLUOP_COMPUTATION_FAST) {
       KERNEL_CHECK(
           MLUBlockKernel3StagePipelineLoghalfFast<<<k_dim, k_type, queue>>>(
@@ -198,7 +199,8 @@ mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineLog(
     KERNEL_CHECK(
         MLUBlockKernel5StagePipelineLogfloatFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, coef));
-  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     if (prefer == MLUOP_COMPUTATION_FAST) {
       KERNEL_CHECK(
           MLUBlockKernel5StagePipelineLoghalfFast<<<k_dim, k_type, queue>>>(

--- a/bangc-ops/kernels/log/log_block.mlu
+++ b/bangc-ops/kernels/log/log_block.mlu
@@ -22,10 +22,11 @@
  *************************************************************************/
 #include "log.h"
 
+#include "core/logging.h"
+#include "kernels/debug.h"
+#include "kernels/kernel.h"
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
-#include "kernels/debug.h"
-#include "core/logging.h"
 
 #define LOG_LOW_BOUND 1e-8
 #define LOG_SCALE 1e12
@@ -165,52 +166,48 @@ UNARY_OP_KERNEL_5PIPELINE_IMPLE(Log, float, Fast);
 UNARY_OP_KERNEL_5PIPELINE_IMPLE(Log, half, Fast);
 UNARY_OP_KERNEL_5PIPELINE_IMPLE(Log, half, HighAcc);
 
-void MLUOP_WIN_API Kernel3StagePipelineLog(
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLog(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num, float coef) {
-  switch (d_type) {
-    case MLUOP_DTYPE_FLOAT: {
-      MLUBlockKernel3StagePipelineLogfloatFast<<<k_dim, k_type, queue>>>(
-          (void *)x, (void *)y, num, coef);
-    }; break;
-    case MLUOP_DTYPE_HALF: {
-      if (prefer == MLUOP_COMPUTATION_FAST) {
-        MLUBlockKernel3StagePipelineLoghalfFast<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, coef);
-      } else {
-        MLUBlockKernel3StagePipelineLoghalfHighAcc<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, coef);
-      }
-    }; break;
-    default: {
-      LOG(ERROR) << "Not implemented.";
-      break;
+  // launch kernel
+  if (d_type == mluOpDataType_t::MLUOP_DTYPE_FLOAT) {
+    KERNEL_CHECK(
+        MLUBlockKernel3StagePipelineLogfloatFast<<<k_dim, k_type, queue>>>(
+            (void *)x, (void *)y, num, coef));
+  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+    if (prefer == MLUOP_COMPUTATION_FAST) {
+      KERNEL_CHECK(
+          MLUBlockKernel3StagePipelineLoghalfFast<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, coef));
+    } else {
+      KERNEL_CHECK(
+          MLUBlockKernel3StagePipelineLoghalfHighAcc<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, coef));
     }
   }
+  return MLUOP_STATUS_SUCCESS;
 }
 
-void MLUOP_WIN_API Kernel5StagePipelineLog(
+mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineLog(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num, float coef) {
-  switch (d_type) {
-    case MLUOP_DTYPE_FLOAT: {
-      MLUBlockKernel5StagePipelineLogfloatFast<<<k_dim, k_type, queue>>>(
-          (void *)x, (void *)y, num, coef);
-    }; break;
-    case MLUOP_DTYPE_HALF: {
-      if (prefer == MLUOP_COMPUTATION_FAST) {
-        MLUBlockKernel5StagePipelineLoghalfFast<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, coef);
-      } else {
-        MLUBlockKernel5StagePipelineLoghalfHighAcc<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, coef);
-      }
-    }; break;
-    default: {
-      LOG(ERROR) << "Not implemented.";
-      break;
+  // launch kernel
+  if (d_type == mluOpDataType_t::MLUOP_DTYPE_FLOAT) {
+    KERNEL_CHECK(
+        MLUBlockKernel5StagePipelineLogfloatFast<<<k_dim, k_type, queue>>>(
+            (void *)x, (void *)y, num, coef));
+  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+    if (prefer == MLUOP_COMPUTATION_FAST) {
+      KERNEL_CHECK(
+          MLUBlockKernel5StagePipelineLoghalfFast<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, coef));
+    } else {
+      KERNEL_CHECK(
+          MLUBlockKernel5StagePipelineLoghalfHighAcc<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, coef));
     }
   }
+  return MLUOP_STATUS_SUCCESS;
 }

--- a/bangc-ops/kernels/sqrt/sqrt.cpp
+++ b/bangc-ops/kernels/sqrt/sqrt.cpp
@@ -67,14 +67,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrt(mluOpHandle_t handle,
   int element_num = mluOpGetTensorElementNum(x_desc);
   if (handle->arch == MLUOP_MLU270) {
     VLOG(5) << "kernel Kernel5StagePipelineSqrt.";
-    KERNEL_CHECK(
-        (Kernel5StagePipelineSqrt(k_dim, k_type, handle->queue, x_desc->dtype,
-                                  prefer, x, y, element_num)));
+    CHECK_RETURN("[mluOpSqrt] ", Kernel5StagePipelineSqrt(
+                                     k_dim, k_type, handle->queue,
+                                     x_desc->dtype, prefer, x, y, element_num));
   } else {
     VLOG(5) << "kernel Kernel3StagePipelineSqrt.";
-    KERNEL_CHECK(
-        (Kernel3StagePipelineSqrt(k_dim, k_type, handle->queue, x_desc->dtype,
-                                  prefer, x, y, element_num)));
+    CHECK_RETURN("[mluOpSqrt] ", Kernel3StagePipelineSqrt(
+                                     k_dim, k_type, handle->queue,
+                                     x_desc->dtype, prefer, x, y, element_num));
   }
 
   GEN_CASE_END();
@@ -113,9 +113,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(
 
   int num_elem = mluOpGetTensorElementNum(y_desc);
   VLOG(5) << "Kernel Kernel3StagePipelineSqrtBackward.";
-  KERNEL_CHECK((Kernel3StagePipelineSqrtBackward(k_dim, k_type, handle->queue,
-                                                 y_desc->dtype, y, diff_y,
-                                                 diff_x, num_elem)));
+  CHECK_RETURN("[mluOpSqrtBackward] ",
+               Kernel3StagePipelineSqrtBackward(k_dim, k_type, handle->queue,
+                                                y_desc->dtype, y, diff_y,
+                                                diff_x, num_elem));
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }

--- a/bangc-ops/kernels/sqrt/sqrt.h
+++ b/bangc-ops/kernels/sqrt/sqrt.h
@@ -25,17 +25,17 @@
 
 #include "mlu_op.h"
 
-void MLUOP_WIN_API Kernel3StagePipelineSqrt(
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineSqrt(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num);
 
-void MLUOP_WIN_API Kernel5StagePipelineSqrt(
+mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineSqrt(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num);
 
-void MLUOP_WIN_API Kernel3StagePipelineSqrtBackward(
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineSqrtBackward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const void *y, const void *diff_y, void *x,
     int num);

--- a/bangc-ops/kernels/sqrt/sqrt_block.mlu
+++ b/bangc-ops/kernels/sqrt/sqrt_block.mlu
@@ -234,7 +234,8 @@ mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineSqrt(
     KERNEL_CHECK(
         MLUBlockKernel3StagePipelineSqrtfloatFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, 0.0));
-  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     if (prefer == MLUOP_COMPUTATION_FAST) {
       KERNEL_CHECK(
           MLUBlockKernel3StagePipelineSqrthalfFast<<<k_dim, k_type, queue>>>(
@@ -257,7 +258,8 @@ mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineSqrt(
     KERNEL_CHECK(
         MLUBlockKernel5StagePipelineSqrtfloatFast<<<k_dim, k_type, queue>>>(
             (void *)x, (void *)y, num, 0.0));
-  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     if (prefer == MLUOP_COMPUTATION_FAST) {
       KERNEL_CHECK(
           MLUBlockKernel5StagePipelineSqrthalfFast<<<k_dim, k_type, queue>>>(
@@ -281,7 +283,8 @@ mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineSqrtBackward(
         MLUBlockKernel3StagePipelineSqrtBackwardfloatFast<<<k_dim, k_type,
                                                             queue>>>(
             (void *)y, (void *)diff_y, (void *)x, num));
-  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+  } else {
+    // half
     KERNEL_CHECK(
         MLUBlockKernel3StagePipelineSqrtBackwardhalfHighAcc<<<k_dim, k_type,
                                                               queue>>>(

--- a/bangc-ops/kernels/sqrt/sqrt_block.mlu
+++ b/bangc-ops/kernels/sqrt/sqrt_block.mlu
@@ -22,11 +22,11 @@
  *************************************************************************/
 #include "sqrt.h"
 
+#include "core/logging.h"
 #include "kernels/binary_op/binary_op_3pipeline.h"
+#include "kernels/debug.h"
 #include "kernels/unary_op/unary_op_3pipeline.h"
 #include "kernels/unary_op/unary_op_5pipeline.h"
-#include "kernels/debug.h"
-#include "core/logging.h"
 
 #define SQRT_HIGH_BOUND 1e4
 #define SQRT_SCALE 1e-6
@@ -225,74 +225,67 @@ UNARY_OP_KERNEL_5PIPELINE_IMPLE(Sqrt, half, HighAcc);
 BINARY_OP_3PIPELINE_IMPLE(SqrtBackward, float, Fast);
 BINARY_OP_3PIPELINE_IMPLE(SqrtBackward, half, HighAcc);
 
-void MLUOP_WIN_API Kernel3StagePipelineSqrt(
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineSqrt(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num) {
-  switch (d_type) {
-    case MLUOP_DTYPE_FLOAT: {
-      MLUBlockKernel3StagePipelineSqrtfloatFast<<<k_dim, k_type, queue>>>(
-          (void *)x, (void *)y, num, 0.0);
-    }; break;
-    case MLUOP_DTYPE_HALF: {
-      if (prefer == MLUOP_COMPUTATION_FAST) {
-        MLUBlockKernel3StagePipelineSqrthalfFast<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, 0.0);
-      } else {
-        MLUBlockKernel3StagePipelineSqrthalfHighAcc<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, 0.0);
-      }
-    }; break;
-    default: {
-      LOG(ERROR) << "Not implemented.";
-      break;
+  // launch kernel
+  if (d_type == mluOpDataType_t::MLUOP_DTYPE_FLOAT) {
+    KERNEL_CHECK(
+        MLUBlockKernel3StagePipelineSqrtfloatFast<<<k_dim, k_type, queue>>>(
+            (void *)x, (void *)y, num, 0.0));
+  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+    if (prefer == MLUOP_COMPUTATION_FAST) {
+      KERNEL_CHECK(
+          MLUBlockKernel3StagePipelineSqrthalfFast<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, 0.0));
+    } else {
+      KERNEL_CHECK(
+          MLUBlockKernel3StagePipelineSqrthalfHighAcc<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, 0.0));
     }
   }
+  return MLUOP_STATUS_SUCCESS;
 }
 
-void MLUOP_WIN_API Kernel5StagePipelineSqrt(
+mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineSqrt(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, int num) {
-  switch (d_type) {
-    case MLUOP_DTYPE_FLOAT: {
-      MLUBlockKernel5StagePipelineSqrtfloatFast<<<k_dim, k_type, queue>>>(
-          (void *)x, (void *)y, num, 0.0);
-    }; break;
-    case MLUOP_DTYPE_HALF: {
-      if (prefer == MLUOP_COMPUTATION_FAST) {
-        MLUBlockKernel5StagePipelineSqrthalfFast<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, 0.0);
-      } else {
-        MLUBlockKernel5StagePipelineSqrthalfHighAcc<<<k_dim, k_type, queue>>>(
-            (void *)x, (void *)y, num, 0.0);
-      }
-    }; break;
-    default: {
-      LOG(ERROR) << "Not implemented.";
-      break;
+  // launch kernel
+  if (d_type == mluOpDataType_t::MLUOP_DTYPE_FLOAT) {
+    KERNEL_CHECK(
+        MLUBlockKernel5StagePipelineSqrtfloatFast<<<k_dim, k_type, queue>>>(
+            (void *)x, (void *)y, num, 0.0));
+  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+    if (prefer == MLUOP_COMPUTATION_FAST) {
+      KERNEL_CHECK(
+          MLUBlockKernel5StagePipelineSqrthalfFast<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, 0.0));
+    } else {
+      KERNEL_CHECK(
+          MLUBlockKernel5StagePipelineSqrthalfHighAcc<<<k_dim, k_type, queue>>>(
+              (void *)x, (void *)y, num, 0.0));
     }
   }
+  return MLUOP_STATUS_SUCCESS;
 }
 
-void MLUOP_WIN_API Kernel3StagePipelineSqrtBackward(
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineSqrtBackward(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     mluOpDataType_t d_type, const void *y, const void *diff_y, void *x,
     int num) {
-  switch (d_type) {
-    case MLUOP_DTYPE_FLOAT: {
-      MLUBlockKernel3StagePipelineSqrtBackwardfloatFast<<<k_dim, k_type,
-                                                          queue>>>(
-          (void *)y, (void *)diff_y, (void *)x, num);
-    }; break;
-    case MLUOP_DTYPE_HALF: {
-      MLUBlockKernel3StagePipelineSqrtBackwardhalfHighAcc<<<k_dim, k_type,
+  // launch kernel
+  if (d_type == mluOpDataType_t::MLUOP_DTYPE_FLOAT) {
+    KERNEL_CHECK(
+        MLUBlockKernel3StagePipelineSqrtBackwardfloatFast<<<k_dim, k_type,
                                                             queue>>>(
-          (void *)y, (void *)diff_y, (void *)x, num);
-    }; break;
-    default: {
-      LOG(ERROR) << "Not implemented.";
-      break;
-    }
+            (void *)y, (void *)diff_y, (void *)x, num));
+  } else if (d_type == mluOpDataType_t::MLUOP_DTYPE_HALF) {
+    KERNEL_CHECK(
+        MLUBlockKernel3StagePipelineSqrtBackwardhalfHighAcc<<<k_dim, k_type,
+                                                              queue>>>(
+            (void *)y, (void *)diff_y, (void *)x, num));
   }
+  return MLUOP_STATUS_SUCCESS;
 }

--- a/bangc-ops/kernels/utils/common.h
+++ b/bangc-ops/kernels/utils/common.h
@@ -239,7 +239,7 @@ __mlu_func__ void __mluop_exp(T *nram_dst, T *nram_src, void *nram_addition,
 }
 
 /******************************************************************************
- * CNNL FUNC: __mluop_log
+ * MLUOPS FUNC: __mluop_log
  * param 'nram_dst' is the nram destination address, which supports half or
  * float data type.
  * param 'nram_src' is the nram source address, which has the same data type


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

	modified:   bangc-ops/kernels/abs/abs_block.mlu
	modified:   bangc-ops/kernels/kernel.h
	modified:   bangc-ops/kernels/log/log.cpp
	modified:   bangc-ops/kernels/log/log.h
	modified:   bangc-ops/kernels/log/log_block.mlu
	modified:   bangc-ops/kernels/sqrt/sqrt.cpp
	modified:   bangc-ops/kernels/sqrt/sqrt.h
	modified:   bangc-ops/kernels/sqrt/sqrt_block.mlu
	modified:   bangc-ops/kernels/utils/common.h

## 3. Test Report

370 & 590 all，--mode op --ops sqrt,log,abs --ops_limit_ratio 1 --limit_num 10
All pass


