### PR TITLE
[Fix](mluOpAdamW): fix invoke kernel error

### DIFF
--- a/kernels/adam_w/adam_w.cpp
+++ b/kernels/adam_w/adam_w.cpp
@@ -246,12 +246,12 @@ mluOpAdamW(mluOpHandle_t handle, const mluOpAdamWDescriptor_t adamw_desc,
       return MLUOP_STATUS_ARCH_MISMATCH;
     }
     case CNRT_FUNC_TYPE_UNION1: {
-      VLOG(5) << "Launch Kernel MLUUnionKernelApplyAdamW<<<Union"
+      VLOG(5) << "Launch Kernel KernelApplyAdamW<<<Union"
               << k_type / CORE_DIM << ", " << k_dim.x << ", " << k_dim.y << ", "
               << k_dim.z << ">>>";
       CHECK_RETURN(
           "[mluOpAdamW]",
-          MLUUnionKernelApplyAdamW(
+          KernelApplyAdamW(
               k_dim, k_type, handle->queue, (void *)param, (void *)param_h,
               (void *)grad, (void *)momentum, (void *)velocity, lr, beta1,
               beta2, bias1, bias2, epsilon, adamw_desc->weight_decay,

--- a/kernels/adam_w/adam_w.h
+++ b/kernels/adam_w/adam_w.h
@@ -33,7 +33,7 @@ struct mluOpAdamWStruct {
   bool use_nesterov = false;
 };
 
-mluOpStatus_t MLUOP_WIN_API MLUUnionKernelApplyAdamW(
+mluOpStatus_t MLUOP_WIN_API KernelApplyAdamW(
     const cnrtDim3_t k_dim, const cnrtFunctionType_t k_type,
     const cnrtQueue_t queue, void *param, void *param_h, void *grad,
     void *momentum, void *velocity, float lr, float beta1, float beta2,

--- a/kernels/adam_w/adam_w_union1.mlu
+++ b/kernels/adam_w/adam_w_union1.mlu
@@ -24,6 +24,7 @@
 #include <mlu.h>
 #include <cmath>
 #include <algorithm>
+#include "core/logging.h"
 #include "kernels/adam_w/adam_w.h"
 #include "kernels/utils/common.h"
 
@@ -133,12 +134,15 @@ __mlu_func__ void storeData(T *ddr_paramh, float *ddr_param,
 }
 
 template <typename T>
-__mlu_func__ void unionApplyAdamW(T *param_h, T *grad, float *param,
-                                  float *momentum, float *velocity, float lr,
-                                  float beta1, float beta2, float bias1,
-                                  float bias2, float epsilon,
-                                  float weight_decay, float scale,
-                                  bool use_nesterov, size_t size) {
+__mlu_global__ void unionApplyAdamW(T *param_h, T *grad, float *param,
+                                    float *momentum, float *velocity, float lr,
+                                    float beta1, float beta2, float bias1,
+                                    float bias2, float epsilon,
+                                    float weight_decay, float scale,
+                                    bool use_nesterov, size_t size) {
+  if (__is_mpu()) {
+    return;
+  }
   // assign task to per core
   int num_align = NFU_ALIGN_SIZE / sizeof(float);
   size_t num_var = size / sizeof(float);
@@ -216,26 +220,24 @@ __mlu_func__ void unionApplyAdamW(T *param_h, T *grad, float *param,
   }
 }
 
-__mlu_global__ void MLUUnionKernelApplyAdamW(
+mluOpStatus_t MLUOP_WIN_API KernelApplyAdamW(
     const cnrtDim3_t k_dim, const cnrtFunctionType_t k_type,
     const cnrtQueue_t queue, void *param, void *param_h, void *grad,
     void *momentum, void *velocity, float lr, float beta1, float beta2,
     float bias1, float bias2, float epsilon, float weight_decay, float scale,
     bool use_nesterov, size_t size, mluOpDataType_t k_data_type) {
-  if (coreId == 0x80) return;
   PERF_TIME_BEGIN();
-
   switch (k_data_type) {
     default: {
       MLULOG("Not Implemented.");
     }
     case MLUOP_DTYPE_BFLOAT16: {
-      unionApplyAdamW((bfloat16_t *)param_h, (bfloat16_t *)grad, (float *)param,
-                      (float *)momentum, (float *)velocity, lr, beta1, beta2,
-                      bias1, bias2, epsilon, weight_decay, scale, use_nesterov,
-                      size);
+      KERNEL_CHECK(unionApplyAdamW<bfloat16_t><<<k_dim, k_type, queue>>>(
+          (bfloat16_t *)param_h, (bfloat16_t *)grad, (float *)param,
+          (float *)momentum, (float *)velocity, lr, beta1, beta2, bias1, bias2,
+          epsilon, weight_decay, scale, use_nesterov, size));
     }; break;
   }
-
   PERF_TIME_END();
+  return MLUOP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.