### PR TITLE
[Fix](mlu-ops): add file and line info to mluOpCnnlCheck func.

### DIFF
--- a/kernels/utils/cnnl_helper.cpp
+++ b/kernels/utils/cnnl_helper.cpp
@@ -27,7 +27,8 @@ void mluOpCnnlCheck(mluOpStatus_t result, char const *const func,
   if (result) {
     std::string error =
         "\"" + std::string(mluOpGetErrorString(result)).replace(0, 5, "CNNL") +
-        " in " + std::string(func) + "\"";
+        " in " + std::string(func) + " at " + std::string(file) +
+        " line: " + std::to_string(line) + "\"";
     LOG(ERROR) << error;
     throw std::runtime_error(error);
   }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Add more info to CALL_CNNL MACRO

## 2. Modification

kernels/utils/cnnl_helper.cpp



## 3. Test Report

if error occurred, it show like following:
take three_nn_forward for example.

[2024-1-10 14:49:32] [CNNL] [Error]:[cnnlSetTransposeDescriptor] Check failed: desc != NULL. 
[2024-1-10 14:49:32] [MLUOP] [Error]:CNNL_HELPER: Internal cnnl api call error accured.
[2024-1-10 14:49:32] [MLUOP] [Error]:"CNNL_STATUS_BAD_PARAM in cnnlSetTransposeDescriptor(NULL, known_dim, known_permute) at /projs/platform/liuduanhui/mluops-dev/mlu-ops/kernels/three_nn_forward/three_nn_forward.cpp line: 54"
