### PR TITLE
[Feature](bangc-ops):Roiaware_pool3d specify 'paramcheck'

### DIFF
--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -232,17 +232,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
      so it's limited by the size of NRAM memory space. */
   if (rois_desc->dtype == MLUOP_DTYPE_FLOAT) {
     if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD) {
-      LOG(ERROR) << API
-                 << ": When the data type is float, max_pts_each_voxel cannot "
-                    "be greater than "
+      LOG(ERROR) << API << ": When the data type is float, "
+                    "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD << ".";
       return MLUOP_STATUS_BAD_PARAM;
     }
   } else {
     if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD) {
-      LOG(ERROR) << API
-                 << ": When the data type is half, max_pts_each_voxel cannot "
-                    "be greater than "
+      LOG(ERROR) << API << ": When the data type is half, "
+                    "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD << ".";
       return MLUOP_STATUS_BAD_PARAM;
     }

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -218,12 +218,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
   if (boxes_num >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << " Check failed: " << "boxes_num should be less than "
+    LOG(ERROR) << API << " Check failed: "
+               << "boxes_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << " Check failed: " << "pts_num should be less than "
+    LOG(ERROR) << API << " Check failed: "
+               << "pts_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
@@ -232,14 +234,16 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
      so it's limited by the size of NRAM memory space. */
   if (rois_desc->dtype == MLUOP_DTYPE_FLOAT) {
     if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD) {
-      LOG(ERROR) << API << " Check failed: " << "When the data type is float, "
+      LOG(ERROR) << API << " Check failed: "
+                 << "When the data type is float, "
                     "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD << ".";
       return MLUOP_STATUS_BAD_PARAM;
     }
   } else {
     if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD) {
-      LOG(ERROR) << API << " Check failed: " << "When the data type is half, "
+      LOG(ERROR) << API << " Check failed: "
+                 << "When the data type is half, "
                     "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD << ".";
       return MLUOP_STATUS_BAD_PARAM;
@@ -265,9 +269,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   // product of boxes_num and pts_num < 2^31
   size_t product_boxesNum_ptsNum = (size_t)boxes_num * (size_t)pts_num;
   if (product_boxesNum_ptsNum > (size_t)INT32_MAX) {
-    LOG(ERROR)
-        << API << " Check failed: "
-        << "product of boxes_num and pts_num should be less than 2^31.";
+    LOG(ERROR) << API << " Check failed: "
+               << "product of boxes_num and pts_num should be less than 2^31.";
     return MLUOP_STATUS_BAD_PARAM;
   }
 
@@ -529,12 +532,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
   if (boxes_num >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << " Check failed: " << "boxes_num should be less than "
+    LOG(ERROR) << API << " Check failed: "
+               << "boxes_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << " Check failed: " << "pts_num should be less than "
+    LOG(ERROR) << API << " Check failed: "
+               << "pts_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
@@ -542,7 +547,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   /* max_pts_each_voxel affects the allocation of NRAM memory space,
      so it's limited by the size of NRAM memory space. */
   if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD) {
-    LOG(ERROR) << API << " Check failed: " 
+    LOG(ERROR) << API << " Check failed: "
                << "max_pts_each_voxel cannot be greater than "
                << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD << ".";
     return MLUOP_STATUS_BAD_PARAM;

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -221,13 +221,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
     LOG(ERROR) << API << " Check failed: "
                << "boxes_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
-    return MLUOP_STATUS_BAD_PARAM;
+    return MLUOP_STATUS_NOT_SUPPORTED;
   }
   if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
     LOG(ERROR) << API << " Check failed: "
                << "pts_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
-    return MLUOP_STATUS_BAD_PARAM;
+    return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
   /* max_pts_each_voxel affects the allocation of NRAM memory space,
@@ -238,7 +238,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
                  << "When the data type is float, "
                     "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD << ".";
-      return MLUOP_STATUS_BAD_PARAM;
+      return MLUOP_STATUS_NOT_SUPPORTED;
     }
   } else {
     if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD) {
@@ -246,7 +246,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
                  << "When the data type is half, "
                     "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD << ".";
-      return MLUOP_STATUS_BAD_PARAM;
+      return MLUOP_STATUS_NOT_SUPPORTED;
     }
   }
 
@@ -271,7 +271,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   if (product_boxesNum_ptsNum > (size_t)INT32_MAX) {
     LOG(ERROR) << API << " Check failed: "
                << "product of boxes_num and pts_num should be less than 2^31.";
-    return MLUOP_STATUS_BAD_PARAM;
+    return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
   // check workspace
@@ -535,13 +535,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
     LOG(ERROR) << API << " Check failed: "
                << "boxes_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
-    return MLUOP_STATUS_BAD_PARAM;
+    return MLUOP_STATUS_NOT_SUPPORTED;
   }
   if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
     LOG(ERROR) << API << " Check failed: "
                << "pts_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
-    return MLUOP_STATUS_BAD_PARAM;
+    return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
   /* max_pts_each_voxel affects the allocation of NRAM memory space,
@@ -550,7 +550,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
     LOG(ERROR) << API << " Check failed: "
                << "max_pts_each_voxel cannot be greater than "
                << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD << ".";
-    return MLUOP_STATUS_BAD_PARAM;
+    return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
   const uint64_t tensor_pts_idx_of_voxels_num =

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -218,12 +218,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
   if (boxes_num >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << ": boxes_num should be less than "
+    LOG(ERROR) << API << " Check failed: " << "boxes_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << ": pts_num should be less than "
+    LOG(ERROR) << API << " Check failed: " << "pts_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
@@ -232,14 +232,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
      so it's limited by the size of NRAM memory space. */
   if (rois_desc->dtype == MLUOP_DTYPE_FLOAT) {
     if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD) {
-      LOG(ERROR) << API << ": When the data type is float, "
+      LOG(ERROR) << API << " Check failed: " << "When the data type is float, "
                     "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD << ".";
       return MLUOP_STATUS_BAD_PARAM;
     }
   } else {
     if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD) {
-      LOG(ERROR) << API << ": When the data type is half, "
+      LOG(ERROR) << API << " Check failed: " << "When the data type is half, "
                     "max_pts_each_voxel cannot be greater than "
                  << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD << ".";
       return MLUOP_STATUS_BAD_PARAM;
@@ -266,15 +266,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   size_t product_boxesNum_ptsNum = (size_t)boxes_num * (size_t)pts_num;
   if (product_boxesNum_ptsNum > (size_t)INT32_MAX) {
     LOG(ERROR)
-        << API
-        << ": product of boxes_num and pts_num should be less than 2^31.";
+        << API << " Check failed: "
+        << "product of boxes_num and pts_num should be less than 2^31.";
     return MLUOP_STATUS_BAD_PARAM;
   }
 
   // check workspace
   if (workspace_size > 0 && workspace == NULL) {
-    LOG(ERROR) << API
-               << ": workspace shouldn't be null when workspace_size > 0.";
+    LOG(ERROR) << API << " Check failed: "
+               << "workspace shouldn't be null when workspace_size > 0.";
     return MLUOP_STATUS_BAD_PARAM;
   }
 
@@ -529,12 +529,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
   if (boxes_num >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << ": boxes_num should be less than "
+    LOG(ERROR) << API << " Check failed: " << "boxes_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
   if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
-    LOG(ERROR) << API << ": pts_num should be less than "
+    LOG(ERROR) << API << " Check failed: " << "pts_num should be less than "
                << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
@@ -542,7 +542,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   /* max_pts_each_voxel affects the allocation of NRAM memory space,
      so it's limited by the size of NRAM memory space. */
   if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD) {
-    LOG(ERROR) << API << ": max_pts_each_voxel cannot be greater than "
+    LOG(ERROR) << API << " Check failed: " 
+               << "max_pts_each_voxel cannot be greater than "
                << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
@@ -570,7 +571,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
 
   // check arch
   if (handle->arch < MLUOP_MLU370) {
-    LOG(ERROR) << API
+    LOG(ERROR) << API << " Check failed: "
                << " The operator does not match the current architecture.";
     return MLUOP_STATUS_ARCH_MISMATCH;
   }

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -102,24 +102,17 @@ static mluOpStatus_t transposeTensor(
     const void *input, const int *permute,
     const mluOpTensorDescriptor_t workspace_dst_desc, void *workspace_dst,
     void *transpose_workspace) {
-  const std::string API = "[mluOpRoiawarePool3dForward]";
   int input_dim = input_desc->dim;
   mluOpTransposeDescriptor_t trans_desc = NULL;
   size_t transpose_workspace_size = 0;
-  PARAM_CHECK(
-      API, MLUOP_STATUS_SUCCESS == mluOpCreateTransposeDescriptor(&trans_desc));
-  PARAM_CHECK(API, MLUOP_STATUS_SUCCESS == mluOpSetTransposeDescriptor(
-                                               trans_desc, input_dim, permute));
-  PARAM_CHECK(API, MLUOP_STATUS_SUCCESS == mluOpGetTransposeWorkspaceSize(
-                                               handle, input_desc, trans_desc,
-                                               &transpose_workspace_size));
-  PARAM_CHECK(API, MLUOP_STATUS_SUCCESS ==
-                       mluOpTranspose_v2(handle, trans_desc, input_desc, input,
-                                         workspace_dst_desc, workspace_dst,
-                                         transpose_workspace,
-                                         transpose_workspace_size));
-  PARAM_CHECK(
-      API, MLUOP_STATUS_SUCCESS == mluOpDestroyTransposeDescriptor(trans_desc));
+  MLUOP_CHECK(mluOpCreateTransposeDescriptor(&trans_desc));
+  MLUOP_CHECK(mluOpSetTransposeDescriptor(trans_desc, input_dim, permute));
+  MLUOP_CHECK(mluOpGetTransposeWorkspaceSize(handle, input_desc, trans_desc,
+                                             &transpose_workspace_size));
+  MLUOP_CHECK(mluOpTranspose_v2(handle, trans_desc, input_desc, input,
+                                workspace_dst_desc, workspace_dst,
+                                transpose_workspace, transpose_workspace_size));
+  MLUOP_CHECK(mluOpDestroyTransposeDescriptor(trans_desc));
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -224,8 +217,36 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
-  PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
-  PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+  if (boxes_num >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
+    LOG(ERROR) << API << ": boxes_num should be less than "
+               << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
+    LOG(ERROR) << API << ": pts_num should be less than "
+               << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  /* max_pts_each_voxel affects the allocation of NRAM memory space,
+     so it's limited by the size of NRAM memory space. */
+  if (rois_desc->dtype == MLUOP_DTYPE_FLOAT) {
+    if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD) {
+      LOG(ERROR) << API
+                 << ": When the data type is float, max_pts_each_voxel cannot "
+                    "be greater than "
+                 << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+  } else {
+    if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD) {
+      LOG(ERROR) << API
+                 << ": When the data type is half, max_pts_each_voxel cannot "
+                    "be greater than "
+                 << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+  }
 
   /* max_pts_each_voxel affects the allocation of NRAM memory space,
      so it's limited by the size of NRAM memory space. */
@@ -346,16 +367,16 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   }
   mluOpTensorDescriptor_t pts_desc_tmp = NULL;
   MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_desc_tmp));
-  PARAM_CHECK(API,
-              MLUOP_STATUS_SUCCESS ==
-                  mluOpSetTensorDescriptor(pts_desc_tmp, MLUOP_LAYOUT_ARRAY,
-                                           data_dtype, pts_dim, pts_tmp_dims));
-  PARAM_CHECK(
-      API, MLUOP_STATUS_SUCCESS ==
-               transposeTensor(handle, pts_desc, pts, pts_permute, pts_desc_tmp,
-                               pts_workspace, transpose_workspace));
-  PARAM_CHECK(
-      API, MLUOP_STATUS_SUCCESS == mluOpDestroyTensorDescriptor(pts_desc_tmp));
+  MLUOP_CHECK(mluOpSetTensorDescriptor(pts_desc_tmp, MLUOP_LAYOUT_ARRAY,
+                                       data_dtype, pts_dim, pts_tmp_dims));
+
+  auto ret = transposeTensor(handle, pts_desc, pts, pts_permute, pts_desc_tmp,
+                             pts_workspace, transpose_workspace);
+  if (ret != MLUOP_STATUS_SUCCESS) {
+    return ret;
+  }
+
+  MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_desc_tmp));
   VLOG(5) << "[mluOpRoiawarePool3dForward] mluOpTranspose pts end.";
 
   VLOG(5) << "[mluOpRoiawarePool3dForward] mluOpTranspose pts_feature start.";
@@ -367,35 +388,32 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   }
   mluOpTensorDescriptor_t pts_feature_desc_tmp = NULL;
   MLUOP_CHECK(mluOpCreateTensorDescriptor(&pts_feature_desc_tmp));
-  PARAM_CHECK(API, MLUOP_STATUS_SUCCESS ==
-                       mluOpSetTensorDescriptor(
-                           pts_feature_desc_tmp, MLUOP_LAYOUT_ARRAY, data_dtype,
-                           pts_feature_dim, pts_feature_tmp_dims));
-  PARAM_CHECK(API,
-              MLUOP_STATUS_SUCCESS ==
-                  transposeTensor(handle, pts_feature_desc, pts_feature,
-                                  pts_feature_permute, pts_feature_desc_tmp,
-                                  pts_feature_workspace, transpose_workspace));
-  PARAM_CHECK(API, MLUOP_STATUS_SUCCESS ==
-                       mluOpDestroyTensorDescriptor(pts_feature_desc_tmp));
+  MLUOP_CHECK(mluOpSetTensorDescriptor(pts_feature_desc_tmp, MLUOP_LAYOUT_ARRAY,
+                                       data_dtype, pts_feature_dim,
+                                       pts_feature_tmp_dims));
+
+  ret = transposeTensor(handle, pts_feature_desc, pts_feature,
+                        pts_feature_permute, pts_feature_desc_tmp,
+                        pts_feature_workspace, transpose_workspace);
+  if (ret != MLUOP_STATUS_SUCCESS) {
+    return ret;
+  }
+
+  MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_feature_desc_tmp));
   VLOG(5) << "[mluOpRoiawarePool3dForward] mluOpTranspose pts_feature end.";
 
   VLOG(5) << "[mluOpRoiawarePool3dForward] mluOpFill_v3 host pointer start.";
   int argmax_initial_value = (pool_method == 0) ? -1 : 0;
-  PARAM_CHECK(
-      API, MLUOP_STATUS_SUCCESS == mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
-                                                &argmax_initial_value,
-                                                argmax_desc, argmax));
+  MLUOP_CHECK(mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
+                           &argmax_initial_value, argmax_desc, argmax));
   int pts_idx_initial_value = 0;
-  PARAM_CHECK(API, MLUOP_STATUS_SUCCESS ==
-                       mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
-                                    &pts_idx_initial_value,
-                                    pts_idx_of_voxels_desc, pts_idx_of_voxels));
+  MLUOP_CHECK(mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
+                           &pts_idx_initial_value, pts_idx_of_voxels_desc,
+                           pts_idx_of_voxels));
   int pooled_features_initial_value = 0;
-  PARAM_CHECK(API, MLUOP_STATUS_SUCCESS ==
-                       mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
-                                    &pooled_features_initial_value,
-                                    pooled_features_desc, pooled_features));
+  MLUOP_CHECK(mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
+                           &pooled_features_initial_value, pooled_features_desc,
+                           pooled_features));
   VLOG(5) << "[mluOpRoiawarePool3dForward] mluOpFill host pointer end.";
 
   cnrtDim3_t k_dim;
@@ -522,8 +540,24 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
-  PARAM_CHECK(API, boxes_num < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
-  PARAM_CHECK(API, channels < THRESHOLD_OF_BOXES_NUM_AND_CHANNELS);
+  if (boxes_num >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
+    LOG(ERROR) << API << ": boxes_num should be less than "
+               << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+  if (channels >= THRESHOLD_OF_BOXES_NUM_AND_CHANNELS) {
+    LOG(ERROR) << API << ": pts_num should be less than "
+               << THRESHOLD_OF_BOXES_NUM_AND_CHANNELS << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  /* max_pts_each_voxel affects the allocation of NRAM memory space,
+     so it's limited by the size of NRAM memory space. */
+  if (max_pts_each_voxel > THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD) {
+    LOG(ERROR) << API << ": max_pts_each_voxel cannot be greater than "
+               << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD << ".";
+    return MLUOP_STATUS_BAD_PARAM;
+  }
 
   /* max_pts_each_voxel affects the allocation of NRAM memory space,
      so it's limited by the size of NRAM memory space. */
@@ -589,10 +623,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   // generate mluOpRoiawarePool3dBackward prototxt end!
 
   int grad_in_initial_value = 0;
-  PARAM_CHECK(
-      API, MLUOP_STATUS_SUCCESS == mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
-                                                &grad_in_initial_value,
-                                                grad_in_desc, grad_in));
+  MLUOP_CHECK(mluOpFill_v3(handle, MLUOP_POINTER_MODE_HOST,
+                           &grad_in_initial_value, grad_in_desc, grad_in));
   VLOG(5)
       << "[mluOpRoiawarePool3dBackward] Initialize output space successfully.";
 

--- a/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/bangc-ops/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -248,16 +248,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
     }
   }
 
-  /* max_pts_each_voxel affects the allocation of NRAM memory space,
-     so it's limited by the size of NRAM memory space. */
-  if (rois_desc->dtype == MLUOP_DTYPE_FLOAT) {
-    PARAM_CHECK(API, max_pts_each_voxel <=
-      THRESHOLD_OF_MAX_PTS_EACH_VOXEL_FLOAT_FORWARD);
-  } else {
-    PARAM_CHECK(API, max_pts_each_voxel <=
-      THRESHOLD_OF_MAX_PTS_EACH_VOXEL_HALF_FORWARD);
-  }
-
   const uint64_t tensor_rois_num = mluOpGetTensorElementNum(rois_desc);
   const uint64_t tensor_pts_num = mluOpGetTensorElementNum(pts_desc);
   const uint64_t tensor_pts_feature_num =
@@ -558,11 +548,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
                << THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
-
-  /* max_pts_each_voxel affects the allocation of NRAM memory space,
-     so it's limited by the size of NRAM memory space. */
-  PARAM_CHECK(API, max_pts_each_voxel <=
-    THRESHOLD_OF_MAX_PTS_EACH_VOXEL_BACKWARD);
 
   const uint64_t tensor_pts_idx_of_voxels_num =
       mluOpGetTensorElementNum(pts_idx_of_voxels_desc);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

规范防呆相关代码.

## 2. Modification

- 调用mluops其他算子应使用MLUOP_CHECK。
- 对宏定义变量的PARAM_CHECK重新改写。
原因：宏定义的变量（如：THRESHOLD_OF_BOXES_NUM_AND_CHANNELS），
使用PARAM_CHECK时，LOG信息只显示字符串，不具备自解释性。
- 调用函数（如：transposeTensor），在函数内部输出LOG。
