### PR TITLE
[Fix](mlu-ops): Fix an error of perf analyses of the whole bench

### DIFF
--- a/tools/perf_analyse/parser.py
+++ b/tools/perf_analyse/parser.py
@@ -61,7 +61,7 @@ class Parser:
 
     def preprocess(self, df):
         # protoName and mlu_platform are used to merge database
-        df['protoName'] = df['file_path'].apply(lambda x: x.split("/")[-1])
+        df['protoName'] = df['file_path']
         df['mlu_platform'] = [
             i.split('[')[0] for i in df['mlu_platform'].to_list()
         ]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

When we run the perf tool to compare multiple operators, the comparison can fail. The reason is that 2 dataframes need to be merged according to their common keys called "protoName". ProtoNames are the names of calculators' testcases, which means there are a lot of repetitive ones like case0 or case_0. But as a key, protoName should be unique in each dataframe. Repetitive names means that merging 2 dataframes can result in incorrect results.

## 2. Modification

I have changed the name of the protoname in function preprocess in file parser.py to the full path of the test case of each calculator so that there are no repeated protoNames.

## 3. Test Report

This is the png generated by the python file for all the calculators, which means the now the bug is solved.
![next](https://github.com/Cambricon/mlu-ops/assets/128373169/eb534900-4066-445e-8e1d-8700edabf28d)
