### PR TITLE
[Fix](mluOpPointsInBoxes):fix precision bug of points_in_boxes

### DIFF
--- a/kernels/points_in_boxes/points_in_boxes_block_kernel.mlu
+++ b/kernels/points_in_boxes/points_in_boxes_block_kernel.mlu
@@ -46,8 +46,8 @@ __mlu_func__ void check_point_in_box(
                    points_compute_num);
   __bang_not(temp0_nram_buffer, temp0_nram_buffer, points_compute_num);
 
-  float cosa = std::cos(-rz);
-  float sina = std::sin(-rz);
+  float cosa = __cn_scalar_cos_f32(-rz);
+  float sina = __cn_scalar_sin_f32(-rz);
 
   __bang_sub_scalar(temp1_nram_buffer, x_nram_buffer, cx, points_compute_num);
   __bang_sub_scalar(temp2_nram_buffer, y_nram_buffer, cy, points_compute_num);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

fix precision bug of points_in_boxes

## 2. Modification

kernels/points_in_boxes/points_in_boxes_block_kernel.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

yuexiaofan@bjys1083:/projs/cnnl/yuexiaofan/mlu-ops-yxf/build/test$ ./mluop_gtest --case_path=/MLU_OPS/SOFT_TRAIN/other/test/jenkins/dev/135/MLU370_MLU590/points_in_boxes/points_in_boxes_data_split_int32_float32_1681869799115.pb
[==========] Running 1 test case from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from points_in_boxes/TestSuite
[ RUN      ] points_in_boxes/TestSuite.mluOp/0
[MLU Hardware Time      ]: 140310 (us)
[MLU Interface Time     ]: 72.825 (us)
[MLU IO Efficiency      ]: 0.265717
[MLU Compute Efficiency ]: 2.13238
[MLU Workspace Size     ]: -1 (Bytes)
[MLU TheoryOps          ]: 3.06374e+11 (Ops)
[MLU TheoryIOs          ]: 1.14532e+10 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[^      OK ] /MLU_OPS/SOFT_TRAIN/other/test/jenkins/dev/135/MLU370_MLU590/points_in_boxes/points_in_boxes_data_split_int32_float32_1681869799115.pb
[       OK ] points_in_boxes/TestSuite.mluOp/0 (17083 ms)
[----------] 1 test from points_in_boxes/TestSuite (17083 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
