### PR TITLE
[Docs](bangc-ops): fix developer guide format problem

### DIFF
--- a/docs/bangc-docs/api_guide/update.rst
+++ b/docs/bangc-docs/api_guide/update.rst
@@ -16,6 +16,7 @@ This section lists contents that were made for each product release.
   **Date:** November 24, 2023
 
   - **Changes:**
+
     - Added the following new operations:
 
       - pad
@@ -26,6 +27,7 @@ This section lists contents that were made for each product release.
   **Date:** October 16, 2023
 
   - **Changes:**
+
     - Added the following new operations:
 
       - transform


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

修复开发手册格式问题。

## 2. Modification

modified:   docs/bangc-docs/api_guide/update.rst
