### PR TITLE
[Feature](bangc-ops): add roi_pooling_forward op

### DIFF
--- a/bangc-ops/kernels/kernel_wrapper/wrapper.h
+++ b/bangc-ops/kernels/kernel_wrapper/wrapper.h
@@ -92,8 +92,7 @@
     const mluOpTensorDescriptor_t, void *, const mluOpTensorDescriptor_t,     \
     void *, const mluOpTensorDescriptor_t, void *
 
-
-#define NMS_PARAM_TYPE                                                     \
+#define NMS_PARAM_TYPE                                                        \
     mluOpHandle_t, const mluOpNmsDescriptor_t,                                \
     const mluOpTensorDescriptor_t, const void *,                              \
     const mluOpTensorDescriptor_t, const void *,                              \
@@ -176,6 +175,18 @@
     const mluOpTensorDescriptor_t,                                            \
     void *
 
+#define ROIPOOLINGFORWARD_PARAM_TYPE                                          \
+    mluOpHandle_t,                                                            \
+    mluOpPoolingMode_t,                                                       \
+    const mluOpTensorDescriptor_t,                                            \
+    const void *,                                                             \
+    const mluOpTensorDescriptor_t,                                            \
+    const void *,                                                             \
+    float,                                                                    \
+    const mluOpTensorDescriptor_t,                                            \
+    void *,                                                                   \
+    int *
+
 /* Kernel register */
 KERNEL_REGISTER(addN, ADDN_PARAM_TYPE);
 KERNEL_REGISTER(addNV2, ADDNV2_PARAM_TYPE);
@@ -199,4 +210,5 @@ KERNEL_REGISTER(nms, NMS_PARAM_TYPE);
 KERNEL_REGISTER(reduce, REDUCE_PARAM_TYPE);
 KERNEL_REGISTER(RoiAlignBackward, ROIALIGNBACKWARD_PARAM_TYPE);
 KERNEL_REGISTER(RoiAlignBackwardV2, ROIALIGNBACKWARD_V2_PARAM_TYPE);
+KERNEL_REGISTER(RoiPoolingForward, ROIPOOLINGFORWARD_PARAM_TYPE);
 #endif  // KERNELS_KERNEL_WRAPPER_WRAPPER_H

--- a/bangc-ops/kernels/kernel_wrapper/wrapper.h
+++ b/bangc-ops/kernels/kernel_wrapper/wrapper.h
@@ -92,7 +92,8 @@
     const mluOpTensorDescriptor_t, void *, const mluOpTensorDescriptor_t,     \
     void *, const mluOpTensorDescriptor_t, void *
 
-#define NMS_PARAM_TYPE                                                        \
+
+#define NMS_PARAM_TYPE                                                     \
     mluOpHandle_t, const mluOpNmsDescriptor_t,                                \
     const mluOpTensorDescriptor_t, const void *,                              \
     const mluOpTensorDescriptor_t, const void *,                              \

--- a/bangc-ops/kernels/roi_pooling_forward/roi_pooling_forward.cpp
+++ b/bangc-ops/kernels/roi_pooling_forward/roi_pooling_forward.cpp
@@ -1,0 +1,42 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "kernels/kernel_wrapper/wrapper.h"
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpRoiPoolingForward(mluOpHandle_t handle,
+                       mluOpPoolingMode_t pooling_mode,
+                       const mluOpTensorDescriptor_t input_desc,
+                       const void *input,
+                       const mluOpTensorDescriptor_t rois_desc,
+                       const void *rois,
+                       float spatial_scale,
+                       const mluOpTensorDescriptor_t output_desc,
+                       void *output,
+                       int *argmax) {
+  RoiPoolingForwardWrapper wrapper;
+  mluOpStatus_t ret = wrapper.invoke(handle, pooling_mode, input_desc, input,
+                                     rois_desc, rois, spatial_scale,
+                                     output_desc, output, argmax);
+  return ret;
+}
+

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -28,7 +28,7 @@
  ******************************************************************************/
 
 #define MLUOP_MAJOR 0
-#define MLUOP_MINOR 7
+#define MLUOP_MINOR 8
 #define MLUOP_PATCHLEVEL 0
 
 #define MLUOP_DIM_MAX 8
@@ -2794,7 +2794,7 @@ mluOpGetTensorAndDataFromTensorSet(mluOpTensorSetDescriptor_t tensorSetDesc,
  * @param[out] y
  * Pointer to the MLU memory that stores the output tensor.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The date types of input tensor and output tensor should be the same.
@@ -3276,7 +3276,8 @@ mluOpDestroyCarafeDescriptor(mluOpCarafeDescriptor_t carafe_desc);
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of \b input, \b mask and \b output tensors must be the same.
@@ -3391,7 +3392,8 @@ mluOpCarafeForward(mluOpHandle_t handle,
  * @param[out] grad_mask
  * Pointer to the MLU memory that stores the gradient with respect to \b mask.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of \b input tensor, \b mask tensor, \b grad_output tensor, \b grad_input tensor, and \b grad_mask
@@ -3551,7 +3553,7 @@ mluOpDiv(mluOpHandle_t handle,
  * A host pointer to the returned size of extra space in bytes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - None.
@@ -3638,8 +3640,9 @@ mluOpGetDynamicPointToVoxelBackwardWorkspaceSize(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradient with respect to \b feats.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS,        ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH,  ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_INTERNAL_ERROR, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -3722,7 +3725,7 @@ mluOpDynamicPointToVoxelBackward(const mluOpHandle_t handle,
  * A host pointer to the returned size of extra space in bytes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - None.
@@ -3804,7 +3807,7 @@ mluOpGetDynamicPointToVoxelForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -3877,7 +3880,7 @@ mluOpDynamicPointToVoxelForward(const mluOpHandle_t handle,
  * A host pointer to the returned size of extra space in bytes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - None.
@@ -3988,7 +3991,7 @@ mluOpGetGenerateProposalsV2WorkspaceSize(mluOpHandle_t handle, const mluOpTensor
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4139,7 +4142,7 @@ mluOpGetPolyNmsWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescriptor_t
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4235,7 +4238,7 @@ mluOpCreateNmsDescriptor(mluOpNmsDescriptor_t *desc);
  * The Nms descriptor to be destroyed.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @note
  * - None
@@ -4382,7 +4385,9 @@ mluOpSetNmsDescriptor(mluOpNmsDescriptor_t nms_desc,
  * Pointer to the MLU memory that stores the number of output boxes.
  *
  * @par Returns
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported combinations of data types for input and output tensors are as follows:
@@ -4568,7 +4573,7 @@ mluOpGetNmsWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4704,7 +4709,8 @@ mluOpPriorBox(mluOpHandle_t handle,
  * \b mapping_channel is [rois[0], pooled_height, pooled_width, output_dim].
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4805,7 +4811,8 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the bottom_grad tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -5033,7 +5040,7 @@ mluOpSetRoiAlignForwardDescriptor_v2(mluOpRoiAlignForwardDescriptor_t roialign_d
  * The RoiAlign descriptor to be destroyed.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - None.
@@ -5094,7 +5101,8 @@ mluOpDestroyRoiAlignForwardDescriptor(mluOpRoiAlignForwardDescriptor_t desc);
  * Pointer to the MLU memory that stores \b output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data type of all tensors should be the same.
@@ -5197,7 +5205,8 @@ mluOpRoiAlignForward(mluOpHandle_t handle,
  * average pooling mode, \b argmax_y is NULL.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5318,7 +5327,7 @@ mluOpRoiAlignForward_v2(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5429,7 +5438,7 @@ mluOpRoiAlignRotatedForward(mluOpHandle_t handle,
  * bottom_grad is [batch_num, H, W, C].
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5524,7 +5533,8 @@ mluOpRoiAlignRotatedBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of input tensors and output tensor must be the same.
@@ -5601,7 +5611,8 @@ mluOpRoiCropForward(mluOpHandle_t handle,
  * original images.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors must be the same.
@@ -5680,7 +5691,8 @@ mluOpRoiCropBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5770,7 +5782,8 @@ mluOpRotatedFeatureAlignForward(const mluOpHandle_t handle_,
  * Pointer to the MLU memory that stores the bottom_input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5845,7 +5858,7 @@ mluOpRotatedFeatureAlignBackward(const mluOpHandle_t handle_,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of input tensor and output tensor should be the same.
@@ -5909,7 +5922,7 @@ mluOpSqrt(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of input tensors and output tensor must be the same.
@@ -6096,7 +6109,7 @@ mluOpGetVoxelizationWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -6200,7 +6213,7 @@ mluOpVoxelization(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of input and output tensors must be the same.
@@ -6301,7 +6314,7 @@ mluOpYoloBox(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -6404,7 +6417,8 @@ mluOpVoxelPoolingForward(mluOpHandle_t handle,
  * memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - By the order of \b bbox1 - \b bbox2 - \b ious, the supported data types of
@@ -6525,7 +6539,8 @@ mluOpGetNmsRotatedWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescripto
  * Pointer to the MLU memory that stores the number of output boxes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - By the order of \b boxes - \b scores - \b output, the supported data types of
@@ -6600,7 +6615,7 @@ mluOpNmsRotated(mluOpHandle_t handle,
  * IOU or IOF. Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - By the order of \b bbox1 - \b bbox2 - \b ious, the supported data types of
@@ -6718,7 +6733,7 @@ mluOpBboxOverlaps(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *  ::MLUOP_STATUS_NOT_SUPPORTED
+ *  ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of features tensor, weights tensor and output tensor should be the same.
@@ -6811,7 +6826,7 @@ mluOpThreeInterpolateForward(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of grad_output tensor, weights tensor and grad_features tensor should be the same.
@@ -6900,7 +6915,7 @@ mluOpThreeInterpolateBackward(mluOpHandle_t handle,
  * nsample: the number of points selected in the sphere.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of new_xyz and xyz must be the same.
@@ -7315,7 +7330,8 @@ mluOpFill_v3(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input tensors \b input, \b target, \b weight , and output
@@ -7428,7 +7444,8 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b grad_input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input tensor \b input, \b target, \b weight , and output
@@ -7594,7 +7611,8 @@ mluOpGetMaskedIm2colForwardWorkspaceSize(mluOpHandle_t handle,
  * based on mask coordinates. The mask area out of the tensor \b feature is padded with 0.
  *
  * @par Return
- * - MLUOP_STATUS_SUCCESS, MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - This function supports the following data types for tensor \b feature, tensor \b mask_h_idx,
@@ -7615,7 +7633,7 @@ mluOpGetMaskedIm2colForwardWorkspaceSize(mluOpHandle_t handle,
  * @par Scale Limitation
  * - The tensor \b mask_h_idx must be 1D.
  * - The tensor \b mask_w_idx must be 1D.
- * - The tensor \b data_col must be 3D.
+ * - The tensor \b data_col must be 2D.
  * - The sizes of the highest dimension of tensor \b feature must be 1.
  * - The sizes of the lowest dimension of tensor \b data_col, the element number of tensor \b mask_h_idx, and
  *   the element number of tensor \b mask_w_idx must be the same.
@@ -7708,7 +7726,8 @@ mluOpMaskedIm2colForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b grad_input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -7827,7 +7846,8 @@ mluOpMoeDispatchBackwardData(mluOpHandle_t handle,
  * @param[out] grad_attn_weight
  * Pointer to the MLU memory that stores the gradient of \b attn_weight tensor.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -7999,7 +8019,8 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b py_grad.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8174,7 +8195,8 @@ mluOpGetMutualInformationForwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b ans.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8345,7 +8367,7 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8445,7 +8467,7 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8519,7 +8541,8 @@ mluOpRoiawarePool3dBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the data of output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8597,7 +8620,8 @@ mluOpPsamaskForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradient of input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -10385,7 +10409,7 @@ mluOpGetIndicePairsWorkspaceSize(mluOpHandle_t handle,
  * the transpose operation.
  *
  * @par Return
- *  ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ALLOC_FAILED, ::MLUOP_STATUS_INTERNAL_ERROR
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ALLOC_FAILED, ::MLUOP_STATUS_INTERNAL_ERROR
  *
  * @par Data Type
  * - None.
@@ -11242,7 +11266,8 @@ mluOpGetActiveRotatedFilterForwardWorkspaceSize(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of input tensor and output tensor should be the same.
@@ -11339,7 +11364,8 @@ mluOpActiveRotatedFilterForward(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -11456,7 +11482,8 @@ mluOpDeformRoiPoolForward(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradient of the offset tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tentors are as follows:
@@ -11528,28 +11555,32 @@ mluOpDeformRoiPoolBackward(const mluOpHandle_t handle,
 
 // Group:BorderAlign
 /*!
- * @brief Extracts the border features of \b input based on the bounding boxes to compute the
- * maximum border features of \b input with the maximum pooling.
+ * @brief Extracts the border features of \b input based on the bounding boxes
+ * to compute the maximum border features of \b input with the maximum pooling.
  * The computing process of this operation is as follows:
- *  1. For each border line of each box (commonly four lines: top, left, bottom and right lines), uniformly samples
- *     pool_size + 1 positions on this line, involving the starting point and endpoint.
+ *  1. For each border line of each box (commonly four lines: top, left, bottom
+ *     and right lines), uniformly samples pool_size + 1 positions on this line,
+ *     involving the starting point and endpoint.
  *  2. Compute the corresponding features on these points by bilinear interpolation.
- *  3. Perform the max pooling over all pool_size + 1 positions to output the pooled features.
+ *  3. Perform the max pooling over all pool_size + 1 positions to output the
+ *     pooled features.
  *
  * @param[in] handle
- * Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in
- * ::mluOpBorderAlignForward operation. For detailed information, see ::mluOPHandle_t.
+ * Handle to a Cambricon MLUOP context that is used to manage MLU devices and
+ * queues in ::mluOpBorderAlignForward operation. For detailed information,
+ * see ::mluOPHandle_t.
  * @param[in] input_desc
  * The descriptor of the input tensor.
  * @param[in] input
- * Pointer to the MLU memory that stores the input tensor. The shape of \b input is [N, H, W, 4C].
- * Channels ranged in [0,C), [C,2C), [2C,3C), [3C,4C) represent the top, left, bottom and right features
- * respectively.
+ * Pointer to the MLU memory that stores the input tensor. The shape of \b input
+ * is [N, H, W, 4C]. Channels ranged in [0,C), [C,2C), [2C,3C), [3C,4C) represent
+ * the top, left, bottom and right features respectively.
  * @param[in] boxes_desc
  * Descriptor of bounding box tensor.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] boxes
- * Pointer to the MLU memory that stores boxes tensors. The shape of \b boxes is [N, H * W, 4].
+ * Pointer to the MLU memory that stores boxes tensors. The shape of \b boxes is
+ * [N, H * W, 4].
  * @param[in] pool_size
  * Number of positions sampled over the boxes' borders.
  * @param[in] output_desc
@@ -11558,41 +11589,42 @@ mluOpDeformRoiPoolBackward(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor. The shape of
  * argmax_idx is [N, H * W, 4, C].
  * @param[in] argmax_idx_desc
- * Descriptor of \b argmax_idx, containing dimension and the layout of \b argmax_idx.
+ * Descriptor of \b argmax_idx, containing dimension and the layout of \b argmax_idx .
  * @param[out] argmax_idx
- * Pointer to the MLU memory that stores the \b argmax_idx tensor, which is the indices of
- * maximum values after the max pooling. The shape of \b argmax_idx is [N, H * W, 4, C].
+ * Pointer to the MLU memory that stores the \b argmax_idx tensor, which is the
+ * indices of maximum values after the max pooling. The shape of \b argmax_idx
+ * is [N, H * W, 4, C].
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM.
- *
- * @par Formula
- * - See "BorderAlignForward Operator" section in "Cambricon BANG C OPS User Guide" for details.
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
- * - This function supports the following data types for input tensor \b input, \b boxes, \b pool_size,
- *    \b output and \b argmax_idx. Data type of the \b input, \b boxes, and \b output tensors must be the same.
- *   - input tensor: half, float.
- *   - boxes tensor: half, float.
- *   - pool_size: int32_t.
- *   - output tensor: half, float.
- *   - argmax_idx: int32_t.
+ * - The supported data types of input and output tensors are as follows:
+ *   - input tensor: half, float
+ *   - boxes tensor: half, float
+ *   - output tensor: half, float
+ *   - argmax_idx tensor: int32_t
+ *   <b>Note that the data type of \b input , \b boxes , and \b output
+ *   must be the same.
  *
  * @par Data Layout
- * - The supported data layout of \b input, \b boxes, \b output, and \b argmax_idx are as follows:
- *   - input tensor: \p MLUOP_LAYOUT_NHWC.
- *   - boxes tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - output tensor: \p MLUOP_LAYOUT_NHWC.
- *   - argmax_idx tensor: \p MLUOP_LAYOUT_NHWC.
+ * - The supported data layout of \b input , \b boxes , \b output , and
+ *   \b argmax_idx are as follows:
+ *   - input tensor: \p MLUOP_LAYOUT_NHWC
+ *   - boxes tensor: \p MLUOP_LAYOUT_ARRAY
+ *   - output tensor: \p MLUOP_LAYOUT_NHWC
+ *   - argmax_idx tensor: \p MLUOP_LAYOUT_NHWC
  *
  * @par Scale Limitation
- * - The \b input, \b output and \b argmax_idx must be 4D.
- * - The \b boxes tensor must be 3D array, and the highest dimension of \b boxes must be 4.
+ * - The \b input, \b output and \b argmax_idx are 4D tensor.
+ * - The \b boxes tensor is 3D tensor.
+ * - The dims[3] of \b boxes should be equal to 4.
  *
  * @par API Dependency
  * - None.
  *
- * @note
+ * @par Note
  * - None.
  *
  * @par Example
@@ -11673,81 +11705,74 @@ mluOpBorderAlignForward(mluOpHandle_t handle,
 // Group:BorderAlign
 /*!
  * @brief Computes the gradient of the input tensor of ::mluOpBorderAlignForward
- * according to the output gradient \b grad_output, the maximum pooling index \b
- * argmax_idx and bounding boxes \b boxes.
+ * according to the output gradient \b grad_output , the maximum pooling index \b
+ * argmax_idx and bounding boxes \b boxes .
  *
  * @param[in] handle
- * Handle to an MLUOPS context that is used to manage MLU devices and
- * queues in ::mluOpBorderAlignBackward operation. For detailed information, see
+ * Handle to an MLUOPS context that is used to manage MLU devices and queues
+ * in ::mluOpBorderAlignBackward operation. For detailed information, see
  * ::mluOpHandle_t.
  * @param[in] grad_output_desc
  * The descriptor of the \b grad_output tensor.
  * @param[in] grad_output
- * Pointer to the MLU memory that stores the output gradient of
- * ::mluOpBorderAlignForward.
- * The shape of \b grad_output is [N, K, 4, C], where N is the number of
- * images, K is the product of
- * the width of images and the height of images, and C is the number of image
- * channels.
+ * Pointer to the MLU memory that stores the output gradient of ::mluOpBorderAlignForward.
+ * The shape of \b grad_output is [N, K, 4, C], where N is the number of images,
+ * K is the product of the width of images and the height of images, and C is the
+ * number of image channels.
  * @param[in] boxes_desc
- * Descriptor of bounding box tensor.
- * For detailed information, see ::mluOpTensorDescriptor_t.
+ * Descriptor of bounding box tensor. For detailed information,
+ * see ::mluOpTensorDescriptor_t.
  * @param[in] boxes
- * Pointer to the MLU memory that stores \b boxes tensors. The shape of
- * \b boxes is [N, H * W, 4].
+ * Pointer to the MLU memory that stores \b boxes tensors. The shape of \b boxes is
+ * [N, H * W, 4].
  * @param[in] argmax_idx_desc
- * Descriptor of \b argmax_idx, containing dimension and the layout of
- * \b argmax_idx.
+ * Descriptor of \b argmax_idx , containing dimension and the layout of \b argmax_idx .
  * @param[in] argmax_idx
- * Pointer to the MLU memory that stores the \b argmax_idx tensor,
- * which is the result of
- * max pooling index. The shape of argmax_idx is [N, K, 4, C].
+ * Pointer to the MLU memory that stores the \b argmax_idx tensor, which is the result
+ * of max pooling index. The shape of argmax_idx is [N, K, 4, C].
  * @param[in] pool_size
  * Number of positions sampled over the boxes borders.
  * @param[in] grad_input_desc
- * Descriptor of \b grad_input, containing dimension and the layout of
- * output.
+ * Descriptor of \b grad_input , containing dimension and the layout of output.
  * @param[out] grad_input
  * Pointer to the MLU memory that stores the gradient of the input
- * tensor of ::mluOpBorderAlignForward.The shape of \b grad_input is [N, H, W, 4C], where
- * N is the number of images, H is the height of images, W is the width of images,
- * and C is the number of image channels.
+ * tensor of ::mluOpBorderAlignForward.The shape of \b grad_input is [N, H, W, 4C],
+ * where N is the number of images, H is the height of images, W is the width of
+ * images, and C is the number of image channels.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM.
- *
- * @par Formula
- * - See "BorderAlignBackward Operator" section in "Cambricon BANG C OPS User Guide"
- * for details.
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
- * - This function supports the following data types for \b grad_output, \b
- * boxes, \b argmax_idx, \b pool_size and \b grad_input. Data types of the \b grad_output, \b boxes,
- * and \b grad_input tensors should be the same.
- *  - grad_output tensor: half, float.
- *  - boxes tensor: half, float.
- *  - argmax_idx: int32_t.
- *  - pool_size: int32_t.
- *  - grad_input tensor: half, float.
+ * - The supported data types of input and output tensors are as follows:
+ *   - grad_output tensor: half, float
+ *   - boxes tensor: half, float
+ *   - argmax_idx tensor: int32_t
+ *   - grad_input tensor: half, float
+ *   <b>Note that the data type of \b grad_output , \b boxes , and \b grad_input
+ *   must be the same.
  *
  * @par Data Layout
- * - The supported data layout of \b grad_output, \b boxes, \b argmax_idx and,
- \b grad_input are as follows:
- *   - grad_output tensor: \p MLUOP_LAYOUT_NHWC.
- *   - boxes tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - argmax_idx tensor: \p MLUOP_LAYOUT_NHWC.
- *   - grad_input tensor: \p MLUOP_LAYOUT_NHWC.
+ * - The supported data layout of \b grad_output , \b boxes , \b argmax_idx and,
+ *   \b grad_input are as follows:
+ *   - grad_output tensor: \p MLUOP_LAYOUT_NHWC
+ *   - boxes tensor: \p MLUOP_LAYOUT_ARRAY
+ *   - argmax_idx tensor: \p MLUOP_LAYOUT_NHWC
+ *   - grad_input tensor: \p MLUOP_LAYOUT_NHWC
+ *
  * @par Scale Limitation
- * - The \b grad_output, \b argmax_idx and \b grad_input should be 4D.
- * - The tensor \b boxes must be 3D array, and the highest dimension of \b
- * boxes must be 4.
+ * - The \b grad_output , \b argmax_idx and \b grad_input are 4D tensor.
+ * - The \b boxes is 3D tensor.
+ * - The dims[3] of \b boxes should be equal to 4.
+ * - The shape of \b grad_output and \b argmax_idx must be the same.
+ * - The value of \b argmax_idx should be in the range of [0, pool_size].
  *
  * @par API Dependency
  * - None.
  *
- * @note
- * - The inputs \b grad_output and \b boxes with NaN or infinity are not
- * supported.
+ * @par Note
+ * - None.
  *
  * @par Example
      @verbatim
@@ -11951,7 +11976,7 @@ mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_INTERNAL_ERROR
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -12338,7 +12363,8 @@ mluOpGetRoiPointPool3dWorkspaceSize(mluOpHandle_t handle,
  * @param[out] pooled_empty_flag
  * Pointer to the MLU memory that stores the second output tensor.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types for input and output are as follows:
@@ -12464,7 +12490,8 @@ mluOpGetThreeNNForwardWorkspaceSize(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b idx tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types for unknown tensor \b unknown, known tensor \b known, dist2
@@ -12750,7 +12777,8 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b dispatch tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - This function supports the following data types for input tensors \b gates , \b indices ,
@@ -12908,7 +12936,7 @@ mluOpGetMoeDispatchBackwardGateWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13002,7 +13030,7 @@ mluOpMoeDispatchBackwardGate(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b points_indices tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13071,7 +13099,8 @@ mluOpPointsInBoxes(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradients tensor of the original images.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -13189,7 +13218,8 @@ mluOpRoiAlignBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b grads_image tensor .
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -13311,7 +13341,8 @@ mluOpRoiAlignBackward_v2(mluOpHandle_t handle,
  * @param[out] data_col
  * Pointer to the MLU memory that stores the output deformable attention feature.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13374,7 +13405,8 @@ mluOpMsDeformAttnForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b grad_input.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13387,7 +13419,7 @@ mluOpMsDeformAttnForward(mluOpHandle_t handle,
  *
  * @par Scale Limitation
  * - The first dimension of tensor \b grad_output and tensor \b shifts must be the same size.
- * - The second dimension of tensor \b grad_output  must be multiple of the second dimension of tensor \b shifts.
+ * - The third dimension of tensor \b grad_output must be multiple of the second dimension of tensor \b shifts.
  *   For example, if the shape of \b grad_output is [N, T, C, HW], the shape of \b shifts is [N, G],
  *   C must be a multiple of G, and C and G cannot be zero.
  *
@@ -13437,7 +13469,8 @@ mluOpTinShiftBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b output.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13450,7 +13483,7 @@ mluOpTinShiftBackward(mluOpHandle_t handle,
  *
  * @par Scale Limitation
  * - The first dimension of tensor \b input and tensor \b shifts must be the same size.
- * - The second dimension of tensor \b input must be multiple of the second dimension of tensor \b shifts.
+ * - The third dimension of tensor \b input must be multiple of the second dimension of tensor \b shifts.
  *   For example, if the shape of \b input is [N, T, C, HW], the shape of \b shifts is [N, G],
  *   C must be a multiple of G, and C and G cannot be zero.
  *
@@ -13563,7 +13596,8 @@ mluOpGetMaskedCol2imForwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b im tensor that is the data copied from \b col tensor.
  *
  * @par Return
- * - MLUOP_STATUS_SUCCESS, MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
+ *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - This function supports the following data types for \b col tensor, \b mask_h_idx tensor,
@@ -13648,7 +13682,8 @@ mluOpMaskedCol2imForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b idx.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13844,6 +13879,7 @@ mluOpRoiPoolingForward(mluOpHandle_t handle,
                        const mluOpTensorDescriptor_t output_desc,
                        void *output,
                        int *argmax);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -28,7 +28,7 @@
  ******************************************************************************/
 
 #define MLUOP_MAJOR 0
-#define MLUOP_MINOR 8
+#define MLUOP_MINOR 7
 #define MLUOP_PATCHLEVEL 0
 
 #define MLUOP_DIM_MAX 8
@@ -442,6 +442,22 @@ typedef enum {
   MLUOP_REDUCE_DMEAN = 1, /*!< Computes the mean value. */
   MLUOP_REDUCE_DMAX  = 2, /*!< Computes the maximun value. */
 } mluOpReduceMode_t;
+
+/*!
+ * @brief Enumeration variables describing the pooling modes that can be used to
+ * implement the pooling operation.
+ */
+typedef enum {
+  MLUOP_POOLING_MAX                           = 0, /*!< The max pooling mode is implemented.*/
+  MLUOP_POOLING_AVERAGE_COUNT_INCLUDE_PADDING = 1,
+  /*!< The average pooling with padding mode is implemented.*/
+  MLUOP_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING = 2,
+  /*!< The average pooling without padding mode is implemented.*/
+  MLUOP_POOLING_FIXED = 3,
+  /*!< The fixed mode is implemented. This mode is used in the unpool operation.
+   * In this mode, each input pixel will be put to the center of the pooling kernel
+   * regardless of the index.*/
+} mluOpPoolingMode_t;
 
 /******************************************************************************
  * MLUOP Runtime Management
@@ -2778,7 +2794,7 @@ mluOpGetTensorAndDataFromTensorSet(mluOpTensorSetDescriptor_t tensorSetDesc,
  * @param[out] y
  * Pointer to the MLU memory that stores the output tensor.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The date types of input tensor and output tensor should be the same.
@@ -3260,8 +3276,7 @@ mluOpDestroyCarafeDescriptor(mluOpCarafeDescriptor_t carafe_desc);
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The data types of \b input, \b mask and \b output tensors must be the same.
@@ -3376,8 +3391,7 @@ mluOpCarafeForward(mluOpHandle_t handle,
  * @param[out] grad_mask
  * Pointer to the MLU memory that stores the gradient with respect to \b mask.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The data types of \b input tensor, \b mask tensor, \b grad_output tensor, \b grad_input tensor, and \b grad_mask
@@ -3537,7 +3551,7 @@ mluOpDiv(mluOpHandle_t handle,
  * A host pointer to the returned size of extra space in bytes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - None.
@@ -3624,9 +3638,8 @@ mluOpGetDynamicPointToVoxelBackwardWorkspaceSize(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradient with respect to \b feats.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS,        ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH,  ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_INTERNAL_ERROR, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -3709,7 +3722,7 @@ mluOpDynamicPointToVoxelBackward(const mluOpHandle_t handle,
  * A host pointer to the returned size of extra space in bytes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - None.
@@ -3791,7 +3804,7 @@ mluOpGetDynamicPointToVoxelForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -3864,7 +3877,7 @@ mluOpDynamicPointToVoxelForward(const mluOpHandle_t handle,
  * A host pointer to the returned size of extra space in bytes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - None.
@@ -3975,7 +3988,7 @@ mluOpGetGenerateProposalsV2WorkspaceSize(mluOpHandle_t handle, const mluOpTensor
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4126,7 +4139,7 @@ mluOpGetPolyNmsWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescriptor_t
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4222,7 +4235,7 @@ mluOpCreateNmsDescriptor(mluOpNmsDescriptor_t *desc);
  * The Nms descriptor to be destroyed.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @note
  * - None
@@ -4369,9 +4382,7 @@ mluOpSetNmsDescriptor(mluOpNmsDescriptor_t nms_desc,
  * Pointer to the MLU memory that stores the number of output boxes.
  *
  * @par Returns
- * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The supported combinations of data types for input and output tensors are as follows:
@@ -4557,7 +4568,7 @@ mluOpGetNmsWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4693,8 +4704,7 @@ mluOpPriorBox(mluOpHandle_t handle,
  * \b mapping_channel is [rois[0], pooled_height, pooled_width, output_dim].
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -4795,8 +4805,7 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the bottom_grad tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -5024,7 +5033,7 @@ mluOpSetRoiAlignForwardDescriptor_v2(mluOpRoiAlignForwardDescriptor_t roialign_d
  * The RoiAlign descriptor to be destroyed.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
  * - None.
@@ -5085,8 +5094,7 @@ mluOpDestroyRoiAlignForwardDescriptor(mluOpRoiAlignForwardDescriptor_t desc);
  * Pointer to the MLU memory that stores \b output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data type of all tensors should be the same.
@@ -5189,8 +5197,7 @@ mluOpRoiAlignForward(mluOpHandle_t handle,
  * average pooling mode, \b argmax_y is NULL.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5311,7 +5318,7 @@ mluOpRoiAlignForward_v2(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5422,7 +5429,7 @@ mluOpRoiAlignRotatedForward(mluOpHandle_t handle,
  * bottom_grad is [batch_num, H, W, C].
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5517,8 +5524,7 @@ mluOpRoiAlignRotatedBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of input tensors and output tensor must be the same.
@@ -5595,8 +5601,7 @@ mluOpRoiCropForward(mluOpHandle_t handle,
  * original images.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of all tensors must be the same.
@@ -5675,8 +5680,7 @@ mluOpRoiCropBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5766,8 +5770,7 @@ mluOpRotatedFeatureAlignForward(const mluOpHandle_t handle_,
  * Pointer to the MLU memory that stores the bottom_input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -5842,7 +5845,7 @@ mluOpRotatedFeatureAlignBackward(const mluOpHandle_t handle_,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of input tensor and output tensor should be the same.
@@ -5906,7 +5909,7 @@ mluOpSqrt(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of input tensors and output tensor must be the same.
@@ -6093,7 +6096,7 @@ mluOpGetVoxelizationWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -6197,7 +6200,7 @@ mluOpVoxelization(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The data types of input and output tensors must be the same.
@@ -6298,7 +6301,7 @@ mluOpYoloBox(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -6401,8 +6404,7 @@ mluOpVoxelPoolingForward(mluOpHandle_t handle,
  * memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - By the order of \b bbox1 - \b bbox2 - \b ious, the supported data types of
@@ -6523,8 +6525,7 @@ mluOpGetNmsRotatedWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescripto
  * Pointer to the MLU memory that stores the number of output boxes.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS,   ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - By the order of \b boxes - \b scores - \b output, the supported data types of
@@ -6599,7 +6600,7 @@ mluOpNmsRotated(mluOpHandle_t handle,
  * IOU or IOF. Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - By the order of \b bbox1 - \b bbox2 - \b ious, the supported data types of
@@ -6717,7 +6718,7 @@ mluOpBboxOverlaps(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *  ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *  ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The data types of features tensor, weights tensor and output tensor should be the same.
@@ -6810,7 +6811,7 @@ mluOpThreeInterpolateForward(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The data types of grad_output tensor, weights tensor and grad_features tensor should be the same.
@@ -6899,7 +6900,7 @@ mluOpThreeInterpolateBackward(mluOpHandle_t handle,
  * nsample: the number of points selected in the sphere.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of new_xyz and xyz must be the same.
@@ -7314,8 +7315,7 @@ mluOpFill_v3(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input tensors \b input, \b target, \b weight , and output
@@ -7428,8 +7428,7 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b grad_input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input tensor \b input, \b target, \b weight , and output
@@ -7595,8 +7594,7 @@ mluOpGetMaskedIm2colForwardWorkspaceSize(mluOpHandle_t handle,
  * based on mask coordinates. The mask area out of the tensor \b feature is padded with 0.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - MLUOP_STATUS_SUCCESS, MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - This function supports the following data types for tensor \b feature, tensor \b mask_h_idx,
@@ -7617,7 +7615,7 @@ mluOpGetMaskedIm2colForwardWorkspaceSize(mluOpHandle_t handle,
  * @par Scale Limitation
  * - The tensor \b mask_h_idx must be 1D.
  * - The tensor \b mask_w_idx must be 1D.
- * - The tensor \b data_col must be 2D.
+ * - The tensor \b data_col must be 3D.
  * - The sizes of the highest dimension of tensor \b feature must be 1.
  * - The sizes of the lowest dimension of tensor \b data_col, the element number of tensor \b mask_h_idx, and
  *   the element number of tensor \b mask_w_idx must be the same.
@@ -7710,8 +7708,7 @@ mluOpMaskedIm2colForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b grad_input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -7830,8 +7827,7 @@ mluOpMoeDispatchBackwardData(mluOpHandle_t handle,
  * @param[out] grad_attn_weight
  * Pointer to the MLU memory that stores the gradient of \b attn_weight tensor.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8003,8 +7999,7 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b py_grad.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8179,8 +8174,7 @@ mluOpGetMutualInformationForwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b ans.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8351,7 +8345,7 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8451,7 +8445,7 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8525,8 +8519,7 @@ mluOpRoiawarePool3dBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the data of output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -8604,8 +8597,7 @@ mluOpPsamaskForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradient of input tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -10393,7 +10385,7 @@ mluOpGetIndicePairsWorkspaceSize(mluOpHandle_t handle,
  * the transpose operation.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ALLOC_FAILED, ::MLUOP_STATUS_INTERNAL_ERROR
+ *  ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ALLOC_FAILED, ::MLUOP_STATUS_INTERNAL_ERROR
  *
  * @par Data Type
  * - None.
@@ -11250,8 +11242,7 @@ mluOpGetActiveRotatedFilterForwardWorkspaceSize(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The data types of input tensor and output tensor should be the same.
@@ -11348,8 +11339,7 @@ mluOpActiveRotatedFilterForward(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the output tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -11466,8 +11456,7 @@ mluOpDeformRoiPoolForward(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradient of the offset tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tentors are as follows:
@@ -11575,8 +11564,7 @@ mluOpDeformRoiPoolBackward(const mluOpHandle_t handle,
  * maximum values after the max pooling. The shape of \b argmax_idx is [N, H * W, 4, C].
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM.
  *
  * @par Formula
  * - See "BorderAlignForward Operator" section in "Cambricon BANG C OPS User Guide" for details.
@@ -11726,8 +11714,7 @@ mluOpBorderAlignForward(mluOpHandle_t handle,
  * and C is the number of image channels.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM.
  *
  * @par Formula
  * - See "BorderAlignBackward Operator" section in "Cambricon BANG C OPS User Guide"
@@ -11964,7 +11951,7 @@ mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_NOT_SUPPORTED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_INTERNAL_ERROR
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -12351,8 +12338,7 @@ mluOpGetRoiPointPool3dWorkspaceSize(mluOpHandle_t handle,
  * @param[out] pooled_empty_flag
  * Pointer to the MLU memory that stores the second output tensor.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types for input and output are as follows:
@@ -12478,8 +12464,7 @@ mluOpGetThreeNNForwardWorkspaceSize(const mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b idx tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The supported data types for unknown tensor \b unknown, known tensor \b known, dist2
@@ -12765,8 +12750,7 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b dispatch tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - This function supports the following data types for input tensors \b gates , \b indices ,
@@ -12924,7 +12908,7 @@ mluOpGetMoeDispatchBackwardGateWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_EXECUTION_FAILED
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13018,7 +13002,7 @@ mluOpMoeDispatchBackwardGate(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b points_indices tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13087,8 +13071,7 @@ mluOpPointsInBoxes(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the gradients tensor of the original images.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -13206,8 +13189,7 @@ mluOpRoiAlignBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b grads_image tensor .
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The data types of all tensors should be the same.
@@ -13329,8 +13311,7 @@ mluOpRoiAlignBackward_v2(mluOpHandle_t handle,
  * @param[out] data_col
  * Pointer to the MLU memory that stores the output deformable attention feature.
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13393,8 +13374,7 @@ mluOpMsDeformAttnForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b grad_input.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13407,7 +13387,7 @@ mluOpMsDeformAttnForward(mluOpHandle_t handle,
  *
  * @par Scale Limitation
  * - The first dimension of tensor \b grad_output and tensor \b shifts must be the same size.
- * - The third dimension of tensor \b grad_output must be multiple of the second dimension of tensor \b shifts.
+ * - The second dimension of tensor \b grad_output  must be multiple of the second dimension of tensor \b shifts.
  *   For example, if the shape of \b grad_output is [N, T, C, HW], the shape of \b shifts is [N, G],
  *   C must be a multiple of G, and C and G cannot be zero.
  *
@@ -13457,8 +13437,7 @@ mluOpTinShiftBackward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b output.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13471,7 +13450,7 @@ mluOpTinShiftBackward(mluOpHandle_t handle,
  *
  * @par Scale Limitation
  * - The first dimension of tensor \b input and tensor \b shifts must be the same size.
- * - The third dimension of tensor \b input must be multiple of the second dimension of tensor \b shifts.
+ * - The second dimension of tensor \b input must be multiple of the second dimension of tensor \b shifts.
  *   For example, if the shape of \b input is [N, T, C, HW], the shape of \b shifts is [N, G],
  *   C must be a multiple of G, and C and G cannot be zero.
  *
@@ -13584,8 +13563,7 @@ mluOpGetMaskedCol2imForwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the \b im tensor that is the data copied from \b col tensor.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_NOT_SUPPORTED,
- *   ::MLUOP_STATUS_EXECUTION_FAILED
+ * - MLUOP_STATUS_SUCCESS, MLUOP_STATUS_BAD_PARAM
  *
  * @par Data Type
  * - This function supports the following data types for \b col tensor, \b mask_h_idx tensor,
@@ -13670,8 +13648,7 @@ mluOpMaskedCol2imForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the tensor \b idx.
  *
  * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH,
- *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
  *
  * @par Data Type
  * - The supported data types of input and output tensors are as follows:
@@ -13715,6 +13692,158 @@ mluOpDiffIouRotatedSortVerticesForward(mluOpHandle_t handle,
                                        const mluOpTensorDescriptor_t idx_desc,
                                        void *idx);
 
+// Group:RoiPoolingForward
+/*!
+ * @brief Generates fixed size feature map and input feature index
+ * of argmax for each Roi(Regions of Interest) to perform ::mluOpRoiPoolingForward operation.
+ *
+ * @param[in] handle
+ * Handle to an MLUOP context that is used to manage MLU devices and queues in
+ * ::mluOpRoiPoolingForward operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] pooling_mode
+ * The pooling mode of roipoolingforward defined in ::mluOpPoolingMode_t.
+ * @param[in] input_desc
+ * The descriptor of the input tensor in the roipoolingforward process. For detailed
+ * information, see ::mluOpTensorDescriptor_t.
+ * @param[in] input
+ * Pointer to the MLU memory that stores the input tensor.
+ * @param[in] rois_desc
+ * The descriptor of rois tensor. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] rois
+ * Pointer to the MLU memory that stores the rois tensor. Rois means regions of interest.
+ * @param[in] spatial_scale
+ * The spatial scale of each regions of interest in the input feature map.
+ * @param[in] output_desc
+ * The descriptor of output tensor. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] output
+ * Pointer to the MLU memory that stores the output tensor.
+ * @param[out] argmax
+ * Pointer to the MLU memory that stores the argmax tensor. Pointer may be NULL. Argmax tensor
+ * means input feature index of maximum for each Roi(Regions of Interest).
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM.
+ *
+ * @par Data Type
+ * - This function supports the following data types for input tensor \b input, rois tensor \b rois,
+ *   output tensor \b output, and argmax tensor \b argmax. The data type of the \b input \b rois \b output
+ *   should be the same. The data type of the argmax is different from others.
+ *   - input tensor: half, float.
+ *   - rois tensor: half, float.
+ *   - output tensor: half, float.
+ *   - argmax tensor: int32.
+ *
+ * @par Data Layout
+ * - The support data layout of \b input, \b rois, \b output, \b argmax are as follows:
+ *   - input tensor: \b MLUOP_LAYOUT_NHWC.
+ *   - rois tensor: \b MLUOP_LAYOUT_ARRAY, only supports 2D tensor.
+ *   - output tensor: \b MLUOP_LAYOUT_NHWC.
+ *   - argmax tensor: \b MLUOP_LAYOUT_NHWC.
+ *
+ * @par Scale Limitation
+ * - The value of \b pooling_mode only support \p MLUOP_POOLING_MAX.
+ * - The input tensor, output tensor and argmax tensor must have four dimensions.
+ * - Data type of half of \b input and \b rois is not recommended due to low precision.
+ * - Size of the lowest dimension of input tensors, output tensor and argmax tensor must be the same.
+ * - The total number of dimension of rois tensor must be 2.
+ * - Size of the highest dimension of output tensor and rois tensor must be the same.
+ * - The shape of \b rois should be [rois_num, 5]. \b rois_num means the total number of \b rois.
+ * - \b Rois[i] consists of [batch_id, x1, y1, x2, y2]. \b batch_id should be in the range of
+ * [0, batch_num - 1]. \b x1 and \b y1 should be greater than or equal to 0. \b x2 should be
+ * greater than \b x1. \b y2 should be greater than \b y1. \b batch_id means id of batch of \b rois. \b x1, \b y1,
+ * \b x2 and \b y2 mean the coordinate values of rois in the input feature map. \b batch_num means the total number
+ * of the batch.
+ * - \b Spatial_scale should be in the range of (0, 1].
+ * - \b Output consists of [rois_num, pooled_h, pooled_w, channels]. In the dimensions of the h and w of the input
+ * and the output, (\b x2 - \b x1) * (\b y2 - \b y1) * \b spatial_scale * \b spatial_scale / (\b pooled_h * \b
+ * pooled_w) < (nram_limitation / 32). Nram_limitation means the limitation of the nram. When the supported MLU platform
+ * is 200, the nram_limitation is (98304 - 4 * \b channels) / 2. When the supported MLU platform is 300,
+ * the nram_limitation is (163804 - 4 * \b channels) / 2. \b pooled_h means height of output. \b pooled_w means width of
+ * output.
+ *
+ * @par API Dependency
+ * - None
+ *
+ * @par Performance Optimization
+ * - None
+ *
+ * @node
+ * - It is not recommended to set the data type of grads tensor, rois tensor and grads_image tensors
+ *   that may cause the low accuracy on MLU200 series.
+ * - When the input data or parameter contains NaN or infinity:
+ *   - On MLU200 series:
+ *     - The \b output is the positive saturation value. The \b argmax is the index of the last NaN in the kernel of the
+ *       pooling.
+ *   - On MLU300 series and CE3226:
+ *     - If the last value in the kernel of the pooling is NaN, the \b argmax is the index of the last value, the \b
+ *       output is the last value,
+ *       as shown in example 2 below. Otherwise, the \b argmax is the index of the maximum value after the last NaN, the
+ *       \b output is the maximum value after the last NaN, as shown in example 3 below.
+ *
+ * @par Example
+ * - The example 1 of the roipoolingforward operation is as follows:
+     @verbatim
+     input two arrays by 1 * 4 * 4 * 1 and 1 * 5 -->input: [[[1.0],[2.0],[3.0],[4.0]],
+                                                            [[5.0],[6.0],[7.0],[8.0]],
+                                                            [[9.0],[10.0],[11.0],[12.0]],
+                                                            [[13.0],[14.0],[15.0],[16.0]]]
+
+     --> rois: [[1.0, 0.0, 0.0, 3.0, 3.0]]
+
+     params:
+         pooling_modek: 0, spatial_scale: 1.0
+
+     output array by 1 * 2 * 2 * 1 --> output: [[[6.0],[8.0]],
+                                                [[14.0],[16.0]]]
+
+     argmax array by 1 * 2 * 2 * 1 --> argmax: [[[5],[7]],
+                                                [[13],[15]]]
+     @endverbatim
+
+   - The example 2 of the roipoolingforward operation is as follows:
+     @verbatim
+     input two arrays by 1 * 2 * 2 * 1 and 1 * 5 --> input: [[[1.0],[2.0]],
+                                                             [[3.0],[NaN]]]
+
+     --> rois: [[1.0, 0.0, 0.0, 1.0, 1.0]]
+
+     params:
+         pooling_mode: 0, spatial_scale: 1.0
+
+     output array by 1 * 1 * 1 * 1 --> output: [[[NaN]]]
+
+     argmax array by 1 * 1 * 1 * 1 --> argmax: [[[3]]]
+     @endverbatim
+
+   - The example 3 of the roipoolingforward operation is as follows:
+     @verbatim
+     input two arrays by 1 * 2 * 2 * 1 and 1 * 5 --> input: [[[1.0],[NaN]],
+                                                             [[3.0],[4.0]]]
+
+     --> rois: [[1.0, 0.0, 0.0, 1.0, 1.0]]
+
+     params:
+         pooling_mode: 0, spatial_scale: 1.0
+
+     output array by 1 * 1 * 1 * 1 --> output: [[[4.0]]]
+
+     argmax array by 1 * 1 * 1 * 1 --> argmax: [[[3]]]
+     @endverbatim
+ *
+ * @par Reference
+ * - https://github.com/pytorch/pytorch/caffe2/operators/roi_pool_op.cu
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpRoiPoolingForward(mluOpHandle_t handle,
+                       mluOpPoolingMode_t pooling_mode,
+                       const mluOpTensorDescriptor_t input_desc,
+                       const void *input,
+                       const mluOpTensorDescriptor_t rois_desc,
+                       const void *rois,
+                       float spatial_scale,
+                       const mluOpTensorDescriptor_t output_desc,
+                       void *output,
+                       int *argmax);
 #if defined(__cplusplus)
 }
 #endif

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_pooling_forward/roi_pooling_forward.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_pooling_forward/roi_pooling_forward.cpp
@@ -1,0 +1,157 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include <string>
+#include <algorithm>
+#include "roi_pooling_forward.h"
+#define getParam(ty, ctx) \
+  (ty) parser_->getProtoNode()->roi_pooling_forward_param().ctx()
+#define getTensorDims(x, y) tensor_desc_[x].tensor->dims[y]
+#define getTensorDesc(x) tensor_desc_[x].tensor
+#define getDevicePtr(x) data_vector_[x].device_ptr
+
+namespace mluoptest {
+static char pooling_mode_str[3][64] =
+                          {"MLUOP_POOLING_MAX",
+                           "MLUOP_POOLING_AVERAGE_COUNT_INCLUDE_PADDING",
+                           "MLUOP_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING"};
+
+void RoiPoolingForwardExecutor::cpuRoiPoolingForward(float *input_v,
+                                                     float *rois,
+                                                     int batch_v,
+                                                     int height,
+                                                     int width,
+                                                     int channels,
+                                                     int pool_height,
+                                                     int pool_width,
+                                                     int rois_num,
+                                                     float spatial_scale,
+                                                     float *output,
+                                                     float *argmax) {
+  int bin_num = rois_num * pool_height * pool_width * channels;
+  theory_ops = 0;
+  for (int index = 0; index < bin_num; index++) {
+    int c = index % channels;
+    int pw = (index / channels) % pool_width;
+    int ph = (index / channels / pool_width) % pool_height;
+    int n = index / channels / pool_width / pool_height;
+
+    const float *offset_rois = rois + n * 5;
+    int batch_id = (int)offset_rois[0];
+    int roi_x1 = round(offset_rois[1] * spatial_scale);
+    int roi_y1 = round(offset_rois[2] * spatial_scale);
+    int roi_x2 = round(offset_rois[3] * spatial_scale);
+    int roi_y2 = round(offset_rois[4] * spatial_scale);
+
+    int roi_w = std::max(roi_x2 - roi_x1 + 1, 1);
+    int roi_h = std::max(roi_y2 - roi_y1 + 1, 1);
+    float bin_size_w = static_cast<float>(roi_w) /
+                       static_cast<float>(pool_width);
+    float bin_size_h = static_cast<float>(roi_h) /
+                       static_cast<float>(pool_height);
+
+    int bin_x1 = floor(static_cast<float>(pw) * bin_size_w);
+    int bin_y1 = floor(static_cast<float>(ph) * bin_size_h);
+    int bin_x2 = ceil(static_cast<float>(pw + 1) * bin_size_w);
+    int bin_y2 = ceil(static_cast<float>(ph + 1) * bin_size_h);
+    bin_x1 = std::min(std::max(bin_x1 + roi_x1, 0), width);
+    bin_y1 = std::min(std::max(bin_y1 + roi_y1, 0), height);
+    bin_x2 = std::min(std::max(bin_x2 + roi_x1, 0), width);
+    bin_y2 = std::min(std::max(bin_y2 + roi_y1, 0), height);
+    bool is_empty = (bin_y2 <= bin_y1) || (bin_x2 <= bin_x1);
+
+    const float *offset_input = input_v + (batch_id * height *
+                                width * channels + c);
+    float max_v = is_empty ? 0 : -FLT_MAX;
+    float max_idx = -1.0;
+    for (int h = bin_y1; h < bin_y2; h++) {
+      for (int w = bin_x1; w < bin_x2; w++) {
+        int offset = (h * width + w) * channels;
+        if (offset_input[offset] > max_v) {
+          max_v = offset_input[offset];
+          max_idx = (float)(offset / channels);
+        }
+        theory_ops++;
+      }
+    }
+    output[index] = max_v;
+    if (argmax != NULL) {
+      argmax[index] = max_idx;
+    }
+  }
+}
+
+void RoiPoolingForwardExecutor::initData() {
+  VLOG(4) << "############################### initData() Begin ##";
+  batch = getTensorDims(0, 0);
+  height = getTensorDims(0, 1);
+  width = getTensorDims(0, 2);
+  channels = getTensorDims(0, 3);
+  pool_height = getTensorDims(2, 1);
+  pool_width = getTensorDims(2, 2);
+  rois_num = getTensorDims(2, 0);
+  spatial_scale = getParam(float, spatial_scale);
+  pooling_mode = getParam(mluOpPoolingMode_t, mode);
+  /*input tensor*/
+  input_mlu = getDevicePtr(0);
+  rois_mlu = getDevicePtr(1);
+  /*output tensor*/
+  output_mlu = getDevicePtr(2);
+  argmax_mlu = (int *)getDevicePtr(3);
+  /*tensor desc*/
+  input_desc = getTensorDesc(0);
+  rois_desc = getTensorDesc(1);
+  output_desc = getTensorDesc(2);
+  VLOG(4) << "############################### initData() End ##";
+}
+
+
+void RoiPoolingForwardExecutor::compute() {
+  VLOG(4) << "############################### compute() Begin ##";
+  initData();
+
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpRoiPoolingForward(handle_, pooling_mode, input_desc,
+                   input_mlu, rois_desc, rois_mlu, spatial_scale,
+                   output_desc, output_mlu, argmax_mlu));
+  interface_timer_.stop();
+  VLOG(4) << "############################### compute() End ##";
+}
+
+void RoiPoolingForwardExecutor::cpuCompute() {
+  VLOG(4) << "############################### cpuCompute() Begin ##";
+  float *input_cpu = cpu_fp32_input_[0];
+  float *rois_cpu = cpu_fp32_input_[1];
+  float *output_cpu = cpu_fp32_output_[0];
+  float *argmax_cpu = cpu_fp32_output_[1];
+
+  cpuRoiPoolingForward(input_cpu, rois_cpu, batch, height, width, channels,
+                       pool_height, pool_width, rois_num, spatial_scale,
+                       output_cpu, argmax_cpu);
+  VLOG(4) << "############################### cpuCompute() End ##";
+}
+
+int64_t RoiPoolingForwardExecutor::getTheoryOps() {
+  return theory_ops * 2;
+}
+
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_pooling_forward/roi_pooling_forward.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_pooling_forward/roi_pooling_forward.h
@@ -1,0 +1,74 @@
+/*************************************************************************
+ * Copyright (C) [2023] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOKType LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHKType HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLUOP_GTEST_SRC_ZOO_ROI_POOLING_FORWARD_ROI_POOLING_FORWARD_H_
+#define TEST_MLUOP_GTEST_SRC_ZOO_ROI_POOLING_FORWARD_ROI_POOLING_FORWARD_H_
+#include "executor.h"
+
+namespace mluoptest {
+
+class RoiPoolingForwardExecutor : public Executor {
+ public:
+  RoiPoolingForwardExecutor() {}
+  ~RoiPoolingForwardExecutor() {}
+
+  void compute() override;
+  void cpuCompute() override;
+  void initData();
+  int64_t getTheoryOps() override;
+
+  void cpuRoiPoolingForward(float *input_v,
+                            float *rois,
+                            int batch_v,
+                            int height,
+                            int width,
+                            int channels,
+                            int pool_height,
+                            int pool_width,
+                            int rois_num,
+                            float spatial_scale,
+                            float *output,
+                            float *argmax);
+
+ private:
+  int batch;
+  int height;
+  int width;
+  int channels;
+  int rois_num;
+  int pool_height;
+  int pool_width;
+  float spatial_scale;
+  mluOpPoolingMode_t pooling_mode     = MLUOP_POOLING_MAX;
+  void *input_mlu                     = NULL;
+  void *rois_mlu                      = NULL;
+  void *output_mlu                    = NULL;
+  int *argmax_mlu                     = NULL;
+  mluOpTensorDescriptor_t input_desc  = NULL;
+  mluOpTensorDescriptor_t rois_desc   = NULL;
+  mluOpTensorDescriptor_t output_desc = NULL;
+  int64_t theory_ops = 0;
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLUOP_GTEST_SRC_ZOO_ROI_POOLING_FORWARD_ROI_POOLING_FORWARD_H_
+

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_pooling_forward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roi_pooling_forward/test_case/case_0.prototxt
@@ -1,0 +1,68 @@
+op_name: "roi_pooling_forward"
+input {
+  id: "input1"
+  shape {
+    dims: 16
+    dims: 64
+    dims: 64
+    dims: 68
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data {
+    seed: 23
+    lower_bound: -5.0
+    upper_bound: 5.0
+    distribution: UNIFORM
+  }
+}
+input {
+  id: "input2"
+  shape {
+    dims: 10
+    dims: 5
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+  random_data {
+    seed: 32
+    lower_bound: 0.0
+    upper_bound: 10.0
+    distribution: UNIFORM
+  }
+}
+output {
+  id: "output1"
+  shape {
+    dims: 10
+    dims: 1
+    dims: 1
+    dims: 68
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  mlu_dtype: DTYPE_FLOAT
+}
+output {
+  id: "output2"
+  shape {
+    dims: 10
+    dims: 1
+    dims: 1
+    dims: 68
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_INT32
+  mlu_dtype: DTYPE_INT32
+}
+roi_pooling_forward_param {
+  spatial_scale: 1.0
+  mode: POOLING_MAX
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 0.003
+  error_threshold: 0.003
+  baseline_device: CPU
+}

--- a/docs/bangc-docs/user_guide/9_operators/index.rst
+++ b/docs/bangc-docs/user_guide/9_operators/index.rst
@@ -60,8 +60,6 @@ mluOpBorderAlignBackward
 -----------------------------
 该算子为 ``mluOpBorderAlignForward`` 的反向算子，通过输入特征值、Box和最大池化值对应的索引求输入的梯度信息。
 
-.. _border_align_forward:
-
 mluOpBorderAlignForward
 -----------------------------
 该算子通过双线性插值和最大池化计算box四条边的最大特征值。包括两个输入 tensor，特征图信息和Box。
@@ -754,6 +752,12 @@ mluOpRoiPointPool3d
    local\_x = (x - cx) * cos(-rz) - (y - cy) * sin(-rz) \\
    local\_y = (x - cx) * sin(-rz) + (y - cy) * cos(-rz) \\
    in\_flag = |local\_x| < \frac{dx}{2} \& |local\_y| < \frac{dy}{2} \& |z - cz| <= \frac{dz}{2}
+
+.. _roi_pooling_forward:
+
+mluOpRoiPoolingForward
+----------------------------------
+该算子用于目标检测模型，在经过卷积层计算后的feature map上，针对检测重点关注的区域，即不同ROI对应的feature map区域进行池化，以得到相同规模的输出，进行全连接计算，满足整个网络训练任务。
 
 .. _rotated_feature_align_backward:
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [ ] diff1: diff1 <= 3e-3
- [ ] diff2: diff2 <= 3e-3

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |             MLU370<br>MLU590         |
|        2       |Job types                             |          block <br> U1 <br> U4       |
|        3       |Layouts                               |          NHWC 、NCHW、ARRAY etc      |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |                                      |
|        6       |Data type(half/float)                 |           half / float etc           |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |                             |
| Whether illegal parameters are passed           |     Normal error    |                             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float/int8                   |          |          |
|Mult-tensor test     |Supports 1-8 dims                 |          |          |
|Layout test          |Supports NCHW/NHWC                |          |          |
|Zero element test    |Whether to support this test      |          |          |
|Stability test       |--gtest_repeat=NUM<br>--thread=NUM|          |          |
|mlu-only mode test   |--mlu-only,see [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)|          |          |
|Mult-platform test   |MLU370/MLU590                     |          |          |
|Nan/INF test         |Whether to support this test      |          |          |
|Memory leak check    |Test result                       |          |          |
|Code coverage check  |Test result                       |          |          |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|op_name|    |    |     |    |    |    |     |
|op_name|    |    |     |    |    |    |     |

Platform：MLU590

|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|op_name|    |    |    |    |    |    |     |
|op_name|    |    |    |    |    |    |     |

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.
