### PR TITLE
[Fix](mlu-ops): fix workspacefree() bug.

### DIFF
--- a/test/mlu_op_gtest/pb_gtest/src/zoo/active_rotated_filter_forward/active_rotated_filter_forward.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/active_rotated_filter_forward/active_rotated_filter_forward.h
@@ -31,7 +31,7 @@ namespace mluoptest {
 class ActiveRotatedFilterForwardExecutor : public Executor {
  public:
   ActiveRotatedFilterForwardExecutor() {}
-  ~ActiveRotatedFilterForwardExecutor() { workspaceFree(); }
+  ~ActiveRotatedFilterForwardExecutor() {}
 
   void paramCheck() override;
   void compute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.h
@@ -33,7 +33,7 @@ namespace mluoptest {
 class DynamicPointToVoxelBackwardExecutor : public Executor {
  public:
   DynamicPointToVoxelBackwardExecutor() {}
-  ~DynamicPointToVoxelBackwardExecutor() { workspaceFree(); }
+  ~DynamicPointToVoxelBackwardExecutor() {}
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.h
@@ -33,7 +33,7 @@ namespace mluoptest {
 class DynamicPointToVoxelForwardExecutor : public Executor {
  public:
   DynamicPointToVoxelForwardExecutor() {}
-  ~DynamicPointToVoxelForwardExecutor() { workspaceFree(); }
+  ~DynamicPointToVoxelForwardExecutor() {}
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.h
@@ -32,7 +32,7 @@ namespace mluoptest {
 class GenerateProposalsV2Executor : public Executor {
  public:
   GenerateProposalsV2Executor() {}
-  ~GenerateProposalsV2Executor() { workspaceFree(); }
+  ~GenerateProposalsV2Executor() {}
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/masked_col2im_forward/masked_col2im_forward.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/masked_col2im_forward/masked_col2im_forward.h
@@ -29,7 +29,7 @@ namespace mluoptest {
 class MaskedCol2imForwardExecutor : public Executor {
  public:
   MaskedCol2imForwardExecutor() {}
-  ~MaskedCol2imForwardExecutor() { workspaceFree(); }
+  ~MaskedCol2imForwardExecutor() {}
 
   void paramCheck() override;
   void compute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/moe_dispatch_backward_gate/moe_dispatch_backward_gate.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/moe_dispatch_backward_gate/moe_dispatch_backward_gate.h
@@ -31,7 +31,7 @@ namespace mluoptest {
 class MoeDispatchBackwardGateExecutor : public Executor {
  public:
   MoeDispatchBackwardGateExecutor() {}
-  ~MoeDispatchBackwardGateExecutor() { workspaceFree(); }
+  ~MoeDispatchBackwardGateExecutor() {}
 
   void paramCheck() override;
   void compute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
@@ -32,7 +32,7 @@ class PolyNmsExecutor : public Executor {
  public:
   PolyNmsExecutor() {}
   ~PolyNmsExecutor() {}
-  
+
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
@@ -31,7 +31,7 @@ namespace mluoptest {
 class PolyNmsExecutor : public Executor {
  public:
   PolyNmsExecutor() {}
-  ~PolyNmsExecutor() { workspaceFree(); }
+  ~PolyNmsExecutor() {}
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
@@ -32,7 +32,6 @@ class PolyNmsExecutor : public Executor {
  public:
   PolyNmsExecutor() {}
   ~PolyNmsExecutor() {}
-
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
@@ -32,6 +32,7 @@ class PolyNmsExecutor : public Executor {
  public:
   PolyNmsExecutor() {}
   ~PolyNmsExecutor() {}
+  
   void paramCheck() override;
   void compute() override;
   void cpuCompute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_forward/roiaware_pool3d_forward.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_forward/roiaware_pool3d_forward.h
@@ -30,7 +30,7 @@ namespace mluoptest {
 class RoiawarePool3dForwardExecutor : public Executor {
  public:
   RoiawarePool3dForwardExecutor() {}
-  ~RoiawarePool3dForwardExecutor() { workspaceFree(); }
+  ~RoiawarePool3dForwardExecutor() {}
   void paramCheck() override;
   void workspaceMalloc() override;
   void workspaceFree() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/roipoint_pool3d/roipoint_pool3d.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/roipoint_pool3d/roipoint_pool3d.h
@@ -31,7 +31,7 @@ namespace mluoptest {
 class RoipointPool3dExecutor : public Executor {
  public:
   RoipointPool3dExecutor() {}
-  ~RoipointPool3dExecutor() { workspaceFree(); }
+  ~RoipointPool3dExecutor() {}
 
   void paramCheck();
   void workspaceMalloc();

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/three_nn_forward/three_nn_forward.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/three_nn_forward/three_nn_forward.h
@@ -29,7 +29,7 @@ namespace mluoptest {
 class ThreeNnForwardExecutor : public Executor {
  public:
   ThreeNnForwardExecutor() {}
-  ~ThreeNnForwardExecutor() { workspaceFree(); }
+  ~ThreeNnForwardExecutor() {}
 
   void paramCheck() override;
   void compute() override;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/voxelization/voxelization.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/voxelization/voxelization.h
@@ -30,7 +30,7 @@ namespace mluoptest {
 class VoxelizationExecutor : public Executor {
  public:
   VoxelizationExecutor() {}
-  ~VoxelizationExecutor() { workspaceFree(); }
+  ~VoxelizationExecutor() {}
 
   void paramCheck() override;
   void workspaceMalloc() override;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

fix workspacefree() bug.

## 2. Modification

test/mlu_op_gtest/pb_gtest/src/zoo/active_rotated_filter_forward/active_rotated_filter_forward.h
test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.h
test/mlu_op_gtest/pb_gtest/src/zoo/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.h
test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.h
test/mlu_op_gtest/pb_gtest/src/zoo/masked_col2im_forward/masked_col2im_forward.h
test/mlu_op_gtest/pb_gtest/src/zoo/moe_dispatch_backward_gate/moe_dispatch_backward_gate.h
test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.h
test/mlu_op_gtest/pb_gtest/src/zoo/roiaware_pool3d_forward/roiaware_pool3d_forward.h
test/mlu_op_gtest/pb_gtest/src/zoo/roipoint_pool3d/roipoint_pool3d.h
test/mlu_op_gtest/pb_gtest/src/zoo/three_nn_forward/three_nn_forward.h
test/mlu_op_gtest/pb_gtest/src/zoo/voxelization/voxelization.h

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.