### PR TITLE
[Feature](mlu-ops):correct partial ops gen case.

### DIFF
--- a/core/gen_case.h
+++ b/core/gen_case.h
@@ -38,8 +38,9 @@
 // #define MLUOP_GEN_CASE_ON_NEW (mluop::gen_case::isGenCaseOn())
 #define MLUOP_GEN_CASE_ON_NEW (mluop::gen_case::genCaseModeGet(true) > 0)
 
-#define GEN_CASE_START(op_name) \
-  mluop::gen_case::PbNode *node = mluop::gen_case::genCaseStart(op_name)
+#define GEN_CASE_START(op_name, op_type) \
+  mluop::gen_case::PbNode *node = mluop::gen_case::genCaseStart(op_name, \
+                                                                op_type)
 
 #define GEN_CASE_DATA(is_input, id, data, data_desc, upper_bound, lower_bound) \
   mluop::gen_case::genCaseData(node, is_input, id, data, data_desc,            \
@@ -599,7 +600,7 @@ void genCaseModeRestore();
 void genCaseModeSet(int mode);
 inline int getOpNameMask(const std::string op_name_, const std::string op_name);
 
-PbNode *genCaseStart(std::string op_name, std::string op_type = "NONE");
+PbNode *genCaseStart(std::string op_name, std::string op_type);
 void genCaseData(PbNode *node, bool is_input, std::string id,
                  const void *device_data, mluOpTensorDescriptor_t desc,
                  double param1, double param2,

--- a/kernels/abs/abs.cpp
+++ b/kernels/abs/abs.cpp
@@ -62,7 +62,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpAbs(mluOpHandle_t handle,
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("abs");
+    GEN_CASE_START("abs", "ABS");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "x", x, x_desc, 10, 0);
     GEN_CASE_DATA(false, "y", y, y_desc, 0, 0);

--- a/kernels/active_rotated_filter/active_rotated_filter.cpp
+++ b/kernels/active_rotated_filter/active_rotated_filter.cpp
@@ -150,7 +150,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpActiveRotatedFilterForward(
 
   // generate mluOpActiveRotatedFilterForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("active_rotated_filter_forward");
+    GEN_CASE_START("active_rotated_filter_forward",
+                   "ACTIVE_ROTATED_FILTER_FORWARD");
     // set handle dump mlu output
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, 100, -100);

--- a/kernels/ball_query/ball_query.cpp
+++ b/kernels/ball_query/ball_query.cpp
@@ -171,7 +171,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
   PARAM_CHECK("[mluOpBallQuery]", idx != NULL);
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("ball_query");
+    GEN_CASE_START("ball_query", "BALL_QUERY");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "input1", new_xyz, new_xyz_desc);
     GEN_CASE_DATA_REAL(true, "input2", xyz, xyz_desc);

--- a/kernels/bbox_overlaps/bbox_overlaps.cpp
+++ b/kernels/bbox_overlaps/bbox_overlaps.cpp
@@ -189,7 +189,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpBboxOverlaps(
 
   // generate mluOpBboxOverlaps prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("bbox_overlaps");
+    GEN_CASE_START("bbox_overlaps", "BBOX_OVERLAPS");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "input", bbox1, bbox1_desc);
     GEN_CASE_DATA_REAL(true, "input", bbox2, bbox2_desc);

--- a/kernels/border_align/border_align_backward/border_align_backward.cpp
+++ b/kernels/border_align/border_align_backward/border_align_backward.cpp
@@ -118,7 +118,7 @@ mluOpStatus_t mluOpBorderAlignBackward(
 
   // generate case prototxt
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("border_align_backward");
+    GEN_CASE_START("border_align_backward", "BORDER_ALIGN_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input1", grad_output, grad_output_desc, 100, 0);
     GEN_CASE_DATA_REAL(true, "input2", boxes, boxes_desc);

--- a/kernels/border_align/border_align_forward/border_align_forward.cpp
+++ b/kernels/border_align/border_align_forward/border_align_forward.cpp
@@ -110,7 +110,7 @@ mluOpStatus_t mluOpBorderAlignForward(
   PARAM_CHECK(API, output != nullptr);
   PARAM_CHECK(API, argmax_idx != nullptr);
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("border_align_forward");
+    GEN_CASE_START("border_align_forward", "BORDER_ALIGN_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input1", input, input_desc, 100, 0);
     GEN_CASE_DATA_REAL(true, "input2", boxes, boxes_desc);

--- a/kernels/box_iou_rotated/box_iou_rotated.cpp
+++ b/kernels/box_iou_rotated/box_iou_rotated.cpp
@@ -197,7 +197,7 @@ mluOpBoxIouRotated(mluOpHandle_t handle, const int mode, const bool aligned,
 
   // generate prototxt
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("box_iou_rotated");
+    GEN_CASE_START("box_iou_rotated", "BOX_IOU_ROTATED");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "input", box1, box1_desc);
     GEN_CASE_DATA_REAL(true, "input", box2, box2_desc);

--- a/kernels/carafe/carafe.cpp
+++ b/kernels/carafe/carafe.cpp
@@ -344,7 +344,8 @@ mluOpStatus_t CarafeForwardParamCheck(
               "The input tensor is not contiguous!");
   PARAM_CHECK(CARAFE_FORWARD_API, !mluop::ifNeedTensorStrideProcess(mask_desc),
               "The mask tensor is not contiguous!");
-  PARAM_CHECK(CARAFE_FORWARD_API, !mluop::ifNeedTensorStrideProcess(output_desc),
+  PARAM_CHECK(CARAFE_FORWARD_API,
+              !mluop::ifNeedTensorStrideProcess(output_desc),
               "The output tensor is not contiguous!");
   /*
    * off-chip data type check
@@ -784,7 +785,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpCarafeForward(
 
   // GEN_CASE
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("carafe_forward");
+    GEN_CASE_START("carafe_forward", "CARAFE_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, 5.1, -5.3);
     GEN_CASE_DATA(true, "mask", mask, mask_desc, 0.0, 1.0);
@@ -840,7 +841,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpCarafeBackward(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("carafe_backward");
+    GEN_CASE_START("carafe_backward", "CARAFE_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, 5.1, -5.3);
     GEN_CASE_DATA(true, "mask", mask, mask_desc, 0.0, 1.0);

--- a/kernels/deform_roi_pool/deform_roi_pool.cpp
+++ b/kernels/deform_roi_pool/deform_roi_pool.cpp
@@ -315,7 +315,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpDeformRoiPoolForward(
 
   // generate mluOpDeformRoiPoolForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("deform_roi_pool_forward");
+    GEN_CASE_START("deform_roi_pool_forward", "DEFORM_ROI_POOL_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, -10, 10);
     GEN_CASE_DATA_REAL(true, "rois", rois, rois_desc);
@@ -401,7 +401,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpDeformRoiPoolBackward(
 
   // generate mluOpDeformRoiPoolBackward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("deform_roi_pool_backward");
+    GEN_CASE_START("deform_roi_pool_backward", "DEFORM_ROI_POOL_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "grad_output", grad_output, grad_output_desc, -10, 10);
     GEN_CASE_DATA(true, "input", input, input_desc, -10, 10);

--- a/kernels/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
+++ b/kernels/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
@@ -169,11 +169,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpDiffIouRotatedSortVerticesForward(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("diff_iou_rotated_sort_vertices_forward");
+    GEN_CASE_START("diff_iou_rotated_sort_vertices_forward",
+                   "DIFF_IOU_ROTATED_SORT_VERTICES_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "vertices", vertices, vertices_desc);
-    GEN_CASE_DATA_REAL(true, "mask", mask, mask_desc);
-    GEN_CASE_DATA_REAL(true, "num_valid", num_valid, num_valid_desc);
+    GEN_CASE_DATA_REAL_V2(true, "mask", mask, mask_desc, 1, 0);
+    GEN_CASE_DATA_REAL_V2(true, "num_valid", num_valid, num_valid_desc, 8, 0);
     GEN_CASE_DATA(false, "idx", idx, idx_desc, 0, 0);
     GEN_CASE_TEST_PARAM_NEW(false, false, true, 0, 0, 0);
   }

--- a/kernels/div/div.cpp
+++ b/kernels/div/div.cpp
@@ -53,7 +53,7 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("div");
+    GEN_CASE_START("div", "DIV");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "x", x, x_desc, 10, 0);
     GEN_CASE_DATA(true, "y", y, y_desc, 10, 0);

--- a/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
+++ b/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
@@ -229,7 +229,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelBackward(
 
   // generator
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("dynamic_point_to_voxel_backward");
+    GEN_CASE_START("dynamic_point_to_voxel_backward",
+                   "DYNAMIC_POINT_TO_VOXEL_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "grad_voxel_feats", grad_voxel_feats,
                        grad_voxel_feats_desc);

--- a/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -244,7 +244,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelForward(
   }
   // generator
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("dynamic_point_to_voxel_forward");
+    GEN_CASE_START("dynamic_point_to_voxel_forward",
+                   "DYNAMIC_POINT_TO_VOXEL_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "feats", feats, feats_desc, -100, 100);
     GEN_CASE_DATA_REAL(true, "coors", coors, coors_desc);

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -274,7 +274,7 @@ mluOpStatus_t fftQuantMatMul(mluOpHandle_t handle, int m, int k, int n,
                                        c_dims);
   INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   if (fftIsIntDtype(a_compute_type) && fftIsIntDtype(b_compute_type) &&
-    c_desc->dtype == MLUOP_DTYPE_HALF) {
+      c_desc->dtype == MLUOP_DTYPE_HALF) {
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
     INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   } else {

--- a/kernels/fft/fft.cpp
+++ b/kernels/fft/fft.cpp
@@ -474,7 +474,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpExecFFT(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("fft");
+    GEN_CASE_START("fft", "FFT");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, fft_plan->input_desc, 1, 0);
     GEN_CASE_DATA(false, "output", output, fft_plan->output_desc, 0, 0);

--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
@@ -199,12 +199,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidForward(
   const int32_t C = static_cast<int32_t>(input_desc->dims[1]);
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("focal_loss_sigmoid_forward");
+    GEN_CASE_START("focal_loss_sigmoid_forward", "FOCAL_LOSS_SIGMOID_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "input", input, input_desc);
-    GEN_CASE_DATA_REAL(true, "target", target, target_desc);
     if (weight != NULL) {
       GEN_CASE_DATA_REAL(true, "weight", weight, weight_desc);
+      GEN_CASE_DATA_REAL_V2(true, "target", target, target_desc, C - 1, 0);
+    } else {
+      GEN_CASE_DATA_REAL_V2(true, "target", target, target_desc, C, 0);
     }
     GEN_CASE_DATA(false, "output", output, output_desc, 0, 0);
     GEN_CASE_OP_PARAM_SINGLE(0, "focal_loss_sigmoid_forward", "prefer", prefer);
@@ -487,7 +489,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidBackward(
   if (MLUOP_GEN_CASE_ON_NEW) {
     const int upper_bound = is_half ? 5 : 20;
     const int lower_bound = -1 * upper_bound;
-    GEN_CASE_START("focal_loss_sigmoid_backward");
+    GEN_CASE_START("focal_loss_sigmoid_backward",
+                   "FOCAL_LOSS_SIGMOID_BACKWARD");
     GEN_CASE_HANDLE(handle);
     FOCAL_LOSS_GEN_CASE_DATA_REAL(true, "input", input, input_desc, upper_bound,
                                   lower_bound);

--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
@@ -203,8 +203,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidForward(
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "input", input, input_desc);
     if (weight != NULL) {
-      GEN_CASE_DATA_REAL(true, "weight", weight, weight_desc);
       GEN_CASE_DATA_REAL_V2(true, "target", target, target_desc, C - 1, 0);
+      GEN_CASE_DATA_REAL(true, "weight", weight, weight_desc);
     } else {
       GEN_CASE_DATA_REAL_V2(true, "target", target, target_desc, C, 0);
     }

--- a/kernels/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/kernels/generate_proposals_v2/generate_proposals_v2.cpp
@@ -226,7 +226,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
 
   // generate prototxt
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("generate_proposals_v2");
+    GEN_CASE_START("generate_proposals_v2", "GENERATE_PROPOSALS_V2");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input1", scores, scores_desc, 10, 0);
     GEN_CASE_DATA(true, "input2", bbox_deltas, bbox_deltas_desc, 10, 0);

--- a/kernels/log/log.cpp
+++ b/kernels/log/log.cpp
@@ -49,7 +49,7 @@ mluOpLog(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("log");
+    GEN_CASE_START("log", "LOG");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "x", x, x_desc, 10, 0);
     GEN_CASE_DATA(false, "y", y, y_desc, 0, 0);

--- a/kernels/masked_im2col/masked_col2im_forward/masked_col2im_forward.cpp
+++ b/kernels/masked_im2col/masked_col2im_forward/masked_col2im_forward.cpp
@@ -247,9 +247,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpMaskedCol2imForward(
   PARAM_CHECK("[mluOpMaskedCol2imForward]", mask_w_idx != NULL);
   PARAM_CHECK("[mluOpMaskedCol2imForward]", im != NULL);
 
+  const int height = im_desc->dims[2];
+  const int width = im_desc->dims[3];
   // generate mluOpMaskedCol2imForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("masked_col2im_forward");
+    GEN_CASE_START("masked_col2im_forward", "MASKED_COL2IM_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "col", col, col_desc, -10, 10);
     GEN_CASE_DATA_REAL(true, "mask_h_idx", mask_h_idx, mask_h_idx_desc);
@@ -319,8 +321,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpMaskedCol2imForward(
   VLOG(5) << "[mluOpMaskedCol2imForward] cnnlTranspose_v2 col end.";
 
   const int channels = im_desc->dims[1];
-  const int height = im_desc->dims[2];
-  const int width = im_desc->dims[3];
   VLOG(5) << "Launch kernel MLUUnion1MaskedCol2imForward<<<" << k_dim.x << ", "
           << k_dim.y << ", " << k_dim.z << ">>>.";
   CHECK_RETURN("[mluOpMaskedCol2imForward]",

--- a/kernels/masked_im2col/masked_im2col_forward/masked_im2col_forward.cpp
+++ b/kernels/masked_im2col/masked_im2col_forward/masked_im2col_forward.cpp
@@ -251,13 +251,18 @@ mluOpStatus_t MLUOP_WIN_API mluOpMaskedIm2colForward(
   PARAM_CHECK("[mluOpMaskedIm2colForward]", mask_w_idx != NULL);
   PARAM_CHECK("[mluOpMaskedIm2colForward]", data_col != NULL);
 
+  const int height = feature_desc->dims[2];
+  const int width = feature_desc->dims[3];
+
   // generate mluOpMaskedIm2colForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("masked_im2col_forward");
+    GEN_CASE_START("masked_im2col_forward", "MASKED_IM2COL_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "feature", feature, feature_desc, -10, 10);
-    GEN_CASE_DATA_REAL(true, "mask_h_idx", mask_h_idx, mask_h_idx_desc);
-    GEN_CASE_DATA_REAL(true, "mask_w_idx", mask_w_idx, mask_w_idx_desc);
+    GEN_CASE_DATA_REAL_V2(true, "mask_h_idx", mask_h_idx, mask_h_idx_desc,
+                          (height - 1), 0);
+    GEN_CASE_DATA_REAL_V2(true, "mask_w_idx", mask_w_idx, mask_w_idx_desc,
+                          (width - 1), 0);
     GEN_CASE_DATA(false, "data_col", data_col, data_col_desc, 0, 0);
     GEN_CASE_OP_PARAM_SINGLE(0, "masked_im2col_forward", "kernel_h", kernel_h);
     GEN_CASE_OP_PARAM_SINGLE(1, "masked_im2col_forward", "kernel_w", kernel_w);
@@ -318,8 +323,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpMaskedIm2colForward(
       MLUOP_STATUS_SUCCESS == mluOpDestroyTensorDescriptor(feature_desc_tmp));
 
   const int channels = feature_desc->dims[1];
-  const int height = feature_desc->dims[2];
-  const int width = feature_desc->dims[3];
   VLOG(5) << "Launch kernel MLUUnion1MaskedIm2colForward<<<" << k_dim.x << ", "
           << k_dim.y << ", " << k_dim.z << ">>>.";
   CHECK_RETURN("[mluOpMaskedIm2colForward]",

--- a/kernels/moe_dispatch/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
@@ -166,11 +166,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpMoeDispatchBackwardData(
 
   // generate prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("moe_dispatch_backward_data");
+    GEN_CASE_START("moe_dispatch_backward_data", "MOE_DISPATCH_BACKWARD_DATA");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "gates", gates, gates_desc, 100, -100);
-    GEN_CASE_DATA_REAL(true, "indices", indices, indices_desc);
-    GEN_CASE_DATA_REAL(true, "locations", locations, locations_desc);
+    GEN_CASE_DATA_REAL_V2(true, "indices", indices, indices_desc, num_experts,
+                          0);
+    GEN_CASE_DATA_REAL_V2(true, "locations", locations, locations_desc,
+                          capacity, 0);
     GEN_CASE_DATA(true, "dispatch", dispatch, dispatch_desc, 100, -100);
     GEN_CASE_DATA(false, "grad_input", grad_input, grad_input_desc, 0, 0);
     GEN_CASE_OP_PARAM_SINGLE(0, "moe_dispatch_backward_data", "samples",

--- a/kernels/moe_dispatch/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -212,10 +212,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpMoeDispatchBackwardGate(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("moe_dispatch_backward_gate");
+    GEN_CASE_START("moe_dispatch_backward_gate", "MOE_DISPATCH_BACKWARD_GATE");
     GEN_CASE_HANDLE(handle);
-    GEN_CASE_DATA_REAL(true, "indices", indices, indices_desc);
-    GEN_CASE_DATA_REAL(true, "locations", locations, locations_desc);
+    GEN_CASE_DATA_REAL_V2(true, "indices", indices, indices_desc, num_experts,
+                          0);
+    GEN_CASE_DATA_REAL_V2(true, "locations", locations, locations_desc,
+                          capacity, 0);
     GEN_CASE_DATA(true, "input", input, input_desc, 0, 0);
     GEN_CASE_DATA(true, "dispatch", dispatch, dispatch_desc, 0, 0);
     GEN_CASE_DATA(false, "grad_gates", grad_gates, grad_gates_desc, 0, 0);

--- a/kernels/moe_dispatch/moe_dispatch_forward/moe_dispatch_forward.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_forward/moe_dispatch_forward.cpp
@@ -165,7 +165,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMoeDispatchForward(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("moe_dispatch_forward");
+    GEN_CASE_START("moe_dispatch_forward", "MOE_DISPATCH_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "gates", gates, gates_desc, 0, 1);
     GEN_CASE_DATA_REAL(true, "indices", indices, indices_desc);

--- a/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -271,7 +271,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnBackward(
       &calc_grad_value_loc_weight_flag);
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("ms_deform_attn_backward");
+    GEN_CASE_START("ms_deform_attn_backward", "MS_DEFORM_ATTN_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "value", value, value_desc);
     GEN_CASE_DATA_REAL(true, "spatial_shapes", spatial_shapes,

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.mlu
@@ -219,7 +219,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
   PARAM_CHECK("[mluOpMsDeformAttnForward]", data_col != NULL);
   // generate mluOpMsDeformAttnForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("ms_deform_attn_forward");
+    GEN_CASE_START("ms_deform_attn_forward", "MS_DEFORM_ATTN_FORWARD");
     // set handle dump mlu output
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "data_value", data_value, data_value_desc, 10, -10);

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_union1_default.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_union1_default.mlu
@@ -270,13 +270,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   span_num_deal, spatial_w_next_point, spatial_h_next_point,
                   num_heads, channels, x_next_point, y_next_point, head_idx);
             }
@@ -297,13 +301,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   span_num_deal, spatial_w, spatial_h, num_heads, channels,
                   x_next_point, y_next_point, head_idx);
             }
@@ -312,15 +320,20 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
           if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
             computeMsDeformAttn(
                 (T *)(ping_data_value_p1_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p2_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p3_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p4_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)auxiliary_a, (T *)auxiliary_b,
-                (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
+                (T *)(ping_data_col_nram +
+                      data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
                 weight, span_num_deal, spatial_w, spatial_h, x, y);
           }
           spatial_w = spatial_w_next_point;
@@ -402,13 +415,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   channels_rem, spatial_w_next_point, spatial_h_next_point,
                   num_heads, channels, x_next_point, y_next_point, head_idx);
             }
@@ -429,13 +446,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   channels_rem, spatial_w, spatial_h, num_heads, channels,
                   x_next_point, y_next_point, head_idx);
             }
@@ -444,15 +465,20 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
           if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
             computeMsDeformAttn(
                 (T *)(ping_data_value_p1_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p2_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p3_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p4_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)auxiliary_a, (T *)auxiliary_b,
-                (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
+                (T *)(ping_data_col_nram +
+                      data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
                 weight, channels_align_rem, spatial_w, spatial_h, x, y);
           }
           spatial_w = spatial_w_next_point;

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_union1_default.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_union1_default.mlu
@@ -270,17 +270,13 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   span_num_deal, spatial_w_next_point, spatial_h_next_point,
                   num_heads, channels, x_next_point, y_next_point, head_idx);
             }
@@ -301,17 +297,13 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   span_num_deal, spatial_w, spatial_h, num_heads, channels,
                   x_next_point, y_next_point, head_idx);
             }
@@ -320,20 +312,15 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
           if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
             computeMsDeformAttn(
                 (T *)(ping_data_value_p1_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p2_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p3_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p4_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)auxiliary_a, (T *)auxiliary_b,
-                (T *)(ping_data_col_nram +
-                      data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
+                (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
                 weight, span_num_deal, spatial_w, spatial_h, x, y);
           }
           spatial_w = spatial_w_next_point;
@@ -415,17 +402,13 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   channels_rem, spatial_w_next_point, spatial_h_next_point,
                   num_heads, channels, x_next_point, y_next_point, head_idx);
             }
@@ -446,17 +429,13 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) *
-                            ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
                   channels_rem, spatial_w, spatial_h, num_heads, channels,
                   x_next_point, y_next_point, head_idx);
             }
@@ -465,20 +444,15 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
           if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
             computeMsDeformAttn(
                 (T *)(ping_data_value_p1_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p2_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p3_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p4_nram +
-                      ((level_idx * num_points + point_idx) % 2) *
-                          ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
                 (T *)auxiliary_a, (T *)auxiliary_b,
-                (T *)(ping_data_col_nram +
-                      data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
+                (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
                 weight, channels_align_rem, spatial_w, spatial_h, x, y);
           }
           spatial_w = spatial_w_next_point;

--- a/kernels/mutual_information/mutual_information_backward/mutual_information_backward.cpp
+++ b/kernels/mutual_information/mutual_information_backward/mutual_information_backward.cpp
@@ -413,7 +413,7 @@ static void mutualInformationBackwardGencase(
     const mluOpTensorDescriptor_t ans_grad_desc, void *ans_grad,
     const bool overwrite_ans_grad, const mluOpTensorDescriptor_t px_grad_desc,
     void *px_grad, const mluOpTensorDescriptor_t py_grad_desc, void *py_grad) {
-  GEN_CASE_START("mutual_information_backward");
+  GEN_CASE_START("mutual_information_backward", "MUTUAL_INFORMATION_BACKWARD");
   GEN_CASE_HANDLE(handle);
 
   GEN_CASE_DATA(true, "px", px, px_desc, -1, 1);

--- a/kernels/mutual_information/mutual_information_forward/mutual_information_forward.cpp
+++ b/kernels/mutual_information/mutual_information_forward/mutual_information_forward.cpp
@@ -335,7 +335,7 @@ static void mutualInformationForwardGencase(
     const mluOpTensorDescriptor_t opt_boundary_desc, const void *opt_boundary,
     const mluOpTensorDescriptor_t p_desc, const void *p,
     const mluOpTensorDescriptor_t ans_desc, void *ans) {
-  GEN_CASE_START("mutual_information_forward");
+  GEN_CASE_START("mutual_information_forward", "MUTUAL_INFORMATION_FORWARD");
   GEN_CASE_HANDLE(handle);
 
   GEN_CASE_DATA(true, "px", px, px_desc, -1, 1);

--- a/kernels/nms_rotated/nms_rotated.cpp
+++ b/kernels/nms_rotated/nms_rotated.cpp
@@ -116,7 +116,7 @@ mluOpNmsRotated(mluOpHandle_t handle, const float iou_threshold,
 
   // generate prototxt
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("nms_rotated");
+    GEN_CASE_START("nms_rotated", "NMS_ROTATED");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "input1", boxes, boxes_desc);
     GEN_CASE_DATA_REAL(true, "input2", scores, scores_desc);

--- a/kernels/points_in_boxes/points_in_boxes.cpp
+++ b/kernels/points_in_boxes/points_in_boxes.cpp
@@ -208,7 +208,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpPointsInBoxes(
   }
   // generate points_in_boxes prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("points_in_boxes");
+    GEN_CASE_START("points_in_boxes", "POINTS_IN_BOXES");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "points", points, points_desc, 100.0, 0.0);
     GEN_CASE_DATA(true, "boxes", boxes, boxes_desc, 100.0, 0.0);

--- a/kernels/poly_nms/poly_nms.cpp
+++ b/kernels/poly_nms/poly_nms.cpp
@@ -117,7 +117,7 @@ mluOpPolyNms(mluOpHandle_t handle, const mluOpTensorDescriptor_t boxes_desc,
 
   // generate prototxt
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("poly_nms");
+    GEN_CASE_START("poly_nms", "POLY_NMS");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input1", boxes, boxes_desc, 10, 0);
     GEN_CASE_DATA(false, "output1", output, output_desc, 0, 0);

--- a/kernels/prior_box/prior_box.cpp
+++ b/kernels/prior_box/prior_box.cpp
@@ -192,7 +192,7 @@ mluOpStatus_t mluOpPriorBox(
                              : min_sizes_num * aspect_ratios_num;
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("prior_box");
+    GEN_CASE_START("prior_box", "PRIOR_BOX");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "input1", min_sizes, min_sizes_desc);
     GEN_CASE_DATA_REAL(true, "input2", aspect_ratios, aspect_ratios_desc);

--- a/kernels/psamask/psamask.cpp
+++ b/kernels/psamask/psamask.cpp
@@ -246,7 +246,7 @@ mluOpStatus_t mluOpPsamaskForward(mluOpHandle_t handle, const int psa_type,
 
   // generate mluOpPsamaskForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("psamask_forward");
+    GEN_CASE_START("psamask_forward", "PSAMASK_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "x", x, x_desc, 10, -10);
     GEN_CASE_DATA(false, "y", y, y_desc, 0, 0);
@@ -316,7 +316,7 @@ mluOpStatus_t mluOpPsamaskBackward(mluOpHandle_t handle, const int psa_type,
 
   // generate mluOpPsamaskBackward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("psamask_backward");
+    GEN_CASE_START("psamask_backward", "PSAMASK_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "dy", dy, dy_desc, 10, -10);
     GEN_CASE_DATA(false, "dx", dx, dx_desc, 0, 0);

--- a/kernels/psroipool/psroipool.cpp
+++ b/kernels/psroipool/psroipool.cpp
@@ -229,7 +229,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolForward(
   const int rois_offset = rois_desc->dims[1];
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("psroipool_forward");
+    GEN_CASE_START("psroipool_forward", "PSROIPOOL_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, 1, 0);
     GEN_CASE_DATA_REAL(true, "rois", rois, rois_desc);
@@ -303,7 +303,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolBackward(
   const int rois_offset = rois_desc->dims[1];
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("psroipool_backward");
+    GEN_CASE_START("psroipool_backward", "PSROIPOOL_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", top_grad, top_grad_desc, 1, 0);
     GEN_CASE_DATA_REAL(true, "mapping_channel", mapping_channel,

--- a/kernels/roi_align_rotated/roi_align_rotated.cpp
+++ b/kernels/roi_align_rotated/roi_align_rotated.cpp
@@ -116,7 +116,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignRotatedForward(
           << ".";
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("roi_align_rotated_forward");
+    GEN_CASE_START("roi_align_rotated_forward", "ROI_ALIGN_ROTATED_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input1", features, features_desc, 10, 0);
     GEN_CASE_DATA_REAL(true, "input2", rois, rois_desc);
@@ -225,7 +225,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignRotatedBackward(
           << ".";
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("roi_align_rotated_backward");
+    GEN_CASE_START("roi_align_rotated_backward", "ROI_ALIGN_ROTATED_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input1", top_grad, top_grad_desc, 10, 0);
     GEN_CASE_DATA_REAL(true, "input2", rois, rois_desc);

--- a/kernels/roi_crop/roi_crop.cpp
+++ b/kernels/roi_crop/roi_crop.cpp
@@ -189,7 +189,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropForward(
   uint32_t bin_num = grid_n * output_h * output_w;
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("roi_crop_forward");
+    GEN_CASE_START("roi_crop_forward", "ROI_CROP_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, -10, 10);
     GEN_CASE_DATA(true, "grid", grid, grid_desc, -1, 1);
@@ -236,7 +236,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiCropBackward(
   uint32_t bin_num = grid_n * output_h * output_w;
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("roi_crop_backward");
+    GEN_CASE_START("roi_crop_backward", "ROI_CROP_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "grad_output", grad_output, grad_output_desc, -10, 10);
     GEN_CASE_DATA(true, "grid", grid, grid_desc, -1, 1);

--- a/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -329,7 +329,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dForward(
 
   // generate mluOpRoiAwarePool3dForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("roiaware_pool3d_forward");
+    GEN_CASE_START("roiaware_pool3d_forward", "ROIAWARE_POOL3D_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "rois", rois, rois_desc);
     GEN_CASE_DATA_REAL(true, "pts", pts, pts_desc);
@@ -625,7 +625,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dBackward(
 
   // generate mluOpRoiAwarePool3dBackward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("roiaware_pool3d_backward");
+    GEN_CASE_START("roiaware_pool3d_backward", "ROIAWARE_POOL3D_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "pts_idx_of_voxels", pts_idx_of_voxels,
                        pts_idx_of_voxels_desc);
@@ -699,8 +699,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetRoiawarePool3dForwardWorkspaceSize(
       << "will be removed in the future release, "
       << "please use [mluOpGetRoiAwarePool3dForwardWorkspaceSize] instead.";
   return mluOpGetRoiAwarePool3dForwardWorkspaceSize(
-              handle, rois_desc, pts_desc, pts_feature_desc,
-              workspace_size);
+      handle, rois_desc, pts_desc, pts_feature_desc, workspace_size);
 }
 
 mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
@@ -720,11 +719,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dForward(
       << "the future release, "
       << "please use [mluOpRoiAwarePool3dForward] instead.";
   return mluOpRoiAwarePool3dForward(
-              handle, pool_method, boxes_num, pts_num, channels, rois_desc,
-              rois, pts_desc, pts, pts_feature_desc, pts_feature, workspace,
-              workspace_size, max_pts_each_voxel, out_x, out_y, out_z,
-              argmax_desc, argmax, pts_idx_of_voxels_desc,
-              pts_idx_of_voxels, pooled_features_desc, pooled_features);
+      handle, pool_method, boxes_num, pts_num, channels, rois_desc, rois,
+      pts_desc, pts, pts_feature_desc, pts_feature, workspace, workspace_size,
+      max_pts_each_voxel, out_x, out_y, out_z, argmax_desc, argmax,
+      pts_idx_of_voxels_desc, pts_idx_of_voxels, pooled_features_desc,
+      pooled_features);
 }
 
 mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
@@ -741,8 +740,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiawarePool3dBackward(
       << "the future release, "
       << "please use [mluOpRoiAwarePool3dBackward] instead.";
   return mluOpRoiAwarePool3dBackward(
-              handle, pool_method, boxes_num, out_x, out_y, out_z,
-              channels, max_pts_each_voxel, pts_idx_of_voxels_desc,
-              pts_idx_of_voxels, argmax_desc, argmax, grad_out_desc,
-              grad_out, grad_in_desc, grad_in);
+      handle, pool_method, boxes_num, out_x, out_y, out_z, channels,
+      max_pts_each_voxel, pts_idx_of_voxels_desc, pts_idx_of_voxels,
+      argmax_desc, argmax, grad_out_desc, grad_out, grad_in_desc, grad_in);
 }

--- a/kernels/roipoint_pool3d/roipoint_pool3d.cpp
+++ b/kernels/roipoint_pool3d/roipoint_pool3d.cpp
@@ -243,7 +243,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiPointPool3d(
 
   // generate mluOpRoiPointPool3d prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("roipoint_pool3d");
+    GEN_CASE_START("roipoint_pool3d", "ROIPOINT_POOL3D");
     // set handle dump mlu output
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "points", points, points_desc, 10, -10);

--- a/kernels/rotated_feature_align/rotated_feature_align.cpp
+++ b/kernels/rotated_feature_align/rotated_feature_align.cpp
@@ -206,7 +206,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRotatedFeatureAlignForward(
 
   // generate mluOpRotatedFeatureAlignForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("rotated_feature_align_forward");
+    GEN_CASE_START("rotated_feature_align_forward",
+                   "ROTATED_FEATURE_ALIGN_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, -10, 10);
     GEN_CASE_DATA_REAL(true, "rois", bboxes, bboxes_desc);
@@ -261,7 +262,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRotatedFeatureAlignBackward(
 
   // generate mluOpRotatedFeatureAlignBackward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("rotated_feature_align_backward");
+    GEN_CASE_START("rotated_feature_align_backward",
+                   "ROTATED_FEATURE_ALIGN_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", top_output, top_output_desc, -100, 100);
     GEN_CASE_DATA_REAL(true, "rois", bboxes, bboxes_desc);

--- a/kernels/sparse_conv/get_indice_pairs/get_indice_pairs.cpp
+++ b/kernels/sparse_conv/get_indice_pairs/get_indice_pairs.cpp
@@ -38,7 +38,7 @@ static void getIndicePairsGencase(
     const mluOpTensorDescriptor_t indice_pairs_desc, void *indice_pairs,
     const mluOpTensorDescriptor_t out_indices_desc, void *out_indices,
     const mluOpTensorDescriptor_t indice_num_desc, void *indice_num) {
-  GEN_CASE_START("get_indice_pairs");
+  GEN_CASE_START("get_indice_pairs", "GET_INDICE_PAIRS");
   GEN_CASE_HANDLE(handle);
   GEN_CASE_DATA_REAL(true, "indices", indices, indices_desc);
   GEN_CASE_DATA_REAL(false, "out_indices", out_indices, out_indices_desc);

--- a/kernels/sparse_conv/indice_convolution_backward_data/indice_convolution_backward_data.cpp
+++ b/kernels/sparse_conv/indice_convolution_backward_data/indice_convolution_backward_data.cpp
@@ -303,7 +303,8 @@ static void spconvbpdataGencase(
     const void *indice_pairs, const int64_t indice_num[], const int64_t inverse,
     const int64_t sub_m, void *workspace, size_t workspace_size,
     const mluOpTensorDescriptor_t input_grad_desc, void *input_grad) {
-  GEN_CASE_START("indice_convolution_backward_data");
+  GEN_CASE_START("indice_convolution_backward_data",
+                 "INDICE_CONVOLUTION_BACKWARD_DATA");
   GEN_CASE_HANDLE(handle);
   GEN_CASE_DATA_REAL(true, "output_grad", output_grad, output_grad_desc);
   GEN_CASE_DATA_REAL(true, "filters", filters, filters_desc);

--- a/kernels/sparse_conv/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/kernels/sparse_conv/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -79,7 +79,8 @@ static void indiceConvFilterGencase(
     const void *indice_pairs, const int64_t indice_num[], const int64_t inverse,
     const int64_t subm, void *workspace, size_t workspace_size,
     const mluOpTensorDescriptor_t filters_grad_desc, void *filters_grad) {
-  GEN_CASE_START("indice_convolution_backward_filter");
+  GEN_CASE_START("indice_convolution_backward_filter",
+                 "INDICE_CONVOLUTION_BACKWARD_FILTER");
   GEN_CASE_HANDLE(handle);
   GEN_CASE_DATA_REAL(true, "features", features, features_desc);
   GEN_CASE_DATA_REAL(true, "output_grad", output_grad, output_grad_desc);

--- a/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
@@ -604,7 +604,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpIndiceConvolutionForward(
 
   // gen_case
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("indice_convolution_forward");
+    GEN_CASE_START("indice_convolution_forward", "INDICE_CONVOLUTION_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "features", features, features_desc);
     GEN_CASE_DATA_REAL(true, "filters", filters, filters_desc);

--- a/kernels/sqrt/sqrt.cpp
+++ b/kernels/sqrt/sqrt.cpp
@@ -50,7 +50,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrt(mluOpHandle_t handle,
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("sqrt");
+    GEN_CASE_START("sqrt", "SQRT");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "x", x, x_desc, 100, 0.1);
     GEN_CASE_DATA(true, "y", y, y_desc, 0, 0);
@@ -99,7 +99,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("sqrt_backward");
+    GEN_CASE_START("sqrt_backward", "SQRT_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "y", y, y_desc, 10, 0.1);
     GEN_CASE_DATA(true, "diff_y", diff_y, dy_desc, -10, 10);

--- a/kernels/sync_batch_norm/sync_batchnorm_backward_reduce/sync_batchnorm_backward_reduce.cpp
+++ b/kernels/sync_batch_norm/sync_batchnorm_backward_reduce/sync_batchnorm_backward_reduce.cpp
@@ -53,8 +53,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetSyncBatchnormBackwardReduceWorkspaceSize(
       << "[mluOpGetSyncBatchnormBackwardReduceWorkspaceSize] is deprecated and"
       << " will be removed in the future release, please use "
       << "[mluOpGetSyncBatchNormBackwardReduceWorkspaceSize] instead.";
-  return mluOpGetSyncBatchNormBackwardReduceWorkspaceSize(
-              handle, desc_x, workspace_size);
+  return mluOpGetSyncBatchNormBackwardReduceWorkspaceSize(handle, desc_x,
+                                                          workspace_size);
 }
 
 mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormBackwardReduce(
@@ -128,11 +128,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchnormBackwardReduce(
       << " will be removed in the future release, please use "
       << "[mluOpSyncBatchNormBackwardReduce] instead.";
   return mluOpSyncBatchNormBackwardReduce(
-              handle, desc_dz, dz, desc_x, x, desc_mean, mean,
-              desc_invstd, invstd, desc_dfilter, dfilter,
-              desc_dbias, dbias, desc_sum_dy, sum_dy,
-              desc_sum_dy_xmu, sum_dy_xmu,
-              needs_input_grad0, needs_input_grad1, needs_input_grad2);
+      handle, desc_dz, dz, desc_x, x, desc_mean, mean, desc_invstd, invstd,
+      desc_dfilter, dfilter, desc_dbias, dbias, desc_sum_dy, sum_dy,
+      desc_sum_dy_xmu, sum_dy_xmu, needs_input_grad0, needs_input_grad1,
+      needs_input_grad2);
 }
 
 mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormBackwardReduce_v2(
@@ -212,9 +211,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchnormBackwardReduce_v2(
       << " will be removed in the future release, please use "
       << "[mluOpSyncBatchNormBackwardReduce_v2] instead.";
   return mluOpSyncBatchNormBackwardReduce_v2(
-              handle, desc_dz, dz, desc_x, x, desc_mean, mean,
-              desc_invstd, invstd, workspace, workspace_size,
-              desc_dfilter, dfilter, desc_dbias, dbias,
-              desc_sum_dy, sum_dy, desc_sum_dy_xmu, sum_dy_xmu,
-              needs_input_grad0, needs_input_grad1, needs_input_grad2);
+      handle, desc_dz, dz, desc_x, x, desc_mean, mean, desc_invstd, invstd,
+      workspace, workspace_size, desc_dfilter, dfilter, desc_dbias, dbias,
+      desc_sum_dy, sum_dy, desc_sum_dy_xmu, sum_dy_xmu, needs_input_grad0,
+      needs_input_grad1, needs_input_grad2);
 }

--- a/kernels/three_interpolate/three_interpolate.cpp
+++ b/kernels/three_interpolate/three_interpolate.cpp
@@ -464,7 +464,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeInterpolateForward(
   int64_t n = output_desc->dims[2];
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("three_interpolate_forward");
+    GEN_CASE_START("three_interpolate_forward", "THREE_INTERPOLATE_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "features", features, features_desc, 0, 100);
     GEN_CASE_DATA(true, "indices", indices, indices_desc, 0, m - 1);
@@ -521,7 +521,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeInterpolateBackward(
   int64_t m = grad_features_desc->dims[2];
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("three_interpolate_backward");
+    GEN_CASE_START("three_interpolate_backward", "THREE_INTERPOLATE_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "grad_output", grad_output, grad_output_desc, 0, 100);
     GEN_CASE_DATA(true, "indices", indices, indices_desc, 0, m - 1);

--- a/kernels/three_nn_forward/three_nn_forward.cpp
+++ b/kernels/three_nn_forward/three_nn_forward.cpp
@@ -201,7 +201,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeNNForward(
 
   // generate mluOpThreeNNForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("three_nn_forward");
+    GEN_CASE_START("three_nn_forward", "THREE_NN_FORWARD");
     // set handle dump mlu output
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "unknown", unknown, unknown_desc, 100, -100);

--- a/kernels/tin_shift/tin_shift.cpp
+++ b/kernels/tin_shift/tin_shift.cpp
@@ -201,7 +201,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpTinShiftForward(
 
   // generate mluOpTinShiftForward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("tin_shift_forward");
+    GEN_CASE_START("tin_shift_forward", "TIN_SHIFT_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, -10, 10);
     GEN_CASE_DATA_REAL(true, "shifts", shifts, shifts_desc);
@@ -265,7 +265,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpTinShiftBackward(
 
   // generate mluOpTinShiftBackward prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("tin_shift_backward");
+    GEN_CASE_START("tin_shift_backward", "TIN_SHIFT_BACKWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "grad_output", grad_output, grad_output_desc, -10, 10);
     GEN_CASE_DATA_REAL(true, "shifts", shifts, shifts_desc);

--- a/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
+++ b/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
@@ -133,7 +133,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpVoxelPoolingForward(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("voxel_pooling_forward");
+    GEN_CASE_START("voxel_pooling_forward", "VOXEL_POOLING_FORWARD");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA_REAL(true, "geom_xyz", geom_xyz, geom_xyz_desc);
     GEN_CASE_DATA_REAL(true, "input_features", input_features,

--- a/kernels/voxelization/voxelization.cpp
+++ b/kernels/voxelization/voxelization.cpp
@@ -244,7 +244,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpVoxelization(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("voxelization");
+    GEN_CASE_START("voxelization", "VOXELIZATION");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "points", points, points_desc, 10, -10);
     GEN_CASE_DATA(true, "voxel_size", voxel_size, voxel_size_desc, 10, -10);

--- a/kernels/yolo_box/yolo_box.cpp
+++ b/kernels/yolo_box/yolo_box.cpp
@@ -166,7 +166,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpYoloBox(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("yolo_box");
+    GEN_CASE_START("yolo_box", "YOLO_BOX");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "x", x, x_desc, 10, 0);
     GEN_CASE_DATA(true, "img_size", img_size, img_size_desc, 1000, 100);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

correct partial ops gen_case. 

## 2. Modification

```bash
modified:   core/gen_case.h
	modified:   kernels/abs/abs.cpp
	modified:   kernels/active_rotated_filter/active_rotated_filter.cpp
	modified:   kernels/ball_query/ball_query.cpp
	modified:   kernels/bbox_overlaps/bbox_overlaps.cpp
	modified:   kernels/border_align/border_align_backward/border_align_backward.cpp
	modified:   kernels/border_align/border_align_forward/border_align_forward.cpp
	modified:   kernels/box_iou_rotated/box_iou_rotated.cpp
	modified:   kernels/carafe/carafe.cpp
	modified:   kernels/deform_roi_pool/deform_roi_pool.cpp
	modified:   kernels/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
	modified:   kernels/div/div.cpp
	modified:   kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
	modified:   kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
	modified:   kernels/fft/common/fft_basic_ops.cpp
	modified:   kernels/fft/fft.cpp
	modified:   kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
	modified:   kernels/generate_proposals_v2/generate_proposals_v2.cpp
	modified:   kernels/log/log.cpp
	modified:   kernels/masked_im2col/masked_col2im_forward/masked_col2im_forward.cpp
	modified:   kernels/masked_im2col/masked_im2col_forward/masked_im2col_forward.cpp
	modified:   kernels/moe_dispatch/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
	modified:   kernels/moe_dispatch/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
	modified:   kernels/moe_dispatch/moe_dispatch_forward/moe_dispatch_forward.cpp
	modified:   kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward.cpp
	modified:   kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.mlu
	modified:   kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_union1_default.mlu
	modified:   kernels/mutual_information/mutual_information_backward/mutual_information_backward.cpp
	modified:   kernels/mutual_information/mutual_information_backward/mutual_information_backward_utils.h
	modified:   kernels/mutual_information/mutual_information_forward/mutual_information_forward.cpp
	modified:   kernels/mutual_information/mutual_information_forward/mutual_information_forward_utils.h
	modified:   kernels/nms_rotated/nms_rotated.cpp
	modified:   kernels/points_in_boxes/points_in_boxes.cpp
	modified:   kernels/poly_nms/poly_nms.cpp
	modified:   kernels/prior_box/prior_box.cpp
	modified:   kernels/psamask/psamask.cpp
	modified:   kernels/psroipool/psroipool.cpp
	modified:   kernels/roi_align_rotated/roi_align_rotated.cpp
	modified:   kernels/roi_crop/roi_crop.cpp
	modified:   kernels/roiaware_pool3d/roiaware_pool3d.cpp
	modified:   kernels/roipoint_pool3d/roipoint_pool3d.cpp
	modified:   kernels/rotated_feature_align/rotated_feature_align.cpp
	modified:   kernels/sparse_conv/get_indice_pairs/get_indice_pairs.cpp
	modified:   kernels/sparse_conv/indice_convolution_backward_data/indice_convolution_backward_data.cpp
	modified:   kernels/sparse_conv/indice_convolution_backward_data/indice_convolution_backward_data.h
	modified:   kernels/sparse_conv/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
	modified:   kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
	modified:   kernels/sqrt/sqrt.cpp
	modified:   kernels/sync_batch_norm/sync_batchnorm_backward_reduce/sync_batchnorm_backward_reduce.cpp
	modified:   kernels/three_interpolate/three_interpolate.cpp
	modified:   kernels/three_nn_forward/three_nn_forward.cpp
	modified:   kernels/tin_shift/tin_shift.cpp
	modified:   kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
	modified:   kernels/voxelization/voxelization.cpp
	modified:   kernels/yolo_box/yolo_box.cpp
```

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.