### PR TITLE
[Fix](bangc-ops): roiaware add Param Check and use __cn_scalar_sin_*

### DIFF
--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -31,7 +31,7 @@
 #include "core/tensor.h"
 #include "core/type.h"
 
-#define threshold_of_boxes_num_and_channels 65536
+#define THRESHOLD_OF_BOXES_NUM_AND_CHANNELS 65536
 
 // policy function
 static mluOpStatus_t kernelPtsIdxOfVoxelsPolicyFunc(
@@ -221,8 +221,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
-  PARAM_CHECK(API, boxes_num < threshold_of_boxes_num_and_channels);
-  PARAM_CHECK(API, channels < threshold_of_boxes_num_and_channels);
+  PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+  PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
 
   const uint64_t tensor_rois_num = mluOpGetTensorElementNum(rois_desc);
   const uint64_t tensor_pts_num = mluOpGetTensorElementNum(pts_desc);
@@ -505,8 +505,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
     Maximum y- or z-dimension of a grid of thread blocks
     should be less than 65536 in cuda. */
-  PARAM_CHECK(API, boxes_num < threshold_of_boxes_num_and_channels);
-  PARAM_CHECK(API, channels < threshold_of_boxes_num_and_channels);
+  PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+  PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
 
   const uint64_t tensor_pts_idx_of_voxels_num =
       mluOpGetTensorElementNum(pts_idx_of_voxels_desc);

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
@@ -46,7 +46,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
     return;
   }
   int nram_pts_num = 0;
-  if (std::is_same<T, float>::value) {
+  if (__mluop_is_float<T>()) {
     nram_pts_num = PAD_DOWN(
         (MAX_NRAM_SIZE / sizeof(float) / FLOAT_NRAM_BUFFER_NUM), ALIGN_NUM);
   } else {
@@ -72,7 +72,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
   float *fp_local_Y = NULL;
   float *fp_local_Z = NULL;
   float *fp_nram_pts_in_flag = NULL;
-  if (std::is_same<T, float>::value) {
+  if (__mluop_is_float<T>()) {
     X = (char *)((float *)data_nram);
     Y = (char *)((float *)data_nram + nram_pts_num);
     Z = (char *)((float *)data_nram + nram_pts_num * 2);
@@ -128,8 +128,15 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
     T dy = cur_roi[4];
     T dz = cur_roi[5];
     T rz = cur_roi[6];
-    T cosa = std::cos(-rz);
-    T sina = std::sin(-rz);
+    T cosa = 1;
+    T sina = 0;
+    if (__mluop_is_float<T>()) {
+      cosa = __cn_scalar_cos_f32(-rz);
+      sina = __cn_scalar_sin_f32(-rz);
+    } else {
+      cosa = __cn_scalar_cos_f16(-rz);
+      sina = __cn_scalar_sin_f16(-rz);
+    }
 
     T dx_2 = dx / 2.0;
     T dy_2 = dy / 2.0;
@@ -166,7 +173,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                         compute_pts_num);
       __bang_mul_scalar((T *)temp_buffer2, (T *)temp_buffer4, (T)sina,
                         compute_pts_num);
-      // local_x
+      // local_x = (X - cx) * cosa - (Y - cy) * sina
       __bang_sub((T *)local_X, (T *)temp_buffer1, (T *)temp_buffer2,
                  compute_pts_num);
       // fabs(local_x)
@@ -182,7 +189,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                         compute_pts_num);
       __bang_mul_scalar((T *)temp_buffer2, (T *)temp_buffer4, (T)cosa,
                         compute_pts_num);
-      // local_y
+      // local_y = (X - cx) * sina + (Y - cy) * cosa
       __bang_add((T *)local_Y, (T *)temp_buffer1, (T *)temp_buffer2,
                  compute_pts_num);
       // fabs(local_y)
@@ -193,6 +200,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
       __bang_and((T *)nram_pts_in_flag, (T *)nram_pts_in_flag,
                  (T *)temp_buffer1,
                  compute_pts_num);  // flush res
+      // judge point in which poolbox
       T x_res = dx / out_x;
       T y_res = dy / out_y;
       T z_res = dz / out_z;
@@ -213,7 +221,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                         compute_pts_num);
 #endif
       // float = float2int + int2float, half = half2int + int2float
-      if (std::is_same<T, float>::value) {
+      if (__mluop_is_float<T>()) {
         __bang_float2int32_tz((int *)temp_buffer1, (float *)local_X,
                               compute_pts_num, 0);
         __bang_float2int32_tz((int *)temp_buffer2, (float *)local_Y,
@@ -320,17 +328,13 @@ __mlu_entry__ void MLUMultiKernelRoiawarePool3dForward(
   int align_num = NFU_ALIGN_SIZE / sizeof(T);
   int align_max_pts_each_voxel = PAD_UP(max_pts_each_voxel, align_num);
   int nram_channels_limit =
-      PAD_DOWN((MAX_NRAM_SIZE - 128 -
-                align_max_pts_each_voxel * (sizeof(int) + sizeof(T))) /
+      PAD_DOWN((MAX_NRAM_SIZE - 128 - align_max_pts_each_voxel * sizeof(int)) /
                    ((align_max_pts_each_voxel + 1) * sizeof(T) + sizeof(int)),
                align_num);
   int *nram_pts_idx_cur_voxel = (int *)data_nram;
   // nram_pts_idx_cur_voxel [align_max_pts_each_voxel]
-  T *nram_max_pts_feature_tmp =
-      (T *)((int *)nram_pts_idx_cur_voxel + align_max_pts_each_voxel);
-  // nram_max_pts_feature_tmp [align_max_pts_each_voxel]
   T *nram_pts_feature_in_voxel =
-      ((T *)nram_max_pts_feature_tmp + align_max_pts_each_voxel);
+      (T *)((int *)nram_pts_idx_cur_voxel + align_max_pts_each_voxel);
   // nram_pts_feature_in_voxel [nram_channels_limit, align_max_pts_each_voxel]
   T *nram_pooled_features_cur_voxel =
       ((T *)nram_pts_feature_in_voxel +
@@ -580,7 +584,7 @@ __mlu_entry__ void MLUMultiKernelRoiawareAvgPool3dBackward(
 
       int align_actual_channels_num = PAD_UP(actual_channels_num, align_num);
 
-      if (std::is_same<T, half>::value) {
+      if (__mluop_is_half<T>()) {
         __bang_half2float((float *)nram_grad_out_cur_loop,
                           (half *)nram_grad_in_cur_loop,
                           align_actual_channels_num);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8366,6 +8366,9 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * - None.
  *
  * @par Scale Limitation
+ * - \b boxes_num should be less than 65536.
+ * - \b channels should be less than 65536.
+ * - The Product of \b boxes_num and \b pts_num should be less than 2G.
  * - The shape of \b rois should be [boxes_num, 7].
  * - The shape of \b pts should be [pts_num, 3].
  * - The shape of \b pts_feature should be [pts_num, channels].


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

MMCV中存在隐含的限制条件，在host端新增相应的参数检查。

- dim3结构体，限制了boxes_num和channels大小。

- pts_mask指针的最大偏移值为 boxes_num * pts_num，它们均为int类型。

sin/cos指令精度与竞品不对齐。

nram_max_pts_feature_tmp该内存空间未使用过。

## 2. Modification

a.**mlu-ops/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp**中 
- boxes_num < 65536
- channels < 65536
- product of boxes_num and pts_num < 2^31

b.**mlu-ops/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu**中
- delete unused memory (nram_max_pts_feature_tmp)
- __cn_scalar_sin_* replace std::sin;__cn_scalar_cos_* replace std::cos

c.**mlu-ops/bangc-ops/mlu_op.h**中
-增加参数限制的注释

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- dynamic threshold
  - [x] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [x] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [x] diff4: mlu diff4 <= max(baseline diff4 * 1, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

### 3.2 Accuracy Test

For the cases used in the New Feature Test section, the features and the number of cases are recorded here. When multiple operations are tested, multiple tables are needed to include details of these operations.

Operation:

|Test Point           | Description                      | Quantity |  Comment |
|----------           |----------------------------------|----------|  --------|
|Data type test       |half/float                   |          |          ||
|Mult-platform test   |MLU370/MLU590    release_test+release_temp        |     all pass     |          |


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

case1
|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|-----|----|----|----|-----|
|baseline|   5575.7 |    |   0.08310758012  |  0.08687124487  |    |   float |   'input_dim': [[128, 7], [16000, 3], [16000, 16]]  |
|modified|  5592.39  |    |   0.08310758012  |  0.08661198522  |    |  float  |   'input_dim': [[128, 7], [16000, 3], [16000, 16]]  |

10个测试样例，性能下降约1%。

Platform：MLU590

case1
|Operation|Mlu_hardware_time(us)|Mlu_interface_time(us)|Mlu_io_efficiency|Mlu_compute_efficiency|Mlu_workwpace_size(Bytes)|Data_type|Shape|
|-------|----|----|----|----|----|----|-----|
|baseline|  3608.8  |    |  0.01428432247  | 0.05592440701   |    |  float  |  {'input_dim': [[128, 7], [16000, 3], [16000, 16]]}   |
|modified|   3615.23 |    |  0.01428432247  |  0.0558249406  |    |  float  |  {'input_dim': [[128, 7], [16000, 3], [16000, 16]]}   |

10个测试样例，性能下降约1%。

### 3.4 Summary Analysis

功能流水和性能流水测试均通过。
