### PR TITLE
[feature](bangc-ops):add batch_matmul_bcast

### DIFF
--- a/bangc-ops/.gitattributes
+++ b/bangc-ops/.gitattributes
@@ -1,0 +1,1 @@
+*.a filter=lfs diff=lfs merge=lfs -text

--- a/bangc-ops/.gitattributes
+++ b/bangc-ops/.gitattributes
@@ -1,1 +1,0 @@
-*.a filter=lfs diff=lfs merge=lfs -text

--- a/bangc-ops/kernels/batch_matmul_bcast/batch_matmul_bcast.cpp
+++ b/bangc-ops/kernels/batch_matmul_bcast/batch_matmul_bcast.cpp
@@ -1,0 +1,63 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#include "kernels/kernel_wrapper/wrapper.h"
+
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast(mluOpHandle_t handle,
+                                                  const bool is_transa,
+                                                  const bool is_transb,
+                                                  const mluOpTensorDescriptor_t a_desc,
+                                                  const void *a,
+                                                  const mluOpTensorDescriptor_t b_desc,
+                                                  const void *b,
+                                                  void *workspace,
+                                                  size_t workspace_size,
+                                                  const mluOpTensorDescriptor_t c_desc,
+                                                  void *c) {
+    BatchMatMulBCastWrapper wrapper;
+    mluOpStatus_t ret = wrapper.invoke(handle, is_transa, is_transb,
+                                       a_desc, a, b_desc, b, workspace,
+                                       workspace_size, c_desc, c);
+    return ret;
+}
+
+
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast_v2(mluOpHandle_t handle,
+                                                     mluOpMatMulDescriptor_t bmm_bcast_desc,
+                                                     mluOpMatMulAlgo_t  algo,
+                                                     const void *alpha,
+                                                     const mluOpTensorDescriptor_t a_desc,
+                                                     const void *a,
+                                                     const mluOpTensorDescriptor_t b_desc,
+                                                     const void *b,
+                                                     const void *beta,
+                                                     const mluOpTensorDescriptor_t c_desc,
+                                                     void *c,
+                                                     void *workspace,
+                                                     size_t workspace_size) {
+    BatchMatMulBCastV2Wrapper wrapper;
+    mluOpStatus_t ret = wrapper.invoke(handle, bmm_bcast_desc, algo, alpha,
+                                       a_desc, a, b_desc, b, beta, c_desc, c,
+                                       workspace, workspace_size);
+    return ret;
+}

--- a/bangc-ops/kernels/batch_matmul_bcast/batch_matmul_bcast.cpp
+++ b/bangc-ops/kernels/batch_matmul_bcast/batch_matmul_bcast.cpp
@@ -23,41 +23,29 @@
 
 #include "kernels/kernel_wrapper/wrapper.h"
 
-mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast(mluOpHandle_t handle,
-                                                  const bool is_transa,
-                                                  const bool is_transb,
-                                                  const mluOpTensorDescriptor_t a_desc,
-                                                  const void *a,
-                                                  const mluOpTensorDescriptor_t b_desc,
-                                                  const void *b,
-                                                  void *workspace,
-                                                  size_t workspace_size,
-                                                  const mluOpTensorDescriptor_t c_desc,
-                                                  void *c) {
-    BatchMatMulBCastWrapper wrapper;
-    mluOpStatus_t ret = wrapper.invoke(handle, is_transa, is_transb,
-                                       a_desc, a, b_desc, b, workspace,
-                                       workspace_size, c_desc, c);
-    return ret;
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast(
+    mluOpHandle_t handle, const bool is_transa, const bool is_transb,
+    const mluOpTensorDescriptor_t a_desc, const void *a,
+    const mluOpTensorDescriptor_t b_desc, const void *b, void *workspace,
+    size_t workspace_size, const mluOpTensorDescriptor_t c_desc, void *c) {
+  BatchMatMulBCastWrapper wrapper;
+  mluOpStatus_t ret =
+      wrapper.invoke(handle, is_transa, is_transb, a_desc, a, b_desc, b,
+                     workspace, workspace_size, c_desc, c);
+  return ret;
 }
 
-
-mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast_v2(mluOpHandle_t handle,
-                                                     mluOpMatMulDescriptor_t bmm_bcast_desc,
-                                                     mluOpMatMulAlgo_t  algo,
-                                                     const void *alpha,
-                                                     const mluOpTensorDescriptor_t a_desc,
-                                                     const void *a,
-                                                     const mluOpTensorDescriptor_t b_desc,
-                                                     const void *b,
-                                                     const void *beta,
-                                                     const mluOpTensorDescriptor_t c_desc,
-                                                     void *c,
-                                                     void *workspace,
-                                                     size_t workspace_size) {
-    BatchMatMulBCastV2Wrapper wrapper;
-    mluOpStatus_t ret = wrapper.invoke(handle, bmm_bcast_desc, algo, alpha,
-                                       a_desc, a, b_desc, b, beta, c_desc, c,
-                                       workspace, workspace_size);
-    return ret;
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast_v2(
+    mluOpHandle_t handle, mluOpMatMulDescriptor_t bmm_bcast_desc,
+    mluOpMatMulAlgo_t algo, const void *alpha,
+    const mluOpTensorDescriptor_t a_desc, const void *a,
+    const mluOpTensorDescriptor_t b_desc, const void *b, const void *beta,
+    const mluOpTensorDescriptor_t c_desc, void *c, void *workspace,
+    size_t workspace_size) {
+  BatchMatMulBCastV2Wrapper wrapper;
+  mluOpStatus_t ret =
+      wrapper.invoke(handle, bmm_bcast_desc, algo, alpha, a_desc, a, b_desc, b,
+                     beta, c_desc, c, workspace, workspace_size);
+  return ret;
 }
+

--- a/bangc-ops/kernels/kernel_wrapper/lib/libextops.a
+++ b/bangc-ops/kernels/kernel_wrapper/lib/libextops.a
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a7f95e5cfc8f18fbd55804507331cbb63549b84b265fbdea0bef8ceff9911d7
-size 121075258

--- a/bangc-ops/kernels/kernel_wrapper/lib/libextops_0.a
+++ b/bangc-ops/kernels/kernel_wrapper/lib/libextops_0.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a2c221f17619e47e6ccb407765a1754d835817b1486a7a903ecba0dfee73ea
+size 70814262

--- a/bangc-ops/kernels/kernel_wrapper/lib/libextops_1.a
+++ b/bangc-ops/kernels/kernel_wrapper/lib/libextops_1.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4ceb5c3def82ade11843649b6bbccdcce06ddbd9b07f9148020b3e135e60350
+size 30151082

--- a/bangc-ops/kernels/kernel_wrapper/lib/libextops_2.a
+++ b/bangc-ops/kernels/kernel_wrapper/lib/libextops_2.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7b130107c55dd2f4a54d479db1e2d01076428d296c6b9249f88f16fd7b8957f
+size 20110180

--- a/bangc-ops/kernels/kernel_wrapper/wrapper.h
+++ b/bangc-ops/kernels/kernel_wrapper/wrapper.h
@@ -257,6 +257,21 @@
       const void *const *, void *, size_t, const mluOpTensorDescriptor_t, \
       void *
 
+#define BATCHMATMULBCAST_V2_PARAM_TYPE                           \
+  mluOpHandle_t, mluOpMatMulDescriptor_t,                        \
+      mluOpMatMulAlgo_t, const void *,                           \
+      const mluOpTensorDescriptor_t, const void *,               \
+      const mluOpTensorDescriptor_t, const void *, const void *, \
+      const mluOpTensorDescriptor_t,                             \
+      void *, void *, size_t
+
+#define BATCHMATMULBCAST_PARAM_TYPE                   \
+  mluOpHandle_t, const bool, const bool,              \
+      const mluOpTensorDescriptor_t, const void *,    \
+      const mluOpTensorDescriptor_t, const void *,    \
+      void *, size_t,                                 \
+      const mluOpTensorDescriptor_t, void *
+
 /* Kernel register */
 KERNEL_REGISTER(addN, ADDN_PARAM_TYPE);
 KERNEL_REGISTER(addNV2, ADDNV2_PARAM_TYPE);
@@ -299,4 +314,6 @@ KERNEL_REGISTER(SyncBatchNormBackwardElemtV2,
 KERNEL_REGISTER(transform, TRANSFORM_PARAM_TYPE);
 KERNEL_REGISTER(StridedSlice, STRIDEDSLICE_PARAM_TYPE);
 KERNEL_REGISTER(Concat, CONCAT_PARAM_TYPE);
+KERNEL_REGISTER(BatchMatMulBCast, BATCHMATMULBCAST_PARAM_TYPE);
+KERNEL_REGISTER(BatchMatMulBCastV2, BATCHMATMULBCAST_V2_PARAM_TYPE);
 #endif  // KERNELS_KERNEL_WRAPPER_WRAPPER_H

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -142,7 +142,7 @@ typedef enum {
   MLUOP_DTYPE_DOUBLE        = 14, /*!< A 64-bit floating-point data type. */
   MLUOP_DTYPE_INT8          = 3,  /*!< An 8-bit signed integer data type. */
   MLUOP_DTYPE_INT16         = 4,  /*!< A 16-bit signed integer data type. */
-  MLUOP_DTYPE_INT31         = 5,   /*!< The data is a 31-bit signed integer data type. */
+  MLUOP_DTYPE_INT31         = 5,  /*!< The data is a 31-bit signed integer data type. */
   MLUOP_DTYPE_INT32         = 6,  /*!< A 32-bit signed integer data type. */
   MLUOP_DTYPE_INT64         = 9,  /*!< A 64-bit signed integer data type. */
   MLUOP_DTYPE_UINT8         = 7,  /*!< An 8-bit unsigned integer data type. */
@@ -15575,7 +15575,8 @@ mluOpSetGenCaseMode(int mode);
  * Cambricon MLUOP Data Structure: BatchMatMulBCast
  ******************************************************************************/
 /**
- * @brief Enumeration variables describing the attribute names of the batch matrix multiplication computation with broadcasting.
+ * @brief Enumeration variables describing the attribute names of the batch matrix multiplication computation with
+ * broadcasting.
  *
  */
 typedef enum {
@@ -15615,7 +15616,8 @@ typedef enum {
  *
  *  You need to call the ::mluOpBatchMatMulBCastDescCreate function to create a descriptor, and call the
  *  ::mluOpSetBatchMatMulBCastDescAttr function to set the information of the matrix multiplication to the descriptor.
- *  Also, you need to destroy the Cambricon MLUOP context at the end with the ::mluOpBatchMatMulBCastDescDestroy function.
+ *  Also, you need to destroy the Cambricon MLUOP context at the end with the ::mluOpBatchMatMulBCastDescDestroy
+ * function.
  */
 typedef struct mluOpBatchMatMulBCastStruct *mluOpBatchMatMulBCastDescriptor_t;
 
@@ -15669,11 +15671,12 @@ typedef struct mluOpBatchMatMulBCastAlgoStruct *mluOpBatchMatMulBCastAlgo_t;
  * @par Example
  * - None.
  */
-mluOpStatus_t MLUOP_WIN_API mluOpGetBatchMatMulBCastWorkspaceSize(mluOpHandle_t handle,
-                                                               const mluOpTensorDescriptor_t a_desc,
-                                                               const mluOpTensorDescriptor_t b_desc,
-                                                               const mluOpTensorDescriptor_t c_desc,
-                                                               size_t *workspace_size);
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetBatchMatMulBCastWorkspaceSize(mluOpHandle_t handle,
+                                      const mluOpTensorDescriptor_t a_desc,
+                                      const mluOpTensorDescriptor_t b_desc,
+                                      const mluOpTensorDescriptor_t c_desc,
+                                      size_t *workspace_size);
 
 // Group:BatchMatMulBCast
 /*!
@@ -15702,9 +15705,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetBatchMatMulBCastWorkspaceSize(mluOpHandle_t 
  * @par Example
  * - None.
  */
-mluOpStatus_t mluOpGetBatchMatMulHeuristicResult(mluOpMatMulHeuristicResult_t result,
-                                               mluOpMatMulAlgo_t algo,
-                                               size_t *workspace_size);
+mluOpStatus_t
+mluOpGetBatchMatMulHeuristicResult(mluOpMatMulHeuristicResult_t result, mluOpMatMulAlgo_t algo, size_t *workspace_size);
 
 // Group:BatchMatMulBCast
 /*!
@@ -15732,8 +15734,8 @@ mluOpStatus_t mluOpGetBatchMatMulHeuristicResult(mluOpMatMulHeuristicResult_t re
  *   Input. The number of requested algorithms. The maximum number of algorithms to be returned.
  *   Currently this value only supports 1.
  * @param[out] result_array
- *   Output. Array containing the algorithm heuristics and associated runtime characteristics, returned by this function,
- *   in the order of increasing estimated compute time.
+ *   Output. Array containing the algorithm heuristics and associated runtime characteristics, returned by this
+ * function, in the order of increasing estimated compute time.
  * @param[out] return_algo_count
  *   Output. A host pointer to the number of algorithms returned by this function.
  *
@@ -15750,15 +15752,15 @@ mluOpStatus_t mluOpGetBatchMatMulHeuristicResult(mluOpMatMulHeuristicResult_t re
  * - None.
  */
 mluOpStatus_t MLUOP_WIN_API
-             mluOpGetBatchMatMulAlgoHeuristic(mluOpHandle_t handle,
-                                             mluOpMatMulDescriptor_t bmm_bcast_desc,
-                                             mluOpTensorDescriptor_t a_desc,
-                                             mluOpTensorDescriptor_t b_desc,
-                                             mluOpTensorDescriptor_t c_desc,
-                                             mluOpMatMulPrefer_t preference,
-                                             int requested_algo_count,
-                                             mluOpMatMulHeuristicResult_t *result_array,
-                                             int *return_algo_count);
+mluOpGetBatchMatMulAlgoHeuristic(mluOpHandle_t handle,
+                                 mluOpMatMulDescriptor_t bmm_bcast_desc,
+                                 mluOpTensorDescriptor_t a_desc,
+                                 mluOpTensorDescriptor_t b_desc,
+                                 mluOpTensorDescriptor_t c_desc,
+                                 mluOpMatMulPrefer_t preference,
+                                 int requested_algo_count,
+                                 mluOpMatMulHeuristicResult_t *result_array,
+                                 int *return_algo_count);
 
 // Group:BatchMatMulBCast
 /*!
@@ -15858,17 +15860,18 @@ mluOpStatus_t MLUOP_WIN_API
  * @par Reference
  * - https://pytorch.org/docs/stable/torch.html?highlight=bmm#torch.bmm
  */
-mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast(mluOpHandle_t handle,
-                                               const bool is_transa,
-                                               const bool is_transb,
-                                               const mluOpTensorDescriptor_t a_desc,
-                                               const void *a,
-                                               const mluOpTensorDescriptor_t b_desc,
-                                               const void *b,
-                                               void *workspace,
-                                               size_t workspace_size,
-                                               const mluOpTensorDescriptor_t c_desc,
-                                               void *c);
+mluOpStatus_t MLUOP_WIN_API
+mluOpBatchMatMulBCast(mluOpHandle_t handle,
+                      const bool is_transa,
+                      const bool is_transb,
+                      const mluOpTensorDescriptor_t a_desc,
+                      const void *a,
+                      const mluOpTensorDescriptor_t b_desc,
+                      const void *b,
+                      void *workspace,
+                      size_t workspace_size,
+                      const mluOpTensorDescriptor_t c_desc,
+                      void *c);
 
 // Group:BatchMatMulBCast
 /*!
@@ -15971,7 +15974,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast(mluOpHandle_t handle,
  *   Once the strides of all tensors are set, the lowest 3 dims of \b a_desc are [batch_size, m, k],
  *   the lowest 3 dims of \b b_desc are [batch_size, k, n], and the lowest 3 dims of \b c_desc are [batch_size, m, n].
  *   The last value of \b c_desc->stride should be equal to \b 1 because transpose operation of \b c is not supported.
- * - If you want to use stride feature, MLUOP_MATMUL_USE_STRIDE attribute of \b bmm_bcast_desc should be specified as \b true
+ * - If you want to use stride feature, MLUOP_MATMUL_USE_STRIDE attribute of \b bmm_bcast_desc should be specified as \b
+ true
  *   with ::mluOpSetMatMulDescAttr. When stride is enabled, transpose information of \b a and \b b will be neglected,
  *   because they may be in conflict with tensors' stride values.
  *
@@ -16016,19 +16020,20 @@ mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast(mluOpHandle_t handle,
  * @par Reference
  * - https://pytorch.org/docs/stable/torch.html?highlight=bmm#torch.bmm
  */
-mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast_v2(mluOpHandle_t handle,
-                                                  mluOpMatMulDescriptor_t bmm_bcast_desc,
-                                                  mluOpMatMulAlgo_t  algo,
-                                                  const void *alpha,
-                                                  const mluOpTensorDescriptor_t a_desc,
-                                                  const void *a,
-                                                  const mluOpTensorDescriptor_t b_desc,
-                                                  const void *b,
-                                                  const void *beta,
-                                                  const mluOpTensorDescriptor_t c_desc,
-                                                  void *c,
-                                                  void *workspace,
-                                                  size_t workspace_size);
+mluOpStatus_t MLUOP_WIN_API
+mluOpBatchMatMulBCast_v2(mluOpHandle_t handle,
+                         mluOpMatMulDescriptor_t bmm_bcast_desc,
+                         mluOpMatMulAlgo_t algo,
+                         const void *alpha,
+                         const mluOpTensorDescriptor_t a_desc,
+                         const void *a,
+                         const mluOpTensorDescriptor_t b_desc,
+                         const void *b,
+                         const void *beta,
+                         const mluOpTensorDescriptor_t c_desc,
+                         void *c,
+                         void *workspace,
+                         size_t workspace_size);
 
 // Group:BatchMatMulBCast
 /*!
@@ -16121,9 +16126,9 @@ mluOpBatchMatMulBCastDescDestroy(mluOpBatchMatMulBCastDescriptor_t bmm_bcast_des
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetBatchMatMulBCastDescAttr(mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
-                                mluOpBatchMatMulBCastDescAttribute_t attr,
-                                const void *buf,
-                                size_t size_in_bytes);
+                                 mluOpBatchMatMulBCastDescAttribute_t attr,
+                                 const void *buf,
+                                 size_t size_in_bytes);
 
 // Group:BatchMatMulBCast
 /*!
@@ -16160,10 +16165,10 @@ mluOpSetBatchMatMulBCastDescAttr(mluOpBatchMatMulBCastDescriptor_t bmm_bcast_des
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetBatchMatMulBCastDescAttr(const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
-                                mluOpBatchMatMulBCastDescAttribute_t attr,
-                                void *buf,
-                                size_t size_in_bytes,
-                                size_t *size_written);
+                                 mluOpBatchMatMulBCastDescAttribute_t attr,
+                                 void *buf,
+                                 size_t size_in_bytes,
+                                 size_t *size_written);
 
 // Group:BatchMatMulBCast
 /*!
@@ -16193,7 +16198,8 @@ mluOpGetBatchMatMulBCastDescAttr(const mluOpBatchMatMulBCastDescriptor_t bmm_bca
  * @par Example
  * - None.
  */
-mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCastAlgoCreate(mluOpBatchMatMulBCastAlgo_t *algo);
+mluOpStatus_t MLUOP_WIN_API
+mluOpBatchMatMulBCastAlgoCreate(mluOpBatchMatMulBCastAlgo_t *algo);
 
 // Group:BatchMatMulBCast
 /*!
@@ -16218,7 +16224,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCastAlgoCreate(mluOpBatchMatMulBCas
  * @par Example
  * - None.
  */
-mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCastAlgoDestroy(mluOpBatchMatMulBCastAlgo_t algo);
+mluOpStatus_t MLUOP_WIN_API
+mluOpBatchMatMulBCastAlgoDestroy(mluOpBatchMatMulBCastAlgo_t algo);
 
 // Group:BatchMatMulBCast
 /*!
@@ -16270,12 +16277,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCastAlgoDestroy(mluOpBatchMatMulBCa
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetQuantizeBatchMatMulBCastAlgorithm(mluOpHandle_t handle,
-                                         const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
-                                         const mluOpTensorDescriptor_t a_desc,
-                                         const mluOpTensorDescriptor_t b_desc,
-                                         const mluOpTensorDescriptor_t c_desc,
-                                         mluOpBatchMatMulBCastPreference_t preference,
-                                         mluOpBatchMatMulBCastAlgo_t *algo);
+                                          const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                                          const mluOpTensorDescriptor_t a_desc,
+                                          const mluOpTensorDescriptor_t b_desc,
+                                          const mluOpTensorDescriptor_t c_desc,
+                                          mluOpBatchMatMulBCastPreference_t preference,
+                                          mluOpBatchMatMulBCastAlgo_t *algo);
 
 // Group:BatchMatMulBCast
 /*!
@@ -16329,14 +16336,14 @@ mluOpGetQuantizeBatchMatMulBCastAlgorithm(mluOpHandle_t handle,
  * @par Example
  * - None.
  */
-mluOpStatus_t MLUOP_WIN_API mluOpGetQuantizeBatchMatMulBCastWorkspaceSize(
-                          mluOpHandle_t handle,
-                          mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
-                          const mluOpTensorDescriptor_t a_desc,
-                          const mluOpTensorDescriptor_t b_desc,
-                          const mluOpTensorDescriptor_t c_desc,
-                          mluOpBatchMatMulBCastAlgo_t algo,
-                          size_t *workspace_size);
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetQuantizeBatchMatMulBCastWorkspaceSize(mluOpHandle_t handle,
+                                              mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                                              const mluOpTensorDescriptor_t a_desc,
+                                              const mluOpTensorDescriptor_t b_desc,
+                                              const mluOpTensorDescriptor_t c_desc,
+                                              mluOpBatchMatMulBCastAlgo_t algo,
+                                              size_t *workspace_size);
 
 // Group:BatchMatMulBCast
 /*!
@@ -16440,7 +16447,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetQuantizeBatchMatMulBCastWorkspaceSize(
  * @par Performance Optimization
  * - For best practices, to have a better performance, matrix \b a does not need to transpose and matrix \b b
  *   needs to transpose.
- * - If \b a and \b b do not need broadcasting, for best practices, it is recommended to call ::mluOpQuantizeBatchMatMul.
+ * - If \b a and \b b do not need broadcasting, for best practices, it is recommended to call
+ ::mluOpQuantizeBatchMatMul.
  *
  * @par Example
  * - The example of the operation is as follows:
@@ -16457,24 +16465,24 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetQuantizeBatchMatMulBCastWorkspaceSize(
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpQuantizeBatchMatMulBCast(mluOpHandle_t handle,
-                             const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
-                             const void *alpha,
-                             const mluOpTensorDescriptor_t a_desc,
-                             const void *a,
-                             const void *a_position,
-                             const void *a_scale,
-                             const void *a_offset,
-                             const mluOpTensorDescriptor_t b_desc,
-                             const void *b,
-                             const void *b_position,
-                             const void *b_scale,
-                             const void *b_offset,
-                             const void *beta,
-                             const mluOpTensorDescriptor_t c_desc,
-                             void *c,
-                             mluOpBatchMatMulBCastAlgo_t algo,
-                             void *workspace,
-                             size_t workspace_size);
+                              const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                              const void *alpha,
+                              const mluOpTensorDescriptor_t a_desc,
+                              const void *a,
+                              const void *a_position,
+                              const void *a_scale,
+                              const void *a_offset,
+                              const mluOpTensorDescriptor_t b_desc,
+                              const void *b,
+                              const void *b_position,
+                              const void *b_scale,
+                              const void *b_offset,
+                              const void *beta,
+                              const mluOpTensorDescriptor_t c_desc,
+                              void *c,
+                              mluOpBatchMatMulBCastAlgo_t algo,
+                              void *workspace,
+                              size_t workspace_size);
 
 #if defined(__cplusplus)
 }

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -142,6 +142,7 @@ typedef enum {
   MLUOP_DTYPE_DOUBLE        = 14, /*!< A 64-bit floating-point data type. */
   MLUOP_DTYPE_INT8          = 3,  /*!< An 8-bit signed integer data type. */
   MLUOP_DTYPE_INT16         = 4,  /*!< A 16-bit signed integer data type. */
+  MLUOP_DTYPE_INT31         = 5,   /*!< The data is a 31-bit signed integer data type. */
   MLUOP_DTYPE_INT32         = 6,  /*!< A 32-bit signed integer data type. */
   MLUOP_DTYPE_INT64         = 9,  /*!< A 64-bit signed integer data type. */
   MLUOP_DTYPE_UINT8         = 7,  /*!< An 8-bit unsigned integer data type. */
@@ -15569,6 +15570,912 @@ mluOpGetConcatWorkspaceSize(mluOpHandle_t handle, const int concat_num, size_t *
  */
 void MLUOP_WIN_API
 mluOpSetGenCaseMode(int mode);
+
+/******************************************************************************
+ * Cambricon MLUOP Data Structure: BatchMatMulBCast
+ ******************************************************************************/
+/**
+ * @brief Enumeration variables describing the attribute names of the batch matrix multiplication computation with broadcasting.
+ *
+ */
+typedef enum {
+  MLUOP_BMM_BCAST_DESC_COMPUTE_TYPE = 0,
+  /*!< Specifies the data type used for multiplication and accumulation operations, and the accumulator
+       for implementing batch matrix multiplication with broadcasting. It must be set before doing
+       batch matrix multiplication with broadcasting. */
+  MLUOP_BMM_BCAST_DESC_SCALE_TYPE = 1,
+  /*!< Specifies the data type of the scaling factors \b alpha and \b beta. Default value is the same
+       as ::MLUOP_BMM_BCAST_DESC_COMPUTE_TYPE. It is not supported now. */
+  MLUOP_BMM_BCAST_DESC_POINTER_MODE = 2,
+  /*!< Specifies whether \b alpha and \b beta are stored on the host or on the device.
+       It is not supported now. */
+  MLUOP_BMM_BCAST_DESC_TRANSA = 3,
+  /*!< Specifies whether transpose should be performed on matrix A.
+       Default value is 0 (false). */
+  MLUOP_BMM_BCAST_DESC_TRANSB = 4,
+  /*!< Specifies whether transpose should be performed on matrix B.
+       Default value is 0 (false). */
+  MLUOP_BMM_BCAST_DESC_TRANSC = 5,
+  /*!< Specifies whether transpose should be performed on matrix C.
+       Default value is 0 (false). It is not supported now. */
+} mluOpBatchMatMulBCastDescAttribute_t;
+
+/*!
+ * @brief Enumeration variables describing the preference of batch matrix multiplication with broadcasting algorithm.
+ */
+typedef enum {
+  MLUOP_BMM_BCAST_FASTEST = 0,
+  /*!< The high-speed preference is used. */
+  MLUOP_BMM_BCAST_LOW_MEMORY_OCCUPY = 1,
+  /*!< The low-memory preference is used. It is not supported now. */
+} mluOpBatchMatMulBCastPreference_t;
+
+/*! The descriptor of the batch matrix multiplication with broadcasting function that holds compute type, bias type,
+ *  transpose flag, and other attributes defined in ::mluOpBatchMatMulBCastDescAttribute_t.
+ *
+ *  You need to call the ::mluOpBatchMatMulBCastDescCreate function to create a descriptor, and call the
+ *  ::mluOpSetBatchMatMulBCastDescAttr function to set the information of the matrix multiplication to the descriptor.
+ *  Also, you need to destroy the Cambricon MLUOP context at the end with the ::mluOpBatchMatMulBCastDescDestroy function.
+ */
+typedef struct mluOpBatchMatMulBCastStruct *mluOpBatchMatMulBCastDescriptor_t;
+
+/*! The descriptor of the batch matrix multiplication with broadcasting computation algorithm.
+ *
+ *  You need to call the ::mluOpBatchMatMulBCastAlgoCreate function to create a descriptor, and call the
+ *  ::mluOpGetQuantizeBatchMatMulBCastAlgorithm function to set the information to the descriptor. Also, you need to
+ *  destroy the Cambricon MLUOP context at the end with the ::mluOpBatchMatMulBCastAlgoDestroy function.
+ */
+typedef struct mluOpBatchMatMulBCastAlgoStruct *mluOpBatchMatMulBCastAlgo_t;
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra workspace
+ * to optimize the batch matrix multiplication with broadcasting operation.
+ *
+ * @par Deprecated
+ * - ::mluOpGetBatchMatMulBCastWorkspaceSize is deprecated and will be removed in the future release.
+ * Please use ::mluOpGetBatchMatMulHeuristicResult instead.
+ *
+ * The size of extra workspace is based on the given information of the batch matrix multiplication
+ * with broadcasting operation, including input tensor descriptor of left matrix \b a_desc, input tensor descriptor of
+ * right matrix \b b_desc and output tensor descriptor \b c_desc.
+ * For more information about the workspace, see "Cambricon MLUOP User Guide".
+ *
+ * @param[in] handle
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the batch
+ *   matrix multiplication with broadcasting operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] a_desc
+ *   Input. The descriptor of the input tensor of left matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] b_desc
+ *   Input. The descriptor of the input tensor of right matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] c_desc
+ *   Input. The descriptor of the input tensor of output matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[out] workspace_size
+ *   Output. Pointer to the returned size of the extra workspace in bytes that is used in
+ *   the matrix multiplication operation.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpGetBatchMatMulBCastWorkspaceSize(mluOpHandle_t handle,
+                                                               const mluOpTensorDescriptor_t a_desc,
+                                                               const mluOpTensorDescriptor_t b_desc,
+                                                               const mluOpTensorDescriptor_t c_desc,
+                                                               size_t *workspace_size);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Gets the matrix multiplication algorithm and workspace size from heuristic result,
+ *        that is previously selected with ::mluOpGetBatchMatMulAlgoHeuristic.
+ *
+ * @param[in] result
+ *   Input. The matrix multiplication heuristic result obtained by ::mluOpGetBatchMatMulAlgoHeuristic.
+ *
+ * @param[out] algo
+ *   Output. The matrix multiplication algorithm.
+ *
+ * @param[out] workspace_size
+ *   Output. Pointer to the returned size of the extra workspace in bytes that is used in
+ *   the matrix multiplication operation.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t mluOpGetBatchMatMulHeuristicResult(mluOpMatMulHeuristicResult_t result,
+                                               mluOpMatMulAlgo_t algo,
+                                               size_t *workspace_size);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Retrieves the possible algorithms can be used in the matrix multiplication.
+ *        The output is placed in result_array[] in the order of increasing estimated compute time.
+ *
+ * @param[in] handle
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the batch
+ *   matrix multiplication with broadcasting operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] bmm_bcast_desc
+ *   Input. The descriptor of the matrix multiplication operations. For detail information,
+ *   see ::mluOpMatMulDescriptor_t.
+ * @param[in] a_desc
+ *   Input. The descriptor of the input tensor of left matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] b_desc
+ *   Input. The descriptor of the input tensor of right matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] c_desc
+ *   Input. The descriptor of the output tensor. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in] preference
+ *   Input. The descriptor of the matrix multiplication that holds the preferences for mluOpMatMulHeuristicResult_t
+ *   configuration. Currently not supported and should be set to NULL.
+ * @param[in] requested_algo_count
+ *   Input. The number of requested algorithms. The maximum number of algorithms to be returned.
+ *   Currently this value only supports 1.
+ * @param[out] result_array
+ *   Output. Array containing the algorithm heuristics and associated runtime characteristics, returned by this function,
+ *   in the order of increasing estimated compute time.
+ * @param[out] return_algo_count
+ *   Output. A host pointer to the number of algorithms returned by this function.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - Currently the maximum number of algorithms \b requested_algo_count only supports 1.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+             mluOpGetBatchMatMulAlgoHeuristic(mluOpHandle_t handle,
+                                             mluOpMatMulDescriptor_t bmm_bcast_desc,
+                                             mluOpTensorDescriptor_t a_desc,
+                                             mluOpTensorDescriptor_t b_desc,
+                                             mluOpTensorDescriptor_t c_desc,
+                                             mluOpMatMulPrefer_t preference,
+                                             int requested_algo_count,
+                                             mluOpMatMulHeuristicResult_t *result_array,
+                                             int *return_algo_count);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Computes the batch matrix multiplication with broadcasting operation,
+ * then returns the results in the output tensor \b c. For more information about quantization,
+ * see "Cambricon MLUOP User Guide".
+ *
+ * This function may need extra MLU memory as the workspace to improve the batch matrix multiplication
+ * with broadcasting performance. You can get the size of the workspace \b workspace_size with the
+ * ::mluOpGetBatchMatMulAlgoHeuristic function.
+ *
+ * @par Deprecated
+ * - ::mluOpBatchMatMulBCast is deprecated and will be removed in the future release.
+ * Please use ::mluOpBatchMatMulBCast_v2 instead.
+ * @param[in] handle
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the batch
+ *   matrix multiplication with broadcasting operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] is_transa
+ *   Input. Boolean value indicating whether \b a matrix is transposed.
+ * @param[in] is_transb
+ *   Input. Boolean value indicating whether \b b matrix is transposed.
+ * @param[in] a_desc
+ *   Input. The descriptor of the input tensor of left matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] a
+ *   Input. Pointer to the MLU memory that stores the left matrix.
+ * @param[in] b_desc
+ *   Input. The descriptor of the input tensor of right matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] b
+ *   Input. Pointer to the MLU memory that stores the right matrix.
+ * @param[in] c_desc
+ *   Input. The descriptor of the output tensor. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] c
+ *   Output. Pointer to the MLU memory that stores the output tensor.
+ * @param[in] workspace
+ *   Input. Pointer to the MLU memory that is used as an extra workspace for the batch matrix multiplication
+ *   with broadcasting operation. For more information about workspace, see "Cambricon MLUOP User Guide".
+ * @param[in] workspace_size
+ *   Input. The size of the extra workspace in bytes that needs to be used in the batch matrix multiplication
+ *   with broadcasting operation. You can get the size of the workspace with the
+ *   ::mluOpGetBatchMatMulBCastWorkspaceSize function.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ *
+ * @par Formula
+ * - See "BatchMatMulBCast Operation" section in "Cambricon MLUOP User Guide" for details.
+ *
+ * @par Data Type
+ * - This function supports any combinations of the following data types for input tensor \b a, \b b and
+ *   output tensor \b c.
+ *   - \b a: int8, int16, int31.
+ *   - \b b: onchip data type: int8, int16, int31.
+ *   - \b c: half, float.
+ * - This function supports the combinations of the following data types for input tensor \b a, \b b and
+ *   output tensor \b c on MLU300 series or above.
+ *   - \b a, \b b, \b c: half, half, half.
+ *   - \b a, \b b, \b c: float, float, float.
+ *
+ * @note
+ * - The combinations of the data types should satisfy the following rules:
+ *   - The data type of \b c must be float when \b a data type is int31 or \b b data type is int31.
+ *   - The number of dimensions is no more than \p MLUOP_DIM_MAX.
+ *   - \b c offchip data type must be the same as \b c onchip data type.
+ *
+ * @par Scale Limitation
+ * - The input tensors and output tensor must meet the following requirements:
+ *   - The \b a and \b b must have no less than two dimensions, and the last two dimensions of \b a and \b b
+ *     are matrix multiplication compatible.
+ *   - The number of columns of \b a matrix must be equal to the number of rows of \b b matrix after both
+ *     inputs have performed the transpose operations according to parameters. With the exception of the
+ *     last two dimensions, the other dimensions need to satisfy the broadcasting rules.
+ *
+ * @par API Dependency
+ * - Before calling this function to implement batch matrix multiplication with broadcasting, you need to prepare
+ *   all the parameters passed to this function. See each parameter description for details.
+ *
+ * @par Performance Optimization
+ * - For best practices, to have a better performance, matrix \b a does not need to transpose and matrix \b b
+ *   needs to transpose.
+ * - If \b a and \b b do not need broadcasting, for best practices, it is recommended to call ::mluOpBatchMatMul.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - The example of the operation is as follows:
+     @verbatim
+      transa:                    false
+      transb:                    false
+      Dimension of input tensor a:  [99, 128]
+      Dimension of input tensor b:  [64, 128, 256]
+      Dimension of output tensor c: [64, 99, 256]
+     @endverbatim
+ *
+ * @par Reference
+ * - https://pytorch.org/docs/stable/torch.html?highlight=bmm#torch.bmm
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast(mluOpHandle_t handle,
+                                               const bool is_transa,
+                                               const bool is_transb,
+                                               const mluOpTensorDescriptor_t a_desc,
+                                               const void *a,
+                                               const mluOpTensorDescriptor_t b_desc,
+                                               const void *b,
+                                               void *workspace,
+                                               size_t workspace_size,
+                                               const mluOpTensorDescriptor_t c_desc,
+                                               void *c);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Computes the batch matrix multiplication with broadcasting operation,
+ * then returns the results in the output tensor \b c. For more information about quantization,
+ * see "Cambricon MLUOP User Guide".
+ *
+ * Compared with ::mluOpBatchMatMulBCast, it supports the use of \b bmm_bcast_desc
+ * to pass parameters like ::MLUOP_MATMUL_DESC_TRANSA.
+ *
+ * This function needs extra MLU memory as the workspace to improve the batch matrix multiplication
+ * with broadcasting performance. You can get the size of the workspace \b workspace_size with the
+ * ::mluOpGetBatchMatMulAlgoHeuristic and ::mluOpGetBatchMatMulHeuristicResult functions in turn.
+ *
+ * @param[in] handle
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the batch
+ *   matrix multiplication with broadcasting operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] bmm_bcast_desc
+ *   Input. The descriptor of the batch matrix multiplication with broadcasting operation.
+ *   For detail information, see ::mluOpMatMulDescriptor_t.
+ * @param[in] algo
+ *   Input. A host pointer to the most suitable algorithm to compute the batch matrix multiplication
+ *   with broadcasting.
+ * @param[in] alpha
+ *   Input. A host pointer to scaling factor of tensor \b a.
+ *   In MLU200, CE3226 and SD5223 series, \p alpha and \p beta setting are not supported currently,
+ *   and the value of alpha in the host pointer should be 1 in this case.
+ * @param[in] a_desc
+ *   Input. The descriptor of the input tensor of left matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] a
+ *   Input. Pointer to the MLU memory that stores the left matrix.
+ * @param[in] b_desc
+ *   Input. The descriptor of the input tensor of right matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] b
+ *   Input. Pointer to the MLU memory that stores the right matrix.
+ * @param[in] beta
+ *   Input. A host pointer to scaling factor of tensor \b c.
+ *   In MLU200, CE3226 and SD5223 series, \p alpha and \p beta setting are not supported currently,
+ *   and the value of beta in the host pointer should be 0 in this case.
+ * @param[in] c_desc
+ *   Input. The descriptor of the output tensor. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[in,out] c
+ *   Output. Pointer to the MLU memory that stores the output tensor.
+ * @param[in] workspace
+ *   Input. Pointer to the MLU memory that is used as an extra workspace for the batch matrix multiplication
+ *   with broadcasting operation. For more information about workspace, see "Cambricon MLUOP User Guide".
+ * @param[in] workspace_size
+ *   Input. The size of the extra workspace in bytes that needs to be used in the batch matrix
+ *   multiplication with broadcasting operation. You can get the size of the workspace with
+ *   the ::mluOpGetBatchMatMulAlgoHeuristic and ::mluOpGetBatchMatMulHeuristicResult functions in turn.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ *
+ * @par Formula
+ * - See "BatchMatMulBCast Operation" section in "Cambricon MLUOP User Guide" for details.
+ *
+ * @par Data Type
+ * - This function supports the following data types for input tensor \b a, \b b and output tensor \b c.
+ *   - The offchip data type of \b a: half, float, int8, int16, int31.
+ *   - The onchip data type of \b a: half, float, int8, int16, int31.
+ *   - The offchip data type of \b b: half, float, int8, int16, int31.
+ *   - The onchip data type of \b b: half, float, int8, int16, int31.
+ *   - The offchip data type of \b c: half, float, int8, int16.
+ *   - The onchip data type of \b c: half, float.
+ * - This function also supports the combinations of the following data types for input tensor \b a, \b b and
+ *   output tensor \b c on MLU300 series or above.
+ *   - \b a, \b b, \b c offchip data type, \b c onchip data type: half, half, half, half.
+ *   - \b a, \b b, \b c offchip data type, \b c onchip data type: half, half, half, float.
+ *   - \b a, \b b, \b c offchip data type, \b c onchip data type: bfloat16, bfloat16, bfloat16, bfloat16.
+ *   - \b a, \b b, \b c offchip data type, \b c onchip data type: bfloat16, bfloat16, bfloat16, float.
+ *   - \b a, \b b, \b c offchip data type, \b c onchip data type: float, float, float, float.
+ *
+ * @note
+ * - The data type of \b c must be float when \b a data type is int31 or \b b data type is int31.
+ * - The data type bitwidth of \b c onchip data type for operation computing is not shorter than
+ *   \b c offchip data type.
+ * - The onchip data type of \b a must be MLUOP_DTYPE_INT31 or MLUOP_DTYPE_INVALID if the offchip
+ *   data type of \b a is MLUOP_DTYPE_INT31.
+ * - The onchip data type of \b b must be MLUOP_DTYPE_INT31 or MLUOP_DTYPE_INVALID if the offchip
+ *   data type of \b b is MLUOP_DTYPE_INT31.
+ * - The offchip data types of \b a and \b b must be fixed point if the offchip data type
+ *   of \b a or \b b is MLUOP_DTYPE_INT31.
+ * - The onchip data types of \b a and \b b must be equal to the offchip data type of \b c
+ *   when the offchip data type of \b c is int8 or int16.
+ * - The offchip data types of \b a and \b b must be equal to the offchip data type of \b c
+ *   when the offchip data type of \b a is floating point and the onchip data type of \b a is
+ *   MLUOP_DTYPE_INVALID or the onchip data type of \b a is the same as the offchip data type
+ *   of \b a.
+ * - The offchip data types of \b a and \b b must be then same when they are both floating
+ *   point.
+ * - The onchip data types of \b a and \b b must be both fixed point on MLU200, CE3226 series.
+ * - If \b a offchip data type is integer, it should be the same as \b a onchip data type.
+ * - The floating point of \b a, \b b and \b c under the same combination need to be consistent.
+ * - The number of dimensions is no more than \p MLUOP_DIM_MAX.
+ * - Strides are supported when data types of tensors \b a, \b b and \b c are half or float or bfloat16.
+ *   You can specify the stride of all dimensions for \b a_desc, \b b_desc, \b c_desc with ::mluOpSetTensorDescriptorEx.
+ *   Once the strides of all tensors are set, the lowest 3 dims of \b a_desc are [batch_size, m, k],
+ *   the lowest 3 dims of \b b_desc are [batch_size, k, n], and the lowest 3 dims of \b c_desc are [batch_size, m, n].
+ *   The last value of \b c_desc->stride should be equal to \b 1 because transpose operation of \b c is not supported.
+ * - If you want to use stride feature, MLUOP_MATMUL_USE_STRIDE attribute of \b bmm_bcast_desc should be specified as \b true
+ *   with ::mluOpSetMatMulDescAttr. When stride is enabled, transpose information of \b a and \b b will be neglected,
+ *   because they may be in conflict with tensors' stride values.
+ *
+ * @par Scale Limitation
+ * - The input tensors and output tensor must meet the following requirements:
+ *   - The \b a and \b b must have no less than two dimensions, and the last two dimensions of \b a and \b b
+ *     are matrix multiplication compatible.
+ *   - The number of columns of \b a matrix must be equal to the number of rows of \b b matrix after both
+ *     inputs have performed the transpose operations according to parameters. With the exception of the
+ *     last two dimensions, the other dimensions need to satisfy the broadcasting rules.
+ *   - the maximum dimension of \b a should be less than or equal to INT_MAX.
+ *   - the maximum dimension of \b b should be less than or equal to INT_MAX.
+ *   - the maximum dimension of \b c should be less than or equal to INT_MAX.
+ *   - the batch size of \b a should be less than or equal to INT_MAX.
+ *   - the batch size of \b b should be less than or equal to INT_MAX.
+ *   - the batch size of \b c should be less than or equal to INT_MAX.
+ *   - the lda of \b a should be less than or equal to INT_MAX.
+ *   - the lda of \b b should be less than or equal to INT_MAX.
+ *   - the lda of \b c should be less than or equal to INT_MAX.
+ *
+ * @par API Dependency
+ * - Before calling this function to implement batch matrix multiplication with broadcasting, you need to prepare
+ *   all the parameters passed to this function. See each parameter description for details.
+ *
+ * @par Performance Optimization
+ * - For best practices, to have a better performance, matrix \b a does not need to transpose and matrix \b b
+ *   needs to transpose.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - The example of the operation is as follows:
+     @verbatim
+      MLUOP_MATMUL_DESC_TRANSA:      false
+      MLUOP_MATMUL_DESC_TRANSB:      false
+      Dimension of input tensor a:  [99, 128]
+      Dimension of input tensor b:  [64, 128, 256]
+      Dimension of output tensor c: [64, 99, 256]
+     @endverbatim
+ *
+ * @par Reference
+ * - https://pytorch.org/docs/stable/torch.html?highlight=bmm#torch.bmm
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCast_v2(mluOpHandle_t handle,
+                                                  mluOpMatMulDescriptor_t bmm_bcast_desc,
+                                                  mluOpMatMulAlgo_t  algo,
+                                                  const void *alpha,
+                                                  const mluOpTensorDescriptor_t a_desc,
+                                                  const void *a,
+                                                  const mluOpTensorDescriptor_t b_desc,
+                                                  const void *b,
+                                                  const void *beta,
+                                                  const mluOpTensorDescriptor_t c_desc,
+                                                  void *c,
+                                                  void *workspace,
+                                                  size_t workspace_size);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Creates a descriptor pointed by \b bmm_bcast_desc for a batch matrix multiplication with
+ *        broadcasting operation, and allocates memory for holding the information about the batch
+ *        matrix multiplication with broadcasting operation. The information is defined in
+ *        ::mluOpBatchMatMulBCastDescriptor_t.
+ *
+ * @param[out] bmm_bcast_desc
+ *   Output. A host pointer to the batch matrix multiplication with broadcasting descriptor that holds
+ *   information about the batch matrix multiplication with broadcasting operation.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ALLOC_FAILED
+ *
+ * @par API Dependency
+ * - After calling this function, you can call the ::mluOpSetBatchMatMulBCastDescAttr function to initialize
+ *   and set the information to the batch matrix multiplication with broadcasting descriptor.
+ * - You need to call the ::mluOpBatchMatMulBCastDescDestroy function to destroy the descriptor.
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpBatchMatMulBCastDescCreate(mluOpBatchMatMulBCastDescriptor_t *bmm_bcast_desc);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Destroys a batch matrix multiplication with broadcasting descriptor \b bmm_bcast_desc
+ *        that is previously created with the ::mluOpBatchMatMulBCastDescCreate.
+ *
+ * The batch matrix multiplication with broadcasting descriptor is defined in ::mluOpBatchMatMulBCastDescriptor_t
+ * and holds the information about the batch matrix multiplication with broadcasting operation.
+ *
+ * @param[in] bmm_bcast_desc
+ *   Input. The batch matrix multiplication with broadcasting descriptor to be destroyed.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpBatchMatMulBCastDescDestroy(mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Initializes the batch matrix multiplication with broadcasting descriptor \b bmm_bcast_desc
+ * that is previously created with the ::mluOpBatchMatMulBCastDescCreate function, and sets
+ * the information about the batch matrix multiplication with broadcasting operation to the batch matrix
+ * multiplication with broadcasting descriptor \b bmm_bcast_desc. The information includes the attribute
+ * defined in ::mluOpBatchMatMulBCastDescAttribute_t \b attr, the host pointer to the attribute value
+ * \b buf, and the size of buffer for verification.
+ *
+ * @param[in,out] bmm_bcast_desc
+ *   Input/output. The descriptor of the batch matrix multiplication with broadcasting operation. For detailed
+ *   information, see ::mluOpBatchMatMulBCastDescriptor_t.
+ * @param[in] attr
+ *   Input. Attribute of batch matrix multiplication with broadcasting descriptor to be set. For detailed
+ *   information, see ::mluOpBatchMatMulBCastDescAttribute_t.
+ * @param[in] buf
+ *   Input. A host pointer to the attribute value set by this function.
+ * @param[in] size_in_bytes
+ *   Input. Buffer in bytes for verification.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpSetBatchMatMulBCastDescAttr(mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                                mluOpBatchMatMulBCastDescAttribute_t attr,
+                                const void *buf,
+                                size_t size_in_bytes);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Returns the pointer to the \b buf and size of the buffer \b size_written of the attribute
+ * retrieved with the given batch matmul multiplication with broadcasting descriptor \b bmm_bcast_desc,
+ * attribute \b attr. And \b size_in_bytes is used to check whether the memory size is same with \b size_written.
+ *
+ * You can set the attribute in the batch matrix multiplication with broadcasting descriptor based on
+ * the return value of this function.
+ *
+ * @param[in] bmm_bcast_desc
+ *   Input. The descriptor of the batch matrix multiplication with broadcasting operation. For detailed
+ *   information, see ::mluOpBatchMatMulBCastDescriptor_t.
+ * @param[in] attr
+ *   Input. Attribute of batch matrix multiplication with broadcasting descriptor to be retrieved.
+ * @param[out] buf
+ *   Output. A host pointer to the attribute value to be retrieved by this function.
+ * @param[in] size_in_bytes
+ *   Input. Buffer in bytes for verification.
+ * @param[out] size_written
+ *   Output. A host pointer to the number of bytes actually written to the buffer.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetBatchMatMulBCastDescAttr(const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                                mluOpBatchMatMulBCastDescAttribute_t attr,
+                                void *buf,
+                                size_t size_in_bytes,
+                                size_t *size_written);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Creates a descriptor pointed by \b algo for a batch matrix multiplication with broadcasting algorithm,
+ *        and allocates memory for holding the information about the algorithm.
+ *        The information is defined in ::mluOpBatchMatMulBCastAlgo_t. For more information about descriptor,
+ *        see "Cambricon MLUOP User Guide".
+ *
+ * @param[out] algo
+ *   Output. A host pointer to the batch matrix multiplication with broadcasting algorithm that holds information about
+ *   the batch matrix multiplication with broadcasting algorithm.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ALLOC_FAILED
+ *
+ * @par API Dependency
+ * - After calling this function, you can call the ::mluOpGetQuantizeBatchMatMulBCastAlgorithm function to initialize
+ *   and set the information to the batch matrix multiplication with broadcasting algorithm.
+ * - You need to call the ::mluOpBatchMatMulBCastAlgoDestroy function to destroy the descriptor.
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCastAlgoCreate(mluOpBatchMatMulBCastAlgo_t *algo);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Destroys a batch matrix multiplication with broadcasting algorithm descriptor \b algo
+ *        that is previously created with the ::mluOpBatchMatMulBCastAlgoCreate.
+ *
+ * The batch matrix multiplication with broadcasting descriptor is defined in ::mluOpBatchMatMulBCastAlgo_t
+ * and holds the information about the batch matrix multiplication with broadcasting algorithm.
+ *
+ * @param[in] algo
+ *   Input. The batch matrix multiplication with broadcasting algorithm descriptor to be destroyed.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpBatchMatMulBCastAlgoDestroy(mluOpBatchMatMulBCastAlgo_t algo);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Returns the most suited batch matrix multiplication with broadcasting algorithm that can be used
+ * in the operation.
+ *
+ * The returned batch matrix multiplication is chosen from all the supported batch matrix with
+ * broadcasting algorithms defined in ::mluOpBatchMatMulBCastAlgo_t and is based on the given batch matrix
+ * multiplication with broadcasting descriptor \b bmm_bcast_desc, tensor descriptor of left matrix \b a_desc,
+ * tensor descriptor of right matrix \b b_desc, tensor descriptor of output matrix \b c_desc, and batch
+ * matrix multiplication with broadcasting algorithm \b preference.
+ *
+ * The computing performance options \b preference defined in the ::mluOpBatchMatMulBCastPreference_t
+ * enum, only supports the high speed mode.
+ *
+ * @param[in] handle
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the batch
+ *   matrix multiplication with broadcasting operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] bmm_bcast_desc
+ *  Input. The descriptor of the batch matrix multiplication with broadcasting operation. For detailed
+ *  information, see ::mluOpBatchMatMulBCastDescriptor_t.
+ * @param[in] a_desc
+ *   Input. The descriptor of the input tensor descriptor of left matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] b_desc
+ *   Input. The descriptor of the input tensor descriptor of right matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] c_desc
+ *   Input. The descriptor of the input tensor descriptor of output matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] preference
+ *   Input. The options for implementing the batch matrix multiplication with broadcasting operation to
+ * get better performance. This parameter only supports MLUOP_BMM_BCAST_FASTEST now.
+ * @param[out] algo
+ *   Output. A host pointer to the returned algorithm that is best suited for computing the batch matrix multiplication
+ *   with broadcasting. The algorithms are defined in the ::mluOpBatchMatMulBCastAlgo_t enum.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetQuantizeBatchMatMulBCastAlgorithm(mluOpHandle_t handle,
+                                         const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                                         const mluOpTensorDescriptor_t a_desc,
+                                         const mluOpTensorDescriptor_t b_desc,
+                                         const mluOpTensorDescriptor_t c_desc,
+                                         mluOpBatchMatMulBCastPreference_t preference,
+                                         mluOpBatchMatMulBCastAlgo_t *algo);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra workspace
+ * to optimize the batch matrix multiplication with broadcasting operation.
+ *
+ * The size of extra workspace is based on the given information of the batch matrix multiplication
+ * with broadcasting operation, including the batch matrix multiplication with broadcasting descriptor
+ * \b bmm_bcast_desc, input tensor descriptor of left matrix \b a_desc, input tensor descriptor of
+ * right matrix \b b_desc, output tensor descriptor \b c_desc, and the batch matrix multiplication
+ * with broadcasting algorithm \b algo. For more information about the workspace, see "Cambricon MLUOP User Guide".
+ *
+ * @param[in] handle
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the batch
+ *   matrix multiplication with broadcasting operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] bmm_bcast_desc
+ *   Input. The descriptor of the batch matrix multiplication with broadcasting operations. For detail information,
+ *   see ::mluOpBatchMatMulBCastDescriptor_t.
+ * @param[in] a_desc
+ *   Input. The descriptor of the input tensor of left matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] b_desc
+ *   Input. The descriptor of the input tensor of right matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] c_desc
+ *   Input. The descriptor of the input tensor of output matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] algo
+ *   Input. The algorithm used to compute the batch matrix multiplication with broadcasting. The algorithms are defined
+ *   in the ::mluOpBatchMatMulBCastAlgo_t enum. You can get the best suited algorithm with the
+ *   ::mluOpGetQuantizeBatchMatMulBCastAlgorithm function.
+ * @param[out] workspace_size
+ *   Output. Pointer to the MLU memory that stores the returned size of the extra workspace in bytes.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par API Dependency
+ * - This function must be called after ::mluOpGetQuantizeBatchMatMulBCastAlgorithm function. You also need to
+ *   call the ::mluOpCreateTensorDescriptor and ::mluOpSetTensorDescriptor functions to create and set
+ *   tensor descriptors \b a_desc, \b b_desc, \b c_desc before calling this function.
+ * - The allocated extra workspace should be passed to the ::mluOpQuantizeBatchMatMulBCast function to
+ *   performs the batch matrix multiplication with broadcasting operation.
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API mluOpGetQuantizeBatchMatMulBCastWorkspaceSize(
+                          mluOpHandle_t handle,
+                          mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                          const mluOpTensorDescriptor_t a_desc,
+                          const mluOpTensorDescriptor_t b_desc,
+                          const mluOpTensorDescriptor_t c_desc,
+                          mluOpBatchMatMulBCastAlgo_t algo,
+                          size_t *workspace_size);
+
+// Group:BatchMatMulBCast
+/*!
+ * @brief Quantizes data type of input tensor \b a and \b b, and computes the batch matrix
+ * multiplication with broadcasting operation, then returns the results in the output tensor \b c.
+ * For more information about quantization, see "Cambricon MLUOP User Guide".
+ *
+ * This function needs extra MLU memory as the workspace to improve the batch matrix multiplication
+ * with broadcasting performance. You can get the size of the workspace \b workspace_size with the
+ * ::mluOpGetQuantizeBatchMatMulBCastWorkspaceSize function. The batch matrix multiplication with broadcasting
+ * is computed based on the algorithm set in \b algo. You can call the
+ * ::mluOpGetQuantizeBatchMatMulBCastAlgorithm function to get the most suited algorithm.
+ *
+ * The scaling factors \b alpha and \b beta are not supported currently.
+ *
+ * @param[in] handle
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the batch
+ *   matrix multiplication with broadcasting operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] bmm_bcast_desc
+ *   Input. The descriptor of the batch matrix multiplication with broadcasting operations.
+ *   For detail information, see ::mluOpBatchMatMulBCastDescriptor_t.
+ * @param[in] alpha, beta
+ *   Input. Reserved for future use. Set the value of these parameters to NULL.
+ * @param[in] a_desc
+ *   Input. The descriptor of the input tensor of left matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] a
+ *   Input. Pointer to the MLU memory that stores the input tensor.
+ * @param[in] a_position
+ *   Input. Pointer to the MLU memory associated tensor \b a quantization param \b position.
+ * @param[in] a_scale
+ *   Input. Pointer to the MLU memory associated tensor \b a quantization param \b scale.
+ *   The value of this parameter can be NULL.
+ * @param[in] a_offset
+ *   Input. Pointer to the MLU memory associated tensor \b a quantization param \b offset.
+ *   The value of this parameter can be NULL.
+ * @param[in] b_desc
+ *   Input. The descriptor of the input tensor of right matrix. For detailed information,
+ *   see ::mluOpTensorDescriptor_t.
+ * @param[in] b
+ *   Input. Pointer to the MLU memory that stores the input tensor.
+ * @param[in] b_position
+ *   Input. Pointer to the MLU memory associated tensor \b b quantization param \b position.
+ * @param[in] b_scale
+ *   Input. Pointer to the MLU memory associated tensor \b b quantization param \b scale.
+ *   The value of this parameter can be NULL.
+ * @param[in] b_offset
+ *   Input. Pointer to the MLU memory associated tensor \b b quantization param \b offset.
+ *   The value of this parameter can be NULL.
+ * @param[in] c_desc
+ *   Input. The descriptor of the output tensor. For detailed information, see ::mluOpTensorDescriptor_t.
+ * @param[out] c
+ *   Output. Pointer to the MLU memory that stores the output tensor.
+ * @param[in] algo
+ *   Input. The algorithm used to compute the batch matrix multiplication with broadcasting.
+ *   The algorithms are defined in the ::mluOpBatchMatMulBCastAlgo_t enum. You can get the best
+ *   suited algorithm with the ::mluOpGetQuantizeBatchMatMulBCastAlgorithm function.
+ * @param[in] workspace
+ *   Input. Pointer to the MLU memory that is used as an extra workspace for the batch matrix multiplication
+ *   with broadcasting operation. For more information about workspace, see "Cambricon MLUOP User Guide".
+ * @param[in] workspace_size
+ *   Input. The size of the extra workspace in bytes that needs to be used in the batch matrix multiplication
+ *   with broadcasting operation. You can get the size of the workspace with the
+ *   ::mluOpGetQuantizeBatchMatMulBCastWorkspaceSize function.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ *
+ * @par Data Type
+ * - This function supports any combinations of the following data types for input tensor \b a, \b b and
+ *   output tensor \b c.
+ *   - \b a ddr data type: half, float.
+ *   - \b a onchip data type: int8, int16, int31.
+ *   - \b b ddr data type: half, float.
+ *   - \b b onchip data type: int8, int16, int31.
+ *   - \b c ddr offchip data type: half, float.
+ *   - The data type for operation computing: half, float.
+ * - \b a ddr data type should be the same as \b b ddr data type.
+ * - \b a ddr data type can be combined with any onchip data type.
+ * - \b b ddr data type can be combined with any onchip data type.
+ *
+ * @note
+ * - The combinations of the data types should satisfy the following rules:
+ *   - The data type bitwidth for operation computing is not shorter than \b c ddr data type.
+ *   - The data type for operation computing must be float when onchip data type is int31.
+ *   - The number of dimensions is no more than \p MLUOP_DIM_MAX.
+ * - This function does not support offline asymmetric quantization currently.
+ *
+ * @par Scale Limitation
+ * - The input tensors and output tensor must meet the following requirements:
+ *   - The \b a and \b b must have no less than two dimensions, and the last two dimensions of \b a and \b b
+ *     are matrix multiplication compatible.
+ *   - The number of columns of \b a matrix must be equal to the number of rows of \b b matrix after both
+ *     inputs have performed the transpose operations according to parameters. With the exception of the last
+ *     two dimensions, the other dimensions need to satisfy the broadcasting rules.
+ *
+ * @par API Dependency
+ * - Before calling this function to implement batch matrix multiplication with broadcasting, you need to prepare
+ *   all the parameters passed to this function. See each parameter description for details.
+ *
+ * @par Performance Optimization
+ * - For best practices, to have a better performance, matrix \b a does not need to transpose and matrix \b b
+ *   needs to transpose.
+ * - If \b a and \b b do not need broadcasting, for best practices, it is recommended to call ::mluOpQuantizeBatchMatMul.
+ *
+ * @par Example
+ * - The example of the operation is as follows:
+     @verbatim
+      transa:                    false
+      transb:                    false
+      Dimension of input tensor a:  [99, 128]
+      Dimension of input tensor b:  [64, 128, 256]
+      Dimension of output tensor c: [64, 99, 256]
+     @endverbatim
+ *
+ * @par Reference
+ * - https://pytorch.org/docs/stable/torch.html?highlight=bmm#torch.bmm
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpQuantizeBatchMatMulBCast(mluOpHandle_t handle,
+                             const mluOpBatchMatMulBCastDescriptor_t bmm_bcast_desc,
+                             const void *alpha,
+                             const mluOpTensorDescriptor_t a_desc,
+                             const void *a,
+                             const void *a_position,
+                             const void *a_scale,
+                             const void *a_offset,
+                             const mluOpTensorDescriptor_t b_desc,
+                             const void *b,
+                             const void *b_position,
+                             const void *b_scale,
+                             const void *b_offset,
+                             const void *beta,
+                             const mluOpTensorDescriptor_t c_desc,
+                             void *c,
+                             mluOpBatchMatMulBCastAlgo_t algo,
+                             void *workspace,
+                             size_t workspace_size);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/include/executor.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/include/executor.h
@@ -256,6 +256,8 @@ enum QuantMode {
 };
 enum ComputeMode { NORMAL = 0, BY_LAYER = 1 };
 
+enum class DramTensorType { ONLY_INPUT, ONLY_OUTPUT, BOTH_INPUT_OUTPUT, BOTH_INPUT_VOLATILE };
+
 struct DataBlock {
   DataBlock(MetaTensor *ts, bool o) {
     is_null = ts->is_null;
@@ -290,6 +292,12 @@ struct DataBlock {
   std::vector<int64_t> shape;
   std::vector<int64_t> stride;
   std::string name;
+
+  DramTensorType dram_tensor_type; 
+  void setDramTensorType(DramTensorType dram_tensor_type_) {
+    dram_tensor_type = dram_tensor_type_;
+  }
+
 };
 
 struct TensorPair {
@@ -400,6 +408,7 @@ class Executor {
     time_point_records_.emplace_back(
         std::make_tuple(name, std::chrono::steady_clock::now()));
   }
+  virtual void setMiscellaneousParam() {}  // set dram_tensor_type, etc if needed
 
  private:
   std::chrono::time_point<std::chrono::steady_clock> time_point_init_ =

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/include/executor.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/include/executor.h
@@ -256,7 +256,12 @@ enum QuantMode {
 };
 enum ComputeMode { NORMAL = 0, BY_LAYER = 1 };
 
-enum class DramTensorType { ONLY_INPUT, ONLY_OUTPUT, BOTH_INPUT_OUTPUT, BOTH_INPUT_VOLATILE };
+enum class DramTensorType {
+  ONLY_INPUT,
+  ONLY_OUTPUT,
+  BOTH_INPUT_OUTPUT,
+  BOTH_INPUT_VOLATILE
+};
 
 struct DataBlock {
   DataBlock(MetaTensor *ts, bool o) {
@@ -293,11 +298,10 @@ struct DataBlock {
   std::vector<int64_t> stride;
   std::string name;
 
-  DramTensorType dram_tensor_type; 
+  DramTensorType dram_tensor_type;
   void setDramTensorType(DramTensorType dram_tensor_type_) {
     dram_tensor_type = dram_tensor_type_;
   }
-
 };
 
 struct TensorPair {
@@ -408,7 +412,8 @@ class Executor {
     time_point_records_.emplace_back(
         std::make_tuple(name, std::chrono::steady_clock::now()));
   }
-  virtual void setMiscellaneousParam() {}  // set dram_tensor_type, etc if needed
+  virtual void setMiscellaneousParam() {
+  }  // set dram_tensor_type, etc if needed
 
  private:
   std::chrono::time_point<std::chrono::steady_clock> time_point_init_ =

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/batch_matmul_bcast.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/batch_matmul_bcast.cpp
@@ -1,0 +1,834 @@
+/*************************************************************************
+ * Copyright (C) [2019-2022] by Cambricon, Inc.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#define USE_OPENBLAS 0
+#include "batch_matmul_bcast.h"
+#if USE_OPENBLAS
+#include <openblas/cblas.h>
+#endif
+
+namespace mluoptest {
+
+bool BatchMatmulBcastExecutor::canBroadCast(std::vector<int> shape0, std::vector<int> shape1) {
+  int64_t ndim = shape1.size();
+  int64_t tensor_dim = shape0.size();
+  if (tensor_dim == 0)
+    return false;
+  for (int64_t i = ndim - 1; i >= 0; i--) {
+    int64_t offset = ndim - 1 - i;
+    int64_t dim = tensor_dim - 1 - offset;
+    int64_t size = (dim >= 0) ? shape0[dim] : 1;
+    if (shape1[i] == -1)
+      shape1[i] = size;
+    if (shape1[i] != size)
+      if (size != 1)
+        return false;
+  }
+  return true;
+}
+
+void BatchMatmulBcastExecutor::paramCheck() {
+  // set flag_quant_mode_ according to quant_mode param
+  QuantizeMode quant_mode = parser_->getProtoNode()->batch_matmul_bcast_param().quant_mode();
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+
+  cast_mode_ = parser_->getProtoNode()->batch_matmul_bcast_param().cast_mode();
+  if (cast_mode_ != MLUOP_MATMUL_BYPASS_QUANTIZE) {
+    switch (cast_mode_) {
+      case MLUOP_MATMUL_OFFLINE_SYMMETRIC_QUANTIZE:
+        flag_quant_mode_ = POSITION_SCALE;
+        break;
+      case MLUOP_MATMUL_OFFLINE_ASYMMETRIC_QUANTIZE:
+        flag_quant_mode_ = POS_SCALE_OFFSET;
+        break;
+      case MLUOP_MATMUL_NO_QUANTIZE:
+        flag_quant_mode_ = NO_QUANT;
+        break;
+      default:
+        LOG(ERROR) << "BatchMatmulBcastExecutor: batch_matmul_bcast cast_mode not set. ";
+    }
+  } else {
+    switch (quant_mode) {
+      case QUANTIZE_POSITION:
+        flag_quant_mode_ = ONLY_POSITION;
+        break;
+      case QUANTIZE_POSITION_SCALE:
+        flag_quant_mode_ = POSITION_SCALE;
+        break;
+      case QUANTIZE_POSITION_SCALE_OFFSET:
+        flag_quant_mode_ = POS_SCALE_OFFSET;
+        break;
+      default:
+        LOG(ERROR) << "BatchMatmulBcastExecutor: batch_matmul_bcast param quant_mode not set.";
+    }
+  }
+
+  if (!parser_->getProtoNode()->has_batch_matmul_bcast_param()) {
+    LOG(ERROR) << "Lose batch_matmul_bcast param. ";
+  }
+
+  if (beta == 0.0f && parser_->getInputNum() != 2) {
+    LOG(ERROR) << "batch_matmul_bcast tensor input number is wrong. "
+               << "when value of beta is " << beta << ", two inputs are required";
+  }
+
+  if (beta != 0.0f && parser_->getInputNum() != 3) {
+    LOG(ERROR) << "batch_matmul_bcast tensor input number is wrong. "
+               << "when value of beta is " << beta << ", three inputs are required";
+  }
+
+  if (parser_->getInputDimSize(0) < 2) {
+    LOG(ERROR) << "batch_matmul_bcast tensor input1 size at lest two dimensions. ";
+  }
+
+  if (parser_->getInputDimSize(1) < 2) {
+    LOG(ERROR) << "batch_matmul_bcast tensor input2 size at lest two dimensions. ";
+  }
+
+  bool is_transa = parser_->getProtoNode()->batch_matmul_bcast_param().is_transa();
+  bool is_transb = parser_->getProtoNode()->batch_matmul_bcast_param().is_transb();
+  bool use_stride = parser_->getProtoNode()->batch_matmul_bcast_param().use_stride();
+
+  int dim_max_a = parser_->getInputDimSize(0);
+  int dim_max_b = parser_->getInputDimSize(1);
+  int input1_col = (is_transa && !use_stride)
+                       ? parser_->getProtoNode()->input(0).shape().dims(dim_max_a - 2)
+                       : parser_->getProtoNode()->input(0).shape().dims(dim_max_a - 1);
+  int input2_row = (is_transb && !use_stride)
+                       ? parser_->getProtoNode()->input(1).shape().dims(dim_max_b - 1)
+                       : parser_->getProtoNode()->input(1).shape().dims(dim_max_b - 2);
+
+  if (input1_col != input2_row) {
+    LOG(ERROR) << "batch_matmul_bcast input1 cols is not equal to input2 rows. ";
+  }
+
+  flag_input_reuse_ = (beta != 0.0f) ? true : false;  // reuse void *c if need bias
+  VLOG(4) << "flag_input_reuse_: " << flag_input_reuse_;
+}
+
+void BatchMatmulBcastExecutor::setQuantizedParam() {
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  auto input_num = (beta == 0.0f) ? parser_->getInputNum() : parser_->getInputNum() - 1;
+  auto output_num = parser_->getOutputNum();
+  auto total_num = input_num + output_num;
+  for (int i = 0; i < total_num; ++i) {
+    if (!parser_->getMetaTensor(i).is_null) {
+      auto pos = parser_->getMetaTensor(i).position;
+      auto scale = parser_->getMetaTensor(i).scale;
+      auto offset = parser_->getMetaTensor(i).offset;
+      MLUOP_CHECK(mluOpSetTensorDescriptorPositionScaleAndOffset(tensor_desc_[i].tensor, pos, scale,
+                                                               offset));
+    }
+  }
+}
+
+void BatchMatmulBcastExecutor::castIn() {
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  auto input_num = parser_->getInputNum();
+  for (int i = 0; i < input_num; ++i) {
+    if (parser_->getMetaTensor(i).total_count == 0) {
+      continue;  // skip if ptr is nullptr
+    }
+
+    // fp32->X
+    auto dtype = parser_->getInputDataType(i);
+    auto oc_dt = parser_->getInputOnchipDataType(i);
+    auto src_data = cpu_fp32_input_[i];
+    auto dst_data = data_vector_[i].host_ptr;
+
+    int p = 0, o = 0;
+    float s = 1.0f;
+
+    MetaTensor *ts = &(parser_->getMetaTensor(i));
+
+    if (oc_dt == MLUOP_DTYPE_INVALID || oc_dt == dtype) {
+      // no onchip p/s/o
+      // just cast data from fp32 to dtype
+      // then memcpy this to mlu
+      // weight(matrix B) do not need asymmetric quant
+      if (i == 1) {
+        castDataIn(src_data, MLUOP_DTYPE_FLOAT, dst_data, dtype, ts->total_count, POSITION_SCALE, &p,
+                   &s, &o, true);
+      } else {
+        castDataIn(src_data, MLUOP_DTYPE_FLOAT, dst_data, dtype, ts->total_count, flag_quant_mode_,
+                   &p, &s, &o, true);
+      }
+      MLUOP_CHECK(mluOpSetTensorDescriptorPositionScaleAndOffset(tensor_desc_[i].tensor, p, s, o));
+    } else {
+      if (i == 1) {
+        // if has onchip_dtype
+        // cast fp32 to onchip dtype to get p/s/o and dequantify fp32 data (let cpu input == mlu
+        // input)
+        // and cast fp32 to offchip dtype then memcpy this to mlu
+        castDataIn(src_data, MLUOP_DTYPE_FLOAT, dst_data, dtype, ts->total_count, POSITION_SCALE, &p,
+                   &s, &o, true);
+      } else {
+        castDataIn(src_data, MLUOP_DTYPE_FLOAT, dst_data, dtype, ts->total_count, flag_quant_mode_,
+                   &p, &s, &o, true);
+      }
+
+      // get oc_dt's p/s and set to tensor.
+      void *temp = cpu_runtime_.allocate(ts->total_count * mluop::getSizeOfDataType(oc_dt));
+      if (i == 1) {
+        castDataIn(src_data, MLUOP_DTYPE_FLOAT, temp, oc_dt, ts->total_count, POSITION_SCALE, &p, &s,
+                   &o, true);
+      } else {
+        castDataIn(src_data, MLUOP_DTYPE_FLOAT, temp, oc_dt, ts->total_count, flag_quant_mode_, &p,
+                   &s, &o, true);
+      }
+      MLUOP_CHECK(mluOpSetTensorDescriptorPositionScaleAndOffset(tensor_desc_[i].tensor, p, s, o));
+      cpu_runtime_.deallocate(temp);
+    }
+
+    if (!ts->stride.empty()) {
+      VLOG(4) << "[WARNING] Executor: " << ts->name << " host ptr been strided_out.";
+      void *temp = cpu_runtime_.allocate(ts->shape_count * sizeof(float));
+      memset(temp, 0x0, ts->shape_count * sizeof(float));
+      tensor_stride_in(temp, cpu_fp32_input_[i], getTensorShapeSizeT(ts), getTensorStrideSizeT(ts),
+                       sizeof(float));
+      cpu_runtime_.deallocate(cpu_fp32_input_[i]);
+      cpu_fp32_input_[i] = (float *)temp;
+      ts->cpu_ptr = (float *)temp;
+    }
+
+#if GTEST_DEBUG_ENABLE
+    if (exe_config_->dump_data) {
+      saveDataToFile("baseline_strided_" + ts->name, cpu_fp32_input_[i], ts->shape_count);
+    }
+#endif
+  }
+}
+
+void BatchMatmulBcastExecutor::castOut() {
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  auto input_num = (beta == 0.0f) ? parser_->getInputNum() : parser_->getInputNum() - 1;
+  auto output_num = parser_->getOutputNum();
+  auto total_num = input_num + output_num;
+  auto dtype = parser_->getOutputDataType(0);
+  for (int i = input_num; i < total_num; ++i) {
+    // fp32 -> X
+    auto dtype = parser_->getMetaTensor(i).dtype;
+    auto count = parser_->getMetaTensor(i).total_count;
+    auto src_data = parser_->getMetaTensor(i).host_ptr;
+    auto dst_data = mlu_fp32_output_[i - input_num];
+    if ((parser_->device() != CPU) && (dtype == MLUOP_DTYPE_INT8 || dtype == MLUOP_DTYPE_INT16))
+      return;
+    castDataOut(src_data, dtype, dst_data, MLUOP_DTYPE_FLOAT, count, flag_quant_mode_, pos_, scale_,
+                offset_);
+  }
+}
+
+void BatchMatmulBcastExecutor::workspaceMalloc() {
+  int32_t is_transa = parser_->getProtoNode()->batch_matmul_bcast_param().is_transa();
+  int32_t is_transb = parser_->getProtoNode()->batch_matmul_bcast_param().is_transb();
+  int32_t use_tf32 = parser_->getProtoNode()->batch_matmul_bcast_param().allow_tf32();
+  int32_t use_stride = parser_->getProtoNode()->batch_matmul_bcast_param().use_stride();
+
+  bmm_bcast_desc_ = cpu_runtime_.allocate(mluOpMatMulDescCreate, mluOpMatMulDescDestroy);
+  MLUOP_CHECK(mluOpSetMatMulDescAttr(bmm_bcast_desc_, MLUOP_MATMUL_DESC_TRANSA, &(is_transa),
+                                   sizeof(int32_t)));
+  MLUOP_CHECK(mluOpSetMatMulDescAttr(bmm_bcast_desc_, MLUOP_MATMUL_DESC_TRANSB, &(is_transb),
+                                   sizeof(int32_t)));
+  MLUOP_CHECK(mluOpSetMatMulDescAttr(bmm_bcast_desc_, MLUOP_MATMUL_CAST_MODE, &(cast_mode_),
+                                   sizeof(cast_mode_)));
+  MLUOP_CHECK(
+      mluOpSetMatMulDescAttr(bmm_bcast_desc_, MLUOP_MATMUL_ALLOW_TF32, &(use_tf32), sizeof(int32_t)));
+  MLUOP_CHECK(mluOpSetMatMulDescAttr(bmm_bcast_desc_, MLUOP_MATMUL_USE_STRIDE, &(use_stride),
+                                   sizeof(int32_t)));
+
+  auto desc_a = tensor_desc_[0].tensor;
+  auto desc_b = tensor_desc_[1].tensor;
+  auto desc_c = tensor_desc_[2].tensor;
+
+  if (cast_mode_ != MLUOP_MATMUL_BYPASS_QUANTIZE) {
+    switch (cast_mode_) {
+      case MLUOP_MATMUL_OFFLINE_SYMMETRIC_QUANTIZE:
+        flag_quant_mode_ = POSITION_SCALE;
+        break;
+      case MLUOP_MATMUL_OFFLINE_ASYMMETRIC_QUANTIZE:
+        flag_quant_mode_ = POS_SCALE_OFFSET;
+        break;
+      case MLUOP_MATMUL_NO_QUANTIZE:
+        flag_quant_mode_ = NO_QUANT;
+        break;
+      default:
+        LOG(ERROR) << "BatchMatmulBcastExecutor: batch_matmul_bcast param cast_mode not set.";
+    }
+    cpuComputeForCastOutput();
+  } else {
+    cpuComputeForCastOutput();
+    if (parser_->device() != CPU) {
+      auto c_offset = parser_->getMetaTensor(2).offset;
+      if (c_offset != 0) {
+        flag_quant_mode_ = POS_SCALE_OFFSET;
+      }
+    }
+  }
+
+  void *workspace = NULL;
+  algo_ = cpu_runtime_.allocate(mluOpMatMulAlgoCreate, mluOpMatMulAlgoDestroy);
+
+#if 0
+  MLUOP_CHECK(
+      mluOpGetBatchMatMulBCastWorkspaceSize(handle_, desc_a, desc_b, desc_c, &workspace_size_));
+#else
+  heuristic_result_ =
+      cpu_runtime_.allocate(mluOpCreateMatMulHeuristicResult, mluOpDestroyMatMulHeuristicResult);
+  // mluOpMatMulPrefer_t prefer; // not supported now
+  int requested_algo_count = 1, return_algo_count = 0;
+  mluOpGetBatchMatMulAlgoHeuristic(handle_, bmm_bcast_desc_, desc_a, desc_b, desc_c,
+                                  nullptr /* prefer */, requested_algo_count, &heuristic_result_,
+                                  &return_algo_count);
+  mluOpGetBatchMatMulHeuristicResult(heuristic_result_, algo_, &workspace_size_);
+/////////// end batch_matmul algo and heuristic result ///////////
+#endif
+
+  if (workspace_size_ > 0) {
+    workspace = mlu_runtime_.allocate(workspace_size_);
+  }
+  workspace_.push_back(workspace);
+
+  eva_->setMluWorkspaceSize(workspace_size_);
+}
+
+void BatchMatmulBcastExecutor::workspaceFree() {
+  if (workspace_[0]) {
+    mlu_runtime_.deallocate(workspace_[0]);
+  }
+}
+
+void BatchMatmulBcastExecutor::cpuComputeForCastOutput() {
+  if (exe_config_->mlu_only) {
+    return;
+  }
+  // ----------------------- baselineOutputMalloc begin ------------------------
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  auto input_num = (beta == 0.0f) ? parser_->getInputNum() : parser_->getInputNum() - 1;
+  auto output_num = parser_->getOutputNum();
+  auto total_num = input_num + output_num;
+  // for outputs
+  for (int i = input_num; i < total_num; ++i) {
+    if (!parser_->getMetaTensor(i).is_null) {
+      auto count = parser_->getMetaTensor(i).total_count;
+      auto name = parser_->getMetaTensor(i).name;
+      parser_->getMetaTensor(i).cpu_ptr =
+          (float *)cpu_runtime_.allocate(count * sizeof(float), name);
+      memset(parser_->getMetaTensor(i).cpu_ptr, 0, count * sizeof(float));
+    }
+    cpu_fp32_output_.push_back(parser_->getMetaTensor(i).cpu_ptr);
+  }
+  // ----------------------- baselineOutputMalloc end --------------------------
+
+  if (parser_->device() != CPU) {
+    // set pos and scale for output
+    float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+    auto input_num = (beta == 0.0f) ? parser_->getInputNum() : parser_->getInputNum() - 1;
+    auto output_num = parser_->getOutputNum();
+    auto total_num = input_num + output_num;
+    for (int i = input_num; i < total_num; ++i) {
+      if (parser_->getMetaTensor(i).is_null == false) {
+        auto pos = parser_->getMetaTensor(i).position;
+        auto scale = parser_->getMetaTensor(i).scale;
+        auto offset = parser_->getMetaTensor(i).offset;
+        MLUOP_CHECK(mluOpSetTensorDescriptorPositionScaleAndOffset(tensor_desc_[i].tensor, pos, scale,
+                                                                 offset));
+      }
+    }
+    setOutputQuantParam();
+    return;
+  }
+}
+
+void BatchMatmulBcastExecutor::setOutputQuantParam() {
+  auto dtype = parser_->getOutputDataType(0);
+  auto count = parser_->getOutputDataCount(0);
+  if (dtype == MLUOP_DTYPE_INT8 || dtype == MLUOP_DTYPE_INT16 || dtype == MLUOP_DTYPE_INT31) {
+    getQuantizedParam(cpu_fp32_output_[0], count, dtype, flag_quant_mode_, &pos_, &scale_,
+                      &offset_);
+    MLUOP_CHECK(mluOpSetTensorDescriptorPositionScaleAndOffset(tensor_desc_.back().tensor, pos_,
+                                                             scale_, offset_));
+  }
+}
+
+void BatchMatmulBcastExecutor::compute() {
+  VLOG(4) << "BatchMatmulBcastExecutor compute ";
+  if (!parser_->getProtoNode()->has_batch_matmul_bcast_param()) {
+    LOG(ERROR) << "Lose batch_matmul_bcast param. ";
+  }
+  int32_t is_transa = parser_->getProtoNode()->batch_matmul_bcast_param().is_transa();
+  int32_t is_transb = parser_->getProtoNode()->batch_matmul_bcast_param().is_transb();
+
+  float alpha = parser_->getProtoNode()->batch_matmul_bcast_param().alpha();
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+
+  auto tensor_a = tensor_desc_[0].tensor;
+  auto tensor_b = tensor_desc_[1].tensor;
+  auto tensor_c = tensor_desc_[2].tensor;
+  auto dev_a = data_vector_[0].device_ptr;
+  auto dev_b = data_vector_[1].device_ptr;
+  auto dev_c = data_vector_[2].device_ptr;
+  VLOG(4) << "call mluOp BatchMatMulBCast()";
+  interface_timer_.start();
+#if 0
+  MLUOP_CHECK(mluOpBatchMatMulBCast(handle_, is_transa, is_transb, tensor_a, dev_a, tensor_b, dev_b,
+                                  workspace_[0], workspace_size_, tensor_c, dev_c));
+#else
+  MLUOP_CHECK(mluOpBatchMatMulBCast_v2(handle_, bmm_bcast_desc_, algo_, &alpha, tensor_a, dev_a,
+                                     tensor_b, dev_b, &beta, tensor_c, dev_c, workspace_[0],
+                                     workspace_size_));
+#endif
+  interface_timer_.stop();
+}
+
+void BatchMatmulBcastExecutor::setMiscellaneousParam() {
+  data_vector_[2].setDramTensorType(DramTensorType::BOTH_INPUT_OUTPUT);
+}
+
+
+void BatchMatmulBcastExecutor::float2double(double *dst, float *src, int64_t num) {
+  for (int64_t i = 0; i < num; ++i) {
+    dst[i] = (double)src[i];
+  }
+}
+
+void BatchMatmulBcastExecutor::qdouble2float(float *dst, double *src, double scale, int64_t num) {
+  for (int64_t i = 0; i < num; ++i) {
+    dst[i] = static_cast<float>(scale * src[i]);
+  }
+}
+
+void BatchMatmulBcastExecutor::int2double(double *dst,
+                                          void *src,
+                                          mluOpDataType_t src_type,
+                                          int64_t num) {
+  if (src_type == MLUOP_DTYPE_INT8) {
+    int8_t *csrc = (int8_t *)src;
+    for (int64_t i = 0; i < num; ++i) {
+      dst[i] = static_cast<double>(csrc[i]);
+    }
+  } else if (src_type == MLUOP_DTYPE_INT16) {
+    float *sdst = static_cast<float *>(cpu_runtime_.allocate(num * sizeof(float)));
+    cnrtQuantizedParam_t param;
+    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtCreateQuantizedParam(&param, 0, 1.0f, 0.0f));
+    GTEST_CHECK(CNRT_RET_SUCCESS ==
+                cnrtCastDataType_V2(src, cnrtShort, sdst, cnrtFloat, num, param, cnrtRounding_rm));
+    for (int64_t i = 0; i < num; ++i) {
+      dst[i] = static_cast<double>(sdst[i]);
+    }
+    cpu_runtime_.deallocate(sdst);
+    cnrtDestroyQuantizedParam(param);
+  }
+}
+
+void BatchMatmulBcastExecutor::cpuCompute() {
+  float alpha = parser_->getProtoNode()->batch_matmul_bcast_param().alpha();
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  if (beta == 0.0f) {
+    assert(parser_->getInputNum() == 2);
+  } else {
+    assert(parser_->getInputNum() == 3);
+  }
+  assert(parser_->getOutputNum() == 1);
+  bool is_transa = parser_->getProtoNode()->batch_matmul_bcast_param().is_transa();
+  bool is_transb = parser_->getProtoNode()->batch_matmul_bcast_param().is_transb();
+  bool use_stride = parser_->getProtoNode()->batch_matmul_bcast_param().use_stride();
+  is_transa = use_stride ? false : is_transa;
+  is_transb = use_stride ? false : is_transb;
+
+  auto desc_a = tensor_desc_[0].tensor;
+  auto desc_b = tensor_desc_[1].tensor;
+  auto desc_c = tensor_desc_[2].tensor;
+
+  auto count1 = parser_->getInputDataCount(0);
+  auto count2 = parser_->getInputDataCount(1);
+  if (count1 == 0 || count2 == 0) {
+    return;
+  }
+
+  int batch_size = 1;
+  for (int i = 0; i < desc_c->dim - 2; ++i) {
+    batch_size *= desc_c->dims[i];
+  }
+  assert(batch_size >= 1);
+
+  int dim_max_a = parser_->getInputDimSize(0);
+  int dim_max_c = parser_->getOutputDimSize(0);
+  int k = is_transa ? (int)parser_->getProtoNode()->input(0).shape().dims(dim_max_a - 2)
+                    : (int)parser_->getProtoNode()->input(0).shape().dims(dim_max_a - 1);
+
+  int m = (int)parser_->getProtoNode()->output(0).shape().dims(dim_max_c - 2);
+  int n = (int)parser_->getProtoNode()->output(0).shape().dims(dim_max_c - 1);
+
+  std::vector<int> shape_expand_a, shape_expand_b;
+
+  for (int i = 0; i < desc_c->dim - 2; ++i) {
+    shape_expand_a.push_back((int)desc_c->dims[i]);
+    shape_expand_b.push_back((int)desc_c->dims[i]);
+  }
+
+  for (int i = desc_a->dim - 2; i < desc_a->dim; ++i) {
+    shape_expand_a.push_back((int)desc_a->dims[i]);
+  }
+
+  for (int i = desc_b->dim - 2; i < desc_b->dim; ++i) {
+    shape_expand_b.push_back((int)desc_b->dims[i]);
+  }
+
+  float *a_expand = (float *)cpu_runtime_.allocate((int64_t)batch_size * m * k * sizeof(float));
+  float *b_expand = (float *)cpu_runtime_.allocate((int64_t)batch_size * n * k * sizeof(float));
+
+  int a_position = desc_a->position;
+  int b_position = desc_b->position;
+  float a_scale = desc_a->scale;
+  float b_scale = desc_b->scale;
+
+  if (desc_a->onchip_dtype == MLUOP_DTYPE_INT31) {
+    a_position = 0.0;
+    a_scale = 1.0;
+  }
+
+  if (desc_b->onchip_dtype == MLUOP_DTYPE_INT31) {
+    b_position = 0.0;
+    b_scale = 1.0;
+  }
+
+  double c_scale = 1.0;
+
+  if (desc_a->onchip_dtype != desc_a->dtype && desc_a->onchip_dtype != MLUOP_DTYPE_INVALID) {
+    c_scale = pow(2.0, a_position) / (a_scale);
+  }
+
+  if (desc_b->onchip_dtype != desc_b->dtype && desc_b->onchip_dtype != MLUOP_DTYPE_INVALID) {
+    c_scale = pow(2.0, b_position) / (b_scale);
+  }
+
+  if ((desc_a->onchip_dtype != desc_a->dtype && desc_a->onchip_dtype != MLUOP_DTYPE_INVALID) &&
+      (desc_b->onchip_dtype != desc_b->dtype && desc_b->onchip_dtype != MLUOP_DTYPE_INVALID)) {
+    c_scale = pow(2.0, a_position + b_position) / (a_scale * b_scale);
+  }
+
+  cnrtQuantizedParam_t a_f2i_param;
+  cnrtQuantizedParam_t b_f2i_param;
+  GTEST_CHECK(CNRT_RET_SUCCESS ==
+              cnrtCreateQuantizedParam(&a_f2i_param, a_position, a_scale, 0.0f));
+  GTEST_CHECK(CNRT_RET_SUCCESS ==
+              cnrtCreateQuantizedParam(&b_f2i_param, b_position, b_scale, 0.0f));
+
+  // bool a_broadcast = canBroadCast(shape_a, shape_expand_a);
+  expandComputeCpu(std::vector<int>(desc_a->dims, desc_a->dims + desc_a->dim), shape_expand_a,
+                   cpu_fp32_input_[0], a_expand);
+
+  // bool can_broadcast = canBroadCast(shape_a, shape_b);
+  expandComputeCpu(std::vector<int>(desc_b->dims, desc_b->dims + desc_b->dim), shape_expand_b,
+                   cpu_fp32_input_[1], b_expand);
+
+  void *a_int = cpu_runtime_.allocate((int64_t)batch_size * m * k * 2 * sizeof(char));
+  void *b_int = cpu_runtime_.allocate((int64_t)batch_size * k * n * 2 * sizeof(char));
+
+  double *a_double =
+      static_cast<double *>(cpu_runtime_.allocate((int64_t)batch_size * m * k * sizeof(double)));
+  double *b_double =
+      static_cast<double *>(cpu_runtime_.allocate((int64_t)batch_size * k * n * sizeof(double)));
+  double *c_tmp_double;
+  if (beta != 0.0f) {
+    c_tmp_double =
+        static_cast<double *>(cpu_runtime_.allocate((int64_t)batch_size * m * n * sizeof(double)));
+  }
+  double *c_double = static_cast<double *>(cpu_runtime_.allocate((int64_t)m * n * sizeof(double)));
+
+  // cast A 2 double
+  if (desc_a->onchip_dtype != desc_a->dtype && desc_a->onchip_dtype != MLUOP_DTYPE_INVALID) {
+    if (desc_a->onchip_dtype == MLUOP_DTYPE_INT8) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtCastDataType_V2(a_expand, cnrtFloat, a_int, cnrtChar,
+                                                          (int64_t)batch_size * m * (int64_t)k, a_f2i_param,
+                                                          cnrtRounding_rm));
+      int2double(a_double, a_int, MLUOP_DTYPE_INT8, (int64_t)batch_size * m * (int64_t)k);
+    } else if (desc_a->onchip_dtype == MLUOP_DTYPE_INT16) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtCastDataType_V2(a_expand, cnrtFloat, a_int, cnrtShort,
+                                                          (int64_t)batch_size * m * (int64_t)k, a_f2i_param,
+                                                          cnrtRounding_rm));
+      int2double(a_double, a_int, MLUOP_DTYPE_INT16, (int64_t)batch_size * m * (int64_t)k);
+    } else if (desc_a->onchip_dtype == MLUOP_DTYPE_INT31) {
+      for (int64_t i = 0; i < (int64_t)batch_size * m * (int64_t)k; ++i) {
+        a_double[i] = static_cast<double>(a_expand[i]);
+      }
+    }
+  } else {
+    float2double(a_double, a_expand, (int64_t)batch_size * m * (int64_t)k);
+  }
+
+  // cast B 2 double
+  if (desc_b->onchip_dtype != desc_b->dtype && desc_b->onchip_dtype != MLUOP_DTYPE_INVALID) {
+    if (desc_b->onchip_dtype == MLUOP_DTYPE_INT8) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtCastDataType_V2(b_expand, cnrtFloat, b_int, cnrtChar,
+                                                          (int64_t)batch_size * n * (int64_t)k, b_f2i_param,
+                                                          cnrtRounding_rm));
+      int2double(b_double, b_int, MLUOP_DTYPE_INT8, (int64_t)batch_size * n * (int64_t)k);
+    } else if (desc_b->onchip_dtype == MLUOP_DTYPE_INT16) {
+      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtCastDataType_V2(b_expand, cnrtFloat, b_int, cnrtShort,
+                                                          (int64_t)batch_size * n * (int64_t)k, b_f2i_param,
+                                                          cnrtRounding_rm));
+      int2double(b_double, b_int, MLUOP_DTYPE_INT16, (int64_t)batch_size * n * (int64_t)k);
+    } else if (desc_b->onchip_dtype == MLUOP_DTYPE_INT31) {
+      for (int64_t i = 0; i < (int64_t)batch_size * n * (int64_t)k; ++i) {
+        b_double[i] = static_cast<double>(b_expand[i]);
+      }
+    }
+  } else {
+    float2double(b_double, b_expand, (int64_t)batch_size * n * (int64_t)k);
+  }
+
+  // C to double
+  if (beta != 0.0f) {
+    float2double(c_tmp_double, cpu_fp32_input_[2], (int64_t)batch_size * m * (int64_t)n);
+  }
+
+#if USE_OPENBLAS
+  const CBLAS_ORDER Order = CblasRowMajor;
+  const CBLAS_TRANSPOSE TransA = is_transa ? CblasTrans : CblasNoTrans;
+  const CBLAS_TRANSPOSE TransB = is_transb ? CblasTrans : CblasNoTrans;
+
+  int lda = is_transa ? m : k;
+  int ldb = is_transb ? k : n;
+  int ldc = n;
+#else
+
+  auto matmul = [](double *lhs, double *rhs, double *bias, double *output, bool is_trans_a,
+                   bool is_trans_b, int M, int N, int K, double alpha, double beta, bool use_beta) {
+    for (int64_t m = 0; m < M; m++) {
+      for (int64_t n = 0; n < N; n++) {
+        output[(int64_t)m * N + n] = 0.0f;
+        for (int64_t k = 0; k < K; k++) {
+          int64_t lhs_idx = (int64_t)m * K + k;
+          if (is_trans_a)
+            lhs_idx = (int64_t)k * M + m;
+          int64_t rhs_idx = (int64_t)k * N + n;
+          if (is_trans_b)
+            rhs_idx = (int64_t)n * K + k;
+          output[(int64_t)m * N + n] += (alpha == 0.0f ? 0.0 : alpha * lhs[lhs_idx] * rhs[rhs_idx]);
+        }
+        if (use_beta == true)
+          output[(int64_t)m * N + n] += beta * bias[(int64_t)m * N + n];
+      }
+    }
+  };
+#endif
+
+  bool use_beta = false;
+  if (beta != 0.0f) {
+    use_beta = true;
+  }
+
+  for (int i = 0; i < batch_size; ++i) {
+#if USE_OPENBLAS
+
+    float *c_tmp_float = (float *)cpu_runtime_.allocate((int64_t)m * n * sizeof(float));
+    if (beta != 0.0f) {
+      memcpy(c_tmp_float, cpu_fp32_input_[2] + (int64_t)i * m * (int64_t)n, (int64_t)m * n * sizeof(float));
+    }
+    cblas_sgemm(Order, TransA, TransB, m, n, k, alpha, cpu_fp32_input_[0] + (int64_t)i * m * (int64_t)k, lda,
+                cpu_fp32_input_[1] + (int64_t)i * k * (int64_t)n, ldb, beta, c_tmp_float, ldc);
+    memcpy(cpu_fp32_output_[0] + (int64_t)i * m * (int64_t)n, c_tmp_float, (int64_t)m * n * sizeof(float));
+    cpu_runtime_.deallocate(c_tmp_float);
+    c_tmp_float = NULL;
+
+#else
+
+    matmul(a_double + (int64_t)i * m * (int64_t)k, b_double + (int64_t)i * k * (int64_t)n, c_tmp_double + (int64_t)i * m * (int64_t)n, c_double,
+           is_transa, is_transb, m, n, k, (double)alpha, (double)beta, use_beta);
+    qdouble2float(cpu_fp32_output_[0] + (int64_t)i * m * (int64_t)n, c_double, c_scale, (int64_t)m * n);
+
+#endif
+  }
+
+  cpu_runtime_.deallocate(a_expand);
+  cpu_runtime_.deallocate(b_expand);
+  cpu_runtime_.deallocate(a_int);
+  cpu_runtime_.deallocate(b_int);
+  cpu_runtime_.deallocate(a_double);
+  cpu_runtime_.deallocate(b_double);
+  cpu_runtime_.deallocate(c_double);
+  if (beta != 0.0f) {
+    cpu_runtime_.deallocate(c_tmp_double);
+  }
+  a_expand = NULL;
+  b_expand = NULL;
+  a_int = NULL;
+  b_int = NULL;
+  a_double = NULL;
+  b_double = NULL;
+  c_double = NULL;
+  c_tmp_double = NULL;
+
+  cnrtDestroyQuantizedParam(a_f2i_param);
+  cnrtDestroyQuantizedParam(b_f2i_param);
+}
+
+int BatchMatmulBcastExecutor::expandNumAfterFirst(int num) {
+  int tmp = 0;
+  while (num) {
+    num = num >> 1;
+    tmp++;
+  }
+  return tmp - 1;
+}
+
+void BatchMatmulBcastExecutor::expandComputeCpu(std::vector<int> shape_a,
+                                                std::vector<int> shape_b,
+                                                float *input,
+                                                float *output) {
+  if (shape_a.size() < MLUOP_DIM_MAX) {
+    shape_a.insert(shape_a.begin(), MLUOP_DIM_MAX - shape_a.size(), 1);
+  }
+  if (shape_b.size() < MLUOP_DIM_MAX) {
+    shape_b.insert(shape_b.begin(), MLUOP_DIM_MAX - shape_b.size(), 1);
+  }
+
+  bool can_broadcast = canBroadCast(shape_a, shape_b);
+  assert(can_broadcast == 1);
+
+  uint64_t sizeA = 1;
+  uint64_t sizeB = 1;
+
+  for (int i = 0; i < MLUOP_DIM_MAX; i++) {
+    sizeA = sizeA * shape_a[i];
+    sizeB = sizeB * shape_b[i];
+  }
+
+#if 0
+  if (!can_broadcast) {
+    memcpy(output, input, sizeA * sizeof(float));
+    return;
+  }
+#endif
+
+  float *tmp = cpu_runtime_.allocate(new float[sizeB]);
+  memcpy(tmp, input, sizeA * sizeof(float));
+
+  int64_t is_first = true;
+  int64_t leftSizeA = 1;
+  int64_t rightSizeA = 1;
+  int64_t leftSizeB = 1;
+  int64_t rightSizeB = 1;
+  int64_t E = 1;
+  int64_t ExpandA = 1;
+
+  int64_t size = MLUOP_DIM_MAX;
+
+  for (int64_t i = size - 1; i >= 0; i--) {
+    rightSizeA = rightSizeA * shape_a[i];
+    rightSizeB = rightSizeB * shape_b[i];
+    leftSizeA = sizeA / rightSizeA;
+    leftSizeB = sizeB / rightSizeB;
+    if (shape_a[i] != shape_b[i]) {
+      E = shape_b[i];
+      ExpandA = ExpandA * shape_a[i];
+      shape_a[i] = shape_b[i];
+      for (int64_t j = 0; j < leftSizeA; j++) {
+        int64_t numAfter = expandNumAfterFirst(E);
+        memcpy(output + j * rightSizeB, tmp + j * (rightSizeB / E), rightSizeB / E * sizeof(float));
+        for (int64_t k = 1; k <= numAfter; k++) {
+          memcpy(output + j * rightSizeB + (1 << (k - 1)) * (rightSizeB / E),
+                 output + j * rightSizeB, (1 << (k - 1)) * (rightSizeB / E) * sizeof(float));
+        }
+        int64_t done = 1 << numAfter;
+        int64_t rem = E - (1 << numAfter);
+        memcpy(output + j * rightSizeB + done * (rightSizeB / E), output + j * rightSizeB,
+               rem * (rightSizeB / E) * sizeof(float));
+      }
+      memcpy(tmp, output, sizeB * sizeof(float));
+    }
+  }
+  memcpy(output, tmp, sizeB * sizeof(float));
+  cpu_runtime_.deallocate(tmp);
+}
+
+void BatchMatmulBcastExecutor::baselineOutputMalloc() {
+  return;
+}
+
+void BatchMatmulBcastExecutor::getBaselineOutput() {
+  if (parser_->device() == CPU) {
+    return;
+  }
+
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  auto input_num = (beta == 0.0f) ? parser_->getInputNum() : parser_->getInputNum() - 1;
+  auto output_num = parser_->getOutputNum();
+  auto total_num = input_num + output_num;
+  for (int i = input_num; i < total_num; ++i) {
+    if (parser_->getMetaTensor(i).is_null == false) {
+      auto count = parser_->getMetaTensor(i).total_count;
+      auto dtype = parser_->getMetaTensor(i).dtype;
+      if (dtype == MLUOP_DTYPE_INT8 || dtype == MLUOP_DTYPE_INT16) {
+        continue;
+      }
+      auto data_size = count * mluop::getSizeOfDataType(dtype);
+      void *temp = cpu_runtime_.allocate(data_size);
+      // MetaTensor is input + output;
+      // cpu_fp32_output is ouptut only, so cpu_fp32_output_id = metatensor_id - input_num
+      parser_->getOutputData(i - input_num, temp);
+      castDataOut(temp, dtype, cpu_fp32_output_[i - input_num], MLUOP_DTYPE_FLOAT, count, NO_QUANT,
+                  pos_, scale_, 0);
+      cpu_runtime_.deallocate(temp);
+    }
+  }
+}
+
+int64_t BatchMatmulBcastExecutor::getTheoryIoSize() {
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  size_t total_size = 0;
+  for (size_t i = 0; i < 2; ++i) {
+    MetaTensor *ts = parser_->input(i);
+    total_size += ts->shape_count * ts->sizeof_dtype;
+  }
+
+  MetaTensor *ts = parser_->output(0);
+  total_size += (beta == 0.0f ? 1 : 2) * ts->shape_count * ts->sizeof_dtype;
+
+  VLOG(4) << "BatchMatmulBcastExecutor: getTheoryIOs: " << total_size << " bytes";
+  return total_size;
+}
+
+int64_t BatchMatmulBcastExecutor::getTheoryOps() {
+  int64_t theory_ops = 0;
+  float beta = parser_->getProtoNode()->batch_matmul_bcast_param().beta();
+  if (beta == 0.0f) {
+    assert(parser_->getInputNum() == 2);
+  } else {
+    assert(parser_->getInputNum() == 3);
+  }
+  assert(parser_->getOutputNum() == 1);
+  bool is_transa = parser_->getProtoNode()->batch_matmul_bcast_param().is_transa();
+  bool is_transb = parser_->getProtoNode()->batch_matmul_bcast_param().is_transb();
+
+  auto desc_c = tensor_desc_[2].tensor;
+
+  int batch_size = 1;
+  for (int i = 0; i < desc_c->dim - 2; ++i) {
+    batch_size *= desc_c->dims[i];
+  }
+  assert(batch_size >= 1);
+
+  int dim_max_a = parser_->getInputDimSize(0);
+  int dim_max_c = parser_->getOutputDimSize(0);
+  int k = is_transa ? (int)parser_->getProtoNode()->input(0).shape().dims(dim_max_a - 2)
+                    : (int)parser_->getProtoNode()->input(0).shape().dims(dim_max_a - 1);
+  int m = (int)parser_->getProtoNode()->output(0).shape().dims(dim_max_c - 2);
+  int n = (int)parser_->getProtoNode()->output(0).shape().dims(dim_max_c - 1);
+
+  theory_ops = (int64_t)2 * batch_size * m * n * (int64_t)k;
+
+  VLOG(4) << "getTheoryOps: " << theory_ops << " ops";
+  return theory_ops;
+}
+
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/batch_matmul_bcast.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/batch_matmul_bcast.h
@@ -1,0 +1,66 @@
+
+/*************************************************************************
+ * Copyright (C) [2019-2022] by Cambricon, Inc.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_BATCH_MATMUL_BCAST_BATCH_MATMUL_BCAST_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_BATCH_MATMUL_BCAST_BATCH_MATMUL_BCAST_H_
+#include <vector>
+#include "executor.h"
+#include "core/type.h"
+
+namespace mluoptest {
+
+class BatchMatmulBcastExecutor : public Executor {
+ public:
+  BatchMatmulBcastExecutor() {}
+  ~BatchMatmulBcastExecutor() {}
+
+  void paramCheck();
+  void cpuComputeForCastOutput();
+  void baselineOutputMalloc();
+  void setOutputQuantParam();
+  void compute();
+  void cpuCompute();
+
+  void castIn() override;
+  void castOut() override;
+  void setQuantizedParam() override;
+  void getBaselineOutput() override;
+
+  void workspaceMalloc();
+  void workspaceFree();
+  void float2double(double *dst, float *src, int64_t num);
+  void int2double(double *dst, void *src, mluOpDataType_t src_type, int64_t num);
+  void qdouble2float(float *dst, double *src, double scale, int64_t num);
+  int expandNumAfterFirst(int num);
+  bool canBroadCast(std::vector<int> shape0, std::vector<int> shape1);
+  void expandComputeCpu(std::vector<int> shape_a,
+                        std::vector<int> shape_b,
+                        float *input,
+                        float *output);
+  int64_t getTheoryOps() override;
+  int64_t getTheoryIoSize() override;
+
+  void setMiscellaneousParam() override;
+ private:
+  int pos_               = 0;
+  float scale_           = 1.;
+  int offset_            = 0;
+  mluOpQuantizeMode_t quant_mode_;
+  MatMulCastMode cast_mode_;
+  mluOpMatMulDescriptor_t bmm_bcast_desc_ = nullptr;
+  mluOpMatMulAlgo_t algo_ = nullptr;
+  size_t workspace_size_ = 0;
+  mluOpMatMulHeuristicResult_t heuristic_result_ = nullptr;
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_BATCH_MATMUL_BCAST_BATCH_MATMUL_BCAST_H_

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/batch_matmul_bcast.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/batch_matmul_bcast.h
@@ -38,22 +38,22 @@ class BatchMatmulBcastExecutor : public Executor {
   void workspaceMalloc();
   void workspaceFree();
   void float2double(double *dst, float *src, int64_t num);
-  void int2double(double *dst, void *src, mluOpDataType_t src_type, int64_t num);
+  void int2double(double *dst, void *src, mluOpDataType_t src_type,
+                  int64_t num);
   void qdouble2float(float *dst, double *src, double scale, int64_t num);
   int expandNumAfterFirst(int num);
   bool canBroadCast(std::vector<int> shape0, std::vector<int> shape1);
-  void expandComputeCpu(std::vector<int> shape_a,
-                        std::vector<int> shape_b,
-                        float *input,
-                        float *output);
+  void expandComputeCpu(std::vector<int> shape_a, std::vector<int> shape_b,
+                        float *input, float *output);
   int64_t getTheoryOps() override;
   int64_t getTheoryIoSize() override;
 
   void setMiscellaneousParam() override;
+
  private:
-  int pos_               = 0;
-  float scale_           = 1.;
-  int offset_            = 0;
+  int pos_ = 0;
+  float scale_ = 1.;
+  int offset_ = 0;
   mluOpQuantizeMode_t quant_mode_;
   MatMulCastMode cast_mode_;
   mluOpMatMulDescriptor_t bmm_bcast_desc_ = nullptr;

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/test_case/case_0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/batch_matmul_bcast/test_case/case_0.prototxt
@@ -1,0 +1,69 @@
+op_name: "batch_matmul_bcast"
+input {
+  id: "input1"
+  shape: {
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 8
+    dims: 256
+    dims: 64
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_INT16
+  random_data: {
+    seed: 23
+    upper_bound: 10
+    lower_bound: 0
+    distribution: UNIFORM
+  }
+}
+input {
+  id: "input2"
+  shape: {
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 256
+    dims: 64
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_INT16
+  random_data: {
+    seed: 25
+    upper_bound: 10
+    lower_bound: -10
+    distribution: UNIFORM
+  }
+}
+output {
+  id: "output"
+  shape: {
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 1
+    dims: 8
+    dims: 256
+    dims: 256
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_FLOAT
+}
+batch_matmul_bcast_param: {
+  is_transa: false
+  is_transb: true
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 0.003
+  error_threshold: 0.003
+  baseline_device: CPU
+}


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

将batch_matmul_bcast算子以二进制形式合入mluops。

## 2. Modification

增加batch_matmul_bcast算子


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [x] float32 mlu diff1 <= 3e-3
    - [x] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [x] float32 mlu diff2 <= 3e-3
    - [x] float16 mlu diff2 <= 3e-3

- dynamic threshold
  - [x] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [x] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [x] MLU370
  - [x] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370
[----------] Global test environment tear-down
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
[==========] 1 test cases from 1 test suites ran. (2229 ms total)
[  PASSED  ] 1 test cases.


### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.