### PR TITLE
[Feature](mlu-ops): Support mluops static library compiling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,15 +165,14 @@ endif()
 
 set(LINK_FLAGS "-Wl,--version-script=${CMAKE_BINARY_DIR}/${MLUOP_SYMBOL_VIS_FILE}")
 message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
-add_library(mluopscore SHARED ${core_src_files})
-add_library(mluopscore_obj OBJECT ${core_src_files})
+add_library(mluopscore ${core_src_files})
 
 target_link_libraries(mluopscore cnnl cnrt cndrv)
 bang_add_library(mluops SHARED ${src_files} ${src_helper_files})
 
 if(${MLUOP_BUILD_STATIC} MATCHES "ON")
   message("-- Build MLUOP static")
-  bang_add_library(mluops_static STATIC ${src_files} ${src_helper_files} $<TARGET_OBJECTS:mluopscore_obj>)
+  bang_add_library(mluops_static STATIC ${src_files} ${src_helper_files} ${core_src_files})
 endif()
 
 target_link_libraries(mluops

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,11 +166,15 @@ endif()
 set(LINK_FLAGS "-Wl,--version-script=${CMAKE_BINARY_DIR}/${MLUOP_SYMBOL_VIS_FILE}")
 message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
 add_library(mluopscore SHARED ${core_src_files})
-add_library(mluops_core_obj OBJECT ${core_src_files})
+add_library(mluopscore_obj OBJECT ${core_src_files})
 
 target_link_libraries(mluopscore cnnl cnrt cndrv)
 bang_add_library(mluops SHARED ${src_files} ${src_helper_files})
-add_library(mluops_static STATIC ${src_files} ${src_helper_files} $<TARGET_OBJECTS:mluops_core_obj>)
+
+if(${MLUOP_BUILD_STATIC} MATCHES "ON")
+  message("-- Build MLUOP static")
+  bang_add_library(mluops_static STATIC ${src_files} ${src_helper_files} $<TARGET_OBJECTS:mluopscore_obj>)
+endif()
 
 target_link_libraries(mluops
   -Wl,--start-group
@@ -189,19 +193,21 @@ set_target_properties(mluops PROPERTIES
   SOVERSION   "${MAJOR_VERSION}"
 )
 
-set_target_properties(mluops_static PROPERTIES
-  OUTPUT_NAME "mluops"
-  PREFIX      "lib"
-  VERSION     "${BUILD_VERSION}"
-  SOVERSION   "${MAJOR_VERSION}"
-)
+if(${MLUOP_BUILD_STATIC} MATCHES "ON")
+  set_target_properties(mluops_static PROPERTIES
+    OUTPUT_NAME "mluops"
+    PREFIX      "lib"
+    VERSION     "${BUILD_VERSION}"
+    SOVERSION   "${MAJOR_VERSION}"
+  )
+endif()
 
 ################################################################################
 # Build MLUOP GTEST
 ################################################################################
-option(MLU_OP_BUILD_GTEST "Build mlu-ops gtest" ON)
-message("-- MLU_OP_BUILD_GTEST=${MLU_OP_BUILD_GTEST}")
-if(${MLU_OP_BUILD_GTEST} MATCHES "ON")
+option(MLUOP_BUILD_GTEST "Build mlu-ops gtest" ON)
+message("-- MLUOP_BUILD_GTEST=${MLUOP_BUILD_GTEST}")
+if(${MLUOP_BUILD_GTEST} MATCHES "ON")
   message("-- Build MLUOP Gtest")
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/test/mlu_op_gtest" "mlu_op_gtest")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ endif()
 
 set(LINK_FLAGS "-Wl,--version-script=${CMAKE_BINARY_DIR}/${MLUOP_SYMBOL_VIS_FILE}")
 message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
-add_library(mluopscore ${core_src_files})
+add_library(mluopscore STATIC ${core_src_files})
 
 target_link_libraries(mluopscore cnnl cnrt cndrv)
 bang_add_library(mluops SHARED ${src_files} ${src_helper_files})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,10 +165,13 @@ endif()
 
 set(LINK_FLAGS "-Wl,--version-script=${CMAKE_BINARY_DIR}/${MLUOP_SYMBOL_VIS_FILE}")
 message(STATUS "LINK_FLAGS:${LINK_FLAGS}")
-add_library(mluopscore STATIC ${core_src_files})
+add_library(mluopscore SHARED ${core_src_files})
+add_library(mluops_core_obj OBJECT ${core_src_files})
 
 target_link_libraries(mluopscore cnnl cnrt cndrv)
 bang_add_library(mluops SHARED ${src_files} ${src_helper_files})
+add_library(mluops_static STATIC ${src_files} ${src_helper_files} $<TARGET_OBJECTS:mluops_core_obj>)
+
 target_link_libraries(mluops
   -Wl,--start-group
   ${arch_binary_files}
@@ -180,6 +183,13 @@ target_link_libraries(mluops
 )
 target_link_libraries(mluops ${LINK_FLAGS})
 set_target_properties(mluops PROPERTIES
+  OUTPUT_NAME "mluops"
+  PREFIX      "lib"
+  VERSION     "${BUILD_VERSION}"
+  SOVERSION   "${MAJOR_VERSION}"
+)
+
+set_target_properties(mluops_static PROPERTIES
   OUTPUT_NAME "mluops"
   PREFIX      "lib"
   VERSION     "${BUILD_VERSION}"

--- a/independent_build.sh
+++ b/independent_build.sh
@@ -103,6 +103,7 @@ usage () {
     echo "    -c, --coverage              Build mlu-ops with coverage test."
     echo "    --asan                      Build with asan check enabled"
     echo "    -d, --debug                 Build mlu-ops with debug mode"
+    echo "    --disable-gtest              Build mlu-ops without gtest"
     echo "    --enable-bang-memcheck      Build with cncc '-mllvm -enable-mlisa-sanitizer -Xbang-cnas -O0 -g' arg to enable memcheck"
     echo "    --mlu370                    Build for target product MLU370: __BANG_ARCH__ = 372"
     echo "                                                                 __MLU_NRAM_SIZE__ = 768KB"
@@ -319,6 +320,11 @@ if [ $# != 0 ]; then
         export MLUOP_BUILD_PREPARE_ONLY="ON"
         prog_log_note "Prepare dependency only."
         ;;
+      --disable-gtest)
+        shift
+        export MLU_OP_BUILD_GTEST="OFF"
+        prog_log_note "Disable gtest."
+        ;;
       --)
         shift
         if [ $# -gt 0 ]; then
@@ -424,7 +430,8 @@ pushd ${BUILD_PATH} > /dev/null
                 -DMLUOP_TARGET_CPU_ARCH="${MLUOP_TARGET_CPU_ARCH}" \
                 -DMLUOP_BUILD_SPECIFIC_OP="${MLUOP_BUILD_SPECIFIC_OP}" \
                 -DMLUOP_SYMBOL_VIS_FILE="${MLUOP_SYMBOL_VIS_FILE}" \
-                -DMLUOP_PACKAGE_INFO_SET="${MLUOP_PACKAGE_INFO_SET}"
+                -DMLUOP_PACKAGE_INFO_SET="${MLUOP_PACKAGE_INFO_SET}" \
+                -DMLU_OP_BUILD_GTEST="${MLUOP_PACKAGE_INFO_SET}"
 
 popd > /dev/null
 ${CMAKE} --build ${BUILD_PATH} --  -j${BUILD_JOBS}

--- a/independent_build.sh
+++ b/independent_build.sh
@@ -19,6 +19,7 @@ export MLUOP_BUILD_COVERAGE_TEST=${MLUOP_BUILD_COVERAGE_TEST:-OFF} # ON/OFF cove
 export MLUOP_BUILD_ASAN_CHECK=${MLUOP_BUILD_ASAN_CHECK:-OFF} # ON/OFF Address Sanitizer (ASan)
 export MLUOP_BUILD_BANG_MEMCHECK=${MLUOP_BUILD_BANG_MEMCHECK:-OFF} # ON/OFF bang memcheck
 export MLUOP_BUILD_PREPARE=${MLUOP_BUILD_PREPARE:-ON}
+export MLU_OP_BUILD_GTEST=${MLU_OP_BUILD_GTEST:-ON}
 export BUILD_JOBS="${BUILD_JOBS:-16}" # concurrent build jobs
 
 # import common method like `download_pkg`, `get_json_val`, `common_extract`, etc
@@ -49,6 +50,7 @@ long_args=(
   mlu590
   no_prepare
   prepare
+  disable-gtest
 )
 
 add_mlu_arch_support () {
@@ -103,7 +105,7 @@ usage () {
     echo "    -c, --coverage              Build mlu-ops with coverage test."
     echo "    --asan                      Build with asan check enabled"
     echo "    -d, --debug                 Build mlu-ops with debug mode"
-    echo "    --disable-gtest              Build mlu-ops without gtest"
+    echo "    --disable-gtest             Build mlu-ops without gtest"
     echo "    --enable-bang-memcheck      Build with cncc '-mllvm -enable-mlisa-sanitizer -Xbang-cnas -O0 -g' arg to enable memcheck"
     echo "    --mlu370                    Build for target product MLU370: __BANG_ARCH__ = 372"
     echo "                                                                 __MLU_NRAM_SIZE__ = 768KB"
@@ -431,7 +433,7 @@ pushd ${BUILD_PATH} > /dev/null
                 -DMLUOP_BUILD_SPECIFIC_OP="${MLUOP_BUILD_SPECIFIC_OP}" \
                 -DMLUOP_SYMBOL_VIS_FILE="${MLUOP_SYMBOL_VIS_FILE}" \
                 -DMLUOP_PACKAGE_INFO_SET="${MLUOP_PACKAGE_INFO_SET}" \
-                -DMLU_OP_BUILD_GTEST="${MLUOP_PACKAGE_INFO_SET}"
+                -DMLU_OP_BUILD_GTEST="${MLU_OP_BUILD_GTEST}"
 
 popd > /dev/null
 ${CMAKE} --build ${BUILD_PATH} --  -j${BUILD_JOBS}

--- a/independent_build.sh
+++ b/independent_build.sh
@@ -19,7 +19,8 @@ export MLUOP_BUILD_COVERAGE_TEST=${MLUOP_BUILD_COVERAGE_TEST:-OFF} # ON/OFF cove
 export MLUOP_BUILD_ASAN_CHECK=${MLUOP_BUILD_ASAN_CHECK:-OFF} # ON/OFF Address Sanitizer (ASan)
 export MLUOP_BUILD_BANG_MEMCHECK=${MLUOP_BUILD_BANG_MEMCHECK:-OFF} # ON/OFF bang memcheck
 export MLUOP_BUILD_PREPARE=${MLUOP_BUILD_PREPARE:-ON}
-export MLU_OP_BUILD_GTEST=${MLU_OP_BUILD_GTEST:-ON}
+export MLUOP_BUILD_GTEST=${MLUOP_BUILD_GTEST:-ON}
+export MLUOP_BUILD_STATIC=${MLUOP_BUILD_GTEST:-OFF}
 export BUILD_JOBS="${BUILD_JOBS:-16}" # concurrent build jobs
 
 # import common method like `download_pkg`, `get_json_val`, `common_extract`, etc
@@ -51,6 +52,7 @@ long_args=(
   no_prepare
   prepare
   disable-gtest
+  enable-static
 )
 
 add_mlu_arch_support () {
@@ -107,6 +109,7 @@ usage () {
     echo "    -d, --debug                 Build mlu-ops with debug mode"
     echo "    --disable-gtest             Build mlu-ops without gtest"
     echo "    --enable-bang-memcheck      Build with cncc '-mllvm -enable-mlisa-sanitizer -Xbang-cnas -O0 -g' arg to enable memcheck"
+    echo "    --enable-static             Build mlu-ops static library"
     echo "    --mlu370                    Build for target product MLU370: __BANG_ARCH__ = 372"
     echo "                                                                 __MLU_NRAM_SIZE__ = 768KB"
     echo "                                                                 __MLU_WRAM_SIZE__ = 1024KB"
@@ -294,6 +297,10 @@ if [ $# != 0 ]; then
           shift
           export MLUOP_BUILD_BANG_MEMCHECK="ON"
           ;;
+      --enable-static)
+          shift
+          export MLUOP_BUILD_STATIC="ON"
+          ;;
       --filter)
         shift
         export MLUOP_BUILD_SPECIFIC_OP=$1
@@ -324,7 +331,7 @@ if [ $# != 0 ]; then
         ;;
       --disable-gtest)
         shift
-        export MLU_OP_BUILD_GTEST="OFF"
+        export MLUOP_BUILD_GTEST="OFF"
         prog_log_note "Disable gtest."
         ;;
       --)
@@ -433,7 +440,8 @@ pushd ${BUILD_PATH} > /dev/null
                 -DMLUOP_BUILD_SPECIFIC_OP="${MLUOP_BUILD_SPECIFIC_OP}" \
                 -DMLUOP_SYMBOL_VIS_FILE="${MLUOP_SYMBOL_VIS_FILE}" \
                 -DMLUOP_PACKAGE_INFO_SET="${MLUOP_PACKAGE_INFO_SET}" \
-                -DMLU_OP_BUILD_GTEST="${MLU_OP_BUILD_GTEST}"
+                -DMLUOP_BUILD_GTEST="${MLUOP_BUILD_GTEST}" \
+                -DMLUOP_BUILD_STATIC="${MLUOP_BUILD_STATIC}"
 
 popd > /dev/null
 ${CMAKE} --build ${BUILD_PATH} --  -j${BUILD_JOBS}

--- a/independent_build.sh
+++ b/independent_build.sh
@@ -20,7 +20,7 @@ export MLUOP_BUILD_ASAN_CHECK=${MLUOP_BUILD_ASAN_CHECK:-OFF} # ON/OFF Address Sa
 export MLUOP_BUILD_BANG_MEMCHECK=${MLUOP_BUILD_BANG_MEMCHECK:-OFF} # ON/OFF bang memcheck
 export MLUOP_BUILD_PREPARE=${MLUOP_BUILD_PREPARE:-ON}
 export MLUOP_BUILD_GTEST=${MLUOP_BUILD_GTEST:-ON}
-export MLUOP_BUILD_STATIC=${MLUOP_BUILD_GTEST:-OFF}
+export MLUOP_BUILD_STATIC=${MLUOP_BUILD_STATIC:-OFF}
 export BUILD_JOBS="${BUILD_JOBS:-16}" # concurrent build jobs
 
 # import common method like `download_pkg`, `get_json_val`, `common_extract`, etc

--- a/samples/mlu-ops/abs_sample/CMakeLists.txt
+++ b/samples/mlu-ops/abs_sample/CMakeLists.txt
@@ -55,7 +55,14 @@ set(BANG_CNCC_FLAGS "${BANG_CNCC_FLAGS}" "--bang-mlu-arch=mtp_220"
 
 # build project
 file(GLOB_RECURSE src_files ${src_files} "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
+if(${MLUOPS_STATIC} MATCHES "ON")
+  #for test static lib
+  message("-- Build sample with static mluops lib")
+  link_libraries("${NEUWARE_HOME}/lib64/libmluops.a")
+  add_executable(${PROJECT_NAME} ${src_files})
+  target_link_libraries(${PROJECT_NAME} cnrt cndrv)
+else()
+  add_executable(${PROJECT_NAME} ${src_files})
+  target_link_libraries(${PROJECT_NAME} mluops cnrt cndrv)
+endif()
 
-add_executable(${PROJECT_NAME} ${src_files})
-
-target_link_libraries(${PROJECT_NAME} mluops cnrt cndrv)

--- a/samples/mlu-ops/abs_sample/build.sh
+++ b/samples/mlu-ops/abs_sample/build.sh
@@ -17,11 +17,15 @@ fi
 
 SCRIPT_DIR=`dirname $0`
 BUILD_PATH=${SCRIPT_DIR}/build
-if [ ! -d "$BUILD_PATH" ]; then
+if [[ ! -d "$BUILD_PATH" ]]; then
   mkdir "$BUILD_PATH"
 fi
 
+if [[ -z ${MLUOPS_STATIC} ]]; then
+  MLUOPS_STATIC=OFF
+fi
+
 cd ./build/
-cmake .. -DNEUWARE_HOME="${NEUWARE_HOME}"
+cmake .. -DNEUWARE_HOME="${NEUWARE_HOME}" -DMLUOPS_STATIC="${MLUOPS_STATIC}"
 cmake --build .
 

--- a/samples/mlu-ops/env.sh
+++ b/samples/mlu-ops/env.sh
@@ -11,10 +11,10 @@ MLU_OP_H=${NEUWARE_HOME}/include/mlu_op.h
 
 if [[ ! -f ${MLU_OP_H} || -h ${MLU_OP_H} ]]; then
   ln -sf ${SCRIPT_PATH}/mlu_op.h ${MLU_OP_H}
-  for MLU_OPS_SO in $(ls ${SCRIPT_PATH}/build/lib/)
+  for MLU_OPS_LIB in $(ls ${SCRIPT_PATH}/build/lib/)
   do 
-    if [[ ${MLU_OPS_SO} == libmluops.so* ]]; then
-      ln -sf ${SCRIPT_PATH}/build/lib/${MLU_OPS_SO} ${NEUWARE_HOME}/lib64/${MLU_OPS_SO}
+    if [[ ${MLU_OPS_LIB} == libmluops.* ]]; then
+      ln -sf ${SCRIPT_PATH}/build/lib/${MLU_OPS_LIB} ${NEUWARE_HOME}/lib64/${MLU_OPS_LIB}
     fi
   done
 fi


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Generate mluops static lib

## 2. Modification

CMakeLists.txt
independent_build.sh
samples/mlu-ops/abs_sample/CMakeLists.txt
samples/mlu-ops/abs_sample/build.sh
samples/mlu-ops/env.sh

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
mlu-ops/samples/mlu-ops/abs_sample$ export MLUOPS_STATIC=ON
mlu-ops/samples/mlu-ops/abs_sample$ ./build.sh 
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
mlu-ops/dep_libs_extract/neuware
-- Build sample with static mluops lib
-- Configuring done
-- Generating done
-- Build files have been written to: mlu-ops/samples/mlu-ops/abs_sample/build
Scanning dependencies of target abs_sample
[ 50%] Building CXX object CMakeFiles/abs_sample.dir/abs_sample.cc.o
[100%] Linking CXX executable bin/abs_sample
[100%] Built target abs_sample
mlu-ops/samples/mlu-ops/abs_sample$ ./run.sh 
---------------------------------
input dims is : 1 
input shape is : [ 1000]
[interface time        ]: 16.314000 us 
[MLU hardware time     ]: 3.000000 us 
[CPU compute time      ]: 8.212000 us 
[diff3                 ]: 0.000000 
---------------------------------
input dims is : 2 
input shape is : [ 99, 48]
[interface time        ]: 23.252000 us 
[MLU hardware time     ]: 5.000000 us 
[CPU compute time      ]: 158.605000 us 
[diff3                 ]: 0.000000 
---------------------------------
input dims is : 4 
input shape is : [ 59, 25, 10, 10]
[interface time        ]: 15.394000 us 
[MLU hardware time     ]: 9.000000 us 
[CPU compute time      ]: 2561.955000 us 
[diff3                 ]: 0.000000 
---------------------------------
input dims is : 4 
input shape is : [ 94, 3, 10, 23]
[interface time        ]: 17.833000 us 
[MLU hardware time     ]: 5.000000 us 
[CPU compute time      ]: 1671.709000 us 
[diff3                 ]: 0.000000 
---------------------------------
input dims is : 6 
input shape is : [ 24, 10, 25, 8, 2, 27]
[interface time        ]: 18.091000 us 
[MLU hardware time     ]: 95.000000 us 
[CPU compute time      ]: 64770.780000 us 
[diff3                 ]: 0.000000
```



### 3.4 Summary Analysis

All cpu case passed and abs_sample with static lib passed and abs sample with dynamic lib passed.