### PR TITLE
[Docs](mlu-ops): Update docs for v1.0.0

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         runner: [mlu370-m8]
-        mlu_ops_version : [0.11.0]
-        cntoolkit_version : [3.7.0]
-        cnnl_version: [1.21.1]
+        mlu_ops_version : [1.0.0]
+        cntoolkit_version : [3.8.4]
+        cnnl_version: [1.23.2]
     runs-on: ${{matrix.runner}}
     steps:
       - uses: actions/checkout@v3
@@ -28,33 +28,33 @@ jobs:
 
       - name: build_mlu_ops
         run: >
-          docker run --rm -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu18.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
+          docker run --rm -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu20.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
           ./build.sh
 
       - name: release_test_cases
         run: >
           docker run --rm --device /dev/cambricon_ctl --device /dev/cambricon_dev0 --device /dev/commu0
-          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu18.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
+          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu20.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
           ./test.sh --cases_dir=/testdata/release_test/default_platform
 
       - name: release_temp_cases
         run: >
           docker run --rm --device /dev/cambricon_ctl --device /dev/cambricon_dev0 --device /dev/commu0
-          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu18.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
+          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu20.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
           ./test.sh --cases_dir=/testdata/release_temp/default_platform
 
       - name: test_release_test_370_cases
         if: matrix.runner == 'mlu370-m8'
         run: >
           docker run --rm --device /dev/cambricon_ctl --device /dev/cambricon_dev0 --device /dev/commu0
-          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu18.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
+          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu20.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
           ./test.sh --cases_dir=/testdata/release_test/370
 
       - name: test_release_temp_370_cases
         if: matrix.runner == 'mlu370-m8'
         run: >
           docker run --rm --device /dev/cambricon_ctl --device /dev/cambricon_dev0 --device /dev/commu0
-          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu18.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
+          -v /testdata:/testdata -v $(pwd):/work -w /work docker-user.extrotec.com:30080/mlu-ops/mluops_ci:devel-x86_64-ubuntu20.04-cntoolkit${{matrix.cntoolkit_version}}-cnnl${{matrix.cnnl_version}}
           ./test.sh --cases_dir=/testdata/release_temp/370
 
       - name: clean

--- a/.github/workflows/mluops_all_system_ci.yaml
+++ b/.github/workflows/mluops_all_system_ci.yaml
@@ -30,10 +30,10 @@ jobs:
     strategy:
       matrix:
         runner: [mlu370-m8]
-        mlu_ops_version : [0.11.0]
-        cntoolkit_version : [3.7.0]
-        cnnl_version: [1.21.1]
-        os: [ubuntu18.04, ubuntu20.04, centos7, centos8, kylin10]
+        mlu_ops_version : [1.0.0]
+        cntoolkit_version : [3.8.4]
+        cnnl_version: [1.23.2]
+        os: [ubuntu20.04, centos7, centos8, kylin10]
     runs-on: ${{matrix.runner}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/mluops_ci.yaml
+++ b/.github/workflows/mluops_ci.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         runner: [mlu370-m8]
-        mlu_ops_version : [v0.11.0]
+        mlu_ops_version : [v1.0.0]
     runs-on: [yellow]
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ MLU-OPS™提供了以下功能：
 ## 依赖条件
 
 - 操作系统：
-  - 支持 x86_64 下 Ubuntu18.04、Ubuntu20.04、Centos7.6、Centos8.5、Kylin10
+  - 支持 x86_64 架构下的 Ubuntu20.04、Centos7.6、Centos8.5、Kylin10
+  - MLU-OPS v1.0.0版本后将不再支持 Ubuntu18.04。Ubuntu22.04系统将在后续的版本提供支持。
 - 寒武纪 MLU SDK：
-  - 编译和运行时依赖 CNToolkit v3.7.0 或更高版本，CNNL v1.21.1 或者更高版本
+  - 编译和运行时依赖 CNToolkit v3.8.4 或更高版本，CNNL v1.23.2 或者更高版本
 - 寒武纪 MLU 驱动：
-  - 运行时依赖驱动 v5.10.15 或更高版本
+  - 运行时依赖驱动 v5.10.25 或更高版本
 - 外部链接库：
   - libxml2-dev、libprotobuf-dev、protobuf-compiler、llvm-6.0-dev、libeigen3-dev>=3.4
 - Python环境：
@@ -61,6 +62,8 @@ MLU-OPS™提供了以下功能：
 
 - 获取 MLU-OPS™ 代码
 
+以Ubuntu20.04版本为例
+
   ```sh
   git clone https://github.com/Cambricon/mlu-ops.git
   cd mlu-ops
@@ -70,12 +73,12 @@ MLU-OPS™提供了以下功能：
 - 准备 CNToolkit、CNNL 环境
 
   ```sh
-  wget https://sdk.cambricon.com/static/Basis/MLU370_X86_ubuntu18.04/cntoolkit_x.x.x-1.ubuntuxx.xx_amd64.deb
-  wget https://sdk.cambricon.com/static/Basis/MLU370_X86_ubuntu18.04/cnnl_x.x.x-1.ubuntuxx.xx_amd64.deb
-  sudo apt-get install ./cntoolkit-x.x.x_ubuntuxx.xx_amd64.deb
+  wget https://sdk.cambricon.com/static/Basis/MLU370_X86_ubuntu20.04/cntoolkit_3.8.4-1.ubuntu20.04_amd64.deb
+  wget https://sdk.cambricon.com/static/Basis/MLU370_X86_ubuntu20.04/cnnl_1.23.2-1.ubuntu20.04_amd64.deb
+  sudo apt-get install ./cntoolkit-3.8.4-1.ubuntu20.04_amd64.deb
   sudo apt-get update
   sudo apt-get install cncc cnas cnbin cndrv cndev cnrt cnrtc cngdb cnperf
-  sudo apt-get install ./cnnl_x.x.x-x.ubuntuxx.xx_amd64.deb
+  sudo apt-get install ./cnnl_1.23.2-1.ubuntu20.04_amd64.deb
   ```
 
 - 准备 Python-3.8.0 环境

--- a/build.property
+++ b/build.property
@@ -1,9 +1,9 @@
 {
-  "version": "0.11.0-1",
+  "version": "1.0.0-1",
   "python": "3.6.0",
   "build_requires": {"cntoolkit": ["release","3.8.4-1"],
-                     "cnnl":["release","1.21.1-1"],
-                     "driver": "5.10.15",
+                     "cnnl":["release","1.23.2-1"],
+                     "driver": "5.10.25",
                      "eigen3": "3.4.0",
                      "libxml2": "2.9.0",
                      "protoc": "3.9.0"},

--- a/docs/api_guide/update.rst
+++ b/docs/api_guide/update.rst
@@ -3,6 +3,142 @@ Update History
 
 This section lists contents that were made for each product release.
 
+* V1.0.0
+
+  **Date:** February 6, 2024
+
+  **Changes:**
+
+  - Added the following new operations:
+
+    - ``dcn``
+
+      - mluOpDCNForward
+      - mluOpDCNBackwardWeight
+      - mluOpDCNBackwardData
+      - mluOpCreateDCNDescriptor
+      - mluOpDestroyDCNDescriptor
+      - mluOpSetDCNDescriptor
+      - mluOpGetDCNBakcwardDataWorkspaceSize
+      - mluOpGetDCNForwardWorkspaceSize
+      - mluOpGetDCNBackwardWeightWorkspaceSize
+
+  - Removed the following operations:
+
+    - ``add_n``
+
+      - mluOpAddN
+      - mluOpGetAddNWorkspaceSize
+      - mluOpAddN_v2
+
+    - ``batch_matmul_bcast``
+
+      - mluOpGetBatchMatMulBCastWorkspaceSize
+      - mluOpGetBatchMatMulHeuristicResult
+      - mluOpGetBatchMatMulAlgoHeuristic
+      - mluOpBatchMatMulBCastDescCreate
+      - mluOpBatchMatMulBCastDescDestroy
+      - mluOpSetBatchMatMulBCastDescAttr
+      - mluOpGetBatchMatMulBCastDescAttr
+      - mluOpBatchMatMulBCastAlgoCreate
+      - mluOpBatchMatMulBCastAlgoDestroy
+      - mluOpGetQuantizeBatchMatMulBCastAlgorithm
+      - mluOpGetQuantizeBatchMatMulBCastWorkspaceSize
+      - mluOpQuantizeBatchMatMulBCast
+      - mluOpBatchMatMulBCast
+      - mluOpBatchMatMulBCast_v2
+
+    - ``copy``
+
+      - mluOpCopy
+
+    - ``concat``
+
+      - mluOpConcat
+      - mluOpGetConcatWorkspaceSize
+
+    - ``expand``
+
+      - mluOpExpand 
+
+    - ``fill``
+
+      - mluOpFill
+      - mluOpFill_v3
+
+    - ``gather_nd``
+
+      - mluOpGatherNd
+
+    - ``matmul``
+
+      - mluOpMatMul
+      - mluOpMatMulDescCreate
+      - mluOpMatMulDescDestroy
+      - mluOpSetMatMulDescAttr
+      - mluOpGetMatMulDescAttr
+      - mluOpCreateMatMulHeuristicResult
+      - mluOpDestroyMatMulHeuristicResult
+      - mluOpGetMatMulHeuristicResult
+      - mluOpGetMatMulAlgoHeuristic
+      - mluOpMatMulAlgoCreate
+      - mluOpMatMulAlgoDestroy
+      - mluOpGetMatMulWorkspaceSize
+      - mluOpMatMul_v2
+
+    - ``nms``
+
+      - mluOpNms
+
+    - ``pad``
+
+      - mluOpPad
+
+    - ``reduce``
+
+      - mluOpReduce
+      - mluOpCreateReduceDescriptor
+      - mluOpDestroyReduceDescriptor
+      - mluOpSetReduceDescriptor
+      - mluOpSetReduceDescriptor_v2
+      - mluOpGetReduceOpWorkspaceSize
+
+    - ``scatter_nd``
+
+      - mluOpScatterNd
+      - mluOpScatterNd_v2
+
+    - ``stride_slice``
+
+      - mluOpStrideSlice
+
+    - ``transform``
+
+      - mluOpTransform
+
+    - ``transpose``
+
+      - mluOpCreateTransposeDescriptor
+      - mluOpDestroyTransposeDescriptor
+      - mluOpSetTransposeDescriptor
+      - mluOpGetTransposeWorkspaceSize
+      - mluOpTranspose
+      - mluOpTranspose_v2
+
+    - ``unique``
+
+      - mluOpUnique
+      - mluOpCreateUniqueDescriptor
+      - mluOpDestroyUniqueDescriptor
+      - mluOpSetUniqueDescriptor
+      - mluOpGetUniqueWorkSpace
+      - mluOpUniqueGetOutLen
+      - mluOpGetUniqueWorkspaceSize
+      - mluOpUnique_v2
+
+  - Removed BangPy APIs.
+
+
 * V0.11.0
 
   **Date:** December 15, 2023

--- a/docs/release_notes/mlu_ops.rst
+++ b/docs/release_notes/mlu_ops.rst
@@ -20,27 +20,9 @@ Cambricon MLU-OPS具有以下特点：
    +-----------------------------+-----------------------------+
    | Cambricon MLU-OPS 版本      | 依赖组件版本                |
    +=============================+=============================+
-   | Cambricon BANG C OPS v0.11.z| CNToolkit >= v3.7.0         |
+   | Cambricon MLU-OPS v1.0.z    | CNToolkit >= v3.8.4         |
    |                             +-----------------------------+
-   |                             | CNNL >= v1.21.1             |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.10.z| CNToolkit >= v3.7.0         |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.9.z | CNToolkit >= v3.7.0         |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.8.z | CNToolkit >= v3.6.1         |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.7.z | CNToolkit >= v3.5.0         |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.6.z | CNToolkit >= v3.4.1         |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.5.z | CNToolkit >= v3.3.0         |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.4.z | CNToolkit = v3.0.2          |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.3.z | CNToolkit >= v3.1.2         |
-   +-----------------------------+-----------------------------+
-   | Cambricon BANG C OPS v0.2.z | CNToolkit >= v3.0.1         |
+   |                             | CNNL >= v1.23.2             |
    +-----------------------------+-----------------------------+
 
 
@@ -54,28 +36,232 @@ Cambricon MLU-OPS具有以下特点：
    +-----------------------------+------------------------+--------------------------------+
    | Cambricon MLU-OPS 版本      | 支持的CPU架构          | 支持的MLU架构                  |
    +=============================+========================+================================+
-   | Cambricon BANG C OPS v0.11.z| x86_64                 | MLU370、MLU590                 |
+   | Cambricon MLU-OPS v1.0.z    | x86_64                 | MLU370、MLU590                 |
    +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.10.z| x86_64                 | MLU370、MLU590                 |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.9.z | x86_64                 | MLU370、MLU590                 |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.8.z | x86_64                 | MLU370、MLU590                 |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.7.z | x86_64                 | MLU370、MLU590                 |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.6.z | x86_64                 | MLU370、MLU590                 |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.5.z | x86_64                 | MLU370、MLU590                 |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.4.z | x86_64                 | MLU290、MLU370                 |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.3.z | x86_64                 | MLU270、MLU290、MLU370         |
-   |                             +------------------------+--------------------------------+
-   |                             | AArch64                | MLU270、MLU290、MLU370         |
-   +-----------------------------+------------------------+--------------------------------+
-   | Cambricon BANG C OPS v0.2.z | x86_64                 | MLU270、MLU290、MLU370         |
-   +-----------------------------+------------------------+--------------------------------+
+
+
+v1.0.0
+-----------------
+
+特性变更
+~~~~~~~~~~~~~~~~~~~~~
+
+- 新增以下算子接口：
+
+   * ``dcn``
+
+     + mluOpDCNForward
+
+     + mluOpDCNBackwardWeight
+
+     + mluOpDCNBackwardData
+
+     + mluOpCreateDCNDescriptor
+
+     + mluOpDestroyDCNDescriptor
+
+     + mluOpSetDCNDescriptor
+
+     + mluOpGetDCNBakcwardDataWorkspaceSize
+
+     + mluOpGetDCNForwardWorkspaceSize
+
+     + mluOpGetDCNBackwardWeightWorkspaceSize
+
+- 经过一整个大版本的废弃声明，移除以下算子接口，如需使用功能，请调用CNNL对应接口：
+
+   * ``add_n``
+
+     + mluOpAddN
+
+     + mluOpGetAddNWorkspaceSize
+
+     + mluOpAddN_v2
+
+   * ``batch_matmul_bcast``
+
+     + mluOpGetBatchMatMulBCastWorkspaceSize
+
+     + mluOpGetBatchMatMulHeuristicResult
+
+     + mluOpGetBatchMatMulAlgoHeuristic
+
+     + mluOpBatchMatMulBCastDescCreate
+
+     + mluOpBatchMatMulBCastDescDestroy
+
+     + mluOpSetBatchMatMulBCastDescAttr
+
+     + mluOpGetBatchMatMulBCastDescAttr
+
+     + mluOpBatchMatMulBCastAlgoCreate
+
+     + mluOpBatchMatMulBCastAlgoDestroy
+
+     + mluOpGetQuantizeBatchMatMulBCastAlgorithm
+
+     + mluOpGetQuantizeBatchMatMulBCastWorkspaceSize
+
+     + mluOpQuantizeBatchMatMulBCast
+
+     + mluOpBatchMatMulBCast
+
+     + mluOpBatchMatMulBCast_v2
+
+   * ``copy``
+
+     + mluOpCopy
+
+   * ``concat``
+
+     + mluOpConcat
+
+     + mluOpGetConcatWorkspaceSize
+
+   * ``expand``
+
+     + mluOpExpand
+
+   * ``fill``
+
+     + mluOpFill
+
+     + mluOpFill_v3
+
+   * ``gather_nd``
+
+     + mluOpGatherNd
+
+   * ``matmul``
+
+     + mluOpMatMul
+
+     + mluOpMatMulDescCreate
+
+     + mluOpMatMulDescDestroy
+
+     + mluOpSetMatMulDescAttr
+
+     + mluOpGetMatMulDescAttr
+
+     + mluOpCreateMatMulHeuristicResult
+
+     + mluOpDestroyMatMulHeuristicResult
+
+     + mluOpGetMatMulHeuristicResult
+
+     + mluOpGetMatMulAlgoHeuristic
+
+     + mluOpMatMulAlgoCreate
+
+     + mluOpMatMulAlgoDestroy
+
+     + mluOpGetMatMulWorkspaceSize
+
+     + mluOpMatMul_v2
+
+   * ``nms``
+
+     + mluOpNms
+
+   * ``pad``
+
+     + mluOpPad
+
+   * ``reduce``
+
+     + mluOpReduce
+
+     + mluOpCreateReduceDescriptor
+
+     + mluOpDestroyReduceDescriptor
+
+     + mluOpSetReduceDescriptor
+
+     + mluOpSetReduceDescriptor_v2
+
+     + mluOpGetReduceOpWorkspaceSize
+
+   * ``scatter_nd``
+
+     + mluOpScatterNd
+
+     + mluOpScatterNd_v2
+
+   * ``stride_slice``
+
+     + mluOpStrideSlice
+
+   * ``transform``
+
+     + mluOpTransform
+
+   * ``transpose``
+
+     + mluOpCreateTransposeDescriptor
+
+     + mluOpDestroyTransposeDescriptor
+
+     + mluOpSetTransposeDescriptor
+
+     + mluOpGetTransposeWorkspaceSize
+
+     + mluOpTranspose
+
+     + mluOpTranspose_v2
+
+   * ``unique``
+
+     + mluOpUnique
+
+     + mluOpCreateUniqueDescriptor
+
+     + mluOpDestroyUniqueDescriptor
+
+     + mluOpSetUniqueDescriptor
+
+     + mluOpGetUniqueWorkSpace
+
+     + mluOpUniqueGetOutLen
+
+     + mluOpGetUniqueWorkspaceSize
+
+     + mluOpUnique_v2
+
+- 新增编译前对环境中各个依赖项的版本检查。
+
+- 更新公共组件core/GTest代码。
+
+- 更新MLU-OPS仓库中对环境安装、编译、测试流程的叙述。
+
+- 移除对Ubuntu18.04系统的支持。
+
+- 移除BangPy组件，调整MLU-OPS仓库代码结构。
+
+已修复问题
+~~~~~~~~~~~~~~~~~~~~~
+
+- 修复以下算子问题：
+
+   * ``voxel_pooling_forward``
+
+     + 移除GTest中额外调用的API接口。
+
+已知遗留问题
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``roi_align_rotated``
+
+   * mluOpRoiAlignRotatedForward接口在输入feature以及rois元素数量接近2G时出现运行超时。
+
+   * mluOpRoiAlignRotatedBackward接口在输入top_grad以及rois元素数量接近2G时出现运行超时。
+
+- ``carafe``
+
+   * mluOpCarafeForward接口在输入input以及mask元素数量超过2G时出现运行错误。
+
+   * mluOpCarafeBackward接口在输入input、mask以及grad_output元素数量接近2G时出现运行超时。
+
 
 v0.11.0
 -----------------

--- a/docs/user_guide/2_update_history/index.rst
+++ b/docs/user_guide/2_update_history/index.rst
@@ -1,6 +1,37 @@
 更新历史
 ========
 
+* **V1.0.0**
+
+  **更新时间**：2024年2月6日
+
+  **更新内容**：
+
+  - 新增以下算子章节内容
+
+     + :ref:`dcn_backward_data`
+     + :ref:`dcn_backward_weight`
+     + :ref:`dcn_forward`
+
+  - 移除以下算子章节内容：
+
+     + add_n
+     + batch_matmul_bcast
+     + copy
+     + concat
+     + expand
+     + fill
+     + gather_nd 
+     + matmul
+     + nms
+     + pad
+     + reduce
+     + scatter_nd
+     + stride_slice
+     + transform
+     + transpose
+     + unique
+
 * **V0.11.0**
 
   **更新时间**：2023年12月15日

--- a/docs/user_guide/9_operators/index.rst
+++ b/docs/user_guide/9_operators/index.rst
@@ -27,7 +27,7 @@ mluOpActiveRotatedFilterForward
 ----------------------------------
 该算子根据输入的方向信息进行编码，生成某个方向上的特征图。
 
-.. _ball_qeury:
+.. _ball_query:
 
 mluOpBallQuery
 -----------------------------
@@ -542,13 +542,13 @@ mluOpRoiCropForward
 
 .. _roiaware_pool3d_backward:
 
-mluOpRoiawarePool3dBackward
+mluOpRoiAwarePool3dBackward
 -----------------------------
-该算子为 ``mluOpRoiawarePool3dForward`` 的反向算子，输入体素中的 idx 以及前向的池化特征值，计算反向梯度值。
+该算子为 ``mluOpRoiAwarePool3dForward`` 的反向算子，输入体素中的 idx 以及前向的池化特征值，计算反向梯度值。
 
 .. _roiaware_pool3d_forward:
 
-mluOpRoiawarePool3dForward
+mluOpRoiAwarePool3dForward
 -----------------------------
 给定一组点和点的特征值，以及一组长方体框，将框中的点的特征进行池化，输出指定数量的体素中的最大或者平均特征值以及点在对应体素中的索引。
 
@@ -720,7 +720,7 @@ mluOpSyncBatchNormElemt
 
 .. _sync_batchnorm_backward_reduce:
 
-mluOpSyncBatchnormBackwardReduce
+mluOpSyncBatchNormBackwardReduce
 ----------------------------------
 该算子用来计算损失函数想对于weight和bias的梯度，以及根据开关情况决定是否输出下级element函数的中间变量 ``sum_dy`` 和 ``sum_dy_xmu`` 。本算子通过多卡通信的方式，解决sync_batchnorm_backward在单卡上batch size数据过大导致训练时间较长的问题。
 

--- a/installer/centos7.5/SPECS/mluops-independent.spec
+++ b/installer/centos7.5/SPECS/mluops-independent.spec
@@ -5,7 +5,7 @@
 
 Name: mluops
 Summary: The Machine Lerning Unit OPerators
-Version: 0.11.0
+Version: 1.0.0
 Release: 1%{?dist}
 License: Cambricon Release License
 Vendor: Cambricon Inc.
@@ -71,6 +71,8 @@ cp $RPM_SOURCE_DIR/neuware-env.conf $RPM_BUILD_ROOT/etc/ld.so.conf.d/
 %postun -p /sbin/ldconfig
 
 %changelog
+* Tue Feb 6 2024 Cambricon Software Team <service@cambricon.com>
+- release mluops v1.0.0
 * Mon Dec 18 2023 Cambricon Software Team <service@cambricon.com>
 - release mluops v0.11.0
 * Fri Nov 24 2023 Cambricon Software Team <service@cambricon.com>

--- a/kernels/tensor_stride_process/tensor_stride_process_host.cpp
+++ b/kernels/tensor_stride_process/tensor_stride_process_host.cpp
@@ -484,3 +484,4 @@ mluOpContiguous(mluOpHandle_t handle, const mluOpTensorDescriptor_t input_desc,
   DESTROY_CNNL_HANDLE(cnnl_handle);
   return MLUOP_STATUS_SUCCESS;
 }
+

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -27,8 +27,8 @@
  * MLU-OPS: Cambricon Open Source operator library for Network
  ******************************************************************************/
 
-#define MLUOP_MAJOR 0
-#define MLUOP_MINOR 11
+#define MLUOP_MAJOR 1
+#define MLUOP_MINOR 0
 #define MLUOP_PATCHLEVEL 0
 
 /*********************************************************************************


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Update docs since MLU-OPS v1.0.0 is going to be released.

## 2. Modification

	modified:   .github/workflows/daily.yaml
	modified:   .github/workflows/mluops_all_system_ci.yaml
	modified:   .github/workflows/mluops_ci.yaml
	modified:   README.md
	modified:   build.property
	modified:   docs/api_guide/update.rst
	modified:   docs/release_notes/mlu_ops.rst
	modified:   docs/user_guide/2_update_history/index.rst
	modified:   docs/user_guide/9_operators/index.rst
	modified:   installer/centos7.5/SPECS/mluops-independent.spec
	modified:   mlu_op.h

## 3. Test Report

No test.