### PR TITLE
[TEST](bangc-ops): Delete op_type in cpu cases of pad operator

### DIFF
--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_0.prototxt
@@ -1,5 +1,4 @@
 op_name: "pad"
-op_type: "PAD"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_1.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_1.prototxt
@@ -1,5 +1,4 @@
 op_name: "pad"
-op_type: "PAD"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_2.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_2.prototxt
@@ -1,5 +1,4 @@
 op_name: "pad"
-op_type: "PAD"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_3.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_3.prototxt
@@ -1,5 +1,4 @@
 op_name: "pad"
-op_type: "PAD"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_4.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_4.prototxt
@@ -1,5 +1,4 @@
 op_name: "pad"
-op_type: "PAD"
 input {
   id: "input1"
   shape: {

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_5.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_5.prototxt
@@ -1,5 +1,4 @@
 op_name: "pad"
-op_type: "PAD"
 input {
   id: "input1"
   shape: {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

delete op_type in cpu cases of pad operator

## 2. Modification

	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_0.prototxt
	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_1.prototxt
	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_2.prototxt
	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_3.prototxt
	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_4.prototxt
	modified:   bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_5.prototxt


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [x] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [x] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test


```bash
duzekun@mlu370-x4-28:/projs/platform/duzekun/dzk_mluops/mlu-ops/bangc-ops/build/test$ ./mluop_gtest --gtest_filter=*pad*
Note: Google Test filter = *pad*
[==========] Running 6 test cases from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from pad/TestSuite
[ RUN      ] pad/TestSuite.mluOp/0
[MLU Hardware Time      ]: 25 (us)
[MLU Interface Time     ]: 177.479 (us)
[MLU IO Efficiency      ]: 0.183305
[MLU Compute Efficiency ]: 0.0137329
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 703125 (Ops)
[MLU TheoryIOs          ]: 1.40779e+06 (Bytes)
[MLU ComputeForce       ]: 2.048e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_0.prototxt
[       OK ] pad/TestSuite.mluOp/0 (32 ms)
[ RUN      ] pad/TestSuite.mluOp/1
[MLU Hardware Time      ]: 5 (us)
[MLU Interface Time     ]: 47.38 (us)
[MLU IO Efficiency      ]: 0.000167969
[MLU Compute Efficiency ]: 1.02539e-05
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 105 (Ops)
[MLU TheoryIOs          ]: 258 (Bytes)
[MLU ComputeForce       ]: 2.048e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_1.prototxt
[       OK ] pad/TestSuite.mluOp/1 (42 ms)
[ RUN      ] pad/TestSuite.mluOp/2
[MLU Hardware Time      ]: 9 (us)
[MLU Interface Time     ]: 35.36 (us)
[MLU IO Efficiency      ]: 0.00678819
[MLU Compute Efficiency ]: 0.000488281
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 4500 (Ops)
[MLU TheoryIOs          ]: 18768 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_2.prototxt
[       OK ] pad/TestSuite.mluOp/2 (9 ms)
[ RUN      ] pad/TestSuite.mluOp/3
[MLU Hardware Time      ]: 4 (us)
[MLU Interface Time     ]: 24.04 (us)
[MLU IO Efficiency      ]: 0.0146419
[MLU Compute Efficiency ]: 0.000598145
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 4900 (Ops)
[MLU TheoryIOs          ]: 17992 (Bytes)
[MLU ComputeForce       ]: 2.048e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_3.prototxt
[       OK ] pad/TestSuite.mluOp/3 (54 ms)
[ RUN      ] pad/TestSuite.mluOp/4
[MLU Hardware Time      ]: 24 (us)
[MLU Interface Time     ]: 33.23 (us)
[MLU IO Efficiency      ]: 0.381886
[MLU Compute Efficiency ]: 0.0286102
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 703125 (Ops)
[MLU TheoryIOs          ]: 2.81557e+06 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_4.prototxt
[       OK ] pad/TestSuite.mluOp/4 (58 ms)
[ RUN      ] pad/TestSuite.mluOp/5
[MLU Hardware Time      ]: 3 (us)
[MLU Interface Time     ]: 65.32 (us)
[MLU IO Efficiency      ]: 0.000104167
[MLU Compute Efficiency ]: 3.90625e-06
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 12 (Ops)
[MLU TheoryIOs          ]: 96 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/pad/test_case/case_5.prototxt
[       OK ] pad/TestSuite.mluOp/5 (10 ms)
[----------] 6 tests from pad/TestSuite (205 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 6 cases of 1 op(s).
ALL PASSED.
[==========] 6 test cases from 1 test suite ran. (2348 ms total)
[  PASSED  ] 6 test cases.

```

