### PR TITLE
[Feature](mluOpLgamma) add new operator lgamma

### DIFF
--- a/kernel_depends.toml
+++ b/kernel_depends.toml
@@ -9,6 +9,7 @@
 abs = ["tensor_stride_process","unary_op"]
 div = ["binary_op","tensor_stride_process"]
 log = ["unary_op","tensor_stride_process"]
+lgamma = ["unary_op","tensor_stride_process"]
 sqrt = ["binary_op", "unary_op", "tensor_stride_process"]
 carafe = ["tensor_stride_process"]
 

--- a/kernels/lgamma/lgamma.cpp
+++ b/kernels/lgamma/lgamma.cpp
@@ -1,0 +1,96 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "lgamma.h"
+
+#include "core/context.h"
+#include "core/gen_case.h"
+#include "core/logging.h"
+#include "core/runtime/device.h"
+#include "core/tensor.h"
+#include "core/type.h"
+#include "kernels/unary_op/unary_op_host.h"
+
+mluOpStatus_t MLUOP_WIN_API mluOpLgamma(mluOpHandle_t handle,
+                                        const mluOpTensorDescriptor_t x_desc,
+                                        const void *x,
+                                        const mluOpTensorDescriptor_t y_desc,
+                                        void *y) {
+  // param check
+  mluOpDataType_t support_type[2] = {MLUOP_DTYPE_HALF, MLUOP_DTYPE_FLOAT};
+  bool zero_element = false;
+  mluOpStatus_t param_check =
+      unaryOpParamCheck("[mluOpLgamma]", handle, x_desc, x, y_desc, y,
+                        support_type, 2, zero_element);
+  if (param_check != MLUOP_STATUS_SUCCESS) {
+    return param_check;
+  }
+  if (zero_element == true) {
+    return MLUOP_STATUS_SUCCESS;
+  }
+
+  if (MLUOP_GEN_CASE_ON_NEW) {
+    GEN_CASE_START("lgamma", "Lgamma");
+    GEN_CASE_HANDLE(handle);
+    GEN_CASE_DATA(true, "x", x, x_desc, 100, 0.1);
+    GEN_CASE_DATA(true, "y", y, y_desc, 0, 0);
+    GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
+  }
+
+  // policy select
+  cnrtDim3_t k_dim;
+  cnrtFunctionType_t k_type;
+  unaryOpPolicyFunc(handle, &k_dim, &k_type, x_desc);
+  VLOG(5) << "[mluOpLgamma] launch kernel policyFUnc[" << k_dim.x << ", "
+          << k_dim.y << ", " << k_dim.z << "]";
+
+  int element_num = mluOpGetTensorElementNum(x_desc);
+  if (handle->arch < MLUOP_MLU370) {
+    LOG(ERROR) << "[mluOpLgamma] now only support ARCH >= <MLU370>\n";
+    return MLUOP_STATUS_ARCH_MISMATCH;
+  }
+
+  bool if_stride_kernel = false;
+  if (mluop::strideCaseWithNotConsistentDense(2, x_desc, y_desc)) {
+    if_stride_kernel = true;
+  }
+  if (if_stride_kernel) {
+    VLOG(5) << "kernel Kernel3StagePipelineWithStrideLgamma";
+    PARAM_CHECK("[mluOpLgamma]", x_desc->dim <= MLUOP_DIM_MAX);
+    mluop::TensorShape x_shape;
+    mluop::TensorShape y_shape;
+    mluop::getTensorShape(x_desc, &x_shape);
+    mluop::getTensorShape(y_desc, &y_shape);
+    CHECK_RETURN("[mluOpLgamma]",
+                 Kernel3StagePipelineWithStrideLgamma(
+                     k_dim, k_type, handle->queue, x_desc->dtype, x, x_shape, y,
+                     y_shape, element_num));
+  } else {
+    VLOG(5) << "kernel Kernel3StagePipelineLgamma.";
+    CHECK_RETURN("[mluOpLgamma]",
+                 Kernel3StagePipelineLgamma(k_dim, k_type, handle->queue,
+                                            x_desc->dtype, x, y, element_num));
+  }
+  GEN_CASE_END();
+
+  return MLUOP_STATUS_SUCCESS;
+}

--- a/kernels/lgamma/lgamma.h
+++ b/kernels/lgamma/lgamma.h
@@ -1,0 +1,39 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef KERNEL_LGAMMA_LGAMMA_H_
+#define KERNEL_LGAMMA_LGAMMA_H_
+
+#include "mlu_op.h"
+#include "kernels/tensor_stride_process/tensor_stride_process_host.h"
+
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLgamma(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    mluOpDataType_t d_type, const void *x, void *y, const int num);
+
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineWithStrideLgamma(
+    const cnrtDim3_t k_dim, const cnrtFunctionType_t k_type,
+    const cnrtQueue_t queue, const mluOpDataType_t d_type, const void *x,
+    mluop::TensorShape x_shape, void *y, mluop::TensorShape y_shape,
+    size_t element_num);
+
+#endif  // KERNEL_LGAMMA_LGAMMA_H_

--- a/kernels/lgamma/lgamma_block.mlu
+++ b/kernels/lgamma/lgamma_block.mlu
@@ -1,0 +1,280 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "lgamma.h"
+
+#include "core/logging.h"
+#include "kernels/debug.h"
+#include "kernels/kernel.h"
+#include "kernels/unary_op/unary_op_3pipeline.h"
+#include "kernels/tensor_stride_process/tensor_stride_process_common.h"
+#include "kernels/unary_op/unary_op_stride_3pipeline.h"
+
+#define AUX_N 3
+
+__nram__ char nram_buffer[UNARY_NRAM_SIZE];
+
+const float epsilon = 1e-15;
+const uint32_t inf_float_value = 0x7f800000;
+const uint32_t nan_float_mask = inf_float_value | 0x7fffff;
+const float log_e_2 =
+    0.69314718055994530941723212145818;  // ln(x) = log(x) * log_e_2
+
+// dst = a*sel + !sel*b
+// a can overlap with dst
+// float 1: [0 01111111 00000000000000000000000] >> 29 -> int 1
+__mlu_func__ void mux2(float *dst, float *a, float *b, float *sel,
+                       uint32_t sz) {
+  __bang_srl((uint32_t *)sel, (uint32_t *)sel, 29, sz);
+  __bang_mul_scalar((int32_t *)sel, (int32_t *)sel, -1, sz);
+  __bang_band((char *)dst, (char *)a, (char *)sel, sz * sizeof(float));
+  __bang_bnot((char *)sel, (char *)sel, sz * sizeof(float));
+  __bang_band((char *)sel, (char *)b, (char *)sel, sz * sizeof(float));
+  __bang_bor((char *)dst, (char *)dst, (char *)sel, sz * sizeof(float));
+}
+
+__mlu_func__ void isFinite(float *dst, float *src, uint32_t sz) {
+  __bang_band_scalar((int *)dst, (int *)src, (int)inf_float_value, sz);
+  __bang_ne_scalar((int *)dst, (int *)dst, (int)inf_float_value, sz);
+  __bang_int322float(dst, (int *)dst, sz, 0);
+}
+
+__mlu_func__ void isInf(float *dst, float *src, uint32_t sz) {
+  __bang_band_scalar((int *)dst, (int *)src, (int)nan_float_mask, sz);
+  __bang_eq_scalar((int *)dst, (int *)dst, (int)inf_float_value, sz);
+  __bang_int322float(dst, (int *)dst, sz, 0);
+}
+
+__mlu_func__ void logHp(float *dst, float *src, uint32_t sz) {
+  __bang_log(dst, src, sz);
+  __bang_mul_scalar(dst, dst, log_e_2, sz);
+}
+
+__mlu_func__ void calcLgamma(float *buf0, float *buf1, float *buf2, float *buf3,
+                             float *buf4, int num_deal) {
+  static const int numCoeff = 4;
+  static const float log_pi = 1.144730;
+  static const float coeff[numCoeff] = {
+      2.50663,
+      34.7892,
+      -20.8994,
+      1.35914,
+  };
+
+  // eliminate the -0 by add epsilon and sub epsilon
+  __bang_add_scalar(buf0, buf0, epsilon, num_deal);
+  __bang_sub_scalar(buf0, buf0, epsilon, num_deal);
+
+  /**
+   * bool need_to_reflect = (input < 0);
+   */
+  __bang_lt_scalar(buf4, buf0, 0, num_deal);
+
+  /**
+   * float reflect_x = need_reflect ? 1-input : input;
+   */
+  // using buf1 -> reflect_x
+  __bang_mul_scalar(buf1, buf0, -1, num_deal);
+  __bang_add_scalar(buf1, buf1, 1, num_deal);
+  mux2(buf1, buf1, buf0, buf4, num_deal);
+
+  /**
+    float accm = coeffs[0];
+    int numCoeff = coeffs.size();   // aka a
+    for (size_t k = 1; k < numCoeff; k++) {
+      accm += coeffs[k] / (reflect_x + k);
+    }
+    */
+  // do loop flatten, using buf2 -> accm
+  __bang_add_scalar(buf3, buf1, 1, num_deal);
+  __bang_recip(buf3, buf3, num_deal);
+  __bang_fusion(FUSION_FMA, buf2, buf3, coeff[1], coeff[0], num_deal);
+
+  __bang_add_scalar(buf3, buf1, 2, num_deal);
+  __bang_recip(buf3, buf3, num_deal);
+  __bang_fusion(FUSION_FMA, buf2, buf3, coeff[2], buf2, num_deal, num_deal);
+
+  __bang_add_scalar(buf3, buf1, 3, num_deal);
+  __bang_recip(buf3, buf3, num_deal);
+  __bang_fusion(FUSION_FMA, buf2, buf3, coeff[3], buf2, num_deal, num_deal);
+
+  /**
+   * float lgamma_x = (reflect_x+0.5)*log(reflect_x+numCoeff) -
+   * (reflect_x+numCoeff) + log(accm/reflect_x);
+   */
+  // using buf1 -> lgamma_x
+  __mluop_div(buf3, buf2, buf1, (float *)0, 0, num_deal);
+  logHp(buf2, buf3, num_deal);
+  __bang_add_scalar(buf3, buf1, numCoeff, num_deal);
+  __bang_add_scalar(buf1, buf1, 0.5, num_deal);
+  __bang_sub(buf2, buf2, buf3, num_deal);
+  logHp(buf3, buf3, num_deal);
+  __bang_fusion(FUSION_FMA, buf1, buf3, buf1, buf2, num_deal, num_deal);
+
+  /**
+   * float abs_input = fabs(input);
+   * float abs_frac_input = abs_input - floorf(abs_input);
+   */
+  // using buf4 -> abs_frac_input
+  __bang_abs(buf2, buf0, num_deal);
+  __bang_floor(buf3, buf2, num_deal);
+  __bang_sub(buf4, buf2, buf3, num_deal);
+
+  /**
+   * float reduced_frac_input = (abs_frac_input > 0.5) ? 1 - abs_frac_input :
+   * abs_frac_input;
+   */
+  // using buf3 -> reduced_frac_input
+  __bang_gt_scalar(buf2, buf4, 0.5, num_deal);
+  __bang_fusion(FUSION_FMA, buf3, buf4, -1, 1, num_deal);
+  mux2(buf3, buf3, buf4, buf2, num_deal);
+
+  /**
+   * float reflection_denom = log(sinf(M_PI * reduced_frac_input));
+   */
+  // using buf2 -> reflection_denom
+  __bang_mul_scalar(buf2, buf3, M_PI, num_deal);
+  __cn_vector_sin_f32(num_deal, buf2, buf2);
+  logHp(buf2, buf2, num_deal);
+
+  /**
+   * float reflection = std::isfinite(reflection_denom) ? log_pi -
+   * reflection_denom - lgamma_x : -reflection_denom;
+   */
+  // using buf3 -> reflection
+  __bang_write_zero(buf4, num_deal);
+  __bang_sub(buf2, buf4, buf2, num_deal);
+  isFinite(buf4, buf2, num_deal);
+  __bang_sub(buf3, buf2, buf1, num_deal);
+  __bang_add_scalar(buf3, buf3, log_pi, num_deal);
+  mux2(buf3, buf3, buf2, buf4, num_deal);
+
+  /**
+   * float result = need_to_reflect ? reflection : lgamma_x;
+   */
+  // using buf2 -> result
+  __bang_lt_scalar(buf4, buf0, 0, num_deal);
+  mux2(buf2, buf3, buf1, buf4, num_deal);
+
+  /**
+   * return isinf(input) ? INFINITY : result;
+   */
+  isInf(buf1, buf0, num_deal);
+  __bang_write_value(buf3, num_deal, (int)(inf_float_value));
+  mux2(buf4, buf3, buf2, buf1, num_deal);
+}
+
+template <typename T1, typename T2>
+__mlu_func__ void auxFunc3LgammaFloat(
+    size_t &output_input_gap, size_t &ping_pong_gap, size_t &auxiliary_a_gap,
+    size_t &auxiliary_b_gap, size_t &span_num_deal, size_t &align_num) {
+  align_num = NFU_ALIGN_SIZE / sizeof(float);
+  // | input-ping | output-ping | input-pong | output-pong | aux1 | aux2 | aux3
+  // | 7 buffer
+  span_num_deal = PAD_DOWN(UNARY_NRAM_SIZE / sizeof(float) / 7,
+                           NFU_ALIGN_SIZE / sizeof(float));
+  ping_pong_gap = 2 * span_num_deal * sizeof(float);
+  output_input_gap = span_num_deal * sizeof(float);
+  auxiliary_a_gap = 4 * span_num_deal * sizeof(float);
+  auxiliary_b_gap = 0;
+}
+
+template <typename T1, typename T2>
+__mlu_func__ void computeLgammaFloat(char *nram_output, char *nram_input,
+                                     char *auxiliary_a, char *auxiliary_b,
+                                     size_t deal_num, size_t actual_num) {
+  float *aux_array[AUX_N];
+  for (size_t i = 0; i < AUX_N; i++) {
+    aux_array[i] = (float *)(auxiliary_a + i * deal_num * sizeof(float));
+  }
+  calcLgamma((float *)nram_input, aux_array[0], aux_array[1], aux_array[2],
+             (float *)nram_output, actual_num);
+}
+
+template <typename T1, typename T2>
+__mlu_func__ void auxFunc3LgammaHalf(size_t &output_input_gap,
+                                     size_t &ping_pong_gap,
+                                     size_t &auxiliary_a_gap,
+                                     size_t &auxiliary_b_gap,
+                                     size_t &span_num_deal, size_t &align_num) {
+  align_num = NFU_ALIGN_SIZE / sizeof(float);
+  // input-ping -- output--ping | input-pong -- ouput-poing | aux....|
+  // 7 buffer
+  span_num_deal = PAD_DOWN(UNARY_NRAM_SIZE / sizeof(float) / 7,
+                           NFU_ALIGN_SIZE / sizeof(float));
+  ping_pong_gap = 2 * span_num_deal * sizeof(float);
+  output_input_gap = span_num_deal * sizeof(float);
+  auxiliary_a_gap = 4 * span_num_deal * sizeof(float);
+  auxiliary_b_gap = 0;
+}
+
+template <typename T1, typename T2>
+__mlu_func__ void computeLgammaHalf(char *nram_output, char *nram_input,
+                                    char *auxiliary_a, char *auxiliary_b,
+                                    size_t deal_num, size_t actual_num) {
+  float *aux_array[AUX_N];
+  for (size_t i = 0; i < AUX_N; i++) {
+    aux_array[i] = (float *)(auxiliary_a + i * deal_num * sizeof(float));
+  }
+
+  __bang_half2float(aux_array[0], (half *)nram_input, actual_num);
+
+  calcLgamma(aux_array[0], (float *)nram_input, aux_array[1], aux_array[2],
+             (float *)nram_output, actual_num);
+
+  __mluop_float2half((half *)nram_output, (float *)nram_output, actual_num);
+}
+
+UNARY_OP_KERNEL_3PIPELINE_IMPLE(Lgamma, Float);
+UNARY_OP_KERNEL_3PIPELINE_WITH_STRIDE_IMPLE(Lgamma, Float);
+
+UNARY_OP_KERNEL_3PIPELINE_IMPLE(Lgamma, Half);
+UNARY_OP_KERNEL_3PIPELINE_WITH_STRIDE_IMPLE(Lgamma, Half);
+
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLgamma(
+    const cnrtDim3_t k_dim, const cnrtFunctionType_t k_type,
+    const cnrtQueue_t queue, const mluOpDataType_t d_type, const void *x,
+    void *y, const int32_t num) {
+  if (d_type == MLUOP_DTYPE_FLOAT) {
+    KERNEL_CHECK(MLUBlockKernel3StagePipelineLgammaFloat<float, float>
+                 <<<k_dim, k_type, queue>>>((char *)x, (char *)y, num););
+  } else {  // d_type == MLUOP_DTYPE_HALF
+    KERNEL_CHECK(MLUBlockKernel3StagePipelineLgammaHalf<half, half>
+                 <<<k_dim, k_type, queue>>>((char *)x, (char *)y, num););
+  }
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineWithStrideLgamma(
+    const cnrtDim3_t k_dim, const cnrtFunctionType_t k_type,
+    const cnrtQueue_t queue, const mluOpDataType_t d_type, const void *x,
+    mluop::TensorShape x_shape, void *y, mluop::TensorShape y_shape,
+    size_t element_num) {
+  if (d_type == MLUOP_DTYPE_FLOAT) {
+    KERNEL_CHECK(MLUBlockKernel3StagePipelineLgammaFloat<float, float>
+                 <<<k_dim, k_type, queue>>>((char *)x, (char *)y, element_num));
+  } else {
+    KERNEL_CHECK(MLUBlockKernel3StagePipelineLgammaHalf<half, half>
+                 <<<k_dim, k_type, queue>>>((char *)x, (char *)y, element_num));
+  }
+  return MLUOP_STATUS_SUCCESS;
+}

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -14435,6 +14435,62 @@ mluOpExecFFT(mluOpHandle_t handle,
  */
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyFFTPlan(mluOpFFTPlan_t fft_plan);
+
+// Group:Lgamma
+/*!
+ * @brief Computes the lgamma value for every element of the input tensor \b x
+ * and returns results in \b y.
+ *
+ * @param[in] handle
+ * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and
+ * queues in the lgamma operation. For detailed information, see
+ * ::mluOpHandle_t.
+ * @param[in] x_desc
+ * The descriptor of the tensor \b x. For detailed information, see
+ * ::mluOpTensorDescriptor_t.
+ * @param[in] x
+ * Pointer to the MLU memory that stores the input tensor.
+ * @param[in] y_desc
+ * The descriptor of the tensor \b y. For detailed information, see
+ * ::mluOpTensorDescriptor_t.
+ * @param[in] y
+ * Pointer to the MLU memory that stores the output tensor.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
+ *
+ * @par Data Type
+ * - The data type of input tensor and output tensor must be the same.
+ * - The supported data types of input and output tensors are as follows:
+ *   - input tensor: half, float
+ *   - output tensor: half, float
+ *
+ * @par Data Layout
+ * - None.
+ *
+ * @par Scale Limitation
+ * - The input tensor and output tensor must have the same shape.
+ *
+ * @par API Dependency
+ * - None.
+ *
+ * @par Note
+ * - Node.
+ *
+ * @par Example
+ * - None.
+ *
+ * @par Reference
+ * - https://pytorch.org/docs/stable/generated/torch.lgamma.html#torch-lgamma
+ */
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpLgamma(mluOpHandle_t handle,
+            const mluOpTensorDescriptor_t x_desc,
+            const void *x,
+            const mluOpTensorDescriptor_t y_desc,
+            void *y);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/lgamma/lgamma.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/lgamma/lgamma.cpp
@@ -1,0 +1,73 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "lgamma.h"
+
+namespace mluoptest {
+
+void LgammaExecutor::paramCheck() {
+  GTEST_CHECK(parser_->inputs().size() == 1,
+              "lgamma tensor input number is wrong.");
+  GTEST_CHECK(parser_->outputs().size() == 1,
+              "lgamma tensor output number is wrong.");
+  inplace_ = parser_->getProtoNode()->lgamma_param().inplace();
+}
+
+void LgammaExecutor::setMiscellaneousParam() {
+  if (inplace_) {
+    data_vector_[0].alsoServeAsOutput();
+    data_vector_[1].onlyServeAsInput();
+  }
+}
+void LgammaExecutor::compute() {
+  VLOG(4) << "LgammaExecutor compute ";
+  auto tensor_x = tensor_desc_[0].tensor;
+  auto tensor_y = tensor_desc_[1].tensor;
+  auto dev_x = data_vector_[0].device_ptr;
+  auto dev_y = data_vector_[1].device_ptr;
+
+  if (inplace_) {
+    dev_y = dev_x;
+  }
+
+  VLOG(4) << "call mluOpLgamma()";
+  interface_timer_.start();
+  MLUOP_CHECK(mluOpLgamma(handle_, tensor_x, dev_x, tensor_y, dev_y));
+  interface_timer_.stop();
+}
+
+void LgammaExecutor::cpuCompute() {
+  auto count = parser_->input(0)->shape_count;
+
+  for (int i = 0; i < count; ++i) {
+    cpu_fp32_output_[0][i] = ::lgamma(cpu_fp32_input_[0][i]);
+  }
+}
+
+int64_t LgammaExecutor::getTheoryOps() {
+  int64_t theory_ops = parser_->input(0)->total_count;
+  VLOG(4) << "getTheoryOps: " << theory_ops << " ops";
+  return theory_ops;
+}
+
+}  // namespace mluoptest
+

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/lgamma/lgamma.h
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/lgamma/lgamma.h
@@ -1,0 +1,46 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef TEST_MLU_OP_GTEST_SRC_ZOO_LGAMMA_LGAMMA_H_
+#define TEST_MLU_OP_GTEST_SRC_ZOO_LGAMMA_LGAMMA_H_
+#include "executor.h"
+
+namespace mluoptest {
+
+class LgammaExecutor : public Executor {
+ public:
+  LgammaExecutor() {}
+  ~LgammaExecutor() {}
+
+  void paramCheck();
+  void setMiscellaneousParam();
+  void compute();
+  void cpuCompute();
+  int64_t getTheoryOps() override;
+
+ private:
+  bool inplace_ = false;
+};
+
+}  // namespace mluoptest
+
+#endif  // TEST_MLU_OP_GTEST_SRC_ZOO_LGAMMA_LGAMMA_H_


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

add new operator lgamma

## 2. Modification

add implementation of lgamma

## 3. Test Report

not yet

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [X] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [X] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 3e-3
    - float16, threshold = 3e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [X] MLU370
  - [X] MLU590
- Job types
  - [x] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [X] Data type test (e.g. float32/int8)
- [X] Multi-dimensional tensor test
- [X] Layout test
- [X] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [X] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

```bash
[       OK ] lgamma/TestSuite.mluOp/70 (62 ms)
[----------] 71 tests from lgamma/TestSuite (3641 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 71 cases of 1 op(s).
ALL PASSED.
[==========] 71 test cases from 1 test suite ran. (8300 ms total)
[  PASSED  ] 71 test cases.
```

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370



### 3.4 Summary Analysis

the v1.0 lgamma implemtentation is a simd operator, and lack of stride support

Please give a brief overview here, if you want to note and summarize the content.