### PR TITLE
[Fix](mlu-ops): Fix getComputeMode

### DIFF
--- a/test/mlu_op_gtest/pb_gtest/src/gtest/test_env.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/gtest/test_env.cpp
@@ -424,7 +424,7 @@ bool TestEnvironment::getComputeMode(std::string bus_id_str, char &mode) {
   compute_mode_file_ss << "/proc/driver/cambricon/mlus/" << bus_id_str
                        << "/exclusive_mode";
   int fd =
-      open(compute_mode_file_ss.str().c_str(), O_CLOEXEC | O_SYNC | O_RDWR);
+      open(compute_mode_file_ss.str().c_str(), O_CLOEXEC | O_SYNC | O_RDONLY);
   char compute_mode[1];
   ssize_t stat = read(fd, compute_mode, 1);
   if (stat == -1) {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

getComputeMode 读取文件失败

## 2. Modification

读写模式可能失败，而getComputeMode 只需要读权限，修改读文件模式.
