### PR TITLE
[Feature](indice_convolution_forward): add fool-check for tensor size

### DIFF
--- a/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
@@ -32,6 +32,7 @@
 #include "kernels/kernel.h"
 #include "kernels/utils/cnnl_helper.h"
 #include "mlu_op.h"
+#include "kernels/sparse_conv/get_indice_pairs/get_indice_pairs_structs.h"
 
 static mluOpStatus_t foolProof(
     const std::string api_name, mluOpHandle_t handle,
@@ -91,6 +92,12 @@ static mluOpStatus_t foolProof(
   PARAM_CHECK(api_name, features_desc->dim == 2);
   PARAM_CHECK(api_name, indice_pairs_desc->dim == 3);
   PARAM_CHECK(api_name, features_out_desc->dim == 2);
+  if (indice_pairs_desc->dims[2] > INDICE_IN_LARGE_TENSOR_NUM) {
+    LOG(ERROR) << api_name << " Check failed: "
+               << "indice_pairs_desc->dims[2] cannot be greater than "
+               << INDICE_IN_LARGE_TENSOR_NUM << ".";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
   if (filters_desc->dim != 5) {
     LOG(ERROR) << api_name
                << "The filters dimension number only support 5 currently,"


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation
添加large tensor 防呆，与indice_convolution_backward_filter、indice_convolution_backward_data算子支持的规模匹配。

## 2. Modification

kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test
测试流水通过:
http://jenkins.svc.cambricon.com/dist/job/MLUOPS/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/375/
http://jenkins.svc.cambricon.com/dist/job/MLUOPS/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/377/

#### 3.2.2 Parameter Check

[2024-3-14 15:1:18] [MLUOP] [Error]:[mluOpGetIndiceConvolutionForwardWorkspaceSize] Check failed: indice_pairs_desc->dims[2] cannot be greater than 1000000.
[2024-3-14 15:1:18] [MLUOP] [Error]:"MLUOP_STATUS_NOT_SUPPORTED in mluOpGetIndiceConvolutionForwardWorkspaceSize( handle_, features_desc_, filters_desc_, indice_pairs_desc_, features_out_desc_, indice_num_.data(), num_active_out_, inverse_, sub_m_, &workspace_size_)"

