### PR TITLE
[Feature](mluOpGenerateProposalsV2): check nan/inf state and reconstruct && perf box decode

### DIFF
--- a/kernels/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/kernels/generate_proposals_v2/generate_proposals_v2.cpp
@@ -32,7 +32,9 @@
 #include "core/tensor.h"
 #include "core/type.h"
 #include "kernels/kernel.h"
+#include "kernels/utils/cnnl_helper.h"
 
+#define GDRAM_ALIGN_SIZE 128
 static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type, const size_t HWA) {
   int job = mluop::runtime::getJobLimitCapability(handle);
@@ -44,10 +46,8 @@ static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
     per_core_num *= 2;
     job /= 2;
   }
-
   k_dim->y = 1;
   k_dim->z = 1;
-
   if (job < 4) {
     k_dim->x = 1;
     *k_type = CNRT_FUNC_TYPE_BLOCK;
@@ -74,13 +74,72 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetGenerateProposalsV2WorkspaceSize(
   PARAM_CHECK_NE(API, scores_desc->dims[2], 0);
   PARAM_CHECK_NE(API, scores_desc->dims[3], 0);
 
-  size_t scores_num = mluOpGetTensorElementNum(scores_desc);
+  const size_t scores_num = mluOpGetTensorElementNum(scores_desc);
   TENSOR_NUM_CHECK(API, scores_num, LARGE_TENSOR_NUM, "");
 
-  size_t H = scores_desc->dims[1];
-  size_t W = scores_desc->dims[2];
-  size_t A = scores_desc->dims[3];
-  *size = 12 * A * H * W * 4 + handle->core_num_per_cluster * 4 * 3;
+  const int64_t n = scores_desc->dims[0];
+  const int64_t h = scores_desc->dims[1];
+  const int64_t w = scores_desc->dims[2];
+  const int64_t a = scores_desc->dims[3];
+  const int64_t hwa = h * w * a;
+  if (handle->arch >= 592) {
+    DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
+    cnnlTensorDescriptor_t origin_indices_desc;
+    cnnlTensorDescriptor_t sorted_score_desc;
+    cnnlTensorDescriptor_t sorted_index_desc;
+    CALL_CNNL(cnnlCreateTensorDescriptor(&origin_indices_desc));
+    CALL_CNNL(cnnlCreateTensorDescriptor(&sorted_score_desc));
+    CALL_CNNL(cnnlCreateTensorDescriptor(&sorted_index_desc));
+
+    int64_t origin_indices_shape[2] = {n, hwa};
+    int64_t sorted_indices_shape[2] = {n, hwa};
+    int64_t sorted_index_shape[2] = {n, hwa};
+
+    cnnlTensorLayout_t layout = CNNL_LAYOUT_ARRAY;
+    CALL_CNNL(cnnlSetTensorDescriptor_v2(origin_indices_desc, layout,
+                                         CNNL_DTYPE_FLOAT, 2,
+                                         origin_indices_shape));
+    CALL_CNNL(cnnlSetTensorDescriptor_v2(sorted_score_desc, layout,
+                                         CNNL_DTYPE_FLOAT, 2 /*dims:{n,hwa}*/,
+                                         sorted_indices_shape));
+    CALL_CNNL(cnnlSetTensorDescriptor_v2(sorted_index_desc, layout,
+                                         CNNL_DTYPE_INT32, 2 /*dims:{n,hwa}*/,
+                                         sorted_index_shape));
+
+    const bool largest = true;  // param for topk, sort from large to small
+    const bool sorted = true;   // param for topk, return sorted indices.
+    const bool lower_index_first = true;  // param for topk, sort preservation
+
+    size_t topk_workspace_size = 0;
+    CALL_CNNL(cnnlGetTopKTensorWorkspaceSize(
+        cnnl_handle, origin_indices_desc, hwa, 1, largest, sorted_score_desc,
+        sorted_index_desc, &topk_workspace_size));
+
+    CALL_CNNL(cnnlDestroyTensorDescriptor(origin_indices_desc));
+    CALL_CNNL(cnnlDestroyTensorDescriptor(sorted_score_desc));
+    CALL_CNNL(cnnlDestroyTensorDescriptor(sorted_index_desc));
+    DESTROY_CNNL_HANDLE(cnnl_handle);
+    size_t data_size = 0;
+    mluOpGetSizeOfDataType(scores_desc->dtype, &data_size);
+
+    const size_t topk_workspace_size_align =
+        PAD_UP(topk_workspace_size, GDRAM_ALIGN_SIZE);
+    const size_t nhwa_size_align =
+        PAD_UP(n * hwa * data_size, GDRAM_ALIGN_SIZE);
+    // topk_workspace_size_align: workspace be used in cnnlTopKTensor_v3.
+    // 2 * nhwa_size_align: workspace be used to store scores and indexes after
+    // topk.
+    // 10 * hwa: workspace be used to store proposals score and box.
+    // handle->core_num_per_cluster * data_size: workspace be used to store per
+    // core proposals_num.
+    *size = topk_workspace_size_align + 2 * nhwa_size_align +
+            10 * hwa * data_size +
+            handle->core_num_per_cluster * handle->cluster_num * data_size;
+  } else {
+    // 4 * hwa: workspace be used store proposals_box/scores
+    // 8 * hwa: workspace be used store decode boxes/scores
+    *size = 12 * hwa * 4 + handle->core_num_per_cluster * 4 * 3;
+  }
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -135,10 +194,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
 
   // check inputs shape
   PARAM_CHECK_EQ(API, scores_desc->dim, 4);
-  int N = scores_desc->dims[0];
-  int H = scores_desc->dims[1];
-  int W = scores_desc->dims[2];
-  int A = scores_desc->dims[3];
+  const int64_t n = scores_desc->dims[0];
+  const int64_t h = scores_desc->dims[1];
+  const int64_t w = scores_desc->dims[2];
+  const int64_t a = scores_desc->dims[3];
 
   // [N,H,W,A4]
   PARAM_CHECK_EQ(API, bbox_deltas_desc->dim, 4);
@@ -169,12 +228,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
   // check output shape
   PARAM_CHECK_EQ(API, rpn_rois_desc->dim, 2);
   PARAM_CHECK_EQ(API, rpn_rois_desc->dims[0],
-                      scores_desc->dims[0] * post_nms_top_n);
+                 scores_desc->dims[0] * post_nms_top_n);
   PARAM_CHECK_EQ(API, rpn_rois_desc->dims[1], 4);
 
   PARAM_CHECK_EQ(API, rpn_roi_probs_desc->dim, 2);
   PARAM_CHECK_EQ(API, rpn_roi_probs_desc->dims[0],
-                      scores_desc->dims[0] * post_nms_top_n);
+                 scores_desc->dims[0] * post_nms_top_n);
   PARAM_CHECK_EQ(API, rpn_roi_probs_desc->dims[1], 1);
 
   PARAM_CHECK_EQ(API, rpn_rois_num_desc->dim, 1);
@@ -184,7 +243,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
   PARAM_CHECK_NE(API, scores_desc->dims[2], 0);
   PARAM_CHECK_NE(API, scores_desc->dims[3], 0);
 
-  if (N == 0) {
+  if (n == 0) {
     VLOG(5) << API << " skip zero element tensor.";
     return MLUOP_STATUS_SUCCESS;
   }
@@ -217,10 +276,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
     return MLUOP_STATUS_BAD_PARAM;
   }
 
-  size_t scores_num = mluOpGetTensorElementNum(scores_desc);
-  size_t bbox_deltas_num = mluOpGetTensorElementNum(bbox_deltas_desc);
-  size_t anchors_num = mluOpGetTensorElementNum(anchors_desc);
-  size_t variances_num = mluOpGetTensorElementNum(variances_desc);
+  const size_t scores_num = mluOpGetTensorElementNum(scores_desc);
+  const size_t bbox_deltas_num = mluOpGetTensorElementNum(bbox_deltas_desc);
+  const size_t anchors_num = mluOpGetTensorElementNum(anchors_desc);
+  const size_t variances_num = mluOpGetTensorElementNum(variances_desc);
   TENSOR_NUM_CHECK(API, scores_num, LARGE_TENSOR_NUM, "");
   TENSOR_NUM_CHECK(API, bbox_deltas_num, LARGE_TENSOR_NUM, "");
   TENSOR_NUM_CHECK(API, anchors_num, LARGE_TENSOR_NUM, "");
@@ -255,21 +314,89 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 3e-3, 3e-3, 0);
   }
 
-  size_t HWA = H * W * A;
+  VLOG(5) << "H : " << h;
+  VLOG(5) << "W : " << w;
+  VLOG(5) << "A : " << a;
+  VLOG(5) << "N : " << n;
+  const size_t hwa = h * w * a;
   cnrtDim3_t k_dim;
   cnrtJobType_t k_type;
-  policyFunc(handle, &k_dim, &k_type, HWA);
-
+  policyFunc(handle, &k_dim, &k_type, hwa);
   VLOG(5) << "Launch Kernel KernelGenerateProposalsV2 <<<k_dim: " << k_type
           << ", " << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";
-  CHECK_RETURN(
-      "[mluOpGenerateProposalsV2]",
-      KernelGenerateProposalsV2(
-          k_dim, k_type, handle->queue, (float *)scores, (float *)bbox_deltas,
-          (float *)im_shape, (float *)anchors, (float *)variances,
-          (float *)workspace, (float *)rpn_rois, (float *)rpn_roi_probs,
-          (int *)rpn_rois_num, (int *)rpn_rois_batch_size, pre_nms_top_n,
-          post_nms_top_n, nms_thresh, min_size, eta, pixel_offset, N, A, H, W));
+
+  if (handle->arch >= 592) {
+    // 1. call cnnlTopk to sort indices: +nan > +inf > number  > -inf > -nan
+    DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
+    cnnlTensorDescriptor_t origin_indices_desc;
+    cnnlTensorDescriptor_t sorted_score_desc;
+    cnnlTensorDescriptor_t sorted_index_desc;
+    CALL_CNNL(cnnlCreateTensorDescriptor(&origin_indices_desc));
+    CALL_CNNL(cnnlCreateTensorDescriptor(&sorted_score_desc));
+    CALL_CNNL(cnnlCreateTensorDescriptor(&sorted_index_desc));
+
+    const int64_t origin_indices_shape[2] = {n, (int64_t)hwa};
+    const int64_t max_k =
+        (pre_nms_top_n <= 0 || pre_nms_top_n > hwa) ? hwa : pre_nms_top_n;
+    const int64_t sorted_indices_shape[2] = {n, max_k};
+    const int64_t sorted_index_shape[2] = {n, max_k};
+
+    cnnlTensorLayout_t layout = CNNL_LAYOUT_ARRAY;
+    CALL_CNNL(cnnlSetTensorDescriptor_v2(origin_indices_desc, layout,
+                                         CNNL_DTYPE_FLOAT, 2,
+                                         origin_indices_shape));
+    CALL_CNNL(cnnlSetTensorDescriptor_v2(
+        sorted_score_desc, layout, CNNL_DTYPE_FLOAT, 2, sorted_indices_shape));
+    CALL_CNNL(cnnlSetTensorDescriptor_v2(
+        sorted_index_desc, layout, CNNL_DTYPE_INT32, 2, sorted_index_shape));
+
+    // need topk scores
+    const bool largest = true;  // param for topk, sort from large to small
+    const bool sorted = true;   // param for topk, return sorted indices.
+    const bool lower_index_first = true;  // param for topk, sort preservation
+
+    size_t topk_workspace_size = 0;
+    CALL_CNNL(cnnlGetTopKTensorWorkspaceSize(
+        cnnl_handle, origin_indices_desc, max_k, 1, largest, sorted_score_desc,
+        sorted_index_desc, &topk_workspace_size));
+    size_t tok_workspace_align_size =
+        PAD_UP(topk_workspace_size, GDRAM_ALIGN_SIZE);
+    size_t data_size = 0;
+    mluOpGetSizeOfDataType(scores_desc->dtype, &data_size);
+    const size_t indices_size = PAD_UP(n * hwa * data_size, GDRAM_ALIGN_SIZE);
+    void *sorted_score = (void *)((char *)workspace + tok_workspace_align_size);
+    void *sorted_index = (void *)((char *)sorted_score + indices_size);
+
+    // call cnnlTopK
+    CALL_CNNL(cnnlTopKTensor_v3(
+        cnnl_handle, origin_indices_desc, scores, max_k, 1, largest, sorted,
+        lower_index_first, workspace, topk_workspace_size, sorted_score_desc,
+        sorted_score, sorted_index_desc, sorted_index));
+
+    CALL_CNNL(cnnlDestroyTensorDescriptor(origin_indices_desc));
+    CALL_CNNL(cnnlDestroyTensorDescriptor(sorted_score_desc));
+    CALL_CNNL(cnnlDestroyTensorDescriptor(sorted_index_desc));
+    DESTROY_CNNL_HANDLE(cnnl_handle);
+    void *workspace_buffer = (void *)((char *)sorted_index + indices_size);
+    CHECK_RETURN(
+        "[mluOpGenerateProposalsV2]",
+        KernelGenerateProposalsV2(
+            k_dim, k_type, handle->queue, (float *)sorted_score,
+            (int32_t *)sorted_index, (float *)bbox_deltas, (float *)im_shape,
+            (float *)anchors, (float *)variances, (float *)workspace_buffer,
+            (float *)rpn_rois, (float *)rpn_roi_probs, (int *)rpn_rois_num,
+            (int *)rpn_rois_batch_size, pre_nms_top_n, post_nms_top_n,
+            nms_thresh, min_size, eta, pixel_offset, n, a, h, w));
+  } else {
+    CHECK_RETURN("[mluOpGenerateProposalsV2]",
+                 KernelGenerateProposalsV2_Default(
+                     k_dim, k_type, handle->queue, (float *)scores,
+                     (float *)bbox_deltas, (float *)im_shape, (float *)anchors,
+                     (float *)variances, (float *)workspace, (float *)rpn_rois,
+                     (float *)rpn_roi_probs, (int *)rpn_rois_num,
+                     (int *)rpn_rois_batch_size, pre_nms_top_n, post_nms_top_n,
+                     nms_thresh, min_size, eta, pixel_offset, n, a, h, w));
+  }
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }

--- a/kernels/generate_proposals_v2/generate_proposals_v2.h
+++ b/kernels/generate_proposals_v2/generate_proposals_v2.h
@@ -27,6 +27,16 @@
 
 mluOpStatus_t MLUOP_WIN_API KernelGenerateProposalsV2(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const float *scores, const int32_t *scores_index, const float *bbox_deltas,
+    const float *im_shape, const float *anchors, const float *variances,
+    float *workspace, float *rpn_rois, float *rpn_roi_probs, int *rpn_rois_num,
+    int *rpn_rois_batch_size, const int pre_nms_top_n, const int post_nms_top_n,
+    const float nms_thresh, const float min_size, const float eta,
+    const bool pixel_offset, const int batch_size, const int Anchors_num,
+    const int H, const int W);
+
+mluOpStatus_t MLUOP_WIN_API KernelGenerateProposalsV2_Default(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const float *scores, const float *bbox_deltas, const float *im_shape,
     const float *anchors, const float *variances, float *workspace,
     float *rpn_rois, float *rpn_roi_probs, int *rpn_rois_num,

--- a/kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
+++ b/kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
@@ -1,0 +1,403 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+
+#define ALIGN_NUM NFU_ALIGN_SIZE / sizeof(float)
+#define PROPOSAL_NRAM_SIZE MAX_NRAM_SIZE
+#define CALC_AREA_NRAM_FLT_CAP CALC_AREA_NRAM_SIZE / sizeof(float)
+
+__nram__ char nram_buffer[PROPOSAL_NRAM_SIZE];
+__mlu_shared__ char sram_buffer[MAX_SRAM_SIZE];
+
+#define FLOAT_MIN_GPV2 (-(float)FLT_MAX)
+
+template <typename T>
+__mlu_func__ void calcExp(T *output, T *input, int length) {
+#define LOG_2_E (1.44269504088f)
+  __bang_mul_scalar(output, input, (float)LOG_2_E, length);
+  __bang_pow2(output, output, length);
+}
+
+template <typename T>
+__mlu_func__ void findCoreMaxBox(T *input_score_ptr, T *score, T *inter_x1,
+                                 T *inter_y1, T *inter_x2, T *max_box,
+                                 const T *input_x1_ptr, const T *input_y1_ptr,
+                                 const T *input_x2_ptr, const T *input_y2_ptr,
+                                 const int input_offset, const int repeat,
+                                 const int remain, const int max_seg_num,
+                                 int &local_max_index) {
+  if (__is_mpu()) {
+    return;
+  }
+  T local_max_score = FLOAT_MIN_GPV2;
+  for (int i = 0; i <= repeat; i++) {
+    if (i == repeat && remain == 0) {
+      break;
+    }
+    const int actual_num = (i == repeat) ? remain : max_seg_num;
+    const int actual_num_align = CEIL_ALIGN(actual_num, ALIGN_NUM);
+    const int seg_offset = input_offset + i * max_seg_num;
+    /******nms load start******/
+    __bang_write_value(score, actual_num_align, FLOAT_MIN_GPV2);
+    __memcpy(score, input_score_ptr + seg_offset, actual_num * sizeof(T),
+             GDRAM2NRAM);
+    /******nms load end******/
+    __bang_argmax(inter_x1, score, actual_num_align);
+    if (inter_x1[0] >= local_max_score) {
+      if (inter_x1[0] == FLOAT_MIN_GPV2) {
+        local_max_score = inter_x1[0];
+        local_max_index = ((int *)inter_x1)[1] + seg_offset;
+        continue;
+      }
+
+      /****** deal multi equal score ******/
+      __bang_write_value(inter_y1, actual_num_align, (T)inter_x1[0]);
+      __bang_eq(inter_x2, score, inter_y1, actual_num_align);
+      const int tmp_index = __bang_findfirst1(inter_x2, actual_num_align);
+
+      local_max_score = inter_x1[0];
+      local_max_index = tmp_index + seg_offset;
+    }
+  }
+  max_box[0] = local_max_score;
+  max_box[1] = input_x1_ptr[local_max_index];
+  max_box[2] = input_y1_ptr[local_max_index];
+  max_box[3] = input_x2_ptr[local_max_index];
+  max_box[4] = input_y2_ptr[local_max_index];
+  ((uint32_t *)(max_box + 5))[0] = local_max_index;
+}
+
+template <typename T>
+__mlu_func__ void findClusterMaxBox(T *sram, T *max_box, T *inter_x1,
+                                    T *input_data_score) {
+  // find the max with sram. copy every core's box info to sram.
+  /******* 6: score,x1,y1,x2,y2,score_index ******/
+  __memcpy(sram + 6 * coreId, max_box, 6 * sizeof(T), NRAM2SRAM);
+  __sync_all_ipu();
+
+  /***************************************************
+   * copy score from sram to nram and find the max.
+   * src: score1, x1, y1, x2, y2, index,
+          score2, x1, y1, x2, y2, index,
+          score3, x1, y1, x2, y2, index,
+          score4, x1, y1, x2, y2, index
+   * dst: score1, score2, score3, score4
+   * src_stride: 6 * sizeof(T)
+   * dst_stride: sizeof(T)
+   * size: sizeof(T)
+   * seg_num: 3
+  ***************************************************/
+  __bang_write_value(inter_x1, 64, FLOAT_MIN_GPV2);
+  __memcpy(inter_x1, sram, sizeof(T), SRAM2NRAM, sizeof(T), 6 * sizeof(T),
+           coreDim - 1);
+  __bang_argmax(max_box, inter_x1, 64);
+  int max_core = ((int *)max_box)[1];
+  __memcpy(max_box, sram + max_core * 6, 6 * sizeof(T), SRAM2NRAM);
+}
+
+template <typename T>
+__mlu_func__ void calMaxArea(T *max_box, const bool pixel_offset, T *max_area) {
+  T max_box_x1 = max_box[1];
+  T max_box_y1 = max_box[2];
+  T max_box_x2 = max_box[3];
+  T max_box_y2 = max_box[4];
+
+  if (pixel_offset) {
+    *max_area =
+        (max_box_x2 - max_box_x1 + T(1)) * (max_box_y2 - max_box_y1 + T(1));
+  } else {
+    *max_area = (max_box_x2 - max_box_x1) * (max_box_y2 - max_box_y1);
+  }
+}
+
+template <typename T>
+__mlu_func__ void storeResult(T *max_box, T *nram_save, T *&output_boxes_tmp,
+                              T *&output_scores_tmp, const int keep,
+                              const int nram_save_limit_count,
+                              const int nms_num, const float thresh_score,
+                              int &nram_save_count, int &output_box_num) {
+  /*****NMS STORE START*****/
+  // store to nram
+  if (max_box[0] > FLOAT_MIN_GPV2) {
+    if (clusterId == 0 && coreId == 0) {
+      __memcpy(nram_save + nram_save_count * 5, max_box, 5 * sizeof(T),
+               NRAM2NRAM, 5 * sizeof(T), 5 * sizeof(T), 0);
+      nram_save_count++;
+      output_box_num++;
+    }
+  }
+  // store to sram/gdram
+  if (output_box_num != 0) {
+    if ((nram_save_count == nram_save_limit_count) ||
+        (float(max_box[0]) <= FLOAT_MIN_GPV2) || keep == nms_num - 1) {
+      if (nram_save_count != 0) {
+        if (clusterId == 0 && coreId == 0) {
+          pvLock();
+          // x1, y1, x2, y2
+          __memcpy(output_boxes_tmp, nram_save + 1, 4 * sizeof(T), NRAM2GDRAM,
+                   4 * sizeof(T), 5 * sizeof(T), nram_save_count - 1);
+          // score
+          __memcpy(output_scores_tmp, nram_save, sizeof(T), NRAM2GDRAM,
+                   sizeof(T), 5 * sizeof(T), nram_save_count - 1);
+          pvUnlock();
+          output_boxes_tmp += nram_save_count * 4;
+          output_scores_tmp += nram_save_count;
+          nram_save_count = 0;
+        }
+      }
+    }
+  }  // if move data nram->sram/gdram
+}
+
+template <typename T>
+__mlu_func__ void scoreUpdate(
+    T *input_score_ptr, const T *input_boxes_ptr, const T *input_x1_ptr,
+    const T *input_y1_ptr, const T *input_x2_ptr, const T *input_y2_ptr,
+    T *scores, T *boxes, T *inter_x1, T *inter_y1, T *inter_x2, T *inter_y2,
+    T *max_box, const float max_box_x1, const float max_box_y1,
+    const float max_box_x2, const float max_box_y2, T *nram_save, int repeat,
+    int remain, int max_seg_num, const float nms_thresh, const int input_offset,
+    const bool pixel_offset, const float max_area, const int input_num_boxes,
+    const int nms_id) {
+  for (int i = 0; i <= repeat; i++) {
+    if (i == repeat && remain == 0) {
+      break;
+    }
+    const int actual_num = (i == repeat) ? remain : max_seg_num;
+    const int actual_num_align = CEIL_ALIGN(actual_num, ALIGN_NUM);
+    const int seg_offset = input_offset + i * max_seg_num;
+    /*****NMS LOAD START*****/
+    __memcpy(scores, input_score_ptr + seg_offset, actual_num * sizeof(T),
+             GDRAM2NRAM, actual_num * sizeof(T), actual_num * sizeof(T), 0);
+    __memcpy(boxes, input_boxes_ptr + seg_offset, actual_num * sizeof(T),
+             GDRAM2NRAM, max_seg_num * sizeof(T), input_num_boxes * sizeof(T),
+             4);
+    T *x1 = boxes;
+    T *y1 = x1 + max_seg_num;
+    T *x2 = y1 + max_seg_num;
+    T *y2 = x2 + max_seg_num;
+    __bang_write_value(inter_y1, actual_num_align, (T)max_box_x1);
+    __bang_maxequal(inter_x1, x1, inter_y1, actual_num_align);
+    // max_x2
+    __bang_write_value(inter_y2, actual_num_align, (T)max_box_x2);
+    __bang_minequal(inter_x2, x2, inter_y2, actual_num_align);
+    __bang_sub(inter_x1, inter_x2, inter_x1, actual_num_align);
+    if (pixel_offset) {
+      __bang_add_scalar(inter_x1, inter_x1, (T)1.0, actual_num_align);
+    }
+    // max_y1
+    __bang_write_value(inter_x2, actual_num_align, (T)max_box_y1);
+    __bang_maxequal(inter_y1, y1, inter_x2, actual_num_align);
+    // max_y2
+    __bang_write_value(inter_x2, actual_num_align, (T)max_box_y2);
+    __bang_minequal(inter_y2, y2, inter_x2, actual_num_align);
+    __bang_sub(inter_y1, inter_y2, inter_y1, actual_num_align);
+    if (pixel_offset) {
+      __bang_add_scalar(inter_y1, inter_y1, (T)1.0, actual_num_align);
+    }
+
+    __bang_write_value(inter_y2, actual_num_align, (T)0.0);
+    __bang_maxequal(inter_x1, inter_x1, inter_y2, actual_num_align);
+    __bang_maxequal(inter_y1, inter_y1, inter_y2, actual_num_align);
+    // get the area_i
+    __bang_mul(inter_x1, inter_x1, inter_y1, actual_num_align);
+    // get the area of input_box (y2-y1) * (x2-x1)
+#if __BANG_ARCH__ > 300
+    if (pixel_offset) {
+      __bang_fusion(FUSION_FSA, inter_y1, x2, x1, (T)1.0, actual_num_align,
+                    actual_num_align);
+      __bang_fusion(FUSION_FSA, inter_y2, y2, y1, (T)1.0, actual_num_align,
+                    actual_num_align);
+      __bang_mul(inter_x2, inter_y1, inter_y2, actual_num_align);
+    } else {
+      __bang_sub(inter_y1, x2, x1, actual_num_align);
+      __bang_fusion(FUSION_FSM, inter_x2, y2, y1, inter_y1, actual_num_align,
+                    actual_num_align);
+    }
+    // get the area_u  max_area + area - area_i
+    __bang_fusion(FUSION_FAS, inter_x2, inter_x2, max_area, inter_x1,
+                  actual_num_align, actual_num_align);
+#else
+    // get the area of input_box (y2-y1) * (x2-x1)
+    __bang_sub(inter_y1, x2, x1, actual_num_align);
+    __bang_sub(inter_y2, y2, y1, actual_num_align);
+    if (pixel_offset) {
+      __bang_add_scalar(inter_y1, inter_y1, (T)1.0, actual_num_align);
+      __bang_add_scalar(inter_y2, inter_y2, (T)1.0, actual_num_align);
+    }
+    __bang_mul(inter_x2, inter_y1, inter_y2, actual_num_align);
+    // get the area_u  max_area + area - area_i
+    __bang_add_scalar(inter_x2, inter_x2, max_area, actual_num_align);
+    __bang_sub(inter_x2, inter_x2, inter_x1, actual_num_align);
+#endif
+    // 2. select the box
+    __bang_mul_scalar(inter_x2, inter_x2, nms_thresh, actual_num_align);
+    __bang_le(inter_y1, inter_x1, inter_x2, actual_num_align);
+    __bang_gt(inter_y2, inter_x1, inter_x2, actual_num_align);
+    __bang_mul(inter_y1, scores, inter_y1, actual_num_align);
+    __bang_mul_scalar(inter_y2, inter_y2, FLOAT_MIN_GPV2, actual_num_align);
+    __bang_add(scores, inter_y1, inter_y2, actual_num_align);
+    /*****NMS COMPUTE END*****/
+    __memcpy(input_score_ptr + seg_offset, scores, actual_num * sizeof(T),
+             NRAM2GDRAM);
+  }
+}
+
+__mlu_func__ void getComputeParams(const int input_num, const int limit,
+                                   const int memory_block,
+                                   const int data_type_size, int *max_seg_num,
+                                   int *repeat, int *remain_num, int *core_num,
+                                   int *core_offset) {
+  int avg_core_num = 0;
+  int rem_core_num = 0;
+  int len_core_num = 0;
+
+  if (clusterDim == 0) {
+    avg_core_num = input_num / taskDim;
+    rem_core_num = input_num % taskDim;
+    len_core_num = avg_core_num + (taskId < rem_core_num);
+    *core_offset =
+        avg_core_num * taskId + (taskId < rem_core_num ? taskId : rem_core_num);
+  } else {
+    const int avg_cluster_num = input_num / clusterDim;
+    const int rem_cluster_num = input_num % clusterDim;
+    const int len_cluster_num = avg_cluster_num + (clusterId < rem_cluster_num);
+    const int cluster_offset_num =
+        avg_cluster_num * clusterId +
+        (clusterId < rem_cluster_num ? clusterId : rem_cluster_num);
+
+    avg_core_num = len_cluster_num / coreDim;
+    rem_core_num = len_cluster_num % coreDim;
+    len_core_num = avg_core_num + (coreId < rem_core_num);
+    *core_offset = cluster_offset_num + avg_core_num * coreId +
+                   (coreId < rem_core_num ? coreId : rem_core_num);
+  }
+
+  *max_seg_num = FLOOR_ALIGN(limit / data_type_size, ALIGN_NUM);
+  *repeat = len_core_num / *max_seg_num;
+  *remain_num = len_core_num % *max_seg_num;
+  *core_num = len_core_num;
+}
+
+template <typename T>
+__mlu_func__ void nonMaximumSuppress(
+    T *output_boxes_ptr, T *output_scores_ptr, int *output_num,
+    T *input_scores_ptr, const T *input_boxes_ptr, T *workspace,
+    const float nms_thresh, const int max_output_num, const int scores_num,
+    const bool pixel_offset, const int box_stride) {
+  // nram 13 * N, N = max_seg_num
+  // | output_boxes | scores | boxes | inter_x1|
+  // |   4 * N      |     N  | 4*N   |   N     |
+
+  // inter_y1| inter_x2 | inter_y2 |
+  // |   N   |   N      |   N      |
+  int32_t *loop_end_flag = (int32_t *)(sram_buffer + 28);
+  loop_end_flag[0] = 0;
+  // scores, boxes, x1, y1, x2, y2, inter_x1, inter_y1, inter_x2, inter_y2
+  const int memory_block = 13;
+  const int nram_save_limit_count = 256;
+
+  // input data gdram ptr
+  const T *input_x1_ptr = input_boxes_ptr;
+  const T *input_y1_ptr = input_x1_ptr + box_stride;
+  const T *input_x2_ptr = input_y1_ptr + box_stride;
+  const T *input_y2_ptr = input_x2_ptr + box_stride;
+
+  int limit = 0;
+  int max_seg_num = 0;
+  int repeat = 0;
+  int remain_num = 0;
+  int core_offset = 0;
+  int core_num = 0;
+  int nram_save_count = 0;
+
+  limit = (MAX_NRAM_SIZE - NFU_ALIGN_SIZE - nram_save_limit_count * 5) /
+          memory_block;
+  getComputeParams(scores_num, limit, memory_block, sizeof(T), &max_seg_num,
+                   &repeat, &remain_num, &core_num, &core_offset);
+  // init nram ptr
+  T *scores = (T *)nram_buffer;
+  T *x1 = scores + max_seg_num;
+  T *y1 = x1 + max_seg_num;
+  T *x2 = y1 + max_seg_num;
+  T *y2 = x2 + max_seg_num;
+  T *boxes = y2 + max_seg_num;
+  T *inter_x1 = boxes + 4 * max_seg_num;
+  T *inter_y1 = inter_x1 + max_seg_num;
+  T *inter_x2 = inter_y1 + max_seg_num;
+  T *inter_y2 = inter_x2 + max_seg_num;
+  T *max_box = inter_y2 + max_seg_num;
+  T *nram_save = max_box + NFU_ALIGN_SIZE;
+
+  const int nms_num = scores_num > max_output_num ? max_output_num : scores_num;
+
+  for (int nms_id = 0; nms_id < nms_num; ++nms_id) {
+    if (taskDim != 1) {
+      __sync_all_ipu();
+    }
+    /*****Find MaxBox Box*****/
+    int max_index = 0;            // the max score index.
+    int global_max_index = 0;     // for u1.
+    T max_area = 0;               // the max score area.
+    max_box[0] = FLOAT_MIN_GPV2;  // init 0.
+    findCoreMaxBox(input_scores_ptr, scores, inter_x1, inter_y1, inter_x2,
+                   max_box, input_x1_ptr, input_y1_ptr, input_x2_ptr,
+                   input_y2_ptr, core_offset, repeat, remain_num, max_seg_num,
+                   max_index);
+    if (taskDim == 1) {
+      calMaxArea(max_box, pixel_offset, &max_area);
+      input_scores_ptr[max_index] = FLOAT_MIN_GPV2;
+      global_max_index = max_index;
+    } else if (taskDim == 4) {
+      __sync_all_ipu();
+      findClusterMaxBox((T *)sram_buffer, max_box, inter_x1, input_scores_ptr);
+      calMaxArea(max_box, pixel_offset, &max_area);
+      global_max_index = ((int *)(max_box + 5))[0];
+    }
+    /******by now, we get: max_score|max_index|max_box|max_area******/
+    storeResult(max_box, nram_save, output_boxes_ptr, output_scores_ptr, nms_id,
+                nram_save_limit_count, nms_num, nms_thresh, nram_save_count,
+                *output_num);
+    if (taskDim == 1) {
+      if (float(max_box[0]) <= FLOAT_MIN_GPV2 || (nms_id == nms_num - 1)) {
+        break;
+      }
+    } else {
+      if (float(max_box[0]) <= FLOAT_MIN_GPV2 || (nms_id == nms_num - 1)) {
+        if (coreId == 0) {
+          loop_end_flag[0] = 1;
+        }
+      }
+      __sync_all_ipu();
+      if (loop_end_flag[0] == 1) {
+        break;
+      }
+    }
+    /*** NMS STORE END***/
+    scoreUpdate(input_scores_ptr, input_boxes_ptr, input_x1_ptr, input_y1_ptr,
+                input_x2_ptr, input_y2_ptr, scores, boxes, inter_x1, inter_y1,
+                inter_x2, inter_y2, max_box, max_box[1], max_box[2], max_box[3],
+                max_box[4], nram_save, repeat, remain_num, max_seg_num,
+                nms_thresh, core_offset, pixel_offset, max_area, box_stride,
+                nms_id);
+  }
+}  // for nms_id < nms_num

--- a/kernels/generate_proposals_v2/generate_proposals_v2_union1_590.mlu
+++ b/kernels/generate_proposals_v2/generate_proposals_v2_union1_590.mlu
@@ -1,0 +1,393 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "generate_proposals_v2.h"
+
+#include <float.h>
+
+#include "core/logging.h"
+#include "kernels/kernel.h"
+#include "kernels/utils/common.h"
+#include "kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h"
+
+template <typename T>
+__mlu_func__ void filterBoxes(T *proposals_score_nram, T *proposals_box_nram,
+                              const T *im_shape, T *temp_nram_xywh,
+                              T *temp_nram_mask, int32_t *after_count,
+                              const int32_t deal_num, const T min_size,
+                              const bool pixel_offset) {
+  T *wh = temp_nram_xywh;
+  T *cx = temp_nram_xywh + 2 * deal_num;
+  T *cy = temp_nram_xywh + 3 * deal_num;
+
+  T *mask_tmp1 = temp_nram_mask;
+  T *mask_tmp2 = temp_nram_mask + deal_num;
+  T *tmp1 = temp_nram_mask + 2 * deal_num;
+
+  // w = box[2] - box[0], h = box[3] - box[1];
+  T *xymin = proposals_box_nram;
+  T *xymax = proposals_box_nram + 2 * deal_num;
+
+  // xmax - xmin, ymax - ymin
+  __bang_sub(wh, xymax, xymin, 2 * deal_num);
+  if (pixel_offset) {
+    T offset = 1.0;
+    // w = w + offset, h = h + offset
+    __bang_add_scalar(wh, wh, offset, deal_num * 2);
+  }
+  // cx = box[0] + 0.5 * w, cy = box[1] + 0.5 * h
+  __bang_fusion(FUSION_FMA, cx, wh, (T)0.5, xymin, 2 * deal_num, 2 * deal_num);
+  float real_min_size = min_size > 1.0 ? min_size : 1.0;
+  // mask_tmp1 = w >= min_size ? 1 : 0;
+  __bang_ge_scalar(mask_tmp1, wh, real_min_size, deal_num * 2);
+  // mask_tmp2 = mask_tmp1 & mask_tmp2
+  __bang_and(mask_tmp2, mask_tmp1, mask_tmp2, deal_num);
+
+  if (pixel_offset) {
+    T im_h = im_shape[0];
+    T im_w = im_shape[1];
+    // mask_tmp1 = cx <= im_w ? 1 : 0;  mask_tmp2 = cy <= im_h ? 1 : 0;
+    __bang_write_value(tmp1, deal_num, im_w);
+    __bang_le(mask_tmp1, cx, tmp1, deal_num);
+    __bang_and(mask_tmp2, mask_tmp2, mask_tmp1, deal_num);
+    __bang_write_value(tmp1, deal_num, im_h);
+    __bang_le(mask_tmp1, cy, tmp1, deal_num);
+    __bang_and(mask_tmp2, mask_tmp2, mask_tmp1, deal_num);
+  }
+
+  int count = __bang_count(mask_tmp2, deal_num);
+  *after_count = count;
+  if (count == deal_num) {
+    return;
+  }
+  // collect and store box and scores
+  __bang_filter(proposals_box_nram, proposals_box_nram, mask_tmp2, deal_num);
+  __bang_filter(proposals_box_nram + 1 * deal_num,
+                proposals_box_nram + 1 * deal_num, mask_tmp2, deal_num);
+  __bang_filter(proposals_box_nram + 2 * deal_num,
+                proposals_box_nram + 2 * deal_num, mask_tmp2, deal_num);
+  __bang_filter(proposals_box_nram + 3 * deal_num,
+                proposals_box_nram + 3 * deal_num, mask_tmp2, deal_num);
+  __bang_filter(proposals_score_nram, proposals_score_nram, mask_tmp2,
+                deal_num);
+}
+
+template <typename T>
+__mlu_func__ void proposalBoxesDecode(
+    const T *sorted_score, const int32_t *sorted_index, const T *bbox_deltals,
+    const T *im_shape, const T *anchors, const T *variances, const T min_size,
+    const bool pixel_offset, T *proposals_score, T *proposals_box,
+    T *proposals_temp, const int64_t pre_nms_num, const int64_t hwa,
+    int32_t *collect_num, int32_t *proposals_num) {
+  if (pre_nms_num == 0) {
+    return;
+  }
+  /*
+  |-----------------------------------------|
+  |    anchors_nram     |   4 * align_count |
+  |  bbox_deltals_nram  |   4 * align_count |
+  |   temp_nram         |   4 * align_count |
+  |   xywh_nram         |   4 * align_count |
+  |   variances_nram    |   4 * align_count |
+  | sorted_index_nram   |   align_count     |
+  | anchors_index_nram  |   align_count     |
+  | proposals_score_nram|   align_count     |
+  -------------------------------------------
+  if variances is nullptr, the variance nram is not needed
+  */
+  const int nram_block = (variances == nullptr) ? 19 : 23;
+  const int align_count =
+      PAD_DOWN((MAX_NRAM_SIZE / sizeof(T) / nram_block), ALIGN_NUM);
+  const int64_t num_per_core = pre_nms_num / taskDim;
+  const int num_rem = pre_nms_num % taskDim;
+  const int64_t num_offset = (taskId < num_rem)
+                                 ? (num_per_core + 1) * taskId
+                                 : num_per_core * taskId + num_rem;
+  const int64_t num_cur_core =
+      (taskId < num_rem) ? num_per_core + 1 : num_per_core;
+  const int repeat = num_cur_core / align_count;
+  const int rem = num_cur_core % align_count;
+
+  T *anchors_nram = (T *)nram_buffer;
+  // 4 * align_count: xywh
+  T *bbox_deltals_nram = anchors_nram + 4 * align_count;
+  T *variances_nram = (variances == nullptr)
+                          ? bbox_deltals_nram
+                          : bbox_deltals_nram + 4 * align_count;
+  T *temp_nram = variances_nram + 4 * align_count;
+  T *xywh_nram = temp_nram + 4 * align_count;
+  T *sorted_index_nram = xywh_nram + 4 * align_count;
+  T *anchors_index_nram = sorted_index_nram + align_count;
+  T *proposals_score_nram = anchors_index_nram + align_count;
+  T *proposals_score_temp = proposals_temp;
+  T *proposals_box_temp = proposals_score_temp + hwa;
+
+  int32_t core_store_offset = 0;
+  for (int iter = 0; iter < repeat + 1; iter++) {
+    if ((rem == 0) && (iter == repeat)) {
+      break;
+    }
+    const int32_t deal_num = (iter == repeat) ? rem : align_count;
+    const int64_t core_iter_offset = num_offset + align_count * iter;
+    // gather anchors:x1,y1,x2,y2 by correspond sorted_index.
+
+    __memcpy(sorted_index_nram, sorted_index + core_iter_offset,
+             deal_num * sizeof(T), GDRAM2NRAM);
+    // sorted_index->anchors_index ([HWA,1]->[HWA,4])
+    __bang_mul_scalar(anchors_index_nram, sorted_index_nram, 4, deal_num);
+    // gather offset (byte).
+    __bang_mul_scalar(anchors_index_nram, anchors_index_nram, sizeof(int32_t),
+                      deal_num);
+    __gather(temp_nram, anchors, (unsigned int *)anchors_index_nram,
+             sizeof(T) * 4, GDRAM2NRAM, sizeof(T) * 4, deal_num);
+    __bang_transpose(anchors_nram, temp_nram, deal_num, 4);
+    T *axymin = anchors_nram;  // axmin,aymin
+    T *axymax = anchors_nram + 2 /*axmax,aymax*/ * deal_num;
+    __gather(temp_nram, bbox_deltals, (unsigned int *)anchors_index_nram,
+             sizeof(T) * 4, GDRAM2NRAM, sizeof(T) * 4, deal_num);
+    // [deal_num, 4]->[4, deal_num]
+    __bang_transpose(bbox_deltals_nram, temp_nram, deal_num, 4);
+    T *dxymin = bbox_deltals_nram;  // dxmin,dymin
+    T *dxmax = bbox_deltals_nram + 2 * deal_num;
+    T *dymax = bbox_deltals_nram + 3 * deal_num;
+    T offset = pixel_offset ? static_cast<T>(1.0) : 0;
+    T *wh = xywh_nram;
+    T *cxy = xywh_nram + 2 /*center_x,center_y*/ * deal_num;
+
+    // w = axmax - axmin + offset , h = aymax - aymin + offset
+    __bang_sub((T *)wh, (T *)axymax, (T *)axymin, 2 * deal_num);  // w,h
+    if (pixel_offset) {
+      // axmax - axmin + offset
+      __bang_add_scalar(wh, wh, offset, deal_num * 2);
+    }
+    // cx = 0.5 * w + axmin;
+    // cy = 0.5 * h + aymin;
+    __bang_fusion(FUSION_FMA, cxy, wh, (T)0.5, axymin, 2 * deal_num,
+                  2 * deal_num);
+    T *d_w = temp_nram;
+    T *d_h = temp_nram + deal_num;
+    T *d_cx = temp_nram + 2 * deal_num;
+    T *d_cy = temp_nram + 3 * deal_num;
+    if (variances) {
+      __gather(temp_nram, variances, (unsigned int *)anchors_index_nram,
+               sizeof(T) * 4, GDRAM2NRAM, sizeof(T) * 4, deal_num);
+      __bang_transpose(variances_nram, temp_nram, deal_num, 4);
+      // d_cx = cx + dxmin * w * var[k];
+      // d_cy = cy + dymin * h * var[k + 1];
+      __bang_mul(d_cx, dxymin, wh, deal_num * 2);
+      // dxmin * w * var[k];
+      __bang_fusion(FUSION_FMA, d_cx, d_cx, variances_nram, cxy, deal_num * 2,
+                    deal_num * 2);
+      // dxmax * var[k + 2]
+      __bang_mul(d_w, dxmax, variances_nram + 2 * deal_num, deal_num * 2);
+    } else {
+      __bang_fusion(FUSION_FMA, d_cx, dxymin, wh, cxy, deal_num * 2,
+                    deal_num * 2);
+    }
+    // Min(dymax * var[k + 3], bbox_clip_default)
+    // bbox_clip_default = std::log(1000.0 / 16.0);
+    const float bbox_clip_default = 4.135166556742356f;
+    T *tmp1 = axymin;
+    T *tmp2 = tmp1 + deal_num;
+    __bang_write_value(tmp1, deal_num, bbox_clip_default);
+    __bang_minequal(dxmax, d_w, tmp1, deal_num);
+    __bang_minequal(dymax, d_h, tmp1, deal_num);
+    // d_w = exp(Min(dxmax * var[k + 2], bbox_clip_default)) * w;
+    calcExp(d_w, dxmax, deal_num);
+    calcExp(d_h, dymax, deal_num);
+
+    __bang_mul(d_w, d_w, wh, deal_num * 2);
+    T *oxymin = wh;   // T *oymin = h;
+    T *oxymax = cxy;  // T *oymax = cy;
+    // T oxmin = d_cx - d_w * 0.5;
+    __bang_mul_scalar(tmp1, d_w, (T)0.5, deal_num * 2);
+    __bang_sub(oxymin, d_cx, tmp1, deal_num * 2);
+    // T oxmax = d_cx + d_w * 0.5 - offset;
+    __bang_add(oxymax, d_cx, tmp1, deal_num * 2);
+    if (pixel_offset) {
+      __bang_sub_scalar(oxymax, oxymax, T(1.0), deal_num * 2);
+    }
+    __bang_write_value(tmp1, deal_num, (T)(im_shape[1] - offset));
+    __bang_write_value(tmp2, deal_num, (T)(im_shape[0] - offset));
+    __bang_minequal(d_w, oxymin, tmp1, deal_num * 2);
+    __bang_minequal(d_cx, oxymax, tmp1, deal_num * 2);
+    __bang_write_value(tmp1, deal_num, (T)(0));
+
+    T *proposals_box_nram = bbox_deltals_nram;
+    __bang_maxequal(proposals_box_nram, tmp1, d_w, deal_num);
+    __bang_maxequal(proposals_box_nram + deal_num, tmp1, d_h, deal_num);
+    __bang_maxequal(proposals_box_nram + 2 * deal_num, tmp1, d_cx, deal_num);
+    __bang_maxequal(proposals_box_nram + 3 * deal_num, tmp1, d_cy, deal_num);
+
+    __memcpy(proposals_score_nram, sorted_score + core_iter_offset,
+             deal_num * sizeof(T), GDRAM2NRAM);
+    // filter bbox
+    int32_t count = 0;
+    filterBoxes(proposals_score_nram, proposals_box_nram, im_shape, temp_nram,
+                variances_nram, &count, deal_num, min_size, pixel_offset);
+
+    // store output:box and score.
+    if (count == 0) {
+      return;
+    }
+    __memcpy(proposals_score_temp + num_offset + core_store_offset,
+             proposals_score_nram, count * sizeof(T), NRAM2GDRAM);
+    __memcpy(proposals_box_temp + num_offset + core_store_offset,
+             proposals_box_nram, count * sizeof(T), NRAM2GDRAM);
+    __memcpy(proposals_box_temp + num_offset + core_store_offset + hwa,
+             proposals_box_nram + deal_num, count * sizeof(T), NRAM2GDRAM);
+    __memcpy(proposals_box_temp + num_offset + core_store_offset + 2 * hwa,
+             proposals_box_nram + 2 * deal_num, count * sizeof(T), NRAM2GDRAM);
+    __memcpy(proposals_box_temp + num_offset + core_store_offset + 3 * hwa,
+             proposals_box_nram + 3 * deal_num, count * sizeof(T), NRAM2GDRAM);
+    core_store_offset += count;
+  }
+
+  collect_num[taskId] = core_store_offset;
+  if (taskDim != 1) {
+    __sync_all_ipu();
+  }
+
+  int current_offset = 0;
+  int all_proposls_num = 0;
+  for (int i = 0; i < taskDim; ++i) {
+    if (i < taskId) {
+      current_offset += collect_num[i];
+    }
+    all_proposls_num += collect_num[i];
+  }
+
+  *proposals_num = all_proposls_num;
+  if (all_proposls_num == 0 || core_store_offset == 0) {
+    return;
+  }
+
+  // step 2
+  __memcpy(proposals_score + current_offset, proposals_score_temp + num_offset,
+           core_store_offset * sizeof(T), GDRAM2GDRAM);
+
+  __memcpy(proposals_box + current_offset, proposals_box_temp + num_offset,
+           core_store_offset * sizeof(T), GDRAM2GDRAM);
+
+  __memcpy(proposals_box + current_offset + hwa,
+           proposals_box_temp + num_offset + hwa, core_store_offset * sizeof(T),
+           GDRAM2GDRAM);
+
+  __memcpy(proposals_box + current_offset + 2 * hwa,
+           proposals_box_temp + num_offset + 2 * hwa,
+           core_store_offset * sizeof(T), GDRAM2GDRAM);
+
+  __memcpy(proposals_box + current_offset + 3 * hwa,
+           proposals_box_temp + num_offset + 3 * hwa,
+           core_store_offset * sizeof(T), GDRAM2GDRAM);
+}
+
+template <typename T>
+__mlu_func__ void ProposalForOneImage(
+    const T *scores, const int32_t *scores_index, const T *bbox_deltas,
+    const T *im_shape, const T *anchors, const T *variances, T *workspace,
+    T *rpn_rois, T *rpn_roi_probs, int *rpn_rois_num,
+    int *one_image_proposals_num, const int pre_nms_top_n,
+    const int post_nms_top_n, const float nms_thresh, const float min_size,
+    const bool pixel_offset, const int hwa, const int topk) {
+  T *proposals_box = workspace;
+  T *proposals_score = workspace + 4 * hwa;
+  T *proposals_temp = workspace + 5 * hwa;
+  int *collect_num = (int *)workspace + 10 * hwa;
+  int proposals_num = 0;
+  collect_num[taskId] = 0;
+  proposalBoxesDecode(scores, scores_index, bbox_deltas, im_shape, anchors,
+                      variances, min_size, pixel_offset, proposals_score,
+                      proposals_box, proposals_temp, topk, hwa, collect_num,
+                      &proposals_num);
+  rpn_rois_num[0] = 0;
+  if (proposals_num == 0) {
+    rpn_rois_num[0] = 1;
+    one_image_proposals_num[0] += rpn_rois_num[0];
+    return;
+  }
+
+  if (taskDim != 1) {
+    __sync_all_ipu();
+  }
+  nonMaximumSuppress(rpn_rois, rpn_roi_probs, rpn_rois_num, proposals_score,
+                     proposals_box, proposals_temp, nms_thresh, post_nms_top_n,
+                     proposals_num, pixel_offset, hwa);
+
+  one_image_proposals_num[0] += rpn_rois_num[0];
+}
+
+template <typename T>
+__mlu_global__ void mluOpGenerateProposalsV2Kernel(
+    const T *scores, const int32_t *scores_index, const T *bbox_deltas,
+    const T *im_shape, const T *anchors, const T *variances, T *workspace,
+    T *rpn_rois, T *rpn_roi_probs, int *rpn_rois_num, int *rpn_rois_batch_size,
+    const int pre_nms_top_n, const int post_nms_top_n, const float nms_thresh,
+    const float min_size, const float eta, const bool pixel_offset,
+    const int batch_size, const int anchors_num, const int W, const int H) {
+  if (__is_mpu()) return;
+  const int hwa = anchors_num * H * W;
+  const int topk =
+      (pre_nms_top_n <= 0 || pre_nms_top_n > hwa) ? hwa : pre_nms_top_n;
+  int all_proposals_num = 0;
+  for (int batch_id = 0; batch_id < batch_size; ++batch_id) {
+    if (taskDim != 1) {
+      __sync_all_ipu();
+    }
+    int one_image_proposals_num = 0;
+    const T *scores_slice = scores + batch_id * topk;
+    const int32_t *scores_slice_index = scores_index + batch_id * topk;
+    const T *bbox_deltas_slice = bbox_deltas + batch_id * 4 * hwa;
+    const T *im_shape_slice = im_shape + batch_id * 2;
+    const T *anchors_slice = anchors;
+    const T *variances_slice = variances;
+
+    T *rpn_rois_slice = rpn_rois + 4 * all_proposals_num;
+    T *rpn_roi_probs_slice = rpn_roi_probs + all_proposals_num;
+    int *rpn_rois_num_slice = rpn_rois_num + batch_id;
+    ProposalForOneImage(scores_slice, scores_slice_index, bbox_deltas_slice,
+                        im_shape_slice, anchors_slice, variances_slice,
+                        workspace, rpn_rois_slice, rpn_roi_probs_slice,
+                        rpn_rois_num_slice, &one_image_proposals_num,
+                        pre_nms_top_n, post_nms_top_n, nms_thresh, min_size,
+                        pixel_offset, hwa, topk);
+    all_proposals_num += one_image_proposals_num;
+  }
+  *rpn_rois_batch_size = all_proposals_num;
+}
+
+mluOpStatus_t MLUOP_WIN_API KernelGenerateProposalsV2(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const float *scores, const int32_t *scores_index, const float *bbox_deltas,
+    const float *im_shape, const float *anchors, const float *variances,
+    float *workspace, float *rpn_rois, float *rpn_roi_probs, int *rpn_rois_num,
+    int *rpn_rois_batch_size, const int pre_nms_top_n, const int post_nms_top_n,
+    const float nms_thresh, const float min_size, const float eta,
+    const bool pixel_offset, const int batch_size, const int anchors_num,
+    const int H, const int W) {
+  KERNEL_CHECK(mluOpGenerateProposalsV2Kernel<<<k_dim, k_type, queue>>>(
+      scores, scores_index, bbox_deltas, im_shape, anchors, variances,
+      workspace, rpn_rois, rpn_roi_probs, rpn_rois_num, rpn_rois_batch_size,
+      pre_nms_top_n, post_nms_top_n, nms_thresh, min_size, eta, pixel_offset,
+      batch_size, anchors_num, W, H));
+  return MLUOP_STATUS_SUCCESS;
+}

--- a/kernels/generate_proposals_v2/generate_proposals_v2_union_default.mlu
+++ b/kernels/generate_proposals_v2/generate_proposals_v2_union_default.mlu
@@ -27,275 +27,7 @@
 #include "core/logging.h"
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
-
-#define PROPOSAL_NRAM_SIZE MAX_NRAM_SIZE
-#define CALC_AREA_NRAM_FLT_CAP CALC_AREA_NRAM_SIZE / sizeof(float)
-
-__nram__ char nram_buffer[PROPOSAL_NRAM_SIZE];
-__mlu_shared__ char sram_buffer[MAX_SRAM_SIZE];
-
-#define FLOAT_MIN (-(float)FLT_MAX)
-#define ALIGN_NUM NFU_ALIGN_SIZE / sizeof(float)
-template <typename T>
-__mlu_func__ void findCoreMaxBox(T *input_score_ptr, T *score, T *inter_x1,
-                                 T *inter_y1, T *inter_x2, T *max_box,
-                                 const T *input_x1_ptr, const T *input_y1_ptr,
-                                 const T *input_x2_ptr, const T *input_y2_ptr,
-                                 const int input_offset, const int repeat,
-                                 const int remain, const int max_seg_num,
-                                 int &local_max_index) {
-  if (__is_mpu()) {
-    return;
-  }
-  T local_max_score = FLOAT_MIN;
-  for (int i = 0; i <= repeat; i++) {
-    if (i == repeat && remain == 0) {
-      break;
-    }
-    const int actual_num = (i == repeat) ? remain : max_seg_num;
-    const int actual_num_align = CEIL_ALIGN(actual_num, ALIGN_NUM);
-    const int seg_offset = input_offset + i * max_seg_num;
-    /******nms load start******/
-    __bang_write_value(score, actual_num_align, FLOAT_MIN);
-    __memcpy(score, input_score_ptr + seg_offset, actual_num * sizeof(T),
-             GDRAM2NRAM);
-    /******nms load end******/
-    __bang_argmax(inter_x1, score, actual_num_align);
-    if (inter_x1[0] >= local_max_score) {
-      if (inter_x1[0] == FLOAT_MIN) {
-        local_max_score = inter_x1[0];
-        local_max_index = ((int *)inter_x1)[1] + seg_offset;
-        continue;
-      }
-
-      /****** deal multi equal score ******/
-      __bang_write_value(inter_y1, actual_num_align, (T)inter_x1[0]);
-      __bang_eq(inter_x2, score, inter_y1, actual_num_align);
-      const int tmp_index = __bang_findfirst1(inter_x2, actual_num_align);
-
-      local_max_score = inter_x1[0];
-      local_max_index = tmp_index + seg_offset;
-    }
-  }
-  max_box[0] = local_max_score;
-  max_box[1] = input_x1_ptr[local_max_index];
-  max_box[2] = input_y1_ptr[local_max_index];
-  max_box[3] = input_x2_ptr[local_max_index];
-  max_box[4] = input_y2_ptr[local_max_index];
-  ((uint32_t *)(max_box + 5))[0] = local_max_index;
-}
-
-template <typename T>
-__mlu_func__ void findClusterMaxBox(T *sram, T *max_box, T *inter_x1,
-                                    T *input_data_score) {
-  // find the max with sram. copy every core's box info to sram.
-  /******* 6: score,x1,y1,x2,y2,score_index ******/
-  __memcpy(sram + 6 * coreId, max_box, 6 * sizeof(T), NRAM2SRAM);
-  __sync_all_ipu();
-
-  /***************************************************
-   * copy score from sram to nram and find the max.
-   * src: score1, x1, y1, x2, y2, index,
-          score2, x1, y1, x2, y2, index,
-          score3, x1, y1, x2, y2, index,
-          score4, x1, y1, x2, y2, index
-   * dst: score1, score2, score3, score4
-   * src_stride: 6 * sizeof(T)
-   * dst_stride: sizeof(T)
-   * size: sizeof(T)
-   * seg_num: 3
-  ***************************************************/
-  __bang_write_value(inter_x1, 64, FLOAT_MIN);
-  __memcpy(inter_x1, sram, sizeof(T), SRAM2NRAM, sizeof(T), 6 * sizeof(T),
-           coreDim - 1);
-  __bang_argmax(max_box, inter_x1, 64);
-  int max_core = ((int *)max_box)[1];
-  __memcpy(max_box, sram + max_core * 6, 6 * sizeof(T), SRAM2NRAM);
-}
-
-template <typename T>
-__mlu_func__ void calMaxArea(T *max_box, const bool pixel_offset, T *max_area) {
-  T max_box_x1 = max_box[1];
-  T max_box_y1 = max_box[2];
-  T max_box_x2 = max_box[3];
-  T max_box_y2 = max_box[4];
-
-  if (pixel_offset) {
-    *max_area =
-        (max_box_x2 - max_box_x1 + T(1)) * (max_box_y2 - max_box_y1 + T(1));
-  } else {
-    *max_area = (max_box_x2 - max_box_x1) * (max_box_y2 - max_box_y1);
-  }
-}
-
-template <typename T>
-__mlu_func__ void storeResult(T *max_box, T *nram_save, T *&output_boxes_tmp,
-                              T *&output_scores_tmp, const int keep,
-                              const int nram_save_limit_count,
-                              const int nms_num, const float thresh_score,
-                              int &nram_save_count, int &output_box_num) {
-  /*****NMS STORE START*****/
-  // store to nram
-  if (max_box[0] > FLOAT_MIN) {
-    if (clusterId == 0 && coreId == 0) {
-      __memcpy(nram_save + nram_save_count * 5, max_box, 5 * sizeof(T),
-               NRAM2NRAM, 5 * sizeof(T), 5 * sizeof(T), 0);
-      nram_save_count++;
-      output_box_num++;
-    }
-  }
-  // store to sram/gdram
-  if (output_box_num != 0) {
-    if ((nram_save_count == nram_save_limit_count) ||
-        (float(max_box[0]) <= FLOAT_MIN) || keep == nms_num - 1) {
-      if (nram_save_count != 0) {
-        if (clusterId == 0 && coreId == 0) {
-          pvLock();
-          // x1, y1, x2, y2
-          __memcpy(output_boxes_tmp, nram_save + 1, 4 * sizeof(T), NRAM2GDRAM,
-                   4 * sizeof(T), 5 * sizeof(T), nram_save_count - 1);
-          // score
-          __memcpy(output_scores_tmp, nram_save, sizeof(T), NRAM2GDRAM,
-                   sizeof(T), 5 * sizeof(T), nram_save_count - 1);
-          pvUnlock();
-          output_boxes_tmp += nram_save_count * 4;
-          output_scores_tmp += nram_save_count;
-          nram_save_count = 0;
-        }
-      }
-    }
-  }  // if move data nram->sram/gdram
-}
-
-template <typename T>
-__mlu_func__ void scoreUpdate(
-    T *input_score_ptr, const T *input_boxes_ptr, const T *input_x1_ptr,
-    const T *input_y1_ptr, const T *input_x2_ptr, const T *input_y2_ptr,
-    T *scores, T *boxes, T *inter_x1, T *inter_y1, T *inter_x2, T *inter_y2,
-    T *max_box, const float max_box_x1, const float max_box_y1,
-    const float max_box_x2, const float max_box_y2, T *nram_save, int repeat,
-    int remain, int max_seg_num, const float nms_thresh, const int input_offset,
-    const bool pixel_offset, const float max_area, const int input_num_boxes,
-    const int nms_id) {
-  for (int i = 0; i <= repeat; i++) {
-    if (i == repeat && remain == 0) {
-      break;
-    }
-    const int actual_num = (i == repeat) ? remain : max_seg_num;
-    const int actual_num_align = CEIL_ALIGN(actual_num, ALIGN_NUM);
-    const int seg_offset = input_offset + i * max_seg_num;
-    /*****NMS LOAD START*****/
-    __memcpy(scores, input_score_ptr + seg_offset, actual_num * sizeof(T),
-             GDRAM2NRAM, actual_num * sizeof(T), actual_num * sizeof(T), 0);
-    __memcpy(boxes, input_boxes_ptr + seg_offset, actual_num * sizeof(T),
-             GDRAM2NRAM, max_seg_num * sizeof(T), input_num_boxes * sizeof(T),
-             4);
-    T *x1 = boxes;
-    T *y1 = x1 + max_seg_num;
-    T *x2 = y1 + max_seg_num;
-    T *y2 = x2 + max_seg_num;
-    __bang_write_value(inter_y1, actual_num_align, (T)max_box_x1);
-    __bang_maxequal(inter_x1, x1, inter_y1, actual_num_align);
-    // max_x2
-    __bang_write_value(inter_y2, actual_num_align, (T)max_box_x2);
-    __bang_minequal(inter_x2, x2, inter_y2, actual_num_align);
-    __bang_sub(inter_x1, inter_x2, inter_x1, actual_num_align);
-    if (pixel_offset) {
-      __bang_add_scalar(inter_x1, inter_x1, (T)1.0, actual_num_align);
-    }
-    // max_y1
-    __bang_write_value(inter_x2, actual_num_align, (T)max_box_y1);
-    __bang_maxequal(inter_y1, y1, inter_x2, actual_num_align);
-    // max_y2
-    __bang_write_value(inter_x2, actual_num_align, (T)max_box_y2);
-    __bang_minequal(inter_y2, y2, inter_x2, actual_num_align);
-    __bang_sub(inter_y1, inter_y2, inter_y1, actual_num_align);
-    if (pixel_offset) {
-      __bang_add_scalar(inter_y1, inter_y1, (T)1.0, actual_num_align);
-    }
-
-    __bang_write_value(inter_y2, actual_num_align, (T)0.0);
-    __bang_maxequal(inter_x1, inter_x1, inter_y2, actual_num_align);
-    __bang_maxequal(inter_y1, inter_y1, inter_y2, actual_num_align);
-    // get the area_i
-    __bang_mul(inter_x1, inter_x1, inter_y1, actual_num_align);
-    // get the area of input_box (y2-y1) * (x2-x1)
-#if __BANG_ARCH__ > 300
-    if (pixel_offset) {
-      __bang_fusion(FUSION_FSA, inter_y1, x2, x1, (T)1.0, actual_num_align,
-                    actual_num_align);
-      __bang_fusion(FUSION_FSA, inter_y2, y2, y1, (T)1.0, actual_num_align,
-                    actual_num_align);
-      __bang_mul(inter_x2, inter_y1, inter_y2, actual_num_align);
-    } else {
-      __bang_sub(inter_y1, x2, x1, actual_num_align);
-      __bang_fusion(FUSION_FSM, inter_x2, y2, y1, inter_y1, actual_num_align,
-                    actual_num_align);
-    }
-    // get the area_u  max_area + area - area_i
-    __bang_fusion(FUSION_FAS, inter_x2, inter_x2, max_area, inter_x1,
-                  actual_num_align, actual_num_align);
-#else
-    // get the area of input_box (y2-y1) * (x2-x1)
-    __bang_sub(inter_y1, x2, x1, actual_num_align);
-    __bang_sub(inter_y2, y2, y1, actual_num_align);
-    if (pixel_offset) {
-      __bang_add_scalar(inter_y1, inter_y1, (T)1.0, actual_num_align);
-      __bang_add_scalar(inter_y2, inter_y2, (T)1.0, actual_num_align);
-    }
-    __bang_mul(inter_x2, inter_y1, inter_y2, actual_num_align);
-    // get the area_u  max_area + area - area_i
-    __bang_add_scalar(inter_x2, inter_x2, max_area, actual_num_align);
-    __bang_sub(inter_x2, inter_x2, inter_x1, actual_num_align);
-#endif
-    // 2. select the box
-    __bang_mul_scalar(inter_x2, inter_x2, nms_thresh, actual_num_align);
-    __bang_le(inter_y1, inter_x1, inter_x2, actual_num_align);
-    __bang_gt(inter_y2, inter_x1, inter_x2, actual_num_align);
-    __bang_mul(inter_y1, scores, inter_y1, actual_num_align);
-    __bang_mul_scalar(inter_y2, inter_y2, FLOAT_MIN, actual_num_align);
-    __bang_add(scores, inter_y1, inter_y2, actual_num_align);
-    /*****NMS COMPUTE END*****/
-    __memcpy(input_score_ptr + seg_offset, scores, actual_num * sizeof(T),
-             NRAM2GDRAM);
-  }
-}
-
-__mlu_func__ void getComputeParams(const int input_num, const int limit,
-                                   const int memory_block,
-                                   const int data_type_size, int *max_seg_num,
-                                   int *repeat, int *remain_num, int *core_num,
-                                   int *core_offset) {
-  int avg_core_num = 0;
-  int rem_core_num = 0;
-  int len_core_num = 0;
-
-  if (clusterDim == 0) {
-    avg_core_num = input_num / taskDim;
-    rem_core_num = input_num % taskDim;
-    len_core_num = avg_core_num + (taskId < rem_core_num);
-    *core_offset =
-        avg_core_num * taskId + (taskId < rem_core_num ? taskId : rem_core_num);
-  } else {
-    const int avg_cluster_num = input_num / clusterDim;
-    const int rem_cluster_num = input_num % clusterDim;
-    const int len_cluster_num = avg_cluster_num + (clusterId < rem_cluster_num);
-    const int cluster_offset_num =
-        avg_cluster_num * clusterId +
-        (clusterId < rem_cluster_num ? clusterId : rem_cluster_num);
-
-    avg_core_num = len_cluster_num / coreDim;
-    rem_core_num = len_cluster_num % coreDim;
-    len_core_num = avg_core_num + (coreId < rem_core_num);
-    *core_offset = cluster_offset_num + avg_core_num * coreId +
-                   (coreId < rem_core_num ? coreId : rem_core_num);
-  }
-
-  *max_seg_num = FLOOR_ALIGN(limit / data_type_size, ALIGN_NUM);
-  *repeat = len_core_num / *max_seg_num;
-  *remain_num = len_core_num % *max_seg_num;
-  *core_num = len_core_num;
-}
+#include "kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h"
 
 template <typename T>
 __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
@@ -335,11 +67,11 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
   T *scores = result + ALIGN_NUM;
   T *ge_mask = scores + max_seg_num;
 
-  T global_max_value = FLOAT_MIN;
-  T local_max_value = FLOAT_MIN;
+  T global_max_value = FLOAT_MIN_GPV2;
+  T local_max_value = FLOAT_MIN_GPV2;
 
   const int align_write_num = CEIL_ALIGN(max_seg_num, ALIGN_NUM);
-  __bang_write_value(scores, align_write_num, FLOAT_MIN);
+  __bang_write_value(scores, align_write_num, FLOAT_MIN_GPV2);
   for (int seg_id = 0; seg_id <= repeat; ++seg_id) {
     if (seg_id == repeat && remain_num == 0) {
       break;
@@ -372,7 +104,7 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
 
   // look for k_score
   T up = global_max_value;
-  T dn = FLOAT_MIN;
+  T dn = FLOAT_MIN_GPV2;
   T mid = dn + (up - dn) * 0.5;
 
   int ge_count = 0;
@@ -389,7 +121,7 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
       const int actual_num = (seg_id == repeat) ? remain_num : max_seg_num;
       const int actual_num_align = CEIL_ALIGN(actual_num, ALIGN_NUM);
 
-      __bang_write_value(scores, actual_num_align, FLOAT_MIN);
+      __bang_write_value(scores, actual_num_align, FLOAT_MIN_GPV2);
       __memcpy(scores, intput_scores_ptr + core_offset + seg_id * max_seg_num,
                sizeof(T) * actual_num, GDRAM2NRAM);
 
@@ -474,13 +206,13 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
       }
 
       // Set the scores of the last `diff` positions of the `mask_eq` equal to 1
-      // to FLOAT_MIN
+      // to FLOAT_MIN_GPV2
       const int count = __bang_count(mask_eq, actual_num_align);
       for (int j = 0; j < count; j++) {
         int eq_score_index = __bang_findlast1(mask_eq, actual_num_align);
         mask_eq[eq_score_index] = 0;
         eq_score_index = eq_score_index + seg_id * max_seg_num;
-        workspace[eq_score_index] = FLOAT_MIN;
+        workspace[eq_score_index] = FLOAT_MIN_GPV2;
         diff_deal_num++;
         if (diff_deal_num == diff) {
           return;
@@ -491,21 +223,11 @@ __mlu_func__ void getKthScore(const T *intput_scores_ptr, T *workspace,
 }
 
 template <typename T>
-__mlu_func__ void calcExp(T *output, T *input, int length) {
-#if __BANG_ARCH__ >= 322
-#define LOG_2_E (1.44269504088f)
-  __bang_mul_scalar(output, input, (float)LOG_2_E, length);
-  __bang_pow2(output, output, length);
-#else
-  __bang_active_exphp(output, input, length);
-#endif
-}
-
-template <typename T>
-__mlu_func__ void createBox(T *proposal_boxes, T *bbox_deltals, T *anchors,
-                            T *variances, T *nram_temp, const int input_stride,
-                            const int count, const T *im_shape,
-                            const bool pixel_offset) {
+__mlu_func__ void proposalBoxesDecode(T *proposal_boxes, T *bbox_deltals,
+                                      T *anchors, T *variances, T *nram_temp,
+                                      const int input_stride, const int count,
+                                      const T *im_shape,
+                                      const bool pixel_offset) {
   // nram space: 10N, N = input_stride
   // | w(oxmin) | h(oymin) | cx(oxmax) | cy(oymax) | d_w | d_h | d_cx | d_cy |
   // tmp1 |
@@ -620,11 +342,11 @@ __mlu_func__ void createBox(T *proposal_boxes, T *bbox_deltals, T *anchors,
 }
 
 template <typename T>
-__mlu_func__ void removeSmallBox(T *proposal_scores, T *proposal_boxes,
-                                 const T *im_shape, T *nram_temp,
-                                 const int input_stride, const int boxes_count,
-                                 int *after_count, const T min_size,
-                                 const bool pixel_offset) {
+__mlu_func__ void filterBoxes(T *proposal_scores, T *proposal_boxes,
+                              const T *im_shape, T *nram_temp,
+                              const int input_stride, const int boxes_count,
+                              int *after_count, const T min_size,
+                              const bool pixel_offset) {
   // nram N = align_count, 7N,
   // | w | h | cx | cy | mask_tmp1 | tmp1 |
   // | N | N | N  | N  | 2N        |  N  |
@@ -782,7 +504,7 @@ __mlu_func__ void createAndRemoveBox(
   T *nram_temp = (T *)ge_mask + max_seg_num;
 
   int core_store_offset = 0;
-  // createbox
+  // proposalBoxesDecode
   for (int seg_id = 0; seg_id <= repeat; ++seg_id) {
     if (seg_id == repeat && remain_num == 0) {
       break;
@@ -794,7 +516,7 @@ __mlu_func__ void createAndRemoveBox(
     const int anchor_offset = (core_offset + seg_id * max_seg_num) * 4;
 
     // load anchors, bbox_deltals, scores, variances
-    __bang_write_value(scores, actual_num_align, FLOAT_MIN);
+    __bang_write_value(scores, actual_num_align, FLOAT_MIN_GPV2);
     __memcpy(scores, intput_scores_ptr + scores_offset, sizeof(T) * actual_num,
              GDRAM2NRAM);
 
@@ -855,11 +577,11 @@ __mlu_func__ void createAndRemoveBox(
     }
 
     // proposals_num = 4 *count
-    createBox(proposals, bbox_deltals, anchors, variances, nram_temp,
-              actual_num_align, count, im_shape, pixel_offset);
+    proposalBoxesDecode(proposals, bbox_deltals, anchors, variances, nram_temp,
+                        actual_num_align, count, im_shape, pixel_offset);
 
-    removeSmallBox(scores, proposals, im_shape, nram_temp, actual_num_align,
-                   count, &after_remove_count, min_size, pixel_offset);
+    filterBoxes(scores, proposals, im_shape, nram_temp, actual_num_align, count,
+                &after_remove_count, min_size, pixel_offset);
 
     if (after_remove_count == 0) {
       continue;
@@ -921,110 +643,6 @@ __mlu_func__ void createAndRemoveBox(
   __memcpy(output_scores + current_offset, output_scores_tmp + core_offset,
            core_store_offset * sizeof(T), GDRAM2GDRAM);
 }
-
-template <typename T>
-__mlu_func__ void nonMaximumSuppress(
-    T *output_boxes_ptr, T *output_scores_ptr, int *output_num,
-    T *input_scores_ptr, const T *input_boxes_ptr, T *workspace,
-    const float nms_thresh, const int max_output_num, const int scores_num,
-    const bool pixel_offset, const int box_stride) {
-  // nram 13 * N, N = max_seg_num
-  // | output_boxes | scores | boxes | inter_x1|
-  // |   4 * N      |     N  | 4*N   |   N     |
-
-  // inter_y1| inter_x2 | inter_y2 |
-  // |   N   |   N      |   N      |
-  int32_t *loop_end_flag = (int32_t *)(sram_buffer + 28);
-  loop_end_flag[0] = 0;
-  // scores, boxes, x1, y1, x2, y2, inter_x1, inter_y1, inter_x2, inter_y2
-  const int memory_block = 13;
-  const int nram_save_limit_count = 256;
-
-  // input data gdram ptr
-  const T *input_x1_ptr = input_boxes_ptr;
-  const T *input_y1_ptr = input_x1_ptr + box_stride;
-  const T *input_x2_ptr = input_y1_ptr + box_stride;
-  const T *input_y2_ptr = input_x2_ptr + box_stride;
-
-  int limit = 0;
-  int max_seg_num = 0;
-  int repeat = 0;
-  int remain_num = 0;
-  int core_offset = 0;
-  int core_num = 0;
-  int nram_save_count = 0;
-
-  limit = (MAX_NRAM_SIZE - NFU_ALIGN_SIZE - nram_save_limit_count * 5) /
-          memory_block;
-  getComputeParams(scores_num, limit, memory_block, sizeof(T), &max_seg_num,
-                   &repeat, &remain_num, &core_num, &core_offset);
-  // init nram ptr
-  T *scores = (T *)nram_buffer;
-  T *x1 = scores + max_seg_num;
-  T *y1 = x1 + max_seg_num;
-  T *x2 = y1 + max_seg_num;
-  T *y2 = x2 + max_seg_num;
-  T *boxes = y2 + max_seg_num;
-  T *inter_x1 = boxes + 4 * max_seg_num;
-  T *inter_y1 = inter_x1 + max_seg_num;
-  T *inter_x2 = inter_y1 + max_seg_num;
-  T *inter_y2 = inter_x2 + max_seg_num;
-  T *max_box = inter_y2 + max_seg_num;
-  T *nram_save = max_box + NFU_ALIGN_SIZE;
-
-  const int nms_num = scores_num > max_output_num ? max_output_num : scores_num;
-
-  for (int nms_id = 0; nms_id < nms_num; ++nms_id) {
-    if (taskDim != 1) {
-      __sync_all_ipu();
-    }
-    /*****Find MaxBox Box*****/
-    int max_index = 0;         // the max score index.
-    int global_max_index = 0;  // for u1.
-    T max_area = 0;            // the max score area.
-    max_box[0] = FLOAT_MIN;    // init 0.
-    findCoreMaxBox(input_scores_ptr, scores, inter_x1, inter_y1, inter_x2,
-                   max_box, input_x1_ptr, input_y1_ptr, input_x2_ptr,
-                   input_y2_ptr, core_offset, repeat, remain_num, max_seg_num,
-                   max_index);
-    if (taskDim == 1) {
-      calMaxArea(max_box, pixel_offset, &max_area);
-      input_scores_ptr[max_index] = FLOAT_MIN;
-      global_max_index = max_index;
-    } else if (taskDim == 4) {
-      __sync_all_ipu();
-      findClusterMaxBox((T *)sram_buffer, max_box, inter_x1, input_scores_ptr);
-      calMaxArea(max_box, pixel_offset, &max_area);
-      global_max_index = ((int *)(max_box + 5))[0];
-    }
-    /******by now, we get: max_score|max_index|max_box|max_area******/
-    storeResult(max_box, nram_save, output_boxes_ptr, output_scores_ptr, nms_id,
-                nram_save_limit_count, nms_num, nms_thresh, nram_save_count,
-                *output_num);
-    if (taskDim == 1) {
-      if (float(max_box[0]) <= FLOAT_MIN || (nms_id == nms_num - 1)) {
-        break;
-      }
-    } else {
-      if (float(max_box[0]) <= FLOAT_MIN || (nms_id == nms_num - 1)) {
-        if (coreId == 0) {
-          loop_end_flag[0] = 1;
-        }
-      }
-      __sync_all_ipu();
-      if (loop_end_flag[0] == 1) {
-        break;
-      }
-    }
-    /*** NMS STORE END***/
-    scoreUpdate(input_scores_ptr, input_boxes_ptr, input_x1_ptr, input_y1_ptr,
-                input_x2_ptr, input_y2_ptr, scores, boxes, inter_x1, inter_y1,
-                inter_x2, inter_y2, max_box, max_box[1], max_box[2], max_box[3],
-                max_box[4], nram_save, repeat, remain_num, max_seg_num,
-                nms_thresh, core_offset, pixel_offset, max_area, box_stride,
-                nms_id);
-  }
-}  // for nms_id < nms_num
 
 template <typename T>
 __mlu_func__ void ProposalForOneImage(
@@ -1113,7 +731,7 @@ __mlu_global__ void mluOpGenerateProposalsV2Kernel(
   *rpn_rois_batch_size = all_proposals_num;
 }
 
-mluOpStatus_t MLUOP_WIN_API KernelGenerateProposalsV2(
+mluOpStatus_t MLUOP_WIN_API KernelGenerateProposalsV2_Default(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
     const float *scores, const float *bbox_deltas, const float *im_shape,
     const float *anchors, const float *variances, float *workspace,

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -3998,9 +3998,10 @@ mluOpGetGenerateProposalsV2WorkspaceSize(mluOpHandle_t handle, const mluOpTensor
  * - None.
  *
  * @par Note
- * - This commit does not support NAN/INF or adaptive NMS.
+ * - The operater does not support adaptive NMS.
  * - The attribute `eta` should not be less than 1.
  * - ``nms_thresh`` should be more than 0.
+ * - On MLU300 series and above, the input \b scores with NaN is not supported.
  *
  * @par Example
  * - None.
@@ -4133,7 +4134,7 @@ mluOpGetPolyNmsWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescriptor_t
  * - None.
  *
  * @par Note
- * - This commit does not support NAN/INF.
+ * - The operator does not support NAN/INF.
  * - The coordinates of the input boxes must all be sorted clockwise or
  *   counterclockwise. If the coordinates of the boxes are out of order,
  *   the calculation result is not guaranteed and is consistent with the


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

check nan/inf state and reconstruct && perf box decode

## 2. Modification

modified:   kernels/generate_proposals_v2/generate_proposals_v2.cpp
modified:   kernels/generate_proposals_v2/generate_proposals_v2.h
new file:   kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
new file:   kernels/generate_proposals_v2/generate_proposals_v2_union1_590.mlu
new file:   kernels/generate_proposals_v2/generate_proposals_v2_union_default.mlu


Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.