### PR TITLE
[Feature](mluOpRoiAwarePool3dForward): add roi_aware_pool3d correct api format

### DIFF
--- a/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -132,16 +132,16 @@ static mluOpStatus_t transposeTensor(
   return MLUOP_STATUS_SUCCESS;
 }
 
-mluOpStatus_t MLUOP_WIN_API mluOpGetRoiawarePool3dForwardWorkspaceSize(
+mluOpStatus_t MLUOP_WIN_API mluOpGetRoiAwarePool3dForwardWorkspaceSize(
     mluOpHandle_t handle, const mluOpTensorDescriptor_t rois_desc,
     const mluOpTensorDescriptor_t pts_desc,
     const mluOpTensorDescriptor_t pts_feature_desc, size_t *workspace_size) {
   // rois_desc and pts_desc is unused parameter.
-  PARAM_CHECK("[mluOpGetRoiawarePool3dForwardWorkspaceSize]",
+  PARAM_CHECK("[mluOpGetRoiAwarePool3dForwardWorkspaceSize]",
               handle != nullptr);
-  PARAM_CHECK("[mluOpGetRoiawarePool3dForwardWorkspaceSize]",
+  PARAM_CHECK("[mluOpGetRoiAwarePool3dForwardWorkspaceSize]",
               pts_feature_desc != nullptr);
-  PARAM_CHECK("[mluOpGetRoiawarePool3dForwardWorkspaceSize]",
+  PARAM_CHECK("[mluOpGetRoiAwarePool3dForwardWorkspaceSize]",
               workspace_size != nullptr);
   const int pts_num = pts_feature_desc->dims[0];
   const int channels = pts_feature_desc->dims[1];
@@ -157,7 +157,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetRoiawarePool3dForwardWorkspaceSize(
   return MLUOP_STATUS_SUCCESS;
 }
 
-mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
+mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dForward(
     mluOpHandle_t handle, const int pool_method, const int boxes_num,
     const int pts_num, const int channels,
     const mluOpTensorDescriptor_t rois_desc, const void *rois,
@@ -176,7 +176,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   // pts_idx_of_voxels: (boxes_num, out_x, out_y, out_z, max_pts_each_voxel)
   // pooled_features: (boxes_num, out_x, out_y, out_z, channels)
 
-  const std::string API = "[mluOpRoiawarePool3dForward]";
+  const std::string API = "[mluOpRoiAwarePool3dForward]";
   // check desc
   PARAM_CHECK(API, handle != NULL);
   PARAM_CHECK(API, rois_desc != NULL);
@@ -327,7 +327,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
     return MLUOP_STATUS_ARCH_MISMATCH;
   }
 
-  // generate mluOpRoiawarePool3dForward prototxt start!
+  // generate mluOpRoiAwarePool3dForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("roiaware_pool3d_forward");
     GEN_CASE_HANDLE(handle);
@@ -353,7 +353,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
     GEN_CASE_OP_PARAM_SINGLE(7, "roiaware_pool3d_forward", "out_z", out_z);
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
   }
-  // generate mluOpRoiawarePool3dForward prototxt end!
+  // generate mluOpRoiAwarePool3dForward prototxt end!
 
   mluOpDataType_t data_dtype = pts_desc->dtype;
   uint64_t pts_dtype_size =
@@ -365,7 +365,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   void *transpose_workspace =
       (char *)pts_feature_workspace + pts_feature_dtype_size;
 
-  VLOG(5) << "[mluOpRoiawarePool3dForward] cnnlTranspose pts start.";
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] cnnlTranspose pts start.";
   int pts_dim = pts_desc->dim;
   int pts_permute[2] = {1, 0};
   int pts_tmp_dims[2] = {0, 0};
@@ -384,9 +384,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   }
 
   MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_desc_tmp));
-  VLOG(5) << "[mluOpRoiawarePool3dForward] cnnlTranspose pts end.";
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] cnnlTranspose pts end.";
 
-  VLOG(5) << "[mluOpRoiawarePool3dForward] cnnlTranspose pts_feature start.";
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] cnnlTranspose pts_feature start.";
   int pts_feature_dim = pts_feature_desc->dim;
   int pts_feature_permute[2] = {1, 0};
   int pts_feature_tmp_dims[2] = {0, 0};
@@ -407,9 +407,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   }
 
   MLUOP_CHECK(mluOpDestroyTensorDescriptor(pts_feature_desc_tmp));
-  VLOG(5) << "[mluOpRoiawarePool3dForward] cnnlTranspose pts_feature end.";
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] cnnlTranspose pts_feature end.";
 
-  VLOG(5) << "[mluOpRoiawarePool3dForward] cnnlFill_v3 host pointer start.";
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] cnnlFill_v3 host pointer start.";
   int argmax_initial_value = (pool_method == 0) ? -1 : 0;
   {
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
@@ -441,7 +441,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
   }
-  VLOG(5) << "[mluOpRoiawarePool3dForward] cnnlFill_v3 host pointer end.";
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] cnnlFill_v3 host pointer end.";
 
   cnrtDim3_t k_dim;
   cnrtFunctionType_t k_type;
@@ -454,19 +454,19 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
   }
 
   int core_dim = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
-  VLOG(5) << "[mluOpRoiawarePool3dForward] Launch Kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] Launch Kernel "
              "KernelPtsIdxOfVoxels<<< Union"
           << k_type / core_dim << ", " << k_dim.x << ", " << k_dim.y << ", "
           << k_dim.z << " >>>"
           << " core_dim : " << core_dim;
-  VLOG(5) << "[mluOpRoiawarePool3dForward] Launch Kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] Launch Kernel "
              "KernelPtsIdxOfVoxels().";
-  CHECK_RETURN("[mluOpRoiawarePool3dForward]",
+  CHECK_RETURN("[mluOpRoiAwarePool3dForward]",
                KernelPtsIdxOfVoxels(
                    k_dim, k_type, handle->queue, rois_desc->dtype, pool_method,
                    boxes_num, pts_num, max_pts_each_voxel, out_x, out_y, out_z,
                    rois, pts_workspace, pts_idx_of_voxels));
-  VLOG(5) << "[mluOpRoiawarePool3dForward] Finish kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] Finish kernel "
              "KernelPtsIdxOfVoxels.";
 
   status = kernelRoiawarePool3dForwardPolicyFunc(handle, pooled_features_desc,
@@ -476,27 +476,27 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
     return status;
   }
 
-  VLOG(5) << "[mluOpRoiawarePool3dForward] Launch Kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] Launch Kernel "
              "KernelRoiawarePool3dForward<<< Union"
           << k_type / core_dim << ", " << k_dim.x << ", " << k_dim.y << ", "
           << k_dim.z << " >>>"
           << " core_dim : " << core_dim;
-  VLOG(5) << "[mluOpRoiawarePool3dForward] Launch Kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] Launch Kernel "
              "KernelRoiawarePool3dForward().";
   CHECK_RETURN(
-      "[mluOpRoiawarePool3dForward]",
+      "[mluOpRoiAwarePool3dForward]",
       KernelRoiawarePool3dForward(
           k_dim, k_type, handle->queue, pooled_features_desc->dtype,
           pool_method, boxes_num, pts_num, channels, max_pts_each_voxel, out_x,
           out_y, out_z, pts_feature_workspace, pts_idx_of_voxels,
           pooled_features, argmax));
-  VLOG(5) << "[mluOpRoiawarePool3dForward] Finish kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dForward] Finish kernel "
              "KernelRoiawarePool3dForward.";
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }
 
-mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
+mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dBackward(
     mluOpHandle_t handle, const int pool_method, const int boxes_num,
     const int out_x, const int out_y, const int out_z, const int channels,
     const int max_pts_each_voxel,
@@ -510,7 +510,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   // grad_out: (boxes_num, out_x, out_y, out_z, channels)
   // grad_in: (pts_num, channels)
 
-  const std::string API = "[mluOpRoiawarePool3dBackward]";
+  const std::string API = "[mluOpRoiAwarePool3dBackward]";
   // check desc
   PARAM_CHECK(API, handle != NULL);
   PARAM_CHECK(API, pts_idx_of_voxels_desc != NULL);
@@ -623,7 +623,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
           << ", max_pts_each_voxel = " << max_pts_each_voxel
           << ", points num = " << grad_in_desc->dims[0];
 
-  // generate mluOpRoiawarePool3dBackward prototxt start!
+  // generate mluOpRoiAwarePool3dBackward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("roiaware_pool3d_backward");
     GEN_CASE_HANDLE(handle);
@@ -645,7 +645,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
                              "max_pts_each_voxel", max_pts_each_voxel);
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
   }
-  // generate mluOpRoiawarePool3dBackward prototxt end!
+  // generate mluOpRoiAwarePool3dBackward prototxt end!
 
   int grad_in_initial_value = 0;
   {
@@ -658,7 +658,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
     DESTROY_CNNL_HANDLE(cnnl_handle);
   }
   VLOG(5)
-      << "[mluOpRoiawarePool3dBackward] Initialize output space successfully.";
+      << "[mluOpRoiAwarePool3dBackward] Initialize output space successfully.";
 
   cnrtDim3_t k_dim;
   cnrtFunctionType_t k_type;
@@ -671,21 +671,78 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
   }
 
   int core_dim = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
-  VLOG(5) << "[mluOpRoiawarePool3dBackward] Launch Kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dBackward] Launch Kernel "
              "KernelRoiawarePool3dBackward<<< Union"
           << k_type / core_dim << ", " << k_dim.x << ", " << k_dim.y << ", "
           << k_dim.z << " >>>"
           << " core_dim : " << core_dim;
-  VLOG(5) << "[mluOpRoiawarePool3dBackward] Launch Kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dBackward] Launch Kernel "
              "KernelRoiawarePool3dBackward().";
   CHECK_RETURN(
-      "[mluOpRoiawarePool3dBackward]",
+      "[mluOpRoiAwarePool3dBackward]",
       KernelRoiawarePool3dBackward(
           k_dim, k_type, handle->queue, grad_out_desc->dtype, pool_method,
           boxes_num, out_x, out_y, out_z, channels, max_pts_each_voxel,
           pts_idx_of_voxels, argmax, grad_out, grad_in));
-  VLOG(5) << "[mluOpRoiawarePool3dBackward] Finish kernel "
+  VLOG(5) << "[mluOpRoiAwarePool3dBackward] Finish kernel "
              "KernelRoiawarePool3dBackward.";
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpGetRoiawarePool3dForwardWorkspaceSize(
+    mluOpHandle_t handle, const mluOpTensorDescriptor_t rois_desc,
+    const mluOpTensorDescriptor_t pts_desc,
+    const mluOpTensorDescriptor_t pts_feature_desc, size_t *workspace_size) {
+  LOG_FIRST_N(WARNING, 1)
+      << "[mluOpGetRoiawarePool3dForwardWorkspaceSize] is deprecated and "
+      << "will be removed in the future release, "
+      << "please use [mluOpGetRoiAwarePool3dForwardWorkspaceSize] instead.";
+  MLUOP_CHECK(mluOpGetRoiAwarePool3dForwardWorkspaceSize(
+                  handle, rois_desc, pts_desc, pts_feature_desc,
+                  workspace_size));
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
+    mluOpHandle_t handle, const int pool_method, const int boxes_num,
+    const int pts_num, const int channels,
+    const mluOpTensorDescriptor_t rois_desc, const void *rois,
+    const mluOpTensorDescriptor_t pts_desc, const void *pts,
+    const mluOpTensorDescriptor_t pts_feature_desc, const void *pts_feature,
+    void *workspace, size_t workspace_size, const int max_pts_each_voxel,
+    const int out_x, const int out_y, const int out_z,
+    const mluOpTensorDescriptor_t argmax_desc, void *argmax,
+    const mluOpTensorDescriptor_t pts_idx_of_voxels_desc,
+    void *pts_idx_of_voxels, const mluOpTensorDescriptor_t pooled_features_desc,
+    void *pooled_features) {
+  LOG_FIRST_N(WARNING, 1)
+      << "[mluOpRoiawarePool3dForward] is deprecated and will be removed in "
+      << "the future release, "
+      << "please use [mluOpRoiAwarePool3dForward] instead.";
+  MLUOP_CHECK(mluOpRoiAwarePool3dForward(
+                  handle, pool_method, boxes_num, pts_num, channels, rois_desc,
+                  rois, pts_desc, pts, pts_feature_desc, pts_feature, workspace,
+                  workspace_size, max_pts_each_voxel, out_x, out_y, out_z,
+                  argmax_desc, argmax, pts_idx_of_voxels_desc,
+                  pts_idx_of_voxels, pooled_features_desc, pooled_features));
+}
+
+mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
+    mluOpHandle_t handle, const int pool_method, const int boxes_num,
+    const int out_x, const int out_y, const int out_z, const int channels,
+    const int max_pts_each_voxel,
+    const mluOpTensorDescriptor_t pts_idx_of_voxels_desc,
+    const void *pts_idx_of_voxels, const mluOpTensorDescriptor_t argmax_desc,
+    const void *argmax, const mluOpTensorDescriptor_t grad_out_desc,
+    const void *grad_out, const mluOpTensorDescriptor_t grad_in_desc,
+    void *grad_in) {
+  LOG_FIRST_N(WARNING, 1)
+      << "[mluOpRoiawarePool3dBackward] is deprecated and will be removed in "
+      << "the future release, "
+      << "please use [mluOpRoiAwarePool3dBackward] instead.";
+  MLUOP_CHECK(mluOpRoiAwarePool3dBackward(
+                  handle, pool_method, boxes_num, out_x, out_y, out_z,
+                  channels, max_pts_each_voxel, pts_idx_of_voxels_desc,
+                  pts_idx_of_voxels, argmax_desc, argmax, grad_out_desc,
+                  grad_out, grad_in_desc, grad_in));
 }

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -7545,17 +7545,21 @@ mluOpMutualInformationForward(mluOpHandle_t handle,
                               const mluOpTensorDescriptor_t ans_desc,
                               void *ans);
 
-// Group:RoiawarePool3d
+// Group:RoiAwarePool3d
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
- * workspace to optimize ::mluOpRoiawarePool3dForward.
+ * workspace to optimize ::mluOpRoiAwarePool3dForward.
  *
- * The size of extra workspace is based on the given information of ::mluOpRoiawarePool3dForward,
+ * The size of extra workspace is based on the given information of ::mluOpRoiAwarePool3dForward,
  * including the input tensor descriptors \b pts_desc.
+ *
+ * @par Deprecated
+ * - :: mluOpGetRoiawarePool3dForwardWorkspaceSize is deprecated and will be removed in the future
+ *   release. It is recommended to use ::mluOpGetRoiAwarePool3dForwardWorkspaceSize instead.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
- * ::mluOpRoiawarePool3dForward. For detailed information, see ::mluOpHandle_t.
+ * ::mluOpRoiAwarePool3dForward. For detailed information, see ::mluOpHandle_t.
  * @param[in] rois_desc
  * The descriptor of the tensor \b rois, which contains the dimension and layout of the rois tensor.
  * @param[in] pts_desc
@@ -7564,7 +7568,7 @@ mluOpMutualInformationForward(mluOpHandle_t handle,
  * The descriptor of the tensor \b pts_feature, which contains the dimension and layout of the pts tensor.
  * @param[out] workspace_size
  * Pointer to the returned size of the extra workspace in bytes that is used in the
- * ::mluOpRoiawarePool3dForward operation.
+ * ::mluOpRoiAwarePool3dForward operation.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
@@ -7597,11 +7601,71 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
                                            const mluOpTensorDescriptor_t pts_feature_desc,
                                            size_t *workspace_size);
 
-// Group:RoiawarePool3d
+// Group:RoiAwarePool3d
 /*!
+ * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
+ * workspace to optimize ::mluOpRoiAwarePool3dForward.
+ *
+ * The size of extra workspace is based on the given information of ::mluOpRoiAwarePool3dForward,
+ * including the input tensor descriptors \b pts_desc.
+ *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
- * ::mluOpRoiawarePool3dForward operation. For detailed information, see ::mluOpHandle_t.
+ * ::mluOpRoiAwarePool3dForward. For detailed information, see ::mluOpHandle_t.
+ * @param[in] rois_desc
+ * The descriptor of the tensor \b rois, which contains the dimension and layout of the rois tensor.
+ * @param[in] pts_desc
+ * The descriptor of the tensor \b pts, which contains the dimension and layout of the pts tensor.
+ * @param[in] pts_feature_desc
+ * The descriptor of the tensor \b pts_feature, which contains the dimension and layout of the pts tensor.
+ * @param[out] workspace_size
+ * Pointer to the returned size of the extra workspace in bytes that is used in the
+ * ::mluOpRoiAwarePool3dForward operation.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @par Data Type
+ * - None.
+ *
+ * @par Data Layout
+ * - None.
+ *
+ * @par Scale Limitation
+ * - None.
+ *
+ * @par API Dependency
+ * - None.
+ *
+ * @par Note
+ * - None.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpGetRoiAwarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
+                                           const mluOpTensorDescriptor_t rois_desc,
+                                           const mluOpTensorDescriptor_t pts_desc,
+                                           const mluOpTensorDescriptor_t pts_feature_desc,
+                                           size_t *workspace_size);
+
+// Group:RoiAwarePool3d
+/*!
+ * @brief Returns \b argmax, \b pts_idx_of_voxels and \b pooled_features calculated by
+ * this operator.
+ *
+ * The operator determine the points in each box based on input coordinates. The collection
+ * of points in boxes are named as voxels and recorded as \b pts_idx_of_voxels. The operator
+ * also performs max pooling or average pooling on the voxels and results in \b argmax
+ * and \b pooled_features.
+ *
+ * @param[in] handle
+ * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
+ * ::mluOpRoiAwarePool3dForward operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] pool_method
  * Pooling method of Roiaware, 0 is 'maxpool', 1 is 'avgpool'. The default value is 0.
  * @param[in] boxes_num
@@ -7624,11 +7688,11 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores the pts_feature tensor.
  * @param[in] workspace
  * Pointer to the MLU memory that is used as an extra workspace for the
- * ::mluOpRoiawarePool3dForward operation.
+ * ::mluOpRoiAwarePool3dForward operation.
  * @param[in] workspace_size
  * The size of the extra workspace in bytes that needs to be used in
- * ::mluOpRoiawarePool3dForward. You can get the size of the workspace with
- * ::mluOpGetRoiawarePool3dForwardWorkspaceSize.
+ * ::mluOpRoiAwarePool3dForward. You can get the size of the workspace with
+ * ::mluOpGetRoiAwarePool3dForwardWorkspaceSize.
  * @param[in] max_pts_each_voxel
  * The maximum number of points per each voxel. An integer value which is the dimension of the pts_idx_of_voxels.
  * @param[in] out_x
@@ -7673,7 +7737,7 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * - The value of \b channels should be less than 65536.
  * - The Product of \b boxes_num and \b pts_num should be less than 2G.
  * - When the data type is floating point, the value of \b max_pts_each_voxel cannot be
- * greater than 2976, and when the data type is half, it cannot be greater than 2944.
+ *   greater than 2976, and when the data type is half, it cannot be greater than 2944.
  * - The shape of \b rois should be [boxes_num, 7].
  * - The shape of \b pts should be [pts_num, 3].
  * - The shape of \b pts_feature should be [pts_num, channels].
@@ -7686,7 +7750,7 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Note
  * - The inputs \b rois and \b pts with NaN or infinity are not supported on MLU300 series.
- * - The inputs \b pts_feature with NaN are not supported on MLU300 series.
+ * - The input \b pts_feature with NaN are not supported on MLU300 series.
  * - The function does not support MLU200 series.
  *
  * @par Example
@@ -7720,11 +7784,149 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
                            const mluOpTensorDescriptor_t pooled_features_desc,
                            void *pooled_features);
 
-// Group:RoiawarePool3d
+// Group:RoiAwarePool3d
 /*!
+ * @brief Returns \b argmax, \b pts_idx_of_voxels and \b pooled_features calculated by
+ * this operator.
+ *
+ * The operator determine the points in each box based on input coordinates. The collection
+ * of points in boxes are named as voxels and recorded as \b pts_idx_of_voxels. The operator
+ * also performs max pooling or average pooling on the voxels and results in \b argmax
+ * and \b pooled_features.
+ *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
- * ::mluOpRoiawarePool3dBackward operation. For detailed information, see ::mluOpHandle_t.
+ * ::mluOpRoiAwarePool3dForward operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] pool_method
+ * Pooling method of Roiaware, 0 is 'maxpool', 1 is 'avgpool'. The default value is 0.
+ * @param[in] boxes_num
+ * An integer value which is the number of the rois.
+ * @param[in] pts_num
+ * An integer value which is the number of the pts.
+ * @param[in] channels
+ * An integer value which is the number of the pts feature of channels.
+ * @param[in] rois_desc
+ * The descriptor of the tensor \b rois, which contains the dimension and layout of the rois tensor.
+ * @param[in] rois
+ * Pointer to the MLU memory that stores the rois tensor.
+ * @param[in] pts_desc
+ * The descriptor of the tensor \b pts, which contains the dimension and layout of the pts tensor.
+ * @param[in] pts
+ * Pointer to the MLU memory that stores the pts tensor.
+ * @param[in] pts_feature_desc
+ * The descriptor of the tensor \b pts_feature, which contains the dimension and layout of the pts_feature tensor.
+ * @param[in] pts_feature
+ * Pointer to the MLU memory that stores the pts_feature tensor.
+ * @param[in] workspace
+ * Pointer to the MLU memory that is used as an extra workspace for the
+ * ::mluOpRoiAwarePool3dForward operation.
+ * @param[in] workspace_size
+ * The size of the extra workspace in bytes that needs to be used in
+ * ::mluOpRoiAwarePool3dForward. You can get the size of the workspace with
+ * ::mluOpGetRoiAwarePool3dForwardWorkspaceSize.
+ * @param[in] max_pts_each_voxel
+ * The maximum number of points per each voxel. An integer value which is the dimension of the pts_idx_of_voxels.
+ * @param[in] out_x
+ * An integer value which is the dimension of the pooled_features.
+ * @param[in] out_y
+ * An integer value which is the dimension of the pooled_features.
+ * @param[in] out_z
+ * An integer value which is the dimension of the pooled_features.
+ * @param[in] argmax_desc
+ * The descriptor of the tensor \b argmax, which contains the dimension and layout of the argmax tensor.
+ * @param[out] argmax
+ * Pointer to the MLU memory that stores the argmax tensor.
+ * @param[in] pts_idx_of_voxels_desc
+ * The descriptor of the tensor \b pts_idx_of_voxels, which contains the dimension and layout of the pts_idx_of_voxels
+ * tensor.
+ * @param[out] pts_idx_of_voxels
+ * Pointer to the MLU memory that stores the pts_idx_of_voxels tensor.
+ * @param[in] pooled_features_desc
+ * The descriptor of the tensor \b pooled_features, which contains the dimension and layout of the pooled_features
+ * tensor.
+ * @param[out] pooled_features
+ * Pointer to the MLU memory that stores the pooled_features tensor.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *
+ * @par Data Type
+ * - The supported data types of input and output tensors are as follows:
+ *   - rois tensor: half, float
+ *   - pts tensor: half, float
+ *   - pts_feature tensor: half, float
+ *   - argmax tensor: int32
+ *   - pts_idx_of_voxels tensor: int32
+ *   - pooled_features tensor: half, float
+ *
+ * @par Data Layout
+ * - None.
+ *
+ * @par Scale Limitation
+ * - The value of \b boxes_num should be less than 65536.
+ * - The value of \b channels should be less than 65536.
+ * - The Product of \b boxes_num and \b pts_num should be less than 2G.
+ * - When the data type is floating point, the value of \b max_pts_each_voxel cannot be
+ *   greater than 2976, and when the data type is half, it cannot be greater than 2944.
+ * - The shape of \b rois should be [boxes_num, 7].
+ * - The shape of \b pts should be [pts_num, 3].
+ * - The shape of \b pts_feature should be [pts_num, channels].
+ * - The shape of \b argmax should be [boxes_num, out_x, out_y, out_z, channels].
+ * - The shape of \b pts_idx_of_voxels should be [boxes_num, out_x, out_y, out_z, max_pts_each_voxel].
+ * - The shape of \b pooled_features should be [boxes_num, out_x, out_y, out_z, channels].
+ *
+ * @par API Dependency
+ * - None.
+ *
+ * @par Note
+ * - The inputs \b rois and \b pts with NaN or infinity are not supported on MLU300 series.
+ * - The input \b pts_feature with NaN are not supported on MLU300 series.
+ * - The function does not support MLU200 series.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://github.com/open-mmlab/mmcv/tree/master/mmcv/ops/roiaware_pool3d.py
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpRoiAwarePool3dForward(mluOpHandle_t handle,
+                           const int pool_method,
+                           const int boxes_num,
+                           const int pts_num,
+                           const int channels,
+                           const mluOpTensorDescriptor_t rois_desc,
+                           const void *rois,
+                           const mluOpTensorDescriptor_t pts_desc,
+                           const void *pts,
+                           const mluOpTensorDescriptor_t pts_feature_desc,
+                           const void *pts_feature,
+                           void *workspace,
+                           size_t workspace_size,
+                           const int max_pts_each_voxel,
+                           const int out_x,
+                           const int out_y,
+                           const int out_z,
+                           const mluOpTensorDescriptor_t argmax_desc,
+                           void *argmax,
+                           const mluOpTensorDescriptor_t pts_idx_of_voxels_desc,
+                           void *pts_idx_of_voxels,
+                           const mluOpTensorDescriptor_t pooled_features_desc,
+                           void *pooled_features);
+
+// Group:RoiAwarePool3d
+/*!
+ * @brief Returns \b pts_idx_of_voxels, \b argmax, \b grad_out and \b grad_in by
+ * performing the backpropagation of ::mluOpRoiAwarePool3dForward.
+ *
+ * @par Deprecated
+ * - :: mluOpRoiawarePool3dBackward is deprecated and will be removed in the future
+ *   release. It is recommended to use ::mluOpRoiAwarePool3dBackward instead.
+ *
+ * @param[in] handle
+ * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
+ * ::mluOpRoiAwarePool3dBackward operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] pool_method
  * Pooling method of Roiaware. 0 is maxpool and 1 is avgpool. The default value is 0.
  * @param[in] boxes_num
@@ -7794,6 +7996,99 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpRoiawarePool3dBackward(mluOpHandle_t handle,
+                            const int pool_method,
+                            const int boxes_num,
+                            const int out_x,
+                            const int out_y,
+                            const int out_z,
+                            const int channels,
+                            const int max_pts_each_voxel,
+                            const mluOpTensorDescriptor_t pts_idx_of_voxels_desc,
+                            const void *pts_idx_of_voxels,
+                            const mluOpTensorDescriptor_t argmax_desc,
+                            const void *argmax,
+                            const mluOpTensorDescriptor_t grad_out_desc,
+                            const void *grad_out,
+                            const mluOpTensorDescriptor_t grad_in_desc,
+                            void *grad_in);
+
+// Group:RoiAwarePool3d
+/*!
+ * @brief Returns \b pts_idx_of_voxels, \b argmax, \b grad_out and \b grad_in by
+ * performing the backpropagation of ::mluOpRoiAwarePool3dForward.
+ *
+ * @param[in] handle
+ * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
+ * ::mluOpRoiAwarePool3dBackward operation. For detailed information, see ::mluOpHandle_t.
+ * @param[in] pool_method
+ * Pooling method of Roiaware. 0 is maxpool and 1 is avgpool. The default value is 0.
+ * @param[in] boxes_num
+ * An integer value which is the dimension of the pts_idx_of_voxels and argmax.
+ * @param[in] out_x
+ * An integer value which is the dimension of the pts_idx_of_voxels and argmax.
+ * @param[in] out_y
+ * An integer value which is the dimension of the pts_idx_of_voxels and argmax.
+ * @param[in] out_z
+ * An integer value which is the dimension of the pts_idx_of_voxels and argmax.
+ * @param[in] channels
+ * An integer value which is the number of the argmax and grad_out of channels.
+ * @param[in] max_pts_each_voxel
+ * The maximum number of points per each voxel. An integer value which is the dimension of the pts_idx_of_voxels.
+ * @param[in] pts_idx_of_voxels_desc
+ * The descriptor of the tensor \b pts_idx_of_voxels, which contains the dimension and layout of the pts_idx_of_voxels
+ * tensor.
+ * @param[out] pts_idx_of_voxels
+ * Pointer to the MLU memory that stores the pts_idx_of_voxels tensor.
+ * @param[in] argmax_desc
+ * The descriptor of the tensor \b argmax, which contains the dimension and layout of the argmax tensor.
+ * @param[out] argmax
+ * Pointer to the MLU memory that stores the argmax tensor.
+ * @param[in] grad_out_desc
+ * The descriptor of the tensor \b grad_out, which contains the dimension and layout of the grad_out tensor.
+ * @param[out] grad_out
+ * Pointer to the MLU memory that stores the grad_out tensor.
+ * @param[in] grad_in_desc
+ * The descriptor of the tensor \b grad_in, which contains the dimension and layout of the grad_in tensor.
+ * @param[in] grad_in
+ * Pointer to the MLU memory that stores the grad_in tensor.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM,
+ *   ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
+ *
+ * @par Data Type
+ * - The supported data types of input and output tensors are as follows:
+ *   - pts_idx_of_voxels tensor: int32
+ *   - argmax tensor: int32
+ *   - grad_out tensor: half, float
+ *   - grad_in tensor: half, float
+ *
+ * @par Data Layout
+ * - None.
+ *
+ * @par Scale Limitation
+ * - The value of \b boxes_num should be less than 65536.
+ * - The value of \b channels should be less than 65536.
+ * - The value of \b max_pts_each_voxel cannot be greater than 98240.
+ * - The shape of \b pts_idx_of_voxels should be [boxes_num, out_x, out_y, out_z, max_pts_each_voxel].
+ * - The shape of \b argmax should be [boxes_num, out_x, out_y, out_z, channels].
+ * - The shape of \b grad_out should be [boxes_num, out_x, out_y, out_z, channels].
+ * - The shape of \b grad_in should be [pts_num, channels].
+ *
+ * @par API Dependency
+ * - None.
+ *
+ * @par Note
+ * - The function does not support MLU200 series.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://github.com/open-mmlab/mmcv/tree/master/mmcv/ops/roiaware_pool3d.py
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpRoiAwarePool3dBackward(mluOpHandle_t handle,
                             const int pool_method,
                             const int boxes_num,
                             const int out_x,

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_backward/roiaware_pool3d_backward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_backward/roiaware_pool3d_backward.cpp
@@ -179,7 +179,7 @@ void RoiawarePool3dBackwardExecutor::compute() {
 
   interface_timer_.start();
 
-  MLUOP_CHECK(mluOpRoiawarePool3dBackward(
+  MLUOP_CHECK(mluOpRoiAwarePool3dBackward(
       handle_, pool_method_, boxes_num_, out_x_, out_y_, out_z_, channels_,
       max_pts_each_voxel_, desc_pts_idx_of_voxels_, dev_pts_idx_of_voxels_,
       desc_argmax_, dev_argmax_, desc_grad_out_, dev_grad_out_, desc_grad_in_,

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
@@ -270,7 +270,7 @@ void RoiawarePool3dForwardExecutor::paramCheck() {
 void RoiawarePool3dForwardExecutor::workspaceMalloc() {
   void *tmp = nullptr;
   // allocate extra space when broadcast
-  MLUOP_CHECK(mluOpGetRoiawarePool3dForwardWorkspaceSize(
+  MLUOP_CHECK(mluOpGetRoiAwarePool3dForwardWorkspaceSize(
       handle_, tensor_desc_[0].tensor, tensor_desc_[1].tensor,
       tensor_desc_[2].tensor, &workspace_size_));
   if (workspace_size_ > 0) {
@@ -300,7 +300,7 @@ void RoiawarePool3dForwardExecutor::compute() {
   printDataInfo();
 
   interface_timer_.start();
-  MLUOP_CHECK(mluOpRoiawarePool3dForward(
+  MLUOP_CHECK(mluOpRoiAwarePool3dForward(
       handle_, pool_method_, boxes_num_, pts_num_, channels_, desc_rois_,
       dev_rois_, desc_pts_, dev_pts_, desc_pts_feature_, dev_pts_feature_,
       workspace_[0], workspace_size_, max_pts_each_voxel_, out_x_, out_y_,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

增加符合仓库api规范的接口，标注废弃旧接口。同时修改api 调用方式。

## 2. Modification

	modified:   mlu_op.h
	modified:   kernels/roiaware_pool3d/roiaware_pool3d.cpp
	modified:   test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_backward/roiaware_pool3d_backward.cpp
	modified:   test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp


## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.