### PR TITLE
[feature](mlu-ops): fix version_pre_chek

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ MLU-OPS 提供了以下功能：
 - 寒武纪 MLU 驱动：
   - 运行时依赖驱动 v5.10.15 或更高版本
 - 外部链接库：
-  - libxml2-dev、libprotobuf-dev<=3.8.0、protobuf-compiler<=3.8.0、llvm-6.0-dev、libeigen3-dev>=3.4
+  - libxml2-dev、libprotobuf-dev、protobuf-compiler、llvm-6.0-dev、libeigen3-dev>=3.4
 - Python环境：
   - 依赖Python-3版本（默认版本 python 3.8.0，最低要求 python 3.6.0）
 

--- a/build.property
+++ b/build.property
@@ -6,6 +6,6 @@
                      "driver": "5.10.15",
                      "eigen3": "3.4.0",
                      "libxml2": "2.9.0",
-                     "protoc": "3.8.0"},
+                     "protoc": "3.6.0"},
   "package_type": ["rpm","deb"]
 }

--- a/independent_build.sh
+++ b/independent_build.sh
@@ -76,14 +76,16 @@ python3_version_check() {
   cur_python_ver=(`python3 --version`)
   stat=$?
   if [ ${stat} != 0 ]; then
-    echo "Not found python3"
-    exit ${stat}
+    echo "Warning: Not found python3"
+    echo "If compilation failed, please check python version"
+    return
   fi
   required_python_version=$(cat build.property|grep "python"|cut -d ':' -f2|cut -d '"' -f2)
   if [[ "$(printf '%s\n' "${cur_python_ver[1]}" "${required_python_version}" \
         | sort -V | head -n1)" == "${cur_python_ver[1]}" ]]; then
-    echo "python version should no less than ${required_python_version}"
-    exit 1
+    echo "Warning: python version should no less than ${required_python_version}"
+    echo "If compilation failed, please check python version"
+    return
   fi
 }
 python3_version_check
@@ -91,10 +93,6 @@ python3_version_check
 build_requires_version_check() {
   # check build_requires
   python3 version_pre_check.py check_build_requires
-  stat=$?
-  if [ ${stat} != 0 ]; then
-    exit ${stat}
-  fi
 }
 
 usage () {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

1.proto 3.9.0版本可以正常编译，但之前限制最高版本为3.8.0
2.版本预检查不通过，应该报warning

## 2. Modification

1.proto 的限制修改为最低版本为3.6.0
2.“exit强制退出”改成报warning

## 3. Test Report

