### PR TITLE
[Fix](bangc-ops): roiaware add annotation and modify docs

### DIFF
--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8483,6 +8483,8 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Scale Limitation
+ * - \b boxes_num should be less than 65536.
+ * - \b channels should be less than 65536.
  * - The shape of \b pts_idx_of_voxels should be [boxes_num, out_x, out_y, out_z, max_pts_each_voxel].
  * - The shape of \b argmax should be [boxes_num, out_x, out_y, out_z, channels].
  * - The shape of \b grad_out should be [boxes_num, out_x, out_y, out_z, channels].

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8382,8 +8382,8 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * - None.
  *
  * @par Scale Limitation
- * - \b boxes_num should be less than 65536.
- * - \b channels should be less than 65536.
+ * - The value of \b boxes_num should be less than 65536.
+ * - The value of \b channels should be less than 65536.
  * - The Product of \b boxes_num and \b pts_num should be less than 2G.
  * - The shape of \b rois should be [boxes_num, 7].
  * - The shape of \b pts should be [pts_num, 3].
@@ -8483,8 +8483,8 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  * - None.
  *
  * @par Scale Limitation
- * - \b boxes_num should be less than 65536.
- * - \b channels should be less than 65536.
+ * - The value of \b boxes_num should be less than 65536.
+ * - The value of \b channels should be less than 65536.
  * - The shape of \b pts_idx_of_voxels should be [boxes_num, out_x, out_y, out_z, max_pts_each_voxel].
  * - The shape of \b argmax should be [boxes_num, out_x, out_y, out_z, channels].
  * - The shape of \b grad_out should be [boxes_num, out_x, out_y, out_z, channels].

--- a/docs/bangc-docs/design_docs/roiaware_pool3d_backward/roiaware_pool3d_backward.md
+++ b/docs/bangc-docs/design_docs/roiaware_pool3d_backward/roiaware_pool3d_backward.md
@@ -162,7 +162,7 @@ mluOpRoiawarePool3dBackward(mluOpHandle_t handle,
 
   0. 根据 `pool_method` 数值确定池化方式，选择不同的 kernel 并 launch，即最大池化选择 KernelRoiawareMaxPool3dBackward(以下称为 KernelMax )，平均池化选择 KernelRoiawareAvgPool3dBackward(以下称为 KernelAvg )，KernelMax 与 KernelAvg 的多核拆分方案是同样的
 
-  1. 将所有 `boxes_num` 个 box 分别划分为`out_x` _ `out_y` _ `out_z`个体素，体素总数共有 voxels*nums = `boxes_num` * `out_x` \_ `out_y` \* `out_z` ，将所有的体素划分以 taskDim 为间隔的若干份，每个 core 将依次跳跃间隔 taskDim 个体素循环处理，根据体素索引 voxels_idx 计算 gdram 上的数据偏移，每一个 core 负责处理其所分到的 voxels；
+  1. 将所有 `boxes_num` 个 box 分别划分为`out_x` _ `out_y` _ `out_z`个体素，体素总数共有 voxels*nums = `boxes_num` * `out_x` * `out_y` * `out_z` ，将所有的体素划分以 taskDim 为间隔的若干份，每个 core 将依次跳跃间隔 taskDim 个体素循环处理，根据体素索引 voxels_idx 计算 gdram 上的数据偏移，每一个 core 负责处理其所分到的 voxels；
 
   2. 当池化方式为最大池化时，执行 3 步骤，当池化方式为平均池化时，执行第 5 步；
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

roiaware_pool3d的mlu_op.h和文档需要修改

## 2. Modification
mlu-ops/bangc-ops/mlu_op.h 增加 roiaware_pool3d_backward的注释

mlu-ops/docs/bangc-docs/design_docs/roiaware_pool3d_forward/roiaware_pool3d_forward.md 和
mlu-ops/docs/bangc-docs/design_docs/roiaware_pool3d_backward/roiaware_pool3d_backward.md中
有符号错误，应该用乘号替换。

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

- dynamic threshold
  - [x] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [x] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [x] diff4: mlu diff3 <= max(baseline diff3 * 1, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [x] MLU370
  - [x] MLU590
- Job types
  - [x] UNION1

### 3.2 Accuracy Test

MLU370 and MLU590 all pass.