### PR TITLE
[Fix](mluOpActiveRotatedFilterForward): Fix gencase bug.

### DIFF
--- a/docs/design_docs/active_rotated_filter_forward/active_rotated_filter_forward.md
+++ b/docs/design_docs/active_rotated_filter_forward/active_rotated_filter_forward.md
@@ -174,7 +174,7 @@ For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
 | 限制类型     | 详细说明                                                     |
 | ------------ | ------------------------------------------------------------ |
 | 规模限制     | 输入input为5维，且dim3 == dim4, dim3 只能为1或者3。dim2 为2的幂数大于0且小于等于128<br>输入indices 为4维，dim0 与input.dim2相等; dim1== dim2, 且与input.dim3相等。<br>indices dim3 只能为2,4,8 |
-| 数据范围限制 | 无                                                           |
+| 数据范围限制 | 输入indices，有特殊规律，由旋转角度决定， 输入input无限制                                                           |
 | 原位限制     | 不支持原位                                                   |
 | stride限制   | 不支持stride机制                                             |
 | 广播限制     | 不支持广播                                                   |

--- a/docs/design_docs/active_rotated_filter_forward/active_rotated_filter_forward.md
+++ b/docs/design_docs/active_rotated_filter_forward/active_rotated_filter_forward.md
@@ -174,7 +174,7 @@ For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
 | 限制类型     | 详细说明                                                     |
 | ------------ | ------------------------------------------------------------ |
 | 规模限制     | 输入input为5维，且dim3 == dim4, dim3 只能为1或者3。dim2 为2的幂数大于0且小于等于128<br>输入indices 为4维，dim0 与input.dim2相等; dim1== dim2, 且与input.dim3相等。<br>indices dim3 只能为2,4,8 |
-| 数据范围限制 | 输入indices，有特殊规律，由旋转角度决定， 输入input无限制                                                           |
+| 数据范围限制 | 输入indices，有特殊规律，由旋转角度决定，参考1.2中旋转示例1和2，输入input无限制                                                           |
 | 原位限制     | 不支持原位                                                   |
 | stride限制   | 不支持stride机制                                             |
 | 广播限制     | 不支持广播                                                   |

--- a/kernels/active_rotated_filter/active_rotated_filter.cpp
+++ b/kernels/active_rotated_filter/active_rotated_filter.cpp
@@ -155,7 +155,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpActiveRotatedFilterForward(
     // set handle dump mlu output
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, input_desc, 100, -100);
-    GEN_CASE_DATA(true, "indices", indices, indices_desc, 100, -100);
+    GEN_CASE_DATA_REAL(true, "indices", indices, indices_desc);
     GEN_CASE_DATA(false, "output", output, output_desc, 0, 0);
     GEN_CASE_TEST_PARAM_NEW(false, false, true, 0.003, 0.003, 0);
   }

--- a/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
+++ b/test/mlu_op_gtest/pb_gtest/gtest_config/test_list
@@ -1,4 +1,5 @@
 [rely_real_data]
+active_rotated_filter_forward
 box_iou_rotated
 masked_col2im_forward
 deform_roi_pool_backward


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Fix gen case bug.

## 2. Modification

docs/design_docs/active_rotated_filter_forward/active_rotated_filter_forward.md
kernels/active_rotated_filter/active_rotated_filter.cpp
test/mlu_op_gtest/pb_gtest/gtest_config/test_list

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [x] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [x] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

### 3.3 Summary Analysis
gen case test passed

detail：

gen case test result：
[----------] 1 test from active_rotated_filter_forward/TestSuite
[ RUN      ] active_rotated_filter_forward/TestSuite.mluOp/0
[2024-3-20 16:57:10] [MLUOP] [Info]:[gen_case] Generate /projs/platform/liuduanhui/mluops-dev/mlu-ops/build/test/gen_case/active_rotated_filter_forward/active_rotated_filter_forward_20240320_16_57_10_016055_tid2921303_device5.prototxt
[MLU Hardware Time      ]: 52 (us)
[MLU Interface Time     ]: 5244.19 (us)
[MLU IO Efficiency      ]: 0.000811298
[MLU Compute Efficiency ]: -1
[MLU Workspace Size     ]: 1440 (Bytes)
[MLU Kernel Name(s)     ]: {}
[MLU TheoryOps          ]: -1 (Ops)
[MLU TheoryIOs          ]: 12960 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF3: 0.000000e+00
[^      OK ] /projs/platform/liuduanhui/mluops-dev/mlu-ops/build/test/./gen_case/active_rotated_filter_forward/active_rotated_filter_forward_20240320_16_34_30_742747_tid2792149_device6.prototxt
[       OK ] active_rotated_filter_forward/TestSuite.mluOp/0 (24 ms)
[----------] 1 test from active_rotated_filter_forward/TestSuite (24 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
