### PR TITLE
[Fix](indice_convolution_forward): fix gen_case and gtest error

### DIFF
--- a/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
@@ -636,8 +636,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpIndiceConvolutionForward(
                              indice_pairs, indice_num, num_act_out, workspace,
                              nullptr, features_out_desc, features_out));
 
-  if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_END();
-  }
+  GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward/indice_convolution_forward.cpp
@@ -98,12 +98,21 @@ void IndiceConvolutionForwardExecutor::cpuCompute() {
   int64_t num_active_in = features_desc_->dims[0];
   int64_t ci = features_desc_->dims[1];
   int64_t co = features_out_desc_->dims[1];
-  int64_t kd = mluOpGetTensordimD(filters_desc_);
-  int64_t kh = mluOpGetTensordimH(filters_desc_);
-  int64_t kw = mluOpGetTensordimW(filters_desc_);
+  bool filters_need_transpose = filters_desc_->layout != MLUOP_LAYOUT_ARRAY;
+  int64_t kd = 0;
+  int64_t kh = 0;
+  int64_t kw = 0;
+  if (filters_need_transpose) {
+    kd = mluOpGetTensordimD(filters_desc_);
+    kh = mluOpGetTensordimH(filters_desc_);
+    kw = mluOpGetTensordimW(filters_desc_);
+  } else {
+    kd = filters_desc_->dims[0];
+    kh = filters_desc_->dims[1];
+    kw = filters_desc_->dims[2];
+  }
   int64_t num_filters = kd * kh * kw;
 
-  bool filters_need_transpose = true;
   int32_t stride[3];
   float *filters_transed = filters;
   if (filters_need_transpose) {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

gen_case逻辑中，多次调用MLUOP_GEN_CASE_ON_NEW时，只有第一次调用会使能。去掉GEN_CASE_END的条件判断。
gtest cpucompute逻辑支持LAYOUT_ARRAY的filter。

## 2. Modification

kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward/indice_convolution_forward.cpp

## 3. Test Report
测试流水通过：http://jenkins.svc.cambricon.com/dist/job/MLUOPS/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/379/
运行多个测例正常生成gen_case
### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

http://jenkins.svc.cambricon.com/dist/job/MLUOPS/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/379/