### PR TITLE
[Fix](mlu-ops): Fix control set for ubuntu22.04 package.

### DIFF
--- a/installer/independent/debian/control
+++ b/installer/independent/debian/control
@@ -4,10 +4,10 @@ Priority: optional
 Maintainer: Cambricon <service@cambricon.com>
 Homepage: http://www.cambricon.com
 Standards-Version: 0.1.1
-Build-Depends:
- debhelper (>= 9.0), cmake, texinfo, lsb-release,
- patchutils, diffstat, xz-utils, python-dev,
- swig, python-six, pkg-config
+#Build-Depends:
+# debhelper (>= 9.0), cmake, texinfo, lsb-release,
+# patchutils, diffstat, xz-utils, python-dev,
+# swig, python-six, pkg-config
 
 Package: mluops
 Architecture: amd64


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Fix control set for ubuntu22.04 package.

## 2. Modification

installer/independent/debian/control

## 3.4 Summary Analysis

do package successfully.