### PR TITLE
[Test](bangc-ops): delete unused op_type

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/active_rotated_filter_forward/test_case/case0_.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/active_rotated_filter_forward/test_case/case0_.prototxt
@@ -1,4 +1,3 @@
-
 op_name: "active_rotated_filter_forward"
 input {
   id: "input"

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/add_n/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/add_n/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "add_n"
-op_type: "ADDN"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/gather_nd/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/gather_nd/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "gather_nd"
-op_type: "GATHER_ND"
 input {
   id: "params"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/gather_nd/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/gather_nd/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "gather_nd"
-op_type: "GATHER_ND"
 input {
   id: "params"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/gather_nd/test_case/case_2.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/gather_nd/test_case/case_2.prototxt
@@ -1,5 +1,4 @@
 op_name: "gather_nd"
-op_type: "GATHER_ND"
 input {
   id: "params"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/matmul/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/matmul/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "matmul"
-op_type: "MATMUL"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/nms/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/nms/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "nms"
-op_type: "NMS"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/nms/test_case/nms3d_case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/nms/test_case/nms3d_case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "nms"
-op_type: "NMS"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/reduce/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/reduce/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "reduce"
-op_type: "REDUCE"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/reduce/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/reduce/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "reduce"
-op_type: "REDUCE"
 input {
 id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/reduce/test_case/case_2.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/reduce/test_case/case_2.prototxt
@@ -1,5 +1,4 @@
 op_name: "reduce"
-op_type: "REDUCE"
 input {
 id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "roialign_forward"
-op_type: "ROIALIGN_FORWARD"
 input {
   id: "input0"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "roialign_forward"
-op_type: "ROIALIGN_FORWARD"
 input {
   id: "input0"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_2.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_2.prototxt
@@ -1,5 +1,4 @@
 op_name: "roialign_forward"
-op_type: "ROIALIGN_FORWARD"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_3.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_3.prototxt
@@ -1,5 +1,4 @@
 op_name: "roialign_forward"
-op_type: "ROIALIGN_FORWARD"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_4.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/roialign_forward/test_case/case_4.prototxt
@@ -1,5 +1,4 @@
 op_name: "roialign_forward"
-op_type: "ROIALIGN_FORWARD"
 input {
   id: "input0"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/scatter_nd/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/scatter_nd/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "scatter_nd"
-op_type: "SCATTER_ND"
 input {
   id: "indices"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/scatter_nd/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/scatter_nd/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "scatter_nd"
-op_type: "SCATTER_ND"
 input {
   id: "indices"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batch_norm_backward_elemt/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batch_norm_backward_elemt/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batch_norm_backward_elemt"
-op_type: "SYNC_BATCHNORM_BACKWARD_ELEMT"
 input {
   id: "diff_y"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_backward_elemt_v2/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_backward_elemt_v2/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batchnorm_backward_elemt_v2"
-op_type: "SYNC_BATCHNORM_BACKWARD_ELEMT_V2"
 input {
   id: "diff_y"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_backward_reduce/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_backward_reduce/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batchnorm_backward_reduce"
-op_type: "SYNC_BATCHNORM_BACKWARD_REDUCE"
 input{
     id:"dz"
     shape:{

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_elemt/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_elemt/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batchnorm_elemt"
-op_type: "SYNC_BATCHNORM_ELEMT"
 input {
   id: "x"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_gather_stats_with_counts/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_gather_stats_with_counts/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batchnorm_gather_stats_with_counts"
-op_type: "SYNC_BATCHNORM_GATHER_STATS_WITH_COUNTS"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_gather_stats_with_counts/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_gather_stats_with_counts/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batchnorm_gather_stats_with_counts"
-op_type: "SYNC_BATCHNORM_GATHER_STATS_WITH_COUNTS"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_gather_stats_with_counts/test_case/case_2.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_gather_stats_with_counts/test_case/case_2.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batchnorm_gather_stats_with_counts"
-op_type: "SYNC_BATCHNORM_GATHER_STATS_WITH_COUNTS"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_stats/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/sync_batchnorm_stats/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "sync_batchnorm_stats"
-op_type: "SYNC_BATCHNORM_STATS"
 input {
   id: "x"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "transform"
-op_type: "TRANSFORM"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "transform"
-op_type: "TRANSFORM"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/complex.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/complex.prototxt
@@ -1,5 +1,4 @@
 op_name: "transform"
-op_type: "TRANSFORM"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/half_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/half_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "transform"
-op_type: "TRANSFORM"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/int32_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transform/test_case/int32_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "transform"
-op_type: "TRANSFORM"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transpose/test_case/8D_int64.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transpose/test_case/8D_int64.prototxt
@@ -1,5 +1,4 @@
 op_name: "transpose"
-op_type: "TRANSPOSE"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transpose/test_case/case2D.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/transpose/test_case/case2D.prototxt
@@ -1,5 +1,4 @@
 op_name: "transpose"
-op_type: "TRANSPOSE"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/unique/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/unique/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "unique"
-op_type: "UNIQUE"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/unique/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/unique/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "unique"
-op_type: "UNIQUE"
 input {
   id: "input"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/unique/test_case/case_2.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/unique/test_case/case_2.prototxt
@@ -1,5 +1,4 @@
 op_name: "unique"
-op_type: "UNIQUE"
 input {
   id: "input"
   shape: {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

OpType 未使能，不再用 string 类型

## 2. Modification

将 CPU 测例中 string类型的 OpType 行删除.