### PR TITLE
[Docs](bangc-ops): fix env var guide link error.

### DIFF
--- a/docs/bangc-docs/user_guide/11_env_var/index.rst
+++ b/docs/bangc-docs/user_guide/11_env_var/index.rst
@@ -52,7 +52,7 @@ MLUOP_GEN_CASE
 - export MLUOP_GEN_CASE=2：生成 prototxt，并保留输入真实值。
 - export MLUOP_GEN_CASE=3：不生成 prototxt，只在屏幕上打印输入输出的 shape 等信息。
 
-更详细请参见 `MLU-OPS GEN_CASE 使用指南<https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md>`_ 。
+更详细请参见 `MLU-OPS GEN_CASE 使用指南 <https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md>`_ 。
 
 .. _MLUOP_MIN_VLOG_LEVEL:
  


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

fix env var guide link error

## 2. Modification

docs/bangc-docs/user_guide/11_env_var/index.rst
Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report
no test.