### PR TITLE
[Fix](bangc-ops): fix warnings when compiling nms_rotated

### DIFF
--- a/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -85,13 +85,13 @@ __mlu_func__ void nms_detection(
    * | nram_save_limit_count | max_seg_iou_pad             |
    *
    * |-- copies_of_nram: 244 copies of ram --|
-   * | score | valid_box | temp_1~10 | intersect_pts_x/y |
-   *   & ordered_pts+x/y | temp_long_1~3 | dist_ram | valid_pts | nums_in_ram |
-   *   & box1 | box2 | box1_buffer |
-   * | 1     | 1         | 10        | 24x2              |
-   *     24x2            | 24x3          | 24       | 24        | 1           |
-   *     5    | 5          | 5          |
-   *
+   * | score           | valid_box     | temp_1~10 | intersect_pts_x/y |
+   * | 1               | 1             | 10        | 24x2              |
+   * | ordered_pts+x/y | temp_long_1~3 | dist_ram  | valid_pts         |
+   * | 24x2            | 24x3          | 24        | 24                |
+   * | nums_in_ram     | box1          | box2      | box1_buffer       | 
+   * | 1               | 5             | 5         | 5                 | 
+   * 
    * |-- reuse memory from dist_ram: 16 copies of ram --|
    * | rotated_pts1/2_x/y                               |
    * | 4x4                                              |
@@ -157,6 +157,14 @@ __mlu_func__ void nms_detection(
     int32_t global_max_index = 0;   //  for U1
     float max_area = 0;             //  the max socre area
     max_box[0] = IN_DT(-INFINITY);  //  init -inf
+
+    // Computing the direction of memcpy inside loop
+    // to remove warnings(address space doesn't match) raises when compiling.
+    // Performance may drop in the 300 series if this computation is moved
+    // outside the loop.
+    boxes_load_dir   = (boxes_load_dir   == SRAM2NRAM) ? SRAM2NRAM : GDRAM2NRAM;
+    scores_load_dir  = (scores_load_dir  == SRAM2NRAM) ? SRAM2NRAM : GDRAM2NRAM;
+    scores_store_dir = (scores_store_dir == NRAM2SRAM) ? NRAM2SRAM : NRAM2GDRAM;
 
     findCoreMaxBox(input_data_score, score, temp, max_box, input_x_ptr,
                    input_y_ptr, input_dx_ptr, input_dy_ptr, scores_load_dir,


### PR DESCRIPTION
## 1. Motivation

fix warnings(address space doesn't match) when compiling nms_rotated.

## 2. Modification

modified: bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu

## 3. Test Report

### 3.1 Functional Test

Platform：MLU370

[----------] 18 tests from nms_rotated/TestSuite (22808 ms total)
[----------] Global test environment tear-down
[ SUMMARY  ] Total 18 cases of 1 op(s).
ALL PASSED.
[==========] 18 test cases from 1 test suite ran. (23423 ms total)
[  PASSED  ] 18 test cases.

Platform：MLU590

[----------] 18 tests from nms_rotated/TestSuite (15098 ms total)
[----------] Global test environment tear-down
[ SUMMARY  ] Total 18 cases of 1 op(s).
ALL PASSED.
[==========] 18 test cases from 1 test suite ran. (15736 ms total)
[  PASSED  ] 18 test cases.

### 3.2 Performance Test

Platform：MLU370-S4
![image](https://github.com/Cambricon/mlu-ops/assets/34612674/99fd8099-68ed-4ead-81c3-fd9305cb5f87)

Platform：MLU370-X4
![image](https://github.com/Cambricon/mlu-ops/assets/34612674/52eebca8-0220-4b7d-83b0-4fe852170aa1)

Platform：MLU370-X8
![image](https://github.com/Cambricon/mlu-ops/assets/34612674/d2131e36-ab42-4a0c-9e15-3527e0fdf540)

Platform：MLU590-H8
![image](https://github.com/Cambricon/mlu-ops/assets/34612674/dcc7c8b8-f66a-4b5e-ba63-609e75a16f0b)

Platform：MLU590-M9
![image](https://github.com/Cambricon/mlu-ops/assets/34612674/92f03215-fd62-4cc4-9176-a8583a6d6e13)

### 3.4 Summary Analysis

All tests passed.