### PR TITLE
[Fix](bangc-ops): roiaware add annotation and modify docs

### DIFF
--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -31,7 +31,7 @@
 #include "core/tensor.h"
 #include "core/type.h"
 
-#define threshold_of_boxes_num_and_channels 65536
+#define THRESHOLD_OF_BOXES_NUM_AND_CHANNELS 65536
 
 // policy function
 static mluOpStatus_t kernelPtsIdxOfVoxelsPolicyFunc(
@@ -221,8 +221,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
-  PARAM_CHECK(API, boxes_num < threshold_of_boxes_num_and_channels);
-  PARAM_CHECK(API, channels < threshold_of_boxes_num_and_channels);
+  PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+  PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
 
   const uint64_t tensor_rois_num = mluOpGetTensorElementNum(rois_desc);
   const uint64_t tensor_pts_num = mluOpGetTensorElementNum(pts_desc);
@@ -505,8 +505,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
     Maximum y- or z-dimension of a grid of thread blocks
     should be less than 65536 in cuda. */
-  PARAM_CHECK(API, boxes_num < threshold_of_boxes_num_and_channels);
-  PARAM_CHECK(API, channels < threshold_of_boxes_num_and_channels);
+  PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+  PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
 
   const uint64_t tensor_pts_idx_of_voxels_num =
       mluOpGetTensorElementNum(pts_idx_of_voxels_desc);

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d_union1.mlu
@@ -46,7 +46,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
     return;
   }
   int nram_pts_num = 0;
-  if (std::is_same<T, float>::value) {
+  if (__mluop_is_float<T>()) {
     nram_pts_num = PAD_DOWN(
         (MAX_NRAM_SIZE / sizeof(float) / FLOAT_NRAM_BUFFER_NUM), ALIGN_NUM);
   } else {
@@ -72,7 +72,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
   float *fp_local_Y = NULL;
   float *fp_local_Z = NULL;
   float *fp_nram_pts_in_flag = NULL;
-  if (std::is_same<T, float>::value) {
+  if (__mluop_is_float<T>()) {
     X = (char *)((float *)data_nram);
     Y = (char *)((float *)data_nram + nram_pts_num);
     Z = (char *)((float *)data_nram + nram_pts_num * 2);
@@ -128,8 +128,15 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
     T dy = cur_roi[4];
     T dz = cur_roi[5];
     T rz = cur_roi[6];
-    T cosa = std::cos(-rz);
-    T sina = std::sin(-rz);
+    T cosa = 1;
+    T sina = 0;
+    if (__mluop_is_float<T>()) {
+      cosa = __cn_scalar_cos_f32(-rz);
+      sina = __cn_scalar_sin_f32(-rz);
+    } else {
+      cosa = __cn_scalar_cos_f16(-rz);
+      sina = __cn_scalar_sin_f16(-rz);
+    }
 
     T dx_2 = dx / 2.0;
     T dy_2 = dy / 2.0;
@@ -166,7 +173,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                         compute_pts_num);
       __bang_mul_scalar((T *)temp_buffer2, (T *)temp_buffer4, (T)sina,
                         compute_pts_num);
-      // local_x
+      // local_x = (X - cx) * cosa - (Y - cy) * sina
       __bang_sub((T *)local_X, (T *)temp_buffer1, (T *)temp_buffer2,
                  compute_pts_num);
       // fabs(local_x)
@@ -182,7 +189,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                         compute_pts_num);
       __bang_mul_scalar((T *)temp_buffer2, (T *)temp_buffer4, (T)cosa,
                         compute_pts_num);
-      // local_y
+      // local_y = (X - cx) * sina + (Y - cy) * cosa
       __bang_add((T *)local_Y, (T *)temp_buffer1, (T *)temp_buffer2,
                  compute_pts_num);
       // fabs(local_y)
@@ -193,6 +200,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
       __bang_and((T *)nram_pts_in_flag, (T *)nram_pts_in_flag,
                  (T *)temp_buffer1,
                  compute_pts_num);  // flush res
+      // judge point in which poolbox
       T x_res = dx / out_x;
       T y_res = dy / out_y;
       T z_res = dz / out_z;
@@ -213,7 +221,7 @@ __mlu_entry__ void MLUMultiKernelPtsIdxOfVoxels(
                         compute_pts_num);
 #endif
       // float = float2int + int2float, half = half2int + int2float
-      if (std::is_same<T, float>::value) {
+      if (__mluop_is_float<T>()) {
         __bang_float2int32_tz((int *)temp_buffer1, (float *)local_X,
                               compute_pts_num, 0);
         __bang_float2int32_tz((int *)temp_buffer2, (float *)local_Y,
@@ -320,17 +328,13 @@ __mlu_entry__ void MLUMultiKernelRoiawarePool3dForward(
   int align_num = NFU_ALIGN_SIZE / sizeof(T);
   int align_max_pts_each_voxel = PAD_UP(max_pts_each_voxel, align_num);
   int nram_channels_limit =
-      PAD_DOWN((MAX_NRAM_SIZE - 128 -
-                align_max_pts_each_voxel * (sizeof(int) + sizeof(T))) /
+      PAD_DOWN((MAX_NRAM_SIZE - 128 - align_max_pts_each_voxel * sizeof(int)) /
                    ((align_max_pts_each_voxel + 1) * sizeof(T) + sizeof(int)),
                align_num);
   int *nram_pts_idx_cur_voxel = (int *)data_nram;
   // nram_pts_idx_cur_voxel [align_max_pts_each_voxel]
-  T *nram_max_pts_feature_tmp =
-      (T *)((int *)nram_pts_idx_cur_voxel + align_max_pts_each_voxel);
-  // nram_max_pts_feature_tmp [align_max_pts_each_voxel]
   T *nram_pts_feature_in_voxel =
-      ((T *)nram_max_pts_feature_tmp + align_max_pts_each_voxel);
+      (T *)((int *)nram_pts_idx_cur_voxel + align_max_pts_each_voxel);
   // nram_pts_feature_in_voxel [nram_channels_limit, align_max_pts_each_voxel]
   T *nram_pooled_features_cur_voxel =
       ((T *)nram_pts_feature_in_voxel +
@@ -580,7 +584,7 @@ __mlu_entry__ void MLUMultiKernelRoiawareAvgPool3dBackward(
 
       int align_actual_channels_num = PAD_UP(actual_channels_num, align_num);
 
-      if (std::is_same<T, half>::value) {
+      if (__mluop_is_half<T>()) {
         __bang_half2float((float *)nram_grad_out_cur_loop,
                           (half *)nram_grad_in_cur_loop,
                           align_actual_channels_num);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8467,6 +8467,8 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Scale Limitation
+ * - \b boxes_num should be less than 65536.
+ * - \b channels should be less than 65536.
  * - The shape of \b pts_idx_of_voxels should be [boxes_num, out_x, out_y, out_z, max_pts_each_voxel].
  * - The shape of \b argmax should be [boxes_num, out_x, out_y, out_z, channels].
  * - The shape of \b grad_out should be [boxes_num, out_x, out_y, out_z, channels].

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8366,6 +8366,9 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * - None.
  *
  * @par Scale Limitation
+ * - \b boxes_num should be less than 65536.
+ * - \b channels should be less than 65536.
+ * - The Product of \b boxes_num and \b pts_num should be less than 2G.
  * - The shape of \b rois should be [boxes_num, 7].
  * - The shape of \b pts should be [pts_num, 3].
  * - The shape of \b pts_feature should be [pts_num, channels].

--- a/docs/bangc-docs/design_docs/roiaware_pool3d_backward/roiaware_pool3d_backward.md
+++ b/docs/bangc-docs/design_docs/roiaware_pool3d_backward/roiaware_pool3d_backward.md
@@ -162,7 +162,7 @@ mluOpRoiawarePool3dBackward(mluOpHandle_t handle,
 
   0. 根据 `pool_method` 数值确定池化方式，选择不同的 kernel 并 launch，即最大池化选择 KernelRoiawareMaxPool3dBackward(以下称为 KernelMax )，平均池化选择 KernelRoiawareAvgPool3dBackward(以下称为 KernelAvg )，KernelMax 与 KernelAvg 的多核拆分方案是同样的
 
-  1. 将所有 `boxes_num` 个 box 分别划分为`out_x` _ `out_y` _ `out_z`个体素，体素总数共有 voxels*nums = `boxes_num` * `out_x` \_ `out_y` \* `out_z` ，将所有的体素划分以 taskDim 为间隔的若干份，每个 core 将依次跳跃间隔 taskDim 个体素循环处理，根据体素索引 voxels_idx 计算 gdram 上的数据偏移，每一个 core 负责处理其所分到的 voxels；
+  1. 将所有 `boxes_num` 个 box 分别划分为`out_x` _ `out_y` _ `out_z`个体素，体素总数共有 voxels*nums = `boxes_num` * `out_x` * `out_y` * `out_z` ，将所有的体素划分以 taskDim 为间隔的若干份，每个 core 将依次跳跃间隔 taskDim 个体素循环处理，根据体素索引 voxels_idx 计算 gdram 上的数据偏移，每一个 core 负责处理其所分到的 voxels；
 
   2. 当池化方式为最大池化时，执行 3 步骤，当池化方式为平均池化时，执行第 5 步；
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

roiaware_pool3d的mlu_op.h和文档需要修改

## 2. Modification
mlu-ops/bangc-ops/mlu_op.h 增加 roiaware_pool3d_backward的注释

mlu-ops/docs/bangc-docs/design_docs/roiaware_pool3d_forward/roiaware_pool3d_forward.md 和
mlu-ops/docs/bangc-docs/design_docs/roiaware_pool3d_backward/roiaware_pool3d_backward.md中
有错误，应该用‘×’替换‘_’。

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

- dynamic threshold
  - [x] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [x] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [x] diff4: mlu diff3 <= max(baseline diff3 * 1, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [x] MLU370
  - [x] MLU590
- Job types
  - [x] UNION1

### 3.2 Accuracy Test

MLU370 and MLU590 all pass.