### PR TITLE
[Feature](bangc-ops): add maximum input size check for box_iou_rotated.

### DIFF
--- a/bangc-ops/kernels/box_iou_rotated/box_iou_rotated.cpp
+++ b/bangc-ops/kernels/box_iou_rotated/box_iou_rotated.cpp
@@ -32,6 +32,7 @@
 
 // each box data contains 5 number: x, y, w, h, a
 #define SINGLE_BOX_DIM 5
+#define MAX_BOX_NUM 10000000
 
 static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type, const bool aligned,
@@ -146,6 +147,12 @@ mluOpBoxIouRotated(mluOpHandle_t handle, const int mode, const bool aligned,
           << "box1_desc->dims[0] should equal to box2_desc->dims[0]. But now "
           << "box1_desc->dims[0] is " << box1_desc->dims[0]
           << ", box2_desc->dims[0] is " << box2_desc->dims[0] << ".";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+    if (box1_desc->dims[0] > MAX_BOX_NUM) {
+      LOG(ERROR) << "[mluOpBoxIouRotated] Check failed: If it is aligned mode, "
+                 << "box1_desc->dims[0] should less than or equal to "
+                 << "10,000,000. But now is " << box1_desc->dims[0] << ".";
       return MLUOP_STATUS_BAD_PARAM;
     }
   } else {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

add maximum input size check for box_iou_rotated

## 2. Modification

bangc-ops/kernels/box_iou_rotated/box_iou_rotated.cpp


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [x] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [x] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

skip

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test
skip

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
[2023-10-9 19:16:1] [MLUOP] [Error]:[mluOpBoxIouRotated] Check failed: If it is aligned mode, box1_desc->dims[0] should less than or equal to 10,000,000. But now is 20000001.
[2023-10-9 19:16:1] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpBoxIouRotated(handle_, mode, aligned, box1, dev_box1, box2, dev_box2, ious, dev_ious)"
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
[2023-10-9 19:11:59] [MLUOP] [Error]:[mluOpBoxIouRotated] Check failed: If it is aligned mode, box1_desc->dims[0] * box2_desc->dims[0] should less than or equal to 10,000,000. But now is 50000000.
[2023-10-9 19:11:59] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpBoxIouRotated(handle_, mode, aligned, box1, dev_box1, box2, dev_box2, ious, dev_ious)"
```


### 3.3 Performance Test
skip

### 3.4 Summary Analysis
release_test/release_temp/benchmark 370/590 passed.
