### PR TITLE
[Feature](bangc-ops): nms_rotated fix code of iou_threshold<0 cases

### DIFF
--- a/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -260,9 +260,7 @@ __mlu_func__ void nms_detection(
       // Initialize valid_box, set actual_box_num boxes to 1, else set to 0
       __bang_write_value(((float *)valid_box), seg_len, 1.0f);
       if (cpy_len < seg_len) {
-        for (uint32_t i = cpy_len; i < seg_len; i++) {
-          ((float *)valid_box)[i] = 0;
-        }
+        __bang_write_zero((float *)valid_box + cpy_len, seg_len - cpy_len);
       }
 
       // Each box data: x, y, w, h, a
@@ -271,18 +269,16 @@ __mlu_func__ void nms_detection(
       __bang_mul((float *)temp10_ram, (float *)box2 + seg_len * 2,
                  (float *)box2 + seg_len * 3, seg_len);
 
-      // Where area < 1e-14(@float), valid_box set to 0
-      if (max_area < (float)1e-14) {
+      //  if (area1 < 1e-14 || area2 < 1e-14) { iou is 0.f; }
+      const float area_thres = (float)1e-14;
+      if (max_area < area_thres) {
         __bang_write_value((float *)valid_box, seg_len, 0.0f);
       }
-
-      __bang_lt_scalar((float *)temp2_ram, (float *)temp10_ram, (float)1e-14,
+      __bang_lt_scalar((float *)temp2_ram, (float *)temp10_ram, area_thres,
                        seg_len);
       __bang_not((float *)temp2_ram, (float *)temp2_ram, seg_len);
-
       __bang_and((float *)valid_box, (float *)valid_box, (float *)temp2_ram,
                  seg_len);
-
       __bang_move((void *)temp9_ram, (void *)valid_box,
                   seg_len * sizeof(float));
       // 1. Calculate new points
@@ -358,48 +354,48 @@ __mlu_func__ void nms_detection(
                   (float *)temp4_ram, (float *)temp5_ram, (float *)temp6_ram,
                   (float *)temp7_ram, (float *)temp8_ram, seg_len);
 
-      if (iou_threshold == IN_DT(-INFINITY)) {
-        // suppress boxes whose iou is 0, for 0 > -inf is always true
-        __bang_not((float *)temp8_ram, (float *)temp9_ram, seg_len);
-      }
+#if __BANG_ARCH__ == 372
+      // calculate finally ious according to mode
+      __bang_write_value((float *)temp4_ram, seg_len, float(max_area));
+      calIntersectIou((float *)temp2_ram, (float *)temp4_ram,
+                      (float *)temp10_ram, (float *)temp1_ram,
+                      (float *)temp2_ram,  /*mode=*/0, seg_len);
       __bang_float2int32((int32_t *)temp9_ram, (float *)temp9_ram, seg_len, 0);
       __bang_lut_s32((int32_t *)temp9_ram, (int32_t *)temp9_ram,
                      (int32_t *)table_float, seg_len, TABLE_LENGTH);
-      // temp1: area_I
-      __bang_band((char *)temp1_ram, (char *)temp1_ram, (char *)temp9_ram,
+      __bang_band((char *)temp2_ram, (char *)temp2_ram, (char *)temp9_ram,
                   seg_len * sizeof(float));
-
+      // temp1: 1 = area_I / area_U > iou_threshold, 0 = else
+      __bang_gt_scalar((float *)temp1_ram, (float *)temp2_ram, iou_threshold,
+                       seg_len);
+#else
       // get the area_U(temp2): area2(temp10) + area1(max_area) - area_I(temp1)
       __bang_add_scalar((float *)temp2_ram, (float *)temp10_ram,
                         float(max_area), seg_len);
       __bang_sub((float *)temp2_ram, (float *)temp2_ram, (float *)temp1_ram,
-                 seg_len);  // area_U
-
-      // temp2: area_U
-      __bang_band((char *)temp2_ram, (char *)temp2_ram, (char *)temp9_ram,
-                  seg_len * sizeof(float));
-
+                 seg_len);
       // temp2: iou_threshold * area_U
       __bang_mul_scalar((float *)temp2_ram, (float *)temp2_ram, iou_threshold,
                         seg_len);
       // temp1: 1 = area_I > iou_threshold * area_U, 0 = else
       __bang_gt((float *)temp1_ram, (float *)temp1_ram, (float *)temp2_ram,
                 seg_len);
-      if (iou_threshold == IN_DT(-INFINITY)) {
+      if (iou_threshold < 0) {
+        __bang_not((float *)temp8_ram, (float *)temp9_ram, seg_len);
         __bang_or((float *)temp1_ram, (float *)temp1_ram, (float *)temp8_ram,
                   seg_len);
+      } else {
+        __bang_and((float *)temp1_ram, (float *)temp1_ram, (float *)temp9_ram,
+                   seg_len);
       }
+#endif
       if (std::is_same<IN_DT, half>::value) {
         __bang_float2half_dn((half *)temp1_ram, (float *)temp1_ram, seg_len);
       }
 
-      // temp1: 1->1, 0->-1
-      __bang_mul_scalar((IN_DT *)temp1_ram, (IN_DT *)temp1_ram, IN_DT(2),
-                        seg_len);
-      __bang_sub_scalar((IN_DT *)temp1_ram, (IN_DT *)temp1_ram, IN_DT(1),
-                        seg_len);
-      __bang_mul_scalar((IN_DT *)temp1_ram, (IN_DT *)temp1_ram,
-                        IN_DT(-INFINITY), seg_len);
+      // temp1: 1->-inf, 0->inf
+      __bang_fusion(FUSION_FSM, (IN_DT *)temp1_ram, (IN_DT *)temp1_ram,
+                    IN_DT(0.5), IN_DT(-INFINITY), seg_len);
       // score: keep value if inf, suppressed if -inf
       __bang_minequal((IN_DT *)score, (IN_DT *)score, (IN_DT *)temp1_ram,
                       seg_len);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -6538,7 +6538,7 @@ mluOpGetNmsRotatedWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescripto
  * - The lowest dimension of \b boxes tensors must be 5 or 6.
  *
  * @par note
- * - The input \b boxes and \b scores with NAN/INF are not supported currently.
+ * - The input \b scores with NAN/INF are not supported currently.
  *
  * @par API Dependency
  * - You need to call::mluOpGetNmsRotatedWorkspaceSize to allocate extra


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. 

## 1. Motivation

nms_rotated fix code of iou_threshold<0 cases

## 2. Modification

1. modified:   bangc-ops/kernels/nms_rotated/nms_rotated_union1.mlu


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- [x] diff3: diff3 <= 0

#### 3.1.2 Operator Scheme checklist

|     No.        |                 Details              |            Check Results             |
|----------------|--------------------------------------|--------------------------------------|
|        1       |Supported hardware                    |          MLU370<br>MLU590            |
|        2       |Job types                             |          block <br> U1               |
|        3       |Layouts                               |          ARRAY                       |
|        4       |Whether multi-dimensions are supported|                                      |
|        5       |Whether element zero is supported     |          支持                         |
|        6       |Data type(half/float)                 |          float                       |
|        7       |Whether there is size limit           |                                      |

#### 3.1.3 New Feature Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test
- [x] Multi-dimensional tensor test
- [ ] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test
- [x] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see[GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).
- [x] For I/O calculation efficiency check details, see: [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md).

#### 3.1.4 Parameter Check

When a new operator is submitted, the test points are given and the test results are stated.

|                   Test Point                    | Acceptance Standard | Test Result (Error Message) |
| ----------------------------------------------- | --------------------| --------------------------- |
| Whether it conforms to the operator restriction |     Normal error    |        本次无修改             |
| Whether illegal parameters are passed           |     Normal error    |        本次无修改             |

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Mult-platform test   |MLU370/MLU590                     |   通过    |  已入库测例+新增测例 |
|Nan/INF test         |Whether to support this test      |   通过    |  已入库测例+新增测例 |
|gen_case test        |Whether to support this test      |   通过    |  已入库测例+新增测例 |
|Memory leak check    |Test result                       |   通过    |  ./build.sh --filter=nms_rotated --asan --enable-bang-memcheck<br>
除运行超时的case以外，没有内存问题     |
|Code coverage check  |Test result                       |   通过    |  ./build.sh --filter=nms_rotated -c<br>run docker<br> export NEUWARE_HOME=${PWD}/dep_libs_extract/neuware<br> ../../../tools/coverage.sh "./mluop_gtest --gtest_filter=*op_name* --cases_dir=xxx"<br> nms_rotated_union1.mlu [95.6%][95.6%] 95.6 %283 / 296       100.0 %3 / 3<br> nms_utils.h            [94.4%][94.4%] 94.4 %571 / 605       100.0 %10 / 10     |

### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

详见测试报告

### 3.4 Summary Analysis

1. 针对边缘case（出现面积<0或box交点<2的box，且iou_threshold<0）优化处理逻辑：iou_threshold<0时，抑制面积<0或box交点<2的box
2. 由于mmcv计算过程中会自动开启fma优化，而mlu没有，因此生成测例时tensor取值范围不能太大，目前测试下来[-3e+10,3e+10]没有问题，[-3e+38,3e+38]有问题（mmcv手动关闭fma后能pass）
3. 功能测试通过，性能测试无下降
