### PR TITLE
[Fix](mlu-ops): fix mlu_only op_list

### DIFF
--- a/docs/design_docs/masked_col2im_forward/masked_col2im_forward.md
+++ b/docs/design_docs/masked_col2im_forward/masked_col2im_forward.md
@@ -82,15 +82,15 @@
 ### 1.4 算子限制
 
 | 限制类型    | 详细说明                                            |
-| ----------- | ------------------------------------------------------------ |
-| 数据类型限制| col和im仅支持half和float，且两者数据类型相同；mask_h_idx和mask_w_idx必须为int32_t                       |
+| -----------| ------------------------------------------------------------ |
+| 数据类型限制 | col和im仅支持half和float，且两者数据类型相同；<br />mask_h_idx和mask_w_idx必须为int32_t                       |
 | 布局限制    | im仅支持NCHW |
-| 规模限制    | im的第一维大小必须是1；col的第二维、mask_h_idx的第一维和mask_w_idx的第一维大小相同；im的第二维和col的第一维大小相同               |
+| 规模限制    | im的第一维大小必须是1；<br />col的第二维、mask_h_idx的第一维和mask_w_idx的第一维大小相同；<br />im的第二维和col的第一维大小相同               |
 | 功能限制    | 无                         |
-| 数据范围限制| mask_h_idx取整范围在[0，height-1]，height是输出col的高；mask_w_idx取整范围在[width-1],width是输出col的宽；mask_h_idx与mask_w_idx组成的坐标不允许重复     |
-| 原位限制    | 不支持原位|
-| stride限制  | 不支持stride机制|
-| 广播限制    | 不支持广播|
+| 数据范围限制 | mask_h_idx 取值范围为[0，height-1]，其中 height 是输出col的高；<br />mask_w_idx 取值范围为 [width-1]，其中 width 是输出col的宽；<br />mask_h_idx与mask_w_idx组成的坐标不允许重复     |
+| 原位限制    | 不支持原位        |
+| stride限制 | 不支持stride机制  |
+| 广播限制    | 不支持广播        |
 
 ### 1.5 验收标准
 

--- a/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
+++ b/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
@@ -1,5 +1,6 @@
 [rely_real_data]
 box_iou_rotated
+masked_col2im_forward
 deform_roi_pool_backward
 deform_roi_pool_forward
 dynamic_point_to_voxel_backward
@@ -20,6 +21,7 @@ nms
 nms_rotated
 points_in_boxes
 prior_box
+psroipool_backward
 roi_align_backward
 roi_align_rotated_backward
 roi_align_rotated_forward


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.