### PR TITLE
[Feature](bangc-ops): roiaware_pool3d add max_pts_each_voxel paramcheck

### DIFF
--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -32,6 +32,9 @@
 #include "core/type.h"
 
 #define THRESHOLD_OF_BOXES_NUM_AND_CHANNELS 65536
+#define THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD 2976
+#define THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD 2944
+#define THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD 98240
 
 // policy function
 static mluOpStatus_t kernelPtsIdxOfVoxelsPolicyFunc(
@@ -223,6 +226,16 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
      should be less than 65536 in cuda. */
   PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
   PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+
+  /* max_pts_each_voxel affects the allocation of NRAM memory space,
+     so it's limited by the size of NRAM memory space. */
+  if (rois_desc->dtype == MLUOP_DTYPE_FLOAT) {
+    PARAM_CHECK(API, max_pts_each_voxel <=
+      THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD);
+  } else {
+    PARAM_CHECK(API, max_pts_each_voxel <=
+      THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD);
+  }
 
   const uint64_t tensor_rois_num = mluOpGetTensorElementNum(rois_desc);
   const uint64_t tensor_pts_num = mluOpGetTensorElementNum(pts_desc);
@@ -507,10 +520,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   PARAM_CHECK(API, out_z > 0);
 
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
-    Maximum y- or z-dimension of a grid of thread blocks
-    should be less than 65536 in cuda. */
+     Maximum y- or z-dimension of a grid of thread blocks
+     should be less than 65536 in cuda. */
   PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
   PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+
+  /* max_pts_each_voxel affects the allocation of NRAM memory space,
+     so it's limited by the size of NRAM memory space. */
+  PARAM_CHECK(API, max_pts_each_voxel <=
+    THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD);
 
   const uint64_t tensor_pts_idx_of_voxels_num =
       mluOpGetTensorElementNum(pts_idx_of_voxels_desc);

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -8385,6 +8385,8 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * - The value of \b boxes_num should be less than 65536.
  * - The value of \b channels should be less than 65536.
  * - The Product of \b boxes_num and \b pts_num should be less than 2G.
+ * - When the data type is floating point, the value of \b max_pts_each_voxel cannot be
+ * greater than 2976, and when the data type is half, it cannot be greater than 2944.
  * - The shape of \b rois should be [boxes_num, 7].
  * - The shape of \b pts should be [pts_num, 3].
  * - The shape of \b pts_feature should be [pts_num, channels].
@@ -8485,6 +8487,7 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  * @par Scale Limitation
  * - The value of \b boxes_num should be less than 65536.
  * - The value of \b channels should be less than 65536.
+ * - The value of \b max_pts_each_voxel cannot be greater than 98240.
  * - The shape of \b pts_idx_of_voxels should be [boxes_num, out_x, out_y, out_z, max_pts_each_voxel].
  * - The shape of \b argmax should be [boxes_num, out_x, out_y, out_z, channels].
  * - The shape of \b grad_out should be [boxes_num, out_x, out_y, out_z, channels].


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Limitation中有max_pts_each_voxel参数防呆，将这个防呆加到host端中

## 2. Modification

mlu-ops/banc-ops/mlu_op.h 增加max_pts_each_voxel参数说明
mlu-ops/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp 增加max_pts_each_voxel防呆
