### PR TITLE
[Fix](bangc-ops): add large tensor num check for psamask.

### DIFF
--- a/bangc-ops/kernels/psamask/psamask.cpp
+++ b/bangc-ops/kernels/psamask/psamask.cpp
@@ -203,6 +203,15 @@ mluOpStatus_t checkParams(const mluOpTensorDescriptor_t input_desc,
                   "same as the h_feature * w_feature.";
     return MLUOP_STATUS_BAD_PARAM;
   }
+
+  // check large tensor
+  if ((mluOpGetTensorElementNum(input_desc) >= LARGE_TENSOR_NUM) ||
+      (mluOpGetTensorElementNum(output_desc) >= LARGE_TENSOR_NUM)) {
+    LOG(ERROR) << api << " Overflow max tensor num."
+               << " Currently, MLU-OPS supports tensor num smaller than 2^31.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
   return MLUOP_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

add large tensor num check for psamask.

## 2. Modification

modified:   bangc-ops/kernels/psamask/psamask.cpp

## 3. Test Report

#### 3.1.4 Parameter Check

the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Large tensor check <br>inputs : "shape":[1,1,2,2147483640]       |     Normal error    |[2023-8-23 15:5:6] [MLUOP] [Error]:[mluOpPsamaskForward] Overflow max tensor num. Currently, MLU-OPS supports tensor num smaller than 2^31. <br>[2023-8-23 15:5:6] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpPsamaskForward(handle_, psa_type, input_desc, input, h_mask, w_mask, output_desc, output)"|


### 3.4 Summary Analysis

Test passed