### PR TITLE
[Feature](bangc-ops): Add new binary op mluOpDCNBackwardData.

### DIFF
--- a/bangc-ops/kernels/dcn_backward_data/dcn_backward_data.cpp
+++ b/bangc-ops/kernels/dcn_backward_data/dcn_backward_data.cpp
@@ -1,0 +1,22 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/

--- a/bangc-ops/kernels/dcn_backward_data/dcn_backward_data.cpp
+++ b/bangc-ops/kernels/dcn_backward_data/dcn_backward_data.cpp
@@ -20,10 +20,8 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
-#include <math.h>
 #include <limits.h>
-#include <cstdio>
-
+#include <math.h>
 #include <vector>
 
 #include "kernels/utils/cnnl_helper.h"

--- a/bangc-ops/kernels/dcn_backward_data/dcn_backward_data.cpp
+++ b/bangc-ops/kernels/dcn_backward_data/dcn_backward_data.cpp
@@ -20,3 +20,153 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
+#include <math.h>
+#include <limits.h>
+#include <cstdio>
+
+#include <vector>
+
+#include "kernels/utils/cnnl_helper.h"
+
+#define DCNBPDATA_API "mluOpDcnBackwardData"
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc) {
+  PARAM_CHECK(DCNBPDATA_API, dcn_desc != NULL);
+  CHECK_FUNC_RETURN(cnnlCreateDCNDescriptor(dcn_desc), CNNL_STATUS_SUCCESS,
+                    "[mluOpDcnBackwardData] Internal error accured in "
+                    "mluOpCreateDCNDescriptor.",
+                    MLUOP_STATUS_INTERNAL_ERROR);
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc) {
+  PARAM_CHECK(DCNBPDATA_API, dcn_desc != NULL);
+  CHECK_FUNC_RETURN(cnnlDestroyDCNDescriptor(dcn_desc), CNNL_STATUS_SUCCESS,
+                    "[mluOpDcnBackwardData] Internal error accured in "
+                    "mluOpDestroyDCNDescriptor.",
+                    MLUOP_STATUS_INTERNAL_ERROR);
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpSetDCNDescriptor(
+    mluOpDCNDescriptor_t dcn_desc, int dimNb, const int pad[],
+    const int stride[], const int dilation[], int deformable_group,
+    int conv_group, int im2col_step, const mluOpDataType_t compute_type) {
+  PARAM_CHECK(DCNBPDATA_API, dcn_desc != NULL);
+  CHECK_FUNC_RETURN(
+      cnnlSetDCNDescriptor(dcn_desc, dimNb, pad, stride, dilation,
+                           deformable_group, conv_group, im2col_step,
+                           cnnlDataType_t(compute_type)),
+      CNNL_STATUS_SUCCESS,
+      "[mluOpDcnBackwardData] Internal error accured in mluOpSetDCNDescriptor.",
+      MLUOP_STATUS_INTERNAL_ERROR);
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpGetDCNBakcwardDataWorkspaceSize(
+    mluOpHandle_t handle, const mluOpDCNDescriptor_t dcn_desc,
+    const mluOpTensorDescriptor_t input_desc,
+    const mluOpTensorDescriptor_t offset_desc,
+    const mluOpTensorDescriptor_t mask_desc,
+    const mluOpTensorDescriptor_t filter_desc,
+    const mluOpTensorDescriptor_t grad_output_desc,
+    const mluOpTensorDescriptor_t grad_input_desc,
+    const mluOpTensorDescriptor_t grad_offset_desc,
+    const mluOpTensorDescriptor_t grad_mask_desc, size_t *workspace_size) {
+  PARAM_CHECK(DCNBPDATA_API, handle != NULL);
+  PARAM_CHECK(DCNBPDATA_API, dcn_desc != NULL);
+  PARAM_CHECK(DCNBPDATA_API, input_desc != NULL);
+  PARAM_CHECK(DCNBPDATA_API, offset_desc != NULL);
+  PARAM_CHECK(DCNBPDATA_API, filter_desc != NULL);
+  PARAM_CHECK(DCNBPDATA_API, dcn_desc != NULL);
+  PARAM_CHECK(DCNBPDATA_API, grad_output_desc != NULL);
+  PARAM_CHECK(DCNBPDATA_API, grad_input_desc != NULL);
+  PARAM_CHECK(DCNBPDATA_API, grad_offset_desc != NULL);
+
+  DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_desc, cnnl_input_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(offset_desc, cnnl_offset_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(mask_desc, cnnl_mask_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(filter_desc, cnnl_filter_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_output_desc,
+                                               cnnl_grad_output_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_input_desc,
+                                               cnnl_grad_input_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_offset_desc,
+                                               cnnl_grad_offset_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_mask_desc,
+                                               cnnl_grad_mask_desc);
+
+  CHECK_FUNC_RETURN(
+      cnnlGetDCNBakcwardDataWorkspaceSize(
+          cnnl_handle, dcn_desc, cnnl_input_desc, cnnl_offset_desc,
+          cnnl_mask_desc, cnnl_filter_desc, cnnl_grad_output_desc,
+          cnnl_grad_input_desc, cnnl_grad_offset_desc, cnnl_grad_mask_desc,
+          workspace_size),
+      CNNL_STATUS_SUCCESS,
+      "[mluOpDcnBackwardData] Internal error accured in mluOpReduce.",
+      MLUOP_STATUS_INTERNAL_ERROR);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_offset_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mask_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_filter_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_output_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_input_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_offset_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_mask_desc);
+
+  DESTROY_CNNL_HANDLE(cnnl_handle);
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpDCNBackwardData(
+    mluOpHandle_t handle, const mluOpDCNDescriptor_t dcn_desc,
+    const mluOpTensorDescriptor_t input_desc, const void *input,
+    const mluOpTensorDescriptor_t offset_desc, const void *offset,
+    const mluOpTensorDescriptor_t mask_desc, const void *mask,
+    const mluOpTensorDescriptor_t filter_desc, const void *filter,
+    const mluOpTensorDescriptor_t grad_output_desc, const void *grad_output,
+    void *workspace, const size_t workspace_size,
+    const mluOpTensorDescriptor_t grad_input_desc, void *grad_input,
+    const mluOpTensorDescriptor_t grad_offset_desc, void *grad_offset,
+    const mluOpTensorDescriptor_t grad_mask_desc, void *grad_mask) {
+  PARAM_CHECK(DCNBPDATA_API, handle != NULL);
+  if (workspace_size > 0) {
+    PARAM_CHECK(DCNBPDATA_API, workspace != NULL);
+  }
+  DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_desc, cnnl_input_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(offset_desc, cnnl_offset_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(mask_desc, cnnl_mask_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(filter_desc, cnnl_filter_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_output_desc,
+                                               cnnl_grad_output_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_input_desc,
+                                               cnnl_grad_input_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_offset_desc,
+                                               cnnl_grad_offset_desc);
+  DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_mask_desc,
+                                               cnnl_grad_mask_desc);
+  CHECK_FUNC_RETURN(
+      cnnlDCNBackwardData(
+          cnnl_handle, dcn_desc, cnnl_input_desc, input, cnnl_offset_desc,
+          offset, cnnl_mask_desc, mask, cnnl_filter_desc, filter,
+          cnnl_grad_output_desc, grad_output, workspace, workspace_size,
+          cnnl_grad_input_desc, grad_input, cnnl_grad_offset_desc, grad_offset,
+          cnnl_grad_mask_desc, grad_mask),
+      CNNL_STATUS_SUCCESS,
+      "[mluOpDcnBackwardData] Internal error accured in mluOpDcnBackwardData.",
+      MLUOP_STATUS_INTERNAL_ERROR);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_offset_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mask_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_filter_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_output_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_input_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_offset_desc);
+  DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grad_mask_desc);
+  DESTROY_CNNL_HANDLE(cnnl_handle);
+  return MLUOP_STATUS_SUCCESS;
+}

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -1064,7 +1064,7 @@ typedef struct cnnlRoiAlignStruct *mluOpRoiAlignForwardDescriptor_t;
  * ::mluOpDestroyUniqueDescriptor function.*/
 typedef struct cnnlUniqueStruct *mluOpUniqueDescriptor_t;
 
-typedef struct cnnlDCNStruct mluOpDCNDescriptor_t;
+typedef struct cnnlDCNStruct *mluOpDCNDescriptor_t;
 
 /*!
  * The descriptor of CARAFE (Content-Aware ReAssembly of FEatures) operation that holds

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -1064,6 +1064,15 @@ typedef struct cnnlRoiAlignStruct *mluOpRoiAlignForwardDescriptor_t;
  * ::mluOpDestroyUniqueDescriptor function.*/
 typedef struct cnnlUniqueStruct *mluOpUniqueDescriptor_t;
 
+/*!
+ * The descriptor of deformable convolution function that holds the deformable convolution
+ * information including the number of input dimensions, padding, stride, dilation,
+ * deformable group, convolution group, and img2col_step.
+ *
+ * You need to call the ::mluOpCreateDCNDescriptor function to create a descriptor, and call the
+ * ::mluOpSetDCNDescriptor function to set the information of the deformable convolution operation
+ * to the descriptor. Also, you need to destroy the Cambricon CNNL context at the end with the
+ * ::mluOpDestroyDCNDescriptor function.*/
 typedef struct cnnlDCNStruct *mluOpDCNDescriptor_t;
 
 /*!
@@ -16620,21 +16629,21 @@ mluOpQuantizeBatchMatMulBCast(mluOpHandle_t handle,
  * @brief Creates a descriptor pointed by \p dcn_desc for a deformable convolution forward
  * or backward operation, and allocates memory for holding the information about the
  * deformable convolution operation. The information is defined in ::mluOpDCNDescriptor_t.
- * For more information about descriptor, see "Cambricon MLUOP User Guide".
+ * For more information about descriptor, see "Cambricon BANG C OPS User Guide".
  *
  * @param[out] dcn_desc
- *   Output. A host pointer to the deformable convolution descriptor that holds information about the
+ *   A host pointer to the deformable convolution descriptor that holds information about the
  *   deformable convolution operation.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_NOT_INITIALIZED
  *
  * @par API Dependency
- * - After calling this function, you can call the ::mluOpSetDCNDescriptor function to initialize
+ * - After calling this function, call ::mluOpSetDCNDescriptor function to initialize
  *   and set the information to the deformable convolution descriptor.
- * - You need to call the ::mluOpDestroyDCNDescriptor function to destroy the descriptor.
+ * - Call ::mluOpDestroyDCNDescriptor function to destroy the descriptor.
  *
- * @note
+ * @par Note
  * - None.
  *
  * @par Requirements
@@ -16642,13 +16651,16 @@ mluOpQuantizeBatchMatMulBCast(mluOpHandle_t handle,
  *
  * @par Example
  * - None.
+ *
+ * @par Reference
+ * - None.
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
 
 // Group:DCN
 /*!
- * @brief Initializes the deformable convolution descriptor \p dcn_desc that is previously
+ * @brief Initializes the deformable convolution descriptor \p dcn_desc that was
  * created with the ::mluOpCreateDCNDescriptor function, and sets the information about the
  * deformable convolution forward and backward operation to the deformable convolution descriptor
  * \p dcn_desc. The information includes the number of deformable convolution dimensions \p dimNb,
@@ -16704,7 +16716,7 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
  * @par API Dependency
  * - Before calling this function, ::mluOpCreateDCNDescriptor should be called.
  *
- * @note
+ * @par Note
  * - Currently, only supports 4D input tensor for deformable convolution forward
  *   and backward operation.
  * - The values of \p pad should be greater than or equal to 0.
@@ -16730,6 +16742,9 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
  *
  * @par Example
  * - None.
+ *
+ * @par Reference
+ * - None.
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetDCNDescriptor(mluOpDCNDescriptor_t dcn_desc,
@@ -16752,17 +16767,20 @@ mluOpSetDCNDescriptor(mluOpDCNDescriptor_t dcn_desc,
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_EXECUTION_FAILED
  *
- * @note
- * - You need to call this function after calling the ::mluOpDCNForward, ::mluOpDCNBackwardData,
- *   or ::mluOpDCNBackwardWeight function. Otherwise, \p MLUOP_STATUS_BAD_PARAM is returned.
- * - This function should be called to destroy the deformable convolution descriptor.
- *   Otherwise, the memory leak may occur.
+ * @par Note
+ * - Call this function after calling the ::mluOpDCNForward, ::mluOpDCNBackwardData,
+ *   or ::mluOpDCNBackwardWeight. Otherwise, \p MLUOP_STATUS_BAD_PARAM is returned.
+ * - It is necessary to call this function destroy the deformable convolution descriptor.
+ *   to avoid the memory leaks.
  *
  * @par Requirements
  * - None.
  *
  * @par Example
  * - None.
+ *
+ * @par Reference
+ * - None
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
@@ -16772,7 +16790,7 @@ mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
  * @brief Returns in \p workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize the deformable convolution backward data operation.
  *
- * The size of extra workspace is based on the given information of the deformable convolution
+ * The size of the extra workspace is based on the information of the deformable convolution
  * backward data operation, including the deformable convolution descriptor \p dcn_desc,
  * input tensor descriptor \p input_desc, offset tensor
  * descriptor \p offset_desc, mask tensor descriptor \p mask_desc, filter tensor descriptor
@@ -16815,7 +16833,7 @@ mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
  *   This parameter is requested to be the same with \p mask_desc. Set this parameter to NULL when mask and
  *   grad_mask are not needed. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] workspace_size
- *   Output. Pointer to the returned size of the extra workspace in bytes that is used in the
+ *   Pointer to the returned size of the extra workspace in bytes that is used in the
  *   deformable convolution backward data operation.
  *
  * @par Return
@@ -16829,13 +16847,16 @@ mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
  * - The allocated extra workspace should be passed to the ::mluOpDCNBackwardData function to perform
  *   the deformable convolution backward data operation.
  *
- * @note
+ * @par Note
  * - None.
  *
  * @par Requirements
  * - None.
  *
  * @par Example
+ * - None.
+ *
+ * @par Reference
  * - None.
  */
 mluOpStatus_t MLUOP_WIN_API
@@ -16900,7 +16921,7 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  * @param[in] workspace
  *   Input. Pointer to the MLU memory that is used as an extra workspace for the
  *   deformable convolution backward data operation. For more information about workspace,
- *   see "Cambricon MLUOP User Guide".
+ *   see "Cambricon BANG C OPS User Guide".
  * @param[in] workspace_size
  *   Input. The size of the extra workspace in bytes that needs to be used in
  *   the deformable convolution backward data operation. You can get the size of the workspace
@@ -16910,26 +16931,26 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  *   This parameter is requested to be the same as \p input_desc. For detailed information,
  *   see ::mluOpTensorDescriptor_t.
  * @param[out] grad_input
- *   Output. Pointer to the MLU memory that stores the gradient with respect to \p input.
+ *   Pointer to the MLU memory that stores the gradient with respect to \p input.
  * @param[in] grad_offset_desc
  *   Input. The descriptor of the gradient with respect to the offset tensor.
  *   This parameter is requested to be the same as \p offset_desc.
  *   For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] grad_offset
- *   Output. Pointer to the MLU memory that stores the gradient with respect to \p offset.
+ *   Pointer to the MLU memory that stores the gradient with respect to \p offset.
  * @param[in] grad_mask_desc
  *   Input. The descriptor of the gradient with respect to the mask tensor.
  *   This parameter is requested to be the same with \p mask_desc. Set this parameter to NULL when mask and
  *   grad_mask are not needed. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] grad_mask
- *   Output. Pointer to the MLU memory that stores the gradient with respect to \p mask.
+ *   Pointer to the MLU memory that stores the gradient with respect to \p mask.
  *   Set this parameter to NULL when mask and grad_mask are not needed.
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
  *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_NUMERICAL_OVERFLOW
  *
  * @par Formula
- * - See "Deformable Convolution Operator" section in "Cambricon MLUOP User Guide" for details.
+ * - See "Deformable Convolution Operator" section in "Cambricon BANG C OPS User Guide" for details.
  *
  * @par Data Type
  * - Offchip data type of \p input, \p offset, \p mask, \p filter, \p grad_output,
@@ -16980,7 +17001,7 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  * @par Performance Optimization
  * - For best practices, to have better performance, set the im2col_step of to the batch size.
  *
- * @note
+ * @par Note
  * - \p input, \p mask, \p filter, and \p grad_output should be smaller enough to prevent the result
  *   from data overflow especially when the data type is \p MLUOP_DTYPE_HALF.
  * - \p offset with NaN is not supported on MLU300 series and lower platforms.

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -16872,7 +16872,7 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
                                      const mluOpTensorDescriptor_t grad_mask_desc,
                                      size_t *workspace_size);
 
-// Group:DCNBackwardData
+// Group:DCN
 /*!
  * @brief Performs the back-propagation of a deformable convolution operation to compute
  * the gradient with respect to input \p grad_input, offset \p grad_offset, and mask

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -16615,20 +16615,19 @@ mluOpQuantizeBatchMatMulBCast(mluOpHandle_t handle,
                               void *workspace,
                               size_t workspace_size);
 
-// Group:DCNForward
+// Group:DCN
 /*!
  * @brief Creates a descriptor pointed by \p dcn_desc for a deformable convolution forward
- *        or backward operation, and allocates memory for holding the information about the
- *        deformable convolution operation. The information is defined in
- *        ::mluOpDCNDescriptor_t. For more information about descriptor,
- *        see "Cambricon CNNL User Guide".
+ * or backward operation, and allocates memory for holding the information about the
+ * deformable convolution operation. The information is defined in ::mluOpDCNDescriptor_t.
+ * For more information about descriptor, see "Cambricon MLUOP User Guide".
  *
  * @param[out] dcn_desc
- *  Output. A host pointer to the deformable convolution descriptor that holds information about the
- *  deformable convolution operation.
- * @par Return
- * - ::CNNL_STATUS_SUCCESS, ::CNNL_STATUS_NOT_INITIALIZED
+ *   Output. A host pointer to the deformable convolution descriptor that holds information about the
+ *   deformable convolution operation.
  *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_NOT_INITIALIZED
  *
  * @par API Dependency
  * - After calling this function, you can call the ::mluOpSetDCNDescriptor function to initialize
@@ -16647,16 +16646,16 @@ mluOpQuantizeBatchMatMulBCast(mluOpHandle_t handle,
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
 
-// Group:DCNForward
+// Group:DCN
 /*!
  * @brief Initializes the deformable convolution descriptor \p dcn_desc that is previously
- *        created with the ::mluOpCreateDCNDescriptor function, and sets the information about the
- *        deformable convolution forward and backward operation to the deformable convolution descriptor
- *        \p dcn_desc. The information includes the number of deformable convolution dimensions \p dimNb,
- *        the padding size for each dimension \p pad, the stride of the sliding window for each dimension
- *        \p stride, the dilation factor for each dimension \p dilation, the number of groups of input
- *        offset to be split along the input channel \p deformable_group, the number of convolution group
- *        \p conv_group, and the maximum image number per deformable convolution computing \p im2col_step.
+ * created with the ::mluOpCreateDCNDescriptor function, and sets the information about the
+ * deformable convolution forward and backward operation to the deformable convolution descriptor
+ * \p dcn_desc. The information includes the number of deformable convolution dimensions \p dimNb,
+ * the padding size for each dimension \p pad, the stride of the sliding window for each dimension
+ * \p stride, the dilation factor for each dimension \p dilation, the number of groups of input
+ * offset to be split along the input channel \p deformable_group, the number of convolution group
+ * \p conv_group, and the maximum image number per deformable convolution computing \p im2col_step.
  *
  * @param[in,out] dcn_desc
  *   Input/output. The descriptor of the deformable convolution operation. For detailed information,
@@ -16697,10 +16696,10 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
  *   while a smaller one will consume a smaller workspace size and have a lower performance.
  * @param[in] compute_type
  *   Input. The data type of temporary result in convolution operation. Only supports
- *   \p CNNL_DTYPE_FLOAT type.
+ *   \p MLUOP_DTYPE_FLOAT type.
  *
  * @par Return
- * - ::CNNL_STATUS_SUCCESS, ::CNNL_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par API Dependency
  * - Before calling this function, ::mluOpCreateDCNDescriptor should be called.
@@ -16726,7 +16725,6 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
  *   the number of batch size in the input tensor, and input batch should be divisible by
  *   \p im2col_step.
  *
- *
  * @par Requirements
  * - None.
  *
@@ -16744,19 +16742,19 @@ mluOpSetDCNDescriptor(mluOpDCNDescriptor_t dcn_desc,
                       int im2col_step,
                       const mluOpDataType_t compute_type);
 
-// Group:DCNForward
+// Group:DCN
 /*!
  * @brief Destroys a deformable convolution descriptor \p dcn_desc that is previously created with
- *        the ::mluOpCreateDCNDescriptor function.
+ * the ::mluOpCreateDCNDescriptor function.
  *
  * @param[in] dcn_desc
  *   Input. The deformable convolution descriptor to be destroyed.
  * @par Return
- * - ::CNNL_STATUS_SUCCESS, ::CNNL_STATUS_EXECUTION_FAILED
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @note
  * - You need to call this function after calling the ::mluOpDCNForward, ::mluOpDCNBackwardData,
- *   or ::mluOpDCNBackwardWeight function. Otherwise, \p CNNL_STATUS_BAD_PARAM is returned.
+ *   or ::mluOpDCNBackwardWeight function. Otherwise, \p MLUOP_STATUS_BAD_PARAM is returned.
  * - This function should be called to destroy the deformable convolution descriptor.
  *   Otherwise, the memory leak may occur.
  *
@@ -16769,10 +16767,10 @@ mluOpSetDCNDescriptor(mluOpDCNDescriptor_t dcn_desc,
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
 
-// Group:DCNBackwardData
+// Group:DCN
 /*!
  * @brief Returns in \p workspace_size the size of the MLU memory that is used as an extra
- *        workspace to optimize the deformable convolution backward data operation.
+ * workspace to optimize the deformable convolution backward data operation.
  *
  * The size of extra workspace is based on the given information of the deformable convolution
  * backward data operation, including the deformable convolution descriptor \p dcn_desc,
@@ -16781,10 +16779,10 @@ mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
  * \p filter_desc, gradient with respect to the output tensor \p grad_output_desc, the gradient
  * with respect to the input tensor \p grad_input_desc, the gradient with respect to the offset
  * tensor \p grad_offset, and the gradient with respect to the mask tensor \p grad_mask_desc.
- * For more information about the workspace, see "Cambricon CNNL User Guide."
+ * For more information about the workspace, see "Cambricon MLUOP User Guide."
  *
  * @param[in] handle
- *   Input. Handle to a Cambricon CNNL context that is used to manage MLU devices and queues in the
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and queues in the
  *   deformable convolution operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] dcn_desc
  *   Input. The descriptor of the deformable convolution operation. For detailed information, see
@@ -16821,7 +16819,7 @@ mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
  *   deformable convolution backward data operation.
  *
  * @par Return
- * - ::CNNL_STATUS_SUCCESS, ::CNNL_STATUS_BAD_PARAM
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par API Dependency
  * - You need to call the ::mluOpCreateTensorDescriptor and ::mluOpSetTensorDescriptor functions
@@ -16856,15 +16854,15 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
 // Group:DCNBackwardData
 /*!
  * @brief Performs the back-propagation of a deformable convolution operation to compute
- *        the gradient with respect to input \p grad_input, offset \p grad_offset, and mask
- *        \p grad_mask based on the gradient of response \p grad_output.
+ * the gradient with respect to input \p grad_input, offset \p grad_offset, and mask
+ * \p grad_mask based on the gradient of response \p grad_output.
  *
  * This function needs extra MLU memory as the workspace to improve the performance.
  * You can get the workspace size with the ::mluOpGetDCNBakcwardDataWorkspaceSize
  * function.
  *
  * @param[in] handle
- *   Input. Handle to a Cambricon CNNL context that is used to manage MLU devices and
+ *   Input. Handle to a Cambricon MLUOP context that is used to manage MLU devices and
  *   queues in the deformable convolution backward data operation. For detailed information,
  *   see ::mluOpHandle_t.
  * @param[in] dcn_desc
@@ -16902,7 +16900,7 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  * @param[in] workspace
  *   Input. Pointer to the MLU memory that is used as an extra workspace for the
  *   deformable convolution backward data operation. For more information about workspace,
- *   see "Cambricon CNNL User Guide".
+ *   see "Cambricon MLUOP User Guide".
  * @param[in] workspace_size
  *   Input. The size of the extra workspace in bytes that needs to be used in
  *   the deformable convolution backward data operation. You can get the size of the workspace
@@ -16927,11 +16925,11 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  *   Output. Pointer to the MLU memory that stores the gradient with respect to \p mask.
  *   Set this parameter to NULL when mask and grad_mask are not needed.
  * @par Return
- * - ::CNNL_STATUS_SUCCESS, ::CNNL_STATUS_BAD_PARAM,
- *   ::CNNL_STATUS_NOT_SUPPORTED, ::CNNL_STATUS_NUMERICAL_OVERFLOW
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_NUMERICAL_OVERFLOW
  *
  * @par Formula
- * - See "Deformable Convolution Operator" section in "Cambricon CNNL User Guide" for details.
+ * - See "Deformable Convolution Operator" section in "Cambricon MLUOP User Guide" for details.
  *
  * @par Data Type
  * - Offchip data type of \p input, \p offset, \p mask, \p filter, \p grad_output,
@@ -16946,11 +16944,11 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  * - \p filter offchip data type can be combined with any supported onchip data types.
  * - This function also supports float-point computation on MLU300 series or above. To perform
  *   float-point computation, the onchip data type of \p grad_output and \p filter should be
- *   \p CNNL_DTYPE_INVALID or the same as the corresponding offchip data type.
+ *   \p MLUOP_DTYPE_INVALID or the same as the corresponding offchip data type.
  *
  * @par Data Layout
  * - The data layout of the input, offset, mask, filter, grad_output, grad_input, grad_offset,
- *   and grad_mask should be \p CNNL_LAYOUT_NHWC.
+ *   and grad_mask should be \p MLUOP_LAYOUT_NHWC.
  *
  * @par Scale Limitation
  * - The input, offset, mask, filter, grad_output, grad_input, grad_offset, grad_mask and
@@ -16984,7 +16982,7 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  *
  * @note
  * - \p input, \p mask, \p filter, and \p grad_output should be smaller enough to prevent the result
- *   from data overflow especially when the data type is \p CNNL_DTYPE_HALF.
+ *   from data overflow especially when the data type is \p MLUOP_DTYPE_HALF.
  * - \p offset with NaN is not supported on MLU300 series and lower platforms.
  *
  * @par Requirements

--- a/bangc-ops/mlu_op.h
+++ b/bangc-ops/mlu_op.h
@@ -16661,7 +16661,7 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
 // Group:DCN
 /*!
  * @brief Initializes the deformable convolution descriptor \p dcn_desc that was
- * created with the ::mluOpCreateDCNDescriptor function, and sets the information about the
+ * created by ::mluOpCreateDCNDescriptor function, and sets the information about the
  * deformable convolution forward and backward operation to the deformable convolution descriptor
  * \p dcn_desc. The information includes the number of deformable convolution dimensions \p dimNb,
  * the padding size for each dimension \p pad, the stride of the sliding window for each dimension
@@ -16674,30 +16674,30 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
  *   see ::mluOpDCNDescriptor_t.
  * @param[in] dimNb
  *   Input. The number of dimensions in the input tensor of the deformable convolution operation.
- *   Currently, the value of this parameter can only be set to 4 and should be the
+ *   Currently, the value of this parameter can only be set to 4 and must be the
  *   same as the one you set in the input tensor descriptor.
  * @param[in] pad
  *   Input. An array that stores the zero-padding size for each dimension of the input tensor
  *   used in the deformable convolution operation.
  *   For each dimension, the padding size represents the number of zeros to be concatenated at the
  *   start and end of that dimension. For 2D deformable convolution, the padding is
- *   on top, bottom, left, and right.
+ *   on the top, bottom, left, and right.
  * @param[in] stride
  *   Input. An array that stores the filter stride for each dimension of the input tensor
  *   used in the deformable convolution operation. For each dimension, the filter stride represents
  *   the number of elements to slide over the input tensor. For 2D deformable
- *   convolution, the stride should be set in height and width order.
+ *   convolution, the stride must be set in height and width order.
  * @param[in] dilation
  *   Input. An array that stores the dilation factor for each dimension of the filter tensor
  *   used in the deformable convolution operation. For each dimension, the dilation factor
  *   represents the spacing between the kernel points. For 2D deformable convolution,
- *   the dilation should be set in height and width order.
+ *   the dilation must be set in height and width order.
  * @param[in] deformable_group
  *   Input. The number of deformable offset groups that split the input offset along the channel
- *   of input tensor. Each deformable group is deformed separately for detecting different input parts.
+ *   of input tensor. Each deformable group is deformed separately to detect different input parts.
  * @param[in] conv_group
- *   Input. The number of groups that the input data is split by the number of channels
- *   in the input tensor. Each convolution group is convolved separately. The filter used for
+ *   Input. The number of groups that the input channel been divided.
+ *   Each convolution group is convolved separately. The filter used for
  *   each group is the filter tensor divides \p conv_group. The result of
  *   the deformable convolution operation is the concatenation of all the group convolution results
  *   along the output channel dimension.
@@ -16707,22 +16707,22 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
  *   A larger \p im2col_step will consume a larger workspace size and have a higher performance,
  *   while a smaller one will consume a smaller workspace size and have a lower performance.
  * @param[in] compute_type
- *   Input. The data type of temporary result in convolution operation. Only supports
+ *   Input. The data type of the temporary result in the convolution operation. Only supports
  *   \p MLUOP_DTYPE_FLOAT type.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
  * @par API Dependency
- * - Before calling this function, ::mluOpCreateDCNDescriptor should be called.
+ * - Before calling this function, ::mluOpCreateDCNDescriptor must be called.
  *
  * @par Note
  * - Currently, only supports 4D input tensor for deformable convolution forward
- *   and backward operation.
- * - The values of \p pad should be greater than or equal to 0.
- * - The values of \p stride should be greater than or equal to 1.
- * - The values of \p dilation should be greater than or equal to 1.
- * - The value of \p deformable_group should be greater than or equal to 1 and
+ *   and backward operations.
+ * - The values of \p pad must be greater than or equal to 0.
+ * - The values of \p stride must be greater than or equal to 1.
+ * - The values of \p dilation must be greater than or equal to 1.
+ * - The value of \p deformable_group must be greater than or equal to 1 and
  *   less than or equal to the number of channels in the input tensor, and input channel must be
  *   divisible by \p deformable_group.
  *   - If \p deformable_group is set to 1, the same input offset is applied to all channels
@@ -16730,11 +16730,11 @@ mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
  *   - If the value of \p deformable_group is between 1 and the number of channels of input tensor,
  *     the input channel will be split into \p deformable_group parts. Each part is responsible for
  *     detecting different input parts, which results in a more flexible geometric transformation.
- * - The value of \p conv_group should be greater than or equal to 1 and less than or equal to the
+ * - The value of \p conv_group must be greater than or equal to 1 and less than or equal to the
  *   number of channels in the input tensor, and input channels and output channels must both be
  *   divisible by \p conv_group.
- * - The value of \p im2col_step should be greater than or equal to 1 and less than or equal to
- *   the number of batch size in the input tensor, and input batch should be divisible by
+ * - The value of \p im2col_step must be greater than or equal to 1 and less than or equal to
+ *   the number of batch sizes in the input tensor, and the input batch must be divisible by
  *   \p im2col_step.
  *
  * @par Requirements
@@ -16759,8 +16759,8 @@ mluOpSetDCNDescriptor(mluOpDCNDescriptor_t dcn_desc,
 
 // Group:DCN
 /*!
- * @brief Destroys a deformable convolution descriptor \p dcn_desc that is previously created with
- * the ::mluOpCreateDCNDescriptor function.
+ * @brief Destroys a deformable convolution descriptor \p dcn_desc that was previously created by
+ * ::mluOpCreateDCNDescriptor.
  *
  * @param[in] dcn_desc
  *   Input. The deformable convolution descriptor to be destroyed.
@@ -16844,7 +16844,7 @@ mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
  *   to create and set the tensor descriptors \p input, \p offset, \p mask (optional), \p filter,
  *   \p grad_output, \p grad_input, \p grad_offset, \p grad_mask (optional) before calling this
  *   function.
- * - The allocated extra workspace should be passed to the ::mluOpDCNBackwardData function to perform
+ * - The allocated extra workspace must be passed to the ::mluOpDCNBackwardData function to perform
  *   the deformable convolution backward data operation.
  *
  * @par Note
@@ -16896,13 +16896,13 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  *   Input. Pointer to the MLU memory that stores the input tensor.
  * @param[in] offset_desc
  *   Input. The descriptor of the offset to be applied for each position in the convolution kernel.
- *   The shape of offset should be (batch, out_height, out_width, 2 * deformable_group *
+ *   The shape of offset must be (batch, out_height, out_width, 2 * deformable_group *
  *   filter_height * filter_width). For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] offset
  *   Input. Pointer to the MLU memory that stores the offset tensor.
  * @param[in] mask_desc
  *   Input. The descriptor of the scaling factor to be applied for each position in the convolution
- *   kernel. The shape of mask should be (batch, out_height, out_width,
+ *   kernel. The shape of mask must be (batch, out_height, out_width,
  *   deformable_group * filter_height * filter_width). Set this parameter to NULL when
  *   mask is not requested. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] mask
@@ -16964,12 +16964,12 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  * - \p grad_output offchip data type can be combined with any supported onchip data types.
  * - \p filter offchip data type can be combined with any supported onchip data types.
  * - This function also supports float-point computation on MLU300 series or above. To perform
- *   float-point computation, the onchip data type of \p grad_output and \p filter should be
+ *   float-point computation, the onchip data type of \p grad_output and \p filter must be
  *   \p MLUOP_DTYPE_INVALID or the same as the corresponding offchip data type.
  *
  * @par Data Layout
  * - The data layout of the input, offset, mask, filter, grad_output, grad_input, grad_offset,
- *   and grad_mask should be \p MLUOP_LAYOUT_NHWC.
+ *   and grad_mask must be \p MLUOP_LAYOUT_NHWC.
  *
  * @par Scale Limitation
  * - The input, offset, mask, filter, grad_output, grad_input, grad_offset, grad_mask and
@@ -16977,19 +16977,19 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  *   (including pad, stride, dilation, deformable_group, conv_group, im2col_step) must meet the
  *   following requirements:
  *   - input tensor: \p batch > 0, \p height > 0, \p width > 0, \p channel > 0
- *   - offset tensor: \p batch should be equal to the batch size of input tensor, \p height and \p width
- *     should be equal to the height and width of output tensor accordingly. \p channel should be equal to
+ *   - offset tensor: \p batch must be equal to the batch size of input tensor, \p height and \p width
+ *     must be equal to the height and width of output tensor accordingly. \p channel must be equal to
  *     deformable_group * filter_height * filter_width * 2.
- *   - grad offset tensor: the data type, layout, and shape of grad offset should be equal to the
+ *   - grad offset tensor: the data type, layout, and shape of grad offset must be equal to the
  *     offset tensor.
- *   - mask tensor: When mask is needed, \p batch should be equal to the batch size of input tensor,
- *     \p height and \p width should be equal to the height and width of output tensor accordingly.
- *     \p channel should be equal to deformable_group * filter_height * filter_width.
- *   - grad mask tensor: the data type, layout and shape of the grad mask should be equal to
+ *   - mask tensor: When mask is needed, \p batch must be equal to the batch size of input tensor,
+ *     \p height and \p width must be equal to the height and width of output tensor accordingly.
+ *     \p channel must be equal to deformable_group * filter_height * filter_width.
+ *   - grad mask tensor: the data type, layout and shape of the grad mask must be equal to
  *     the mask tensor. When mask is passed NULL, grad mask must be NULL.
  *   - The data bytes of (im2col_step * out_height * out_filter * filter_h * filter_w * input_channel)
- *     should be less than or equal to the INT_MAX defined in limits.h.
- *   - When mask is not needed, \p mask, \p mask_desc, \p grad_mask and \p grad_mask_desc should be
+ *     must be less than or equal to the INT_MAX defined in limits.h.
+ *   - When mask is not needed, \p mask, \p mask_desc, \p grad_mask and \p grad_mask_desc must be
  *     set to NULL. When it is needed, any of \p mask, \p mask_desc, \p grad_mask and
  *     \p grad_mask_desc cannot be NULL.
  *
@@ -17002,7 +17002,7 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
  * - For best practices, to have better performance, set the im2col_step of to the batch size.
  *
  * @par Note
- * - \p input, \p mask, \p filter, and \p grad_output should be smaller enough to prevent the result
+ * - \p input, \p mask, \p filter, and \p grad_output must be smaller enough to prevent the result
  *   from data overflow especially when the data type is \p MLUOP_DTYPE_HALF.
  * - \p offset with NaN is not supported on MLU300 series and lower platforms.
  *

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/pb_test_tools.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/pb_test_tools.cpp
@@ -36,7 +36,6 @@
 
 #include "variable.h"
 
-
 namespace mluoptest {
 
 extern GlobalVar global_var;
@@ -303,6 +302,8 @@ cnrtDataType_t cvtMluOpDtypeToCnrt(mluOpDataType_t dtype) {
 
 mluOpDataType_t cvtProtoDtypeToMluOp(DataType dtype) {
   switch (dtype) {
+    case DTYPE_UNSET:
+      return MLUOP_DTYPE_INVALID;
     case DTYPE_HALF:
       return MLUOP_DTYPE_HALF;
     case DTYPE_FLOAT:

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.cpp
@@ -131,6 +131,9 @@ void DcnBackwardDataExecutor::workspaceMalloc() {
 
   dcn_desc_ = cpu_runtime_.allocate(mluOpCreateDCNDescriptor,
                                     mluOpDestroyDCNDescriptor);
+
+  VLOG(5) << compute_type_ << "  11111";
+
   MLUOP_CHECK(mluOpSetDCNDescriptor(dcn_desc_, dimNb_, pad_, stride_, dilation_,
                                     deformable_group_, conv_group_,
                                     im2col_step_, compute_type_));

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.cpp
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.cpp
@@ -1,0 +1,751 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#include <string>
+#include "dcn_backward_data.h"
+#define USE_OPENBLAS 0
+
+#if USE_OPENBLAS
+#include <openblas/cblas.h>
+#endif
+
+namespace mluoptest {
+
+static inline bool isFixData(mluOpDataType_t type) {
+  if (MLUOP_DTYPE_INT8 == type || MLUOP_DTYPE_INT16 == type ||
+      MLUOP_DTYPE_INT31 == type) {
+    return true;
+  }
+  return false;
+}
+
+void DcnBackwardDataExecutor::paramCheck() {
+  if (!parser_->getProtoNode()->has_dcn_param()) {
+    LOG(ERROR) << "Missing dcn param. ";
+  }
+
+  int input_tensor_number = parser_->inputs().size();
+  int output_tensor_number = parser_->outputs().size();
+  if (!((input_tensor_number == 5 && output_tensor_number == 3) ||
+        (input_tensor_number == 4 && output_tensor_number == 2))) {
+    // if use mask, mask and grad_mask is valid, input number = 5 and
+    // output_number =3. otherwise, mask and grad_mask should be null
+    LOG(ERROR)
+        << "The number of input tensors and output tensors is mismatched.";
+  }
+  use_mask_ = input_tensor_number == 5;
+  auto dcn_desc_node = parser_->getProtoNode()->dcn_param();
+  dimNb_ = dcn_desc_node.dimnb();
+
+  for (int pad_iter = 0; pad_iter < dcn_desc_node.pad_size(); pad_iter++) {
+    pad_[pad_iter] = dcn_desc_node.pad(pad_iter);
+  }
+  for (int iter = 0; iter < dcn_desc_node.stride_size(); iter++) {
+    stride_[iter] = dcn_desc_node.stride(iter);
+  }
+  for (int iter = 0; iter < dcn_desc_node.dilation_size(); iter++) {
+    dilation_[iter] = dcn_desc_node.dilation(iter);
+  }
+  conv_group_ = dcn_desc_node.conv_group();
+  deformable_group_ = dcn_desc_node.deformable_group();
+  im2col_step_ = dcn_desc_node.im2col_step();
+  compute_type_ = cvtProtoDtypeToMluOp(dcn_desc_node.compute_type());
+
+  mluOpDataType_t dtype;
+  dtype = cvtProtoDtypeToMluOp(
+      parser_->getProtoNode()->input(2 + use_mask_).onchip_dtype());
+  weight_oc_dt_ = dtype;
+  parser_->input(2 + use_mask_)->oc_dt = MLUOP_DTYPE_INVALID;
+
+  dtype = cvtProtoDtypeToMluOp(
+      parser_->getProtoNode()->input(3 + use_mask_).onchip_dtype());
+  grad_output_oc_dt_ = dtype;
+  parser_->input(3 + use_mask_)->oc_dt = MLUOP_DTYPE_INVALID;
+}
+
+int DcnBackwardDataExecutor::getCoefficientOfLT2CT() {
+  auto input_dtype =
+      cvtProtoDtypeToMluOp(parser_->getProtoNode()->input(0).dtype());
+  int lt_compute_force = 0;
+  int ct_compute_force = input_dtype == MLUOP_DTYPE_FLOAT ? 32 : 64;
+  if (isFixData(grad_output_oc_dt_)) {  // intx peak compute force
+    if (grad_output_oc_dt_ == MLUOP_DTYPE_INT16 &&
+        weight_oc_dt_ == MLUOP_DTYPE_INT16) {
+      lt_compute_force = 2 * 2048;
+    } else if (grad_output_oc_dt_ == MLUOP_DTYPE_INT16 &&
+               weight_oc_dt_ == MLUOP_DTYPE_INT31) {
+      lt_compute_force = 2 * 2048 / 2;
+    } else if (grad_output_oc_dt_ == MLUOP_DTYPE_INT31 &&
+               weight_oc_dt_ == MLUOP_DTYPE_INT16) {
+      lt_compute_force = 2 * 2048 / 2;
+    } else {  // int31 x int31
+      lt_compute_force = 2 * 2048 / 4;
+    }
+  } else {  // float/half peak compute force
+    if (input_dtype == MLUOP_DTYPE_FLOAT) {
+      lt_compute_force = 2 * 1.5 * 1024;
+    } else {
+      lt_compute_force = 2 * 0.375 * 1024;
+    }
+  }
+  return lt_compute_force / ct_compute_force;
+}
+
+void DcnBackwardDataExecutor::workspaceMalloc() {
+  VLOG(4) << "DCNBackwardDataExecutor workspaceMalloc";
+  bool use_mask_ = parser_->inputs().size() == 5;
+  bool use_grad_mask_ = parser_->outputs().size() == 3;
+  // input
+  input_desc_ = parser_->inputs()[0].tensor;
+  offset_desc_ = parser_->inputs()[1].tensor;
+  mask_desc_ = use_mask_ ? parser_->inputs()[2].tensor : nullptr;
+  weight_desc_ = parser_->inputs()[2 + use_mask_].tensor;
+  grad_output_desc_ = parser_->inputs()[3 + use_mask_].tensor;
+  // output
+  grad_input_desc_ = parser_->outputs()[0].tensor;
+  grad_offset_desc_ = parser_->outputs()[1].tensor;
+  grad_mask_desc_ = use_grad_mask_ ? parser_->outputs()[2].tensor : nullptr;
+
+  grad_output_desc_->onchip_dtype = grad_output_oc_dt_;
+  weight_desc_->onchip_dtype = weight_oc_dt_;
+
+  dcn_desc_ = cpu_runtime_.allocate(mluOpCreateDCNDescriptor,
+                                    mluOpDestroyDCNDescriptor);
+  MLUOP_CHECK(mluOpSetDCNDescriptor(dcn_desc_, dimNb_, pad_, stride_, dilation_,
+                                    deformable_group_, conv_group_,
+                                    im2col_step_, compute_type_));
+  MLUOP_CHECK(mluOpGetDCNBakcwardDataWorkspaceSize(
+      handle_, dcn_desc_, input_desc_, offset_desc_, mask_desc_, weight_desc_,
+      grad_output_desc_, grad_input_desc_, grad_offset_desc_, grad_mask_desc_,
+      &workspace_size_));
+  VLOG(4) << "dcn Backward Data workspace size: " << workspace_size_;
+
+  if (workspace_size_ > 0) {
+    dev_workspace_ = mlu_runtime_.allocate(workspace_size_);
+    workspace_.push_back(dev_workspace_);
+  }
+}
+
+void DcnBackwardDataExecutor::workspaceFree() {
+  if (workspace_size_ > 0) {
+    mlu_runtime_.deallocate(dev_workspace_);
+  }
+}
+
+void DcnBackwardDataExecutor::compute() {
+  VLOG(4) << "DCNBackwardDataExecutor compute";
+  bool use_mask_ = parser_->inputs().size() == 5;
+  bool use_grad_mask_ = parser_->outputs().size() == 3;
+  // input
+  input_desc_ = parser_->inputs()[0].tensor;
+  offset_desc_ = parser_->inputs()[1].tensor;
+  mask_desc_ = use_mask_ ? parser_->inputs()[2].tensor : nullptr;
+  weight_desc_ = parser_->inputs()[2 + use_mask_].tensor;
+  grad_output_desc_ = parser_->inputs()[3 + use_mask_].tensor;
+  // output
+  grad_input_desc_ = parser_->outputs()[0].tensor;
+  grad_offset_desc_ = parser_->outputs()[1].tensor;
+  grad_mask_desc_ = use_grad_mask_ ? parser_->outputs()[2].tensor : nullptr;
+
+  void *dev_input = data_vector_[0].device_ptr;
+  void *dev_offset = data_vector_[1].device_ptr;
+  void *dev_mask = use_mask_ ? data_vector_[2].device_ptr : nullptr;
+  void *dev_weight = data_vector_[2 + use_mask_].device_ptr;
+  void *dev_grad_output = data_vector_[3 + use_mask_].device_ptr;
+  void *dev_grad_input = data_vector_[4 + use_mask_].device_ptr;
+  void *dev_grad_offset = data_vector_[5 + use_mask_].device_ptr;
+  void *dev_grad_mask =
+      use_mask_ ? data_vector_[6 + use_mask_].device_ptr : nullptr;
+
+  grad_output_desc_->onchip_dtype = grad_output_oc_dt_;
+  weight_desc_->onchip_dtype = weight_oc_dt_;
+
+  VLOG(4) << "call mluOpDCNBackwardData()";
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpDCNBackwardData(
+      handle_, dcn_desc_, input_desc_, dev_input, offset_desc_, dev_offset,
+      mask_desc_, dev_mask, weight_desc_, dev_weight, grad_output_desc_,
+      dev_grad_output, dev_workspace_, workspace_size_, grad_input_desc_,
+      dev_grad_input, grad_offset_desc_, dev_grad_offset, grad_mask_desc_,
+      dev_grad_mask));
+  interface_timer_.stop();
+}
+
+void DcnBackwardDataExecutor::cpuCompute() {
+  bool use_mask_ = parser_->inputs().size() == 5;
+  float *host_input = cpu_fp32_input_[0];
+  float *host_offset = cpu_fp32_input_[1];
+  float *host_mask = use_mask_ ? cpu_fp32_input_[2] : nullptr;
+  float *host_weight = cpu_fp32_input_[2 + use_mask_];
+  float *host_grad_output = cpu_fp32_input_[3 + use_mask_];
+
+  float *host_grad_input = cpu_fp32_output_[0];
+  float *host_grad_offset = cpu_fp32_output_[1];
+  float *host_grad_mask = use_mask_ ? cpu_fp32_output_[2] : nullptr;
+
+  input_desc_ = tensor_desc_[0].tensor;
+  offset_desc_ = tensor_desc_[1].tensor;
+  mask_desc_ = use_mask_ ? tensor_desc_[2].tensor : nullptr;
+  weight_desc_ = tensor_desc_[2 + use_mask_].tensor;
+  grad_output_desc_ = tensor_desc_[3 + use_mask_].tensor;
+  grad_input_desc_ = tensor_desc_[4 + use_mask_].tensor;
+  grad_offset_desc_ = tensor_desc_[5 + use_mask_].tensor;
+  grad_mask_desc_ = use_mask_ ? tensor_desc_[6 + use_mask_].tensor : nullptr;
+
+  hostDCNBackwardData(input_desc_, host_input, offset_desc_, host_offset,
+                      mask_desc_, host_mask, weight_desc_, host_weight,
+                      grad_output_desc_, host_grad_output, grad_input_desc_,
+                      host_grad_input, grad_offset_desc_, host_grad_offset,
+                      grad_mask_desc_, host_grad_mask);
+}
+
+void DcnBackwardDataExecutor::transposeGradOutput(const float *output,
+                                                  const int group,
+                                                  const int ndhw, const int c,
+                                                  float *transpose_output) {
+  // [1, im2col * d * h * w, group, c]
+  // ->
+  // [1, group, im2col * d * h * w, c]
+  VLOG(4) << "transposeGradOutput()";
+  for (int ndhw_iter = 0; ndhw_iter < ndhw; ndhw_iter++) {
+    for (int group_iter = 0; group_iter < group; group_iter++) {
+      for (int c_iter = 0; c_iter < c; c_iter++) {
+        transpose_output[group_iter * ndhw * c + ndhw_iter * c + c_iter] =
+            output[ndhw_iter * group * c + group_iter * c + c_iter];
+      }
+    }
+  }
+}
+
+void DcnBackwardDataExecutor::transposeGradCol(const float *dcol,
+                                               const int group,
+                                               const int middle, const int c,
+                                               float *transpose_dcol) {
+  VLOG(4) << "transposeGradCol()";
+  for (int middle_iter = 0; middle_iter < middle; middle_iter++) {
+    for (int group_iter = 0; group_iter < group; group_iter++) {
+      for (int c_iter = 0; c_iter < c; c_iter++) {
+        transpose_dcol[middle_iter * group * c + group_iter * c + c_iter] =
+            dcol[group_iter * middle * c + middle_iter * c + c_iter];
+      }
+    }
+  }
+}
+
+void DcnBackwardDataExecutor::hostDCNBackwardData(
+    const mluOpTensorDescriptor_t input_desc, float *input,
+    const mluOpTensorDescriptor_t offset_desc, float *offset,
+    const mluOpTensorDescriptor_t mask_desc, float *mask,
+    const mluOpTensorDescriptor_t weight_desc, float *weight,
+    const mluOpTensorDescriptor_t grad_output_desc, float *grad_output,
+    mluOpTensorDescriptor_t grad_input_desc, float *grad_input,
+    mluOpTensorDescriptor_t grad_offset_desc, float *grad_offset,
+    mluOpTensorDescriptor_t grad_mask_desc, float *grad_mask) {
+  int n = mluOpGetTensordimN(input_desc);
+  int di = dimNb_ == 5 ? mluOpGetTensordimD(input_desc) : 1;
+  int hi = mluOpGetTensordimH(input_desc);
+  int wi = mluOpGetTensordimW(input_desc);
+
+  int d_o = dimNb_ == 5 ? mluOpGetTensordimD(grad_output_desc) : 1;
+  int ho = mluOpGetTensordimH(grad_output_desc);
+  int wo = mluOpGetTensordimW(grad_output_desc);
+
+  int kd = dimNb_ == 5 ? mluOpGetTensordimD(weight_desc) : 1;
+  int kh = mluOpGetTensordimH(weight_desc);
+  int kw = mluOpGetTensordimW(weight_desc);
+
+  int ci = mluOpGetTensordimC(weight_desc);
+  int co = mluOpGetTensordimN(weight_desc) / conv_group_;
+  int c_per_deform_group = ci / deformable_group_;
+  int im2col_step = im2col_step_;
+
+  float *dcol = cpu_runtime_.allocate(
+      new float[im2col_step * d_o * ho * wo * kd * kh * kw * conv_group_ * ci]);
+
+  for (int iter = 0; iter < n * di * hi * wi * conv_group_ * ci; iter++) {
+    grad_input[iter] = 0.0;
+  }
+  for (int iter = 0;
+       iter < n * d_o * ho * wo * kd * kh * kw * deformable_group_ * 2;
+       iter++) {
+    grad_offset[iter] = 0.0;
+  }
+  if (grad_mask != nullptr) {
+    for (int iter = 0;
+         iter < n * d_o * ho * wo * kd * kh * kw * deformable_group_; iter++) {
+      grad_mask[iter] = 0.0;
+    }
+  }
+#if USE_OPENBLAS
+#else
+  auto matmul = [](float *lhs, float *rhs, float *output, bool is_trans_a,
+                   bool is_trans_b, int M, int N, int K) {
+    for (int m = 0; m < M; m++) {
+      for (int n = 0; n < N; n++) {
+        output[m * N + n] = 0.0f;
+        for (int k = 0; k < K; k++) {
+          int lhs_idx = m * K + k;
+          if (is_trans_a) lhs_idx = k * M + m;
+          int rhs_idx = k * N + n;
+          if (is_trans_b) rhs_idx = n * K + k;
+          output[m * N + n] += lhs[lhs_idx] * rhs[rhs_idx];
+        }
+      }
+    }
+  };
+#endif
+
+  for (int batch_iter = 0; batch_iter < n / im2col_step; batch_iter++) {
+    VLOG(4) << "iter: " << batch_iter << " / " << n / im2col_step << ".";
+    float *trans_grad_output;
+    if (conv_group_ == 1) {
+      trans_grad_output =
+          grad_output + batch_iter * im2col_step * d_o * ho * wo * co;
+    } else {
+      trans_grad_output = cpu_runtime_.allocate(
+          new float[conv_group_ * im2col_step * d_o * ho * wo * co]);
+      float *grad_output_iter =
+          grad_output + batch_iter * im2col_step * d_o * ho * wo * co;
+      transposeGradOutput(grad_output_iter, conv_group_,
+                          im2col_step * d_o * ho * wo, co, trans_grad_output);
+      theory_ops_ += conv_group_ * im2col_step * d_o * ho * wo, co;
+    }
+
+    for (int group_iter = 0; group_iter < conv_group_; group_iter++) {
+      float *grad_output_addr =
+          trans_grad_output + group_iter * im2col_step * ho * wo * co;
+      float *weight_addr = weight + group_iter * co * kh * kw * ci;
+      float *col_addr =
+          dcol + group_iter * im2col_step * d_o * ho * wo * kd * kh * kw * ci;
+#if USE_OPENBLAS
+      const CBLAS_ORDER Order = CblasRowMajor;
+      const CBLAS_TRANSPOSE TransA = CblasNoTrans;
+      const CBLAS_TRANSPOSE TransB = CblasNoTrans;
+      const float alpha = 1.0;
+      const float beta = 0.0;
+
+      cblas_sgemm(Order, TransA, TransB, im2col_step * d_o * ho * wo,
+                  kd * kh * kw * ci, co, alpha, grad_output_addr, co,
+                  weight_addr, kd * kh * kw * ci, beta, col_addr,
+                  kd * kh * kw * ci);
+#else
+      matmul(grad_output_addr, weight_addr, col_addr, false, false,
+             im2col_step * d_o * ho * wo, kd * kh * kw * ci, co);
+#endif
+      int coeff = getCoefficientOfLT2CT();
+      theory_ops_ += 2 * im2col_step * d_o * ho * wo * kd * kh * kw * ci * co /
+                     coeff;  // lt2ct
+    }
+
+    float *trans_grad_col;
+    if (conv_group_ != 1) {
+      trans_grad_col = cpu_runtime_.allocate(
+          new float[im2col_step * d_o * ho * wo * kh * kw * conv_group_ * ci]);
+      transposeGradCol(dcol, conv_group_,
+                       im2col_step * d_o * ho * wo * kd * kh * kw, ci,
+                       trans_grad_col);
+      theory_ops_ +=
+          conv_group_ * im2col_step * d_o * ho * wo * kd * kh * kw * ci;
+    } else {
+      trans_grad_col = dcol;
+    }
+
+    if (dimNb_ == 4) {
+      int input_deal_once = im2col_step * hi * wi * ci;
+      int offset_deal_once =
+          im2col_step * ho * wo * deformable_group_ * kh * kw * 2;
+      int mask_deal_once = im2col_step * ho * wo * deformable_group_ * kh * kw;
+      float *input_addr = input + batch_iter * input_deal_once;
+      float *offset_addr = offset + batch_iter * offset_deal_once;
+      float *mask_addr =
+          mask == nullptr ? nullptr : mask + batch_iter * mask_deal_once;
+      float *grad_input_addr = grad_input + batch_iter * input_deal_once;
+      float *grad_offset_addr = grad_offset + batch_iter * offset_deal_once;
+      float *grad_mask_addr = grad_mask == nullptr
+                                  ? nullptr
+                                  : grad_mask + batch_iter * mask_deal_once;
+
+      col2img4D(trans_grad_col, input_addr, offset_addr, mask_addr,
+                grad_input_addr, grad_offset_addr, grad_mask_addr, im2col_step,
+                hi, wi, ci, co, kh, kw, pad_, stride_, dilation_,
+                deformable_group_, conv_group_);
+      // bilinear(16) + grad_mask(2) + grad_offset(8)
+      theory_ops_ += im2col_step * ho * wo * kh * kw * deformable_group_ *
+                     c_per_deform_group * 28;
+      // grad input (2 * grad bilinear loop (4))
+      theory_ops_ += im2col_step * ho * wo * kh * kw * deformable_group_ *
+                     c_per_deform_group * 4 * 2;
+    } else {  // dimNb == 5
+      // TODO(sunhui): reserve for 3D DCN Backward Data
+    }
+    if (conv_group_ != 1) {
+      cpu_runtime_.deallocate(trans_grad_col);
+      cpu_runtime_.deallocate(trans_grad_output);
+    }
+  }  // end batch iteration
+  cpu_runtime_.deallocate(dcol);
+}
+
+/*
+ * grad_col: n, ho, wo, kh, kw, deform_group, ci_per_deform_group
+ * input: n, hi, wi, conv_group * ci
+ * offset: n, ho, wo, deform_group, kh, kw, 2
+ * mask: n, ho, wo, deform_group, kh, kw
+ */
+void DcnBackwardDataExecutor::col2img4D(float *grad_col, float *input,
+                                        float *offset, float *mask,
+                                        float *grad_input, float *grad_offset,
+                                        float *grad_mask, int n, int hi, int wi,
+                                        int ci, int co, int kh, int kw,
+                                        int pad[], int stride[], int dilation[],
+                                        int deform_group, int conv_group) {
+  int pt = pad[0];
+  int pb = pad[1];
+  int pl = pad[2];
+  int pr = pad[3];
+  int ho = (hi + pt + pb - dilation[0] * (kh - 1) - 1) / stride[0] + 1;
+  int wo = (wi + pl + pr - dilation[1] * (kw - 1) - 1) / stride[1] + 1;
+  int ci_per_deform_group = ci * conv_group / deform_group;
+
+  float *cur_top_grad = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *mval = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *bilinear_result =
+      cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *valh = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *valw = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *interp_weight_h =
+      cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *interp_weight_w =
+      cpu_runtime_.allocate(new float[ci_per_deform_group]);
+
+  for (int i_iter = 0; i_iter < n * ho * wo * kh * kw * deform_group;
+       i_iter++) {
+    int deform_iter = i_iter % deform_group;
+    int kw_iter = (i_iter / deform_group) % kw;
+    int kh_iter = (i_iter / deform_group / kw) % kh;
+    int wo_iter = (i_iter / deform_group / kw / kh) % wo;
+    int ho_iter = (i_iter / deform_group / kw / kh / wo) % ho;
+    int n_iter = (i_iter / deform_group / kw / kh / wo / ho) % n;
+
+    int offset_offset = n_iter * ho * wo * deform_group * kh * kw * 2 +
+                        ho_iter * wo * deform_group * kh * kw * 2 +
+                        wo_iter * deform_group * kh * kw * 2 +
+                        deform_iter * kh * kw * 2 + kh_iter * kw * 2 +
+                        kw_iter * 2;
+    float offset_h = offset[offset_offset + 0];
+    float offset_w = offset[offset_offset + 1];
+
+    float mask_value = 1.0;
+    if (mask != nullptr) {
+      int mask_offset = n_iter * ho * wo * deform_group * kh * kw +
+                        ho_iter * wo * deform_group * kh * kw +
+                        wo_iter * deform_group * kh * kw +
+                        deform_iter * kh * kw + kh_iter * kw + kw_iter;
+      mask_value = mask[mask_offset];
+    }
+
+    float h_im = ho_iter * stride[0] - pt + kh_iter * dilation[0] + offset_h;
+    float w_im = wo_iter * stride[1] - pl + kw_iter * dilation[1] + offset_w;
+
+    int col_offset =
+        n_iter * ho * wo * kh * kw * deform_group * ci_per_deform_group +
+        ho_iter * wo * kh * kw * deform_group * ci_per_deform_group +
+        wo_iter * kh * kw * deform_group * ci_per_deform_group +
+        kh_iter * kw * deform_group * ci_per_deform_group +
+        kw_iter * deform_group * ci_per_deform_group +
+        deform_iter * ci_per_deform_group;
+    for (int iter = 0; iter < ci_per_deform_group; iter++) {
+      cur_top_grad[iter] = grad_col[col_offset + iter];
+    }
+
+    int cur_h = int(h_im);
+    int cur_w = int(w_im);
+
+    // dcn backward data prospect
+    for (int dh_iter = -2; dh_iter < 3; dh_iter++) {
+      for (int dw_iter = -2; dw_iter < 3; dw_iter++) {
+        if (cur_h + dh_iter >= 0 && cur_h + dh_iter < hi &&
+            cur_w + dw_iter >= 0 && cur_w + dw_iter < wi &&
+            fabs(h_im - (cur_h + dh_iter)) < 1.0 &&
+            fabs(w_im - (cur_w + dw_iter)) < 1.0) {
+          float weight = 0.0;
+          if (h_im <= -1 || h_im >= hi || w_im <= -1 || w_im >= wi) {
+            continue;
+          } else {
+            int h_low = floor(h_im);
+            int w_low = floor(w_im);
+            int h_high = h_low + 1;
+            int w_high = w_low + 1;
+            int tmp_h = cur_h + dh_iter;
+            int tmp_w = cur_w + dw_iter;
+            if (tmp_h == h_low && tmp_w == w_low) {
+              weight = (tmp_h + 1.0 - h_im) * (tmp_w + 1.0 - w_im);
+            } else if (tmp_h == h_low && tmp_w == w_high) {
+              weight = (tmp_h + 1.0 - h_im) * (w_im + 1.0 - tmp_w);
+            } else if (tmp_h == h_high && tmp_w == w_low) {
+              weight = (h_im + 1.0 - tmp_h) * (tmp_w + 1.0 - w_im);
+            } else if (tmp_h == h_high && tmp_w == w_high) {
+              weight = (h_im + 1.0 - tmp_h) * (w_im + 1.0 - tmp_w);
+            }
+          }
+          int grad_img_offset =
+              n_iter * hi * wi * deform_group * ci_per_deform_group +
+              (cur_h + dh_iter) * wi * deform_group * ci_per_deform_group +
+              (cur_w + dw_iter) * deform_group * ci_per_deform_group +
+              deform_iter * ci_per_deform_group;
+          for (int iter = 0; iter < ci_per_deform_group; iter++) {
+            grad_input[grad_img_offset + iter] +=
+                weight * cur_top_grad[iter] * mask_value;
+          }
+        }  // if cur h and cur w is valid
+      }    // dw iter
+    }      // dh iter
+    // dcn backward data end
+
+    // dcn backward mask
+
+    for (int iter = 0; iter < ci_per_deform_group; iter++) {
+      mval[iter] = 0.0;
+    }
+
+    if (h_im > -1 && h_im < hi && w_im > -1 && w_im < wi) {
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        im2col_bilinear(input, n_iter, h_im, w_im, deform_iter, hi, wi,
+                        deform_group, ci_per_deform_group, bilinear_result);
+        mval[iter] = cur_top_grad[iter] * bilinear_result[iter];
+      }
+    } else {
+      h_im = -2.0;
+      w_im = -2.0;
+    }
+    if (grad_mask != nullptr) {
+      int mask_offset = n_iter * ho * wo * deform_group * kh * kw +
+                        ho_iter * wo * deform_group * kh * kw +
+                        wo_iter * deform_group * kh * kw +
+                        deform_iter * kh * kw + kh_iter * kw + kw_iter;
+      float grad_mask_value = 0.0;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        grad_mask_value += mval[iter];
+      }
+      grad_mask[mask_offset] = grad_mask_value;
+    }
+    // dcn backward mask end
+
+    // dcn backward offset
+
+    col2img_coordinate(input, n_iter, h_im, w_im, deform_iter, hi, wi,
+                       deform_group, ci_per_deform_group, interp_weight_h,
+                       interp_weight_w);
+    for (int iter = 0; iter < ci_per_deform_group; iter++) {
+      valh[iter] = cur_top_grad[iter] * interp_weight_h[iter] * mask_value;
+      valw[iter] = cur_top_grad[iter] * interp_weight_w[iter] * mask_value;
+    }
+    float grad_offset_h = 0.0;
+    float grad_offset_w = 0.0;
+    for (int iter = 0; iter < ci_per_deform_group; iter++) {
+      grad_offset_h += valh[iter];
+      grad_offset_w += valw[iter];
+    }
+
+    grad_offset[offset_offset + 0] = grad_offset_h;
+    grad_offset[offset_offset + 1] = grad_offset_w;
+  }  // i iter
+}
+
+void DcnBackwardDataExecutor::col2img_coordinate(
+    float *input, int n_iter, float h_im, float w_im, int deform_iter, int hi,
+    int wi, int deform_group, int ci_per_deform_group, float *weight_h,
+    float *weight_w) {
+  int h_low = floor(h_im);
+  int w_low = floor(w_im);
+  int h_high = h_low + 1;
+  int w_high = w_low + 1;
+  float lh = h_im - h_low;
+  float lw = w_im - w_low;
+
+  for (int iter = 0; iter < ci_per_deform_group; iter++) {
+    weight_h[iter] = 0.0;
+    weight_w[iter] = 0.0;
+  }
+  if (h_im > -1 && h_im < hi && w_im > -1 && w_im < wi) {
+    if (h_low >= 0 && w_low >= 0) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_low * wi * deform_group * ci_per_deform_group +
+                         w_low * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        weight_h[iter] += -1.0 * (w_high - w_im) * input[input_offset + iter];
+        weight_w[iter] += -1.0 * (h_high - h_im) * input[input_offset + iter];
+      }
+    }
+    if (h_low >= 0 && w_high < wi) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_low * wi * deform_group * ci_per_deform_group +
+                         w_high * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        weight_h[iter] += -1.0 * (w_im - w_low) * input[input_offset + iter];
+        weight_w[iter] += 1.0 * (h_high - h_im) * input[input_offset + iter];
+      }
+    }
+    if (h_high < hi && w_low >= 0) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_high * wi * deform_group * ci_per_deform_group +
+                         w_low * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        weight_h[iter] += 1.0 * (w_high - w_im) * input[input_offset + iter];
+        weight_w[iter] += -1.0 * (h_im - h_low) * input[input_offset + iter];
+      }
+    }
+    if (h_high < hi && w_high < wi) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_high * wi * deform_group * ci_per_deform_group +
+                         w_high * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        weight_h[iter] += 1.0 * (w_im - w_low) * input[input_offset + iter];
+        weight_w[iter] += 1.0 * (h_im - h_low) * input[input_offset + iter];
+      }
+    }
+  }
+}
+
+void DcnBackwardDataExecutor::im2col_bilinear(
+    float *input, int n_iter, float h_im, float w_im, int deform_iter, int hi,
+    int wi, int deform_group, int ci_per_deform_group, float *bilinear_result) {
+  int h_low = floor(h_im);
+  int w_low = floor(w_im);
+  int h_high = h_low + 1;
+  int w_high = w_low + 1;
+
+  float lh = h_im - h_low;
+  float lw = w_im - w_low;
+  float hh = 1.0 - lh;
+  float hw = 1.0 - lw;
+
+  float *v1 = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *v2 = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *v3 = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  float *v4 = cpu_runtime_.allocate(new float[ci_per_deform_group]);
+  for (int iter = 0; iter < ci_per_deform_group; iter++) {
+    v1[iter] = 0.0;
+    v2[iter] = 0.0;
+    v3[iter] = 0.0;
+    v4[iter] = 0.0;
+    bilinear_result[iter] = 0.0;
+  }
+
+  if (h_im > -1.0 && w_im > -1.0 && h_im < hi && w_im < wi) {
+    if (h_low >= 0 && w_low >= 0) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_low * wi * deform_group * ci_per_deform_group +
+                         w_low * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        v1[iter] = input[input_offset + iter];
+      }
+    }
+    if (h_low >= 0 && w_high <= wi - 1) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_low * wi * deform_group * ci_per_deform_group +
+                         w_high * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        v2[iter] = input[input_offset + iter];
+      }
+    }
+    if (h_high <= hi - 1 && w_low >= 0) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_high * wi * deform_group * ci_per_deform_group +
+                         w_low * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        v3[iter] = input[input_offset + iter];
+      }
+    }
+    if (h_high <= hi - 1 && w_high <= wi - 1) {
+      int input_offset = n_iter * hi * wi * deform_group * ci_per_deform_group +
+                         h_high * wi * deform_group * ci_per_deform_group +
+                         w_high * deform_group * ci_per_deform_group +
+                         deform_iter * ci_per_deform_group;
+      for (int iter = 0; iter < ci_per_deform_group; iter++) {
+        v4[iter] = input[input_offset + iter];
+      }
+    }
+    float w1 = hh * hw;
+    float w2 = hh * lw;
+    float w3 = lh * hw;
+    float w4 = lh * lw;
+
+    for (int iter = 0; iter < ci_per_deform_group; iter++) {
+      bilinear_result[iter] =
+          w1 * v1[iter] + w2 * v2[iter] + w3 * v3[iter] + w4 * v4[iter];
+    }
+  }
+  cpu_runtime_.deallocate(v1);
+  cpu_runtime_.deallocate(v2);
+  cpu_runtime_.deallocate(v3);
+  cpu_runtime_.deallocate(v4);
+}
+
+int64_t DcnBackwardDataExecutor::getTheoryOps() {
+  if (exe_config_->mlu_only) {
+    int n = mluOpGetTensordimN(input_desc_);
+    int di = dimNb_ == 5 ? mluOpGetTensordimD(input_desc_) : 1;
+    int hi = mluOpGetTensordimH(input_desc_);
+    int wi = mluOpGetTensordimW(input_desc_);
+
+    int d_o = dimNb_ == 5 ? mluOpGetTensordimD(grad_output_desc_) : 1;
+    int ho = mluOpGetTensordimH(grad_output_desc_);
+    int wo = mluOpGetTensordimW(grad_output_desc_);
+
+    int kd = dimNb_ == 5 ? mluOpGetTensordimD(weight_desc_) : 1;
+    int kh = mluOpGetTensordimH(weight_desc_);
+    int kw = mluOpGetTensordimW(weight_desc_);
+
+    int ci = mluOpGetTensordimC(weight_desc_);
+    int co = mluOpGetTensordimN(weight_desc_) / conv_group_;
+    int c_per_deform_group = ci / deformable_group_;
+
+    theory_ops_ = 0;
+    // if conv group > 1, transpose grad output and the column data
+    if (conv_group_ > 1) {
+      theory_ops_ += parser_->getOutputDataCount(0);
+      theory_ops_ += conv_group_ * n * d_o * ho * wo * kd * kh * kw * ci;
+    }
+    int coeff = getCoefficientOfLT2CT();
+    theory_ops_ +=
+        2 * conv_group_ * n * d_o * ho * wo * kd * kh * kw * ci * co / coeff;
+    // bilinear(16) + grad_mask(2) + grad_offset(8)
+    theory_ops_ +=
+        n * ho * wo * kh * kw * deformable_group_ * c_per_deform_group * 28;
+    // grad input (2 * grad bilinear loop (4))
+    theory_ops_ +=
+        n * ho * wo * kh * kw * deformable_group_ * c_per_deform_group * 4 * 2;
+  }
+  VLOG(4) << "getTheoryOps: " << theory_ops_ << " ops";
+  return theory_ops_;
+}
+
+}  // namespace mluoptest

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.h
@@ -31,7 +31,6 @@
 #define MAX_DILATION_DIM 3
 
 namespace mluoptest {
-
 class DcnBackwardDataExecutor : public Executor {
  public:
   DcnBackwardDataExecutor() {}

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.h
@@ -98,4 +98,4 @@ class DcnBackwardDataExecutor : public Executor {
 };
 
 }  // namespace mluoptest
-#endif  // TEST_MLUOP_GTEST_PBGTEST_SRC_ZOO_DCN_BACKWARD_DATA_DCN_BACKWARD_DATA_H_
+#endif  // TEST_MLUOP_GTEST_GTEST_SRC_ZOO_DCN_BACKWARD_DATA_DCN_BACKWARD_DATA_H

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.h
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.h
@@ -1,0 +1,101 @@
+/*************************************************************************
+ * Copyright (C) [2022] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#ifndef TEST_MLUOP_GTEST_PBGTEST_SRC_ZOO_DCN_BACKWARD_DATA_DCN_BACKWARD_DATA_H_
+#define TEST_MLUOP_GTEST_PBGTEST_SRC_ZOO_DCN_BACKWARD_DATA_DCN_BACKWARD_DATA_H_
+#include <vector>
+#include "executor.h"
+
+#define MAX_PAD_DIM 6
+#define MAX_STRIDE_DIM 3
+#define MAX_DILATION_DIM 3
+
+namespace mluoptest {
+
+class DcnBackwardDataExecutor : public Executor {
+ public:
+  DcnBackwardDataExecutor() {}
+  ~DcnBackwardDataExecutor() {}
+
+  void paramCheck();
+  void compute();
+  void workspaceMalloc();
+  void workspaceFree();
+  void cpuCompute();
+  int64_t getTheoryOps() override;
+
+ private:
+  bool use_mask_;
+  mluOpDCNDescriptor_t dcn_desc_;
+  mluOpTensorDescriptor_t input_desc_, offset_desc_, mask_desc_, weight_desc_,
+      grad_output_desc_;
+  mluOpTensorDescriptor_t grad_input_desc_, grad_offset_desc_, grad_mask_desc_;
+  size_t workspace_size_;
+  int pad_[MAX_PAD_DIM] = {0};
+  int stride_[MAX_STRIDE_DIM] = {1};
+  int dilation_[MAX_DILATION_DIM] = {1};
+  int dimNb_ = 4;
+  int deformable_group_ = 1;
+  int conv_group_ = 1;
+  int im2col_step_ = 1;
+  int64_t theory_ops_ = 0;
+  mluOpDataType_t compute_type_ = MLUOP_DTYPE_FLOAT;
+  mluOpDataType_t grad_output_oc_dt_, weight_oc_dt_;
+  void *dev_workspace_ = nullptr;
+  void hostDCNBackwardData(
+      const mluOpTensorDescriptor_t input_desc, float *input,
+      const mluOpTensorDescriptor_t offset_desc, float *offset,
+      const mluOpTensorDescriptor_t mask_desc, float *mask,
+      const mluOpTensorDescriptor_t weight_desc, float *weight,
+      const mluOpTensorDescriptor_t grad_output_desc, float *output,
+      mluOpTensorDescriptor_t grad_input_desc, float *grad_input,
+      mluOpTensorDescriptor_t grad_offset_desc, float *grad_offset,
+      mluOpTensorDescriptor_t grad_mask_desc, float *grad_mask);
+
+  void transposeGradOutput(const float *output, const int group, const int ndhw,
+                           const int c, float *transpose_output);
+  void transposeGradCol(const float *dcol, const int group, const int middle,
+                        const int c, float *transpose_dcol);
+
+  void batch_batmul(int batch, int m, int k, int n, float *mat1, float *mat2,
+                    float *mat3);
+
+  void col2img4D(float *grad_col, float *input, float *offset, float *mask,
+                 float *grad_input, float *grad_offset, float *grad_mask, int n,
+                 int hi, int wi, int ci, int co, int kh, int kw, int pad[],
+                 int stride[], int dilation[], int deformable_group,
+                 int conv_group);
+
+  void im2col_bilinear(float *input, int n_iter, float h_im, float w_im,
+                       int deform_iter, int hi, int wi, int deform_group,
+                       int ci_per_deform_group, float *bilinear_result);
+
+  void col2img_coordinate(float *input, int n_iter, float h_im, float w_im,
+                          int deform_iter, int hi, int wi, int deform_group,
+                          int ci_per_deform_group, float *weight_h,
+                          float *weight_w);
+  int getCoefficientOfLT2CT();
+};
+
+}  // namespace mluoptest
+#endif  // TEST_MLUOP_GTEST_PBGTEST_SRC_ZOO_DCN_BACKWARD_DATA_DCN_BACKWARD_DATA_H_

--- a/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/test_case/case0.prototxt
+++ b/bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/test_case/case0.prototxt
@@ -1,0 +1,114 @@
+op_name: "dcn_backward_data"
+op_type: DCN_BACKWARD_DATA
+input {
+  id: "input"
+    shape: {
+    dims: 1
+    dims: 128
+    dims: 128
+    dims: 64
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 23
+    upper_bound: 1.7
+    lower_bound: -2.2
+    distribution: UNIFORM
+  }
+}
+input {
+id: "offset"
+  shape: {
+    dims: 1
+    dims: 128
+    dims: 128
+    dims: 18
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 23
+    upper_bound: 1.5
+    lower_bound: -1.5
+    distribution: UNIFORM
+  }
+}
+input {
+  id: "weight"
+  shape: {
+    dims: 64
+    dims: 3
+    dims: 3
+    dims: 64
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 23
+    upper_bound: 1
+    lower_bound: 0
+    distribution: UNIFORM
+  }
+}
+input {
+  id: "grad_output"
+  shape: {
+    dims: 1
+    dims: 128
+    dims: 128
+    dims: 64
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+  random_data: {
+    seed: 23
+    upper_bound: 0.5
+    lower_bound: -0.5
+    distribution: UNIFORM
+  }
+}
+output {
+  id: "grad_input"
+  shape: {
+    dims: 1
+    dims: 128
+    dims: 128
+    dims: 64
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+}
+output {
+  id: "grad_offset"
+  shape: {
+    dims: 1
+    dims: 128
+    dims: 128
+    dims: 18
+  }
+  layout: LAYOUT_NHWC
+  dtype: DTYPE_FLOAT
+}
+dcn_param: {
+  dimnb: 4
+  pad: 1
+  pad: 1
+  pad: 1
+  pad: 1
+  stride: 1
+  stride: 1
+  dilation: 1
+  dilation: 1
+  deformable_group: 1
+  conv_group: 1
+  im2col_step: 1
+  compute_type: 2
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 0.003
+  error_threshold: 0.003
+  baseline_device: CPU
+}

--- a/docs/bangc-docs/BANGC-OPS-OpList.md
+++ b/docs/bangc-docs/BANGC-OPS-OpList.md
@@ -101,3 +101,4 @@ MLU Binary Op算子结构：　
 | voxel_pooling_forward                  | √             |               |
 | voxelization                           | √             |               |
 | yolo_box                               | √             |               |
+| dcn_backward_data                      |               | √             |

--- a/docs/bangc-docs/user_guide/9_operators/index.rst
+++ b/docs/bangc-docs/user_guide/9_operators/index.rst
@@ -1008,3 +1008,9 @@ mluOpConcat
  - ``N`` 为每个input和output的维度数。
  - ``sum(axis_1, ..., axis_m)`` 表示对待拼接维度求和，output的拼接维度大小为所有input拼接维度的总和。
  - 除拼接维度外，其余维度的大小需要相等。
+
+.. _dcn_backward_data:
+
+mluOpDCNBackwardData
+---------------------------------
+该算子用于求取可变形卷积算子关于input、offset、mask的反向梯度；

--- a/docs/bangc-docs/user_guide/9_operators/index.rst
+++ b/docs/bangc-docs/user_guide/9_operators/index.rst
@@ -1013,4 +1013,4 @@ mluOpConcat
 
 mluOpDCNBackwardData
 ---------------------------------
-该算子用于求取可变形卷积算子关于input、offset、mask的反向梯度；
+该算子用于求取可变形卷积算子关于input、offset、mask的反向梯度。


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Add new binary-op mluOpDCNBackwardData.

## 2. Modification
bangc-ops/kernels/dcn_backward_data/dcn_backward_data.cpp
bangc-ops/mlu_op.h
bangc-ops/test/mlu_op_gtest/pb_gtest/src/pb_test_tools.cpp
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.cpp
bangc-ops/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_data/dcn_backward_data.h
docs/bangc-docs/BANGC-OPS-OpList.md

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [x] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [x] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [x] MLU370
  - [x] MLU590
- Job types
  - [ ] BLOCK
  - [x] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [x] Data type test (e.g. float32/int8)
- [x] Multi-dimensional tensor test
- [x] Layout test
- [x] Different size/integer remainder end segment/alignment misalignment test
- [x] Zero dimensional tensor test/zero element test
- [x] stability test
- [x] Multiple platform test
- [x] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [x] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [x] For I/O calculation efficiency check details, see: [MLU-OPS-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
[MLU Hardware Time      ]: 353 (us)
[MLU Interface Time     ]: 403.358 (us)
[MLU IO Efficiency      ]: 0.0598806
[MLU Compute Efficiency ]: 0.00218556
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 790020 (Ops)
[MLU TheoryIOs          ]: 6.49355e+06 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: 8.0384e-05 (us)
[GPU IO Efficiency      ]: 0.235106
[GPU Compute Efficiency ]: 0.00121334
[GPU Workspace Size     ]: 0 (Bytes)
[Diffs]:
[output1]
DIFF1: 5.732006e-08
DIFF2: 7.739434e-08
[output2]
DIFF1: 1.952590e-07
DIFF2: 2.119860e-07
[output3]
DIFF1: 1.972027e-07
DIFF2: 2.122958e-07
[^      OK ] /data/mlu-ops/backup/release_temp/dcn_backward_data/dcn_backward_data_8_manual_float32_float32_1655989916393.pb
[       OK ] dcn_backward_data/TestSuite.mluOp/99 (398 ms)
[----------] 100 tests from dcn_backward_data/TestSuite (72132 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 100 cases of 1 op(s).
ALL PASSED.
[==========] 100 test cases from 1 test suite ran. (76218 ms total)
[  PASSED  ] 100 test cases.

```

Platform：MLU590
```bash
[MLU Hardware Time      ]: 63 (us)
[MLU Interface Time     ]: 134.173 (us)
[MLU IO Efficiency      ]: 0.0503282
[MLU Compute Efficiency ]: 0.00544271
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 790020 (Ops)
[MLU TheoryIOs          ]: 6.49355e+06 (Bytes)
[MLU ComputeForce       ]: 2.304e+12 (op/s)
[MLU IoBandWidth        ]: 2048 (GB/s)
[GPU Hardware Time      ]: 8.0384e-05 (us)
[GPU IO Efficiency      ]: 0.235106
[GPU Compute Efficiency ]: 0.00121334
[GPU Workspace Size     ]: 0 (Bytes)
[Diffs]:
[output1]
DIFF1: 7.173844e-08
DIFF2: 9.022284e-08
[output2]
DIFF1: 1.952590e-07
DIFF2: 2.119860e-07
[output3]
DIFF1: 1.972027e-07
DIFF2: 2.122958e-07
[^      OK ] /data/mlu-ops/backup/release_temp/dcn_backward_data/dcn_backward_data_8_manual_float32_float32_1655989916393.pb
[       OK ] dcn_backward_data/TestSuite.mluOp/99 (39 ms)
[----------] 100 tests from dcn_backward_data/TestSuite (24846 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 100 cases of 1 op(s).
ALL PASSED.
[==========] 100 test cases from 1 test suite ran. (28360 ms total)
[  PASSED  ] 100 test cases.
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.