### PR TITLE
fft_c2c_2d

### DIFF
--- a/kernels/fft/c2c_fft/c2c_fft.h
+++ b/kernels/fft/c2c_fft/c2c_fft.h
@@ -31,6 +31,10 @@ mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan);
 mluOpStatus_t setFFT1dReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
                                   const std::string api);
 
+mluOpStatus_t setFFT1dReserveArea_v2(mluOpHandle_t handle,
+                                     mluOpFFTPlan_t fft_plan,
+                                     const std::string api);
+
 mluOpStatus_t execFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                         const void *input, const float scale_factor,
                         void *workspace, void *output, int direction);

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -24,7 +24,8 @@
 #include "fft_basic_ops.h"
 
 bool fftIsIntDtype(const mluOpDataType_t dtype) {
-  if (dtype == MLUOP_DTYPE_INT8 || dtype == MLUOP_DTYPE_INT16) {
+  if (dtype == MLUOP_DTYPE_INT8 || dtype == MLUOP_DTYPE_INT16 ||
+      dtype == MLUOP_DTYPE_INT31) {
     return true;
   } else {
     return false;
@@ -50,13 +51,14 @@ mluOpStatus_t fftGetQuantizeParamWorkspaceSize(mluOpHandle_t handle,
   if (data_type != compute_type) {
     // create descriptor
     mluOpTensorDescriptor_t input_desc;
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&input_desc));
+    status = mluOpCreateTensorDescriptor(&input_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // set descriptor
     int64_t input_dims[1] = {array_length};
-    CHECK_RETURN(api,
-                 mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
-                                             data_type, 1, input_dims));
+    status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
+                                         data_type, 1, input_dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                       cnnl_handle);  // convert to cnnl_handle
@@ -84,13 +86,14 @@ mluOpStatus_t fftQuantizePositionScale(mluOpHandle_t handle, int array_length,
   if (data_type != compute_type) {
     // create descriptor
     mluOpTensorDescriptor_t quant_desc;
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&quant_desc));
+    status = mluOpCreateTensorDescriptor(&quant_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // set descriptor
     int64_t quant_dims[1] = {array_length};
-    CHECK_RETURN(api,
-                 mluOpSetTensorDescriptor_v2(quant_desc, MLUOP_LAYOUT_ARRAY,
-                                             data_type, 1, quant_dims));
+    status = mluOpSetTensorDescriptor_v2(quant_desc, MLUOP_LAYOUT_ARRAY,
+                                         data_type, 1, quant_dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                       cnnl_handle);  // convert to cnnl_handle
@@ -124,9 +127,12 @@ mluOpStatus_t fftGetQuantizeMatMulWorkspaceSize(
   mluOpTensorDescriptor_t a_desc = nullptr;
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&a_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&b_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&c_desc));
+  status = mluOpCreateTensorDescriptor(&a_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&b_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&c_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   // set descriptor
   int64_t a_dims[2];
@@ -146,23 +152,30 @@ mluOpStatus_t fftGetQuantizeMatMulWorkspaceSize(
     b_dims[0] = k;
     b_dims[1] = n;
   }
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 2, a_dims));
-  CHECK_RETURN(api,
-               mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 2, b_dims));
-  CHECK_RETURN(api,
-               mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 2, c_dims));
-  if (fftIsIntDtype(a_compute_type) && fftIsIntDtype(b_compute_type) &&
-      c_desc->dtype == MLUOP_DTYPE_HALF) {
-    CHECK_RETURN(
-        api, mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT));
+  status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
+                                       a_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
+                                       b_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
+                                       c_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  if (a_compute_type == MLUOP_DTYPE_INT31 ||
+      b_compute_type == MLUOP_DTYPE_INT31) {
+    status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  } else if (fftIsIntDtype(a_compute_type) && fftIsIntDtype(b_compute_type) &&
+             c_desc->dtype == MLUOP_DTYPE_HALF) {
+    status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   } else {
-    CHECK_RETURN(api,
-                 mluOpSetTensorDescriptorOnchipDataType(c_desc, data_type));
+    status = mluOpSetTensorDescriptorOnchipDataType(c_desc, data_type);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   }
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
@@ -227,9 +240,12 @@ mluOpStatus_t fftQuantMatMul(mluOpHandle_t handle, int m, int k, int n,
   mluOpTensorDescriptor_t a_desc = nullptr;
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&a_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&b_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&c_desc));
+  status = mluOpCreateTensorDescriptor(&a_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&b_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&c_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   // set descriptor
   int64_t a_dims[2];
@@ -249,23 +265,30 @@ mluOpStatus_t fftQuantMatMul(mluOpHandle_t handle, int m, int k, int n,
     b_dims[0] = k;
     b_dims[1] = n;
   }
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 2, a_dims));
-  CHECK_RETURN(api,
-               mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 2, b_dims));
-  CHECK_RETURN(api,
-               mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 2, c_dims));
-  if (fftIsIntDtype(a_compute_type) && fftIsIntDtype(b_compute_type) &&
-      c_desc->dtype == MLUOP_DTYPE_HALF) {
-    CHECK_RETURN(
-        api, mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT));
+  status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
+                                       a_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
+                                       b_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
+                                       c_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  if (a_compute_type == MLUOP_DTYPE_INT31 ||
+      b_compute_type == MLUOP_DTYPE_INT31) {
+    status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  } else if (fftIsIntDtype(a_compute_type) && fftIsIntDtype(b_compute_type) &&
+             c_desc->dtype == MLUOP_DTYPE_HALF) {
+    status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   } else {
-    CHECK_RETURN(api,
-                 mluOpSetTensorDescriptorOnchipDataType(c_desc, data_type));
+    status = mluOpSetTensorDescriptorOnchipDataType(c_desc, data_type);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   }
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
@@ -344,9 +367,12 @@ mluOpStatus_t fftBatchMatMulBcast(
   mluOpTensorDescriptor_t a_desc = nullptr;
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&a_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&b_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&c_desc));
+  status = mluOpCreateTensorDescriptor(&a_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&b_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&c_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   // set descriptor
   int a_dims[2];
@@ -366,16 +392,19 @@ mluOpStatus_t fftBatchMatMulBcast(
     b_dims[1] = k;
     b_dims[2] = n;
   }
-  CHECK_RETURN(api, mluOpSetTensorDescriptor(a_desc, MLUOP_LAYOUT_ARRAY,
-                                             data_type, 2, a_dims));
-  CHECK_RETURN(api,
-               mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor(b_desc, MLUOP_LAYOUT_ARRAY,
-                                             data_type, 3, b_dims));
-  CHECK_RETURN(api,
-               mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor(c_desc, MLUOP_LAYOUT_ARRAY,
-                                             data_type, 3, c_dims));
+  status = mluOpSetTensorDescriptor(a_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
+                                    a_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor(b_desc, MLUOP_LAYOUT_ARRAY, data_type, 3,
+                                    b_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor(c_desc, MLUOP_LAYOUT_ARRAY, data_type, 3,
+                                    c_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   c_desc->onchip_dtype = MLUOP_DTYPE_FLOAT;
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
@@ -410,7 +439,8 @@ mluOpStatus_t fftGetTransposeWorkspaceSize(mluOpHandle_t handle,
 
   // create descriptor
   mluOpTensorDescriptor_t input_desc = nullptr;
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&input_desc));
+  status = mluOpCreateTensorDescriptor(&input_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   cnnlTransposeDescriptor_t trans_desc = nullptr;
   CALL_CNNL(cnnlCreateTransposeDescriptor(&trans_desc));
@@ -418,8 +448,9 @@ mluOpStatus_t fftGetTransposeWorkspaceSize(mluOpHandle_t handle,
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
   // set descriptor
-  CHECK_RETURN(api, mluOpSetTensorDescriptor(input_desc, MLUOP_LAYOUT_ARRAY,
-                                             data_type, dim_num, ori_dims));
+  status = mluOpSetTensorDescriptor(input_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                    dim_num, ori_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_desc, cnnl_input_desc);
 
   CALL_CNNL(cnnlSetTransposeDescriptor(trans_desc, dim_num, permute));
@@ -445,15 +476,18 @@ mluOpStatus_t fftTranspose(mluOpHandle_t handle, int dim_num, int ori_dims[],
   // create descriptor
   mluOpTensorDescriptor_t input_desc = nullptr;
   mluOpTensorDescriptor_t transed_input_desc = nullptr;
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&input_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&transed_input_desc));
+  status = mluOpCreateTensorDescriptor(&input_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&transed_input_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   // set descriptor
-  CHECK_RETURN(api, mluOpSetTensorDescriptor(input_desc, MLUOP_LAYOUT_ARRAY,
-                                             data_type, dim_num, ori_dims));
-  CHECK_RETURN(api,
-               mluOpSetTensorDescriptor(transed_input_desc, MLUOP_LAYOUT_ARRAY,
-                                        data_type, dim_num, transed_dims));
+  status = mluOpSetTensorDescriptor(input_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                    dim_num, ori_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor(transed_input_desc, MLUOP_LAYOUT_ARRAY,
+                                    data_type, dim_num, transed_dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -491,18 +525,24 @@ mluOpStatus_t fftGetOptensorWorkspaceSize(mluOpHandle_t handle,
   mluOpTensorDescriptor_t in1_desc = nullptr;
   mluOpTensorDescriptor_t in2_desc = nullptr;
   mluOpTensorDescriptor_t out_desc = nullptr;
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&in1_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&in2_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&out_desc));
+  status = mluOpCreateTensorDescriptor(&in1_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&in2_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&out_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   // set descriptor
   int64_t dims[1] = {elem_num};
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(in1_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 1, dims));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(in2_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 1, dims));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(out_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 1, dims));
+  status = mluOpSetTensorDescriptor_v2(in1_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                       1, dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(in2_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                       1, dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(out_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                       1, dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -516,6 +556,7 @@ mluOpStatus_t fftGetOptensorWorkspaceSize(mluOpHandle_t handle,
   CALL_CNNL(cnnlGetOpTensorWorkspaceSize(cnnl_handle, cnnl_in1_desc,
                                          cnnl_in2_desc, cnnl_out_desc,
                                          &workspace_size));
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   // destroy descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_in1_desc);
@@ -538,18 +579,24 @@ mluOpStatus_t fftOptensor(mluOpHandle_t handle, int elem_num, void *in1_ptr,
   mluOpTensorDescriptor_t in1_desc = nullptr;
   mluOpTensorDescriptor_t in2_desc = nullptr;
   mluOpTensorDescriptor_t out_desc = nullptr;
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&in1_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&in2_desc));
-  CHECK_RETURN(api, mluOpCreateTensorDescriptor(&out_desc));
+  status = mluOpCreateTensorDescriptor(&in1_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&in2_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpCreateTensorDescriptor(&out_desc);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   // set descriptor
   int64_t dims[1] = {elem_num};
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(in1_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 1, dims));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(in2_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 1, dims));
-  CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(out_desc, MLUOP_LAYOUT_ARRAY,
-                                                data_type, 1, dims));
+  status = mluOpSetTensorDescriptor_v2(in1_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                       1, dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(in2_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                       1, dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  status = mluOpSetTensorDescriptor_v2(out_desc, MLUOP_LAYOUT_ARRAY, data_type,
+                                       1, dims);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle

--- a/kernels/fft/common/fft_common_kernels.mlu
+++ b/kernels/fft/common/fft_common_kernels.mlu
@@ -56,7 +56,7 @@ __mlu_func__ void convert(half *dst, float *src, int length) {
   [output] src_addr: output data
  */
 template <typename T>
-__mlu_func__ void __mluop_mod(T *src_addr, T *temp_addr, T n, int len) {
+__mlu_func__ void __mluOp_mod(T *src_addr, T *temp_addr, T n, int len) {
   T array_max;
   __bang_argmax(temp_addr, src_addr, len);
   array_max = temp_addr[0];
@@ -152,7 +152,8 @@ __mlu_func__ void generateRFFTHalfDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mluop_get_indices(deal_size, (float)0.0, inc_addr, nullptr, inc_addr,
+                      nullptr);
 
   // generate sin and cos vectors
   const float scale = -2.0 * M_PI / n;
@@ -165,7 +166,7 @@ __mlu_func__ void generateRFFTHalfDFTMatrixImpl(int n, void *output) {
     // generate offsets
     __memcpy(offset_addr, inc_addr, deal_size * sizeof(float), NRAM2NRAM);
     __bang_mul_scalar(offset_addr, offset_addr, (float)row_i, deal_size);
-    __mluop_mod(offset_addr, temp_addr, (float)n, deal_size);
+    __mluOp_mod(offset_addr, temp_addr, (float)n, deal_size);
 
     genSelectOffsetVec(offset_addr, offset_int_addr, pad_col);
 
@@ -236,7 +237,8 @@ __mlu_func__ void generateRFFTFullDFTMatrixImpl(int row, int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mluop_get_indices(deal_size, (float)0.0, inc_addr, nullptr, inc_addr,
+                      nullptr);
 
   // generate sin and cos vectors
   const float scale = -2.0 * M_PI / n;
@@ -249,7 +251,7 @@ __mlu_func__ void generateRFFTFullDFTMatrixImpl(int row, int n, void *output) {
     // generate offsets
     __memcpy(offset_addr, inc_addr, deal_size * sizeof(float), NRAM2NRAM);
     __bang_mul_scalar(offset_addr, offset_addr, (float)row_i, deal_size);
-    __mluop_mod(offset_addr, temp_addr, (float)n, deal_size);
+    __mluOp_mod(offset_addr, temp_addr, (float)n, deal_size);
 
     genSelectOffsetVec(offset_addr, offset_int_addr, pad_col);
 
@@ -325,7 +327,8 @@ __mlu_func__ void generateIRFFTHalfDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mluop_get_indices(deal_size, (float)0.0, inc_addr, nullptr, inc_addr,
+                      nullptr);
 
   // generate sin and cos coefficient vectors
   __bang_write_value((float *)cos_coeff_addr, deal_size, (float)2.0);
@@ -346,7 +349,7 @@ __mlu_func__ void generateIRFFTHalfDFTMatrixImpl(int n, void *output) {
     // generate offsets
     __memcpy(offset_addr, inc_addr, pad_col * sizeof(float), NRAM2NRAM);
     __bang_mul_scalar(offset_addr, offset_addr, (float)row_i, pad_col);
-    __mluop_mod(offset_addr, temp_addr, (float)n, pad_col);
+    __mluOp_mod(offset_addr, temp_addr, (float)n, pad_col);
 
     genSelectOffsetVec(offset_addr, offset_int_addr, pad_col);
 
@@ -420,7 +423,8 @@ __mlu_func__ void generateIRFFTFullDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mluop_get_indices(deal_size, (float)0.0, inc_addr, nullptr, inc_addr,
+                      nullptr);
 
   // generate sin and cos vectors
   const float scale = 2.0 * M_PI / n;
@@ -433,7 +437,7 @@ __mlu_func__ void generateIRFFTFullDFTMatrixImpl(int n, void *output) {
     // generate offsets
     __memcpy(offset_addr, inc_addr, pad_col * sizeof(float), NRAM2NRAM);
     __bang_mul_scalar(offset_addr, offset_addr, (float)row_i, pad_col);
-    __mluop_mod(offset_addr, temp_addr, (float)n, pad_col);
+    __mluOp_mod(offset_addr, temp_addr, (float)n, pad_col);
 
     genSelectOffsetVec(offset_addr, offset_int_addr, pad_col);
 
@@ -516,7 +520,8 @@ __mlu_func__ void generateC2CFFTDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mluop_get_indices(deal_size, (float)0.0, inc_addr, nullptr, inc_addr,
+                      nullptr);
 
   // generate sin and cos vectors
   const float forward_scale = -2.0 * M_PI / n;
@@ -535,7 +540,7 @@ __mlu_func__ void generateC2CFFTDFTMatrixImpl(int n, void *output) {
     // generate offsets
     __memcpy(offset_addr, inc_addr, pad_col * sizeof(float), NRAM2NRAM);
     __bang_mul_scalar(offset_addr, offset_addr, (float)row_i, pad_col);
-    __mluop_mod(offset_addr, temp_addr, (float)n, pad_col);
+    __mluOp_mod(offset_addr, temp_addr, (float)n, pad_col);
 
     genSelectOffsetVec(offset_addr, offset_int_addr, pad_col);
 

--- a/kernels/fft/fft.cpp
+++ b/kernels/fft/fft.cpp
@@ -74,7 +74,595 @@ mluOpStatus_t MLUOP_WIN_API mluOpCreateFFTPlan(mluOpFFTPlan_t *fft_plan) {
     LOG(ERROR) << "[mluOpCreateFFTPlan]: alloc failed";
     return MLUOP_STATUS_ALLOC_FAILED;
   }
+  ts->factors = new int[FFT_MAXFACTORS];
   *fft_plan = ts;
+  return MLUOP_STATUS_SUCCESS;
+}
+
+template <typename DT>
+mluOpStatus_t MLUOP_WIN_API fftGenerateTwiddlesLine(
+    void *_twiddles, const int butterfly_num, const int section_num,
+    const int radix, const int nfft, const int dir) {
+  int j, k;
+  DT phase;
+  DT *twiddles = (DT *)_twiddles;
+  const int sign = (dir == FFT_FORWARD) ? -1 : 1;
+  for (j = 0; j < butterfly_num; j++) {
+    // phase = 1 when k = 0
+    for (k = 1; k < radix; k++) {
+      phase = sign * 2 * (DT)FFT_PI * section_num * k * j / nfft;
+      twiddles[(butterfly_num * (k - 1) + j)] = (DT)cos(phase);  // r
+      twiddles[(butterfly_num * (k - 1) + j) + butterfly_num * (radix - 1)] =
+          (DT)sin(phase);  // i
+      // twiddles[(butterfly_num * (k - 1) + j) * 2] = (DT)cos(phase);     // r
+      // twiddles[(butterfly_num * (k - 1) + j) * 2 + 1] = (DT)sin(phase); // i
+    }  // radix
+  }    // butterfly_num
+  return MLUOP_STATUS_SUCCESS;
+}
+
+/**
+ * @details
+ * @brief   The control interfaces of the generation of FFT's twiddles.
+ * @param[in]   generator       twiddle generation function pointer.
+ * @param[out]  *twiddles       stores the twiddles information generated in
+ * this function, first stage's is ignored.
+ * @param[in]   *factors         the way plan factoring the length of inpue
+ * sequence.
+ * @param[in]   nfft            the length of FFT.
+ * @param[in]   dir             the flag for FFT/IFFT.
+ * @return none
+ */
+
+template <typename DT>
+mluOpStatus_t MLUOP_WIN_API fftGenerateTwiddles(void *&_twiddles, int *factors,
+                                                const int _nfft,
+                                                const int dir) {
+  // twiddles = _twiddles;
+  DT *twiddles = new DT[_nfft * 2 * 2];  // complex *2(large+small)
+  _twiddles = twiddles;
+  int stage_count = factors[0];
+  int cur_large_radix, cur_small_radix, section_num, butterfly_num,
+      loop_stage;  // current radix
+  int tw_offset = 0;
+  int small_stage_count, small_loop_stage, small_factors_offset;
+
+  // for other stage, ignore first stage
+  for (loop_stage = 2; loop_stage <= stage_count; loop_stage++) {
+    cur_large_radix = factors[5 * loop_stage];
+    section_num = factors[5 * loop_stage + 1];
+    butterfly_num = factors[5 * loop_stage + 2];
+    fftGenerateTwiddlesLine<DT>(twiddles, butterfly_num, section_num,
+                                cur_large_radix, _nfft, dir);
+    twiddles += butterfly_num * (cur_large_radix - 1) * 2;
+    tw_offset += butterfly_num * (cur_large_radix - 1);
+  }  // stage_count
+
+  // do not ignore first stage
+  for (loop_stage = 1; loop_stage <= stage_count; loop_stage++) {
+    cur_large_radix = factors[5 * loop_stage];
+    small_factors_offset = factors[5 * loop_stage + 4];
+    small_stage_count = factors[small_factors_offset];
+    factors[small_factors_offset + 2] = tw_offset;
+    // cur_radix = factors[4 * loop_stage];
+    // section_num = factors[4 * loop_stage + 1];
+    // butterfly_num = factors[4 * loop_stage + 2];
+    // butterfly_num = factors[4 * loop_stage + 2];
+    // generator(twiddles, butterfly_num, section_num, cur_radix, _nfft, dir);
+    // twiddles += butterfly_num * (cur_radix - 1);
+
+    for (small_loop_stage = 2; small_loop_stage <= small_stage_count;
+         small_loop_stage++) {
+      cur_small_radix = factors[small_factors_offset + 4 * small_loop_stage];
+      section_num = factors[small_factors_offset + 4 * small_loop_stage + 1];
+      butterfly_num = factors[small_factors_offset + 4 * small_loop_stage + 2];
+      // butterfly_num = factors[small_factors_offset + 4 * small_loop_stage +
+      // 2];
+      fftGenerateTwiddlesLine<DT>(twiddles, butterfly_num, section_num,
+                                  cur_small_radix, cur_large_radix, dir);
+      twiddles += butterfly_num * (cur_small_radix - 1) * 2;
+      tw_offset +=
+          butterfly_num * (cur_small_radix - 1);  // complex element offset
+    }                                             // small_stage_count
+  }                                               // stage_count
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+template <typename DT>
+mluOpStatus_t MLUOP_WIN_API fftGenerateDftMatrixKernel(DT *dft_matrix,
+                                                       const int radix,
+                                                       const int dir) {
+  int j, k;
+  DT phase;
+
+  const int sign = (dir == FFT_FORWARD) ? -1 : 1;
+  for (j = 0; j < radix; j++) {
+    // phase = 1 when k = 0
+    for (k = 0; k < radix; k++) {
+      phase = sign * 2 * (DT)FFT_PI * k * j / radix;
+      dft_matrix[radix * k + j] = (DT)cos(phase);                  // r
+      dft_matrix[radix * k + j + radix * radix] = (DT)sin(phase);  // i
+      // twiddles[(butterfly_num * (k - 1) + j) * 2] = (DT)cos(phase);     // r
+      // twiddles[(butterfly_num * (k - 1) + j) * 2 + 1] = (DT)sin(phase); // i
+    }  // radix
+  }    // butterfly_num
+  return MLUOP_STATUS_SUCCESS;
+}
+
+template <typename DT>
+mluOpStatus_t MLUOP_WIN_API fftGenerateDftMatrix(void *&_dft_matrix,
+                                                 int *factors, const int _nfft,
+                                                 const int dir) {
+  // allocate space for dft_matrix_table and dft_matrix
+  DT *dft_matrix = new DT[DFT_TABLE_SIZE];  // complex *2(large+small)
+  dft_table_entry *dft_matrix_table = (dft_table_entry *)dft_matrix;
+  _dft_matrix = dft_matrix;
+
+  dft_table_entry *dft_matrix_table_end = dft_matrix_table + MAX_DFT_MATRIX_NR;
+  dft_matrix = (DT *)dft_matrix_table_end;
+
+  int cur_table_entry = 0;
+
+  // radix == -1 means the end of table
+  // init table
+  for (int i = 0; i < MAX_DFT_MATRIX_NR; i++) {
+    dft_matrix_table[i] = {-1, -1};
+  }
+  // dft_matrix_table =
+  int stage_count = factors[0];
+  int cur_large_radix, cur_small_radix, section_num, butterfly_num,
+      loop_stage;  // current radix
+  int tw_offset = 0;
+  int small_stage_count, small_loop_stage, small_factors_offset;
+
+  // initialize offset as the end of table
+  // transform  dft_table_entry to complex DT
+  int cur_offset =
+      (MAX_DFT_MATRIX_NR + 1) * sizeof(dft_table_entry) / (sizeof(DT) * 2);
+
+  for (loop_stage = 1; loop_stage <= stage_count; loop_stage++) {
+    cur_large_radix = factors[5 * loop_stage];
+    small_factors_offset = factors[5 * loop_stage + 4];
+    small_stage_count = factors[small_factors_offset];
+
+    for (small_loop_stage = 2; small_loop_stage <= small_stage_count;
+         small_loop_stage++) {
+      cur_small_radix = factors[small_factors_offset + 4 * small_loop_stage];
+      section_num = factors[small_factors_offset + 4 * small_loop_stage + 1];
+      butterfly_num = factors[small_factors_offset + 4 * small_loop_stage + 2];
+
+      for (int entry = 0;; entry++) {
+        if (dft_matrix_table[entry].radix == -1) {
+          DT *dft_matrix_real = dft_matrix;
+
+          fftGenerateDftMatrixKernel<DT>(dft_matrix, cur_small_radix, dir);
+          cur_table_entry++;
+          dft_matrix_table[cur_table_entry] = {cur_small_radix, cur_offset};
+          cur_offset += cur_small_radix * cur_small_radix;
+          if (cur_table_entry == MAX_DFT_MATRIX_NR) {
+            LOG(ERROR) << "[fftGenerateDftMatrix]: too much dft matrices";
+          }
+
+          break;
+        }
+
+        if (dft_matrix_table[entry].radix == cur_small_radix) {
+          break;
+        }
+      }
+    }  // small_stage_count
+  }    // stage_count
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+#define MaxLargeRadix 2048
+
+// int fftTwoStepFactor(const int _n, int *facbuf)
+// {
+//   int n = _n;
+//   if ((facbuf == NULL) || (n <= 0))
+//   {
+//     printf("ERROR, facbuf is NULL or n smaller and equal to 0.  __FILE__: %s,
+//     __LINE__: %d. \n", __FILE__, __LINE__); exit(1);
+//   }
+
+//   int r, in_stride, section_num, stage_num = 0, out_stride = 1;
+//   int radix_basic[] = {3, 4, 5, 6, 7, 8, 9, 11, 13, 16};
+
+//   int large_radix = 1;
+
+//   while (n > 1)
+//   {
+
+//     if ((n % 1024) == 0)
+//     {
+//       r = 1024;
+//       // set small factors
+//     }
+//     else if ((n % 512) == 0)
+//     {
+//       r = 512;
+//       // set small factors
+//     }
+//     else
+//     {
+//       // prime
+//       // r = n;
+//       large_radix = 1;
+//       while (n > 1 || large_radix < MaxLargeRadix)
+//       {
+//         if ((n % 1024) == 0)
+//         {
+//           r = 1024;
+//           // set small factors
+//         }
+//         else if ((n % 512) == 0)
+//         {
+//           r = 512;
+//           // set small factors
+//         }
+//         else
+//         {
+//           r =n;
+//         }
+//       }
+//     }
+
+//     // printf("radix%d = %d\n", stage_num+1, r);
+//     n /= r;
+//     in_stride = _n / r;
+//     section_num = n;
+//     stage_num++;
+
+//     facbuf[4 * stage_num] = r;
+//     facbuf[4 * stage_num + 1] = section_num;
+//     facbuf[4 * stage_num + 2] = out_stride;
+//     facbuf[4 * stage_num + 3] = in_stride;
+
+//     out_stride *= r;
+//   }
+
+//   facbuf[0] = stage_num;
+//   facbuf[1] = _n;
+//   facbuf[2] = 0;
+
+//   if (stage_num > 21)
+//   {
+//     // Since nfft is openfft_int32_t, stage_num can never be greater than 21,
+//     because 3^21 > 2^32 printf("ERROR, unsupported length for int32 type.
+//     __FILE__: %s, __LINE__: %d. \n", __FILE__, __LINE__); exit(1);
+//   }
+
+//   return 0;
+// }
+
+#define MaxLargeRadix 2048
+
+// mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanC2C1D (
+//     mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
+//     mluOpTensorDescriptor_t input_desc, mluOpTensorDescriptor_t output_desc,
+//     const int rank, const int *n)
+
+// data struct
+// factors[0]: stage_count
+// factors[1]: nfft
+// factors[2]: null
+// factors[3]: null
+// factors[4]: null
+// factors[5]: null
+
+// i-th large radix info:
+// factors[5*(i+1)+0]: radix
+// factors[5*(i+1)+1]: section_num
+// factors[5*(i+1)+2]: butterfly_num
+// factors[5*(i+1)+3]: in_stride
+// factors[5*(i+1)+4]: small_factors_offset
+
+// factors[small_factors_offset+0]: small_stage_count
+// factors[small_factors_offset+1]: large radix
+// factors[small_factors_offset+2]: tw_offset
+
+// i-th large radix, j-th small radix info:
+// factors[small_factors_offset+4*(j+1)+0]: radix
+// factors[small_factors_offset+4*(j+1)+1]: section_num
+// factors[small_factors_offset+4*(j+1)+2]: butterfly_num
+// factors[small_factors_offset+4*(j+1)+3]: in_stride
+
+mluOpStatus_t MLUOP_WIN_API fftFactor(const int _n, int *facbuf,
+                                      int &small_factors_offset) {
+  int n = _n;
+  // if ((facbuf == NULL) || (n <= 0))
+  // {
+  //   printf("ERROR, facbuf is NULL or n smaller and equal to 0.  __FILE__: %s,
+  //   __LINE__: %d. \n", __FILE__, __LINE__); exit(1);
+  // }
+
+  int r, in_stride, section_num, stage_num = 0, out_stride = 1;
+  int radix_basic[] = {3, 4, 5, 6, 7, 8, 9, 11, 13, 16};
+
+  int large_radix = 1;
+  facbuf += small_factors_offset;
+
+  while (n > 1) {
+    if ((n % 1024) == 0) {
+      r = 1024;
+      // set small factors
+    } else if ((n % 512) == 0) {
+      r = 512;
+      // set small factors
+    } else if ((n % 9) == 0) {
+      r = 9;
+    } else if ((n % 3) == 0) {
+      r = 3;
+    } else {
+      // prime
+      r = n;
+
+      // large_radix = 1;
+      // while (n > 1 || large_radix < MaxLargeRadix)
+      // {
+      //   if ((n % 1024) == 0)
+      //   {
+      //     r = 1024;
+      //     // set small factors
+      //   }
+      //   else if ((n % 512) == 0)
+      //   {
+      //     r = 512;
+      //     // set small factors
+      //   }
+      //   else
+      //   {
+      //     r =n;
+      //   }
+      // }
+    }
+
+    n /= r;
+    in_stride = _n / r;
+    section_num = n;
+    stage_num++;
+
+    facbuf[4 * stage_num + 0] = r;
+    facbuf[4 * stage_num + 1] = section_num;
+    facbuf[4 * stage_num + 2] = out_stride;
+    facbuf[4 * stage_num + 3] = in_stride;
+
+    out_stride *= r;
+  }
+
+  facbuf[0] = stage_num;
+  facbuf[1] = _n;
+  facbuf[2] = 0;  // tw_offset
+  facbuf[3] = 0;
+
+  if (stage_num > 21) {
+    // Since nfft is openfft_int32_t, stage_num can never be greater than 21,
+    // because 3^21 > 2^32 printf("ERROR, unsupported length for int32 type.
+    // __FILE__: %s, __LINE__: %d. \n", __FILE__, __LINE__); exit(1);
+  }
+
+  small_factors_offset += (stage_num + 1) * 4;
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API fftTwoStepFactor(const int _n, int *facbuf) {
+  int n = _n;
+  // if ((facbuf == NULL) || (n <= 0))
+  // {
+  //   printf("ERROR, facbuf is NULL or n smaller and equal to 0.  __FILE__: %s,
+  //   __LINE__: %d. \n", __FILE__, __LINE__); exit(1);
+  // }
+
+  int r, in_stride, section_num, stage_num = 0, out_stride = 1;
+  int radix_basic[] = {3, 4, 5, 6, 7, 8, 9, 11, 13, 16};
+
+  int large_radix = 1;
+  int small_factors_offset = 22 * 5;
+
+  while (n > 1) {
+    if ((n % 1024) == 0) {
+      r = 1024;
+      // set small factors
+    } else if ((n % 512) == 0) {
+      r = 512;
+      // set small factors
+    } else if ((n % 2187) == 0) {
+      r = 2187;
+    } else if ((n % 729) == 0) {
+      r = 729;
+    } else if ((n % 243) == 0) {
+      r = 243;
+    } else if ((n % 81) == 0) {
+      r = 81;
+    } else if ((n % 27) == 0) {
+      r = 27;
+    } else if ((n % 9) == 0) {
+      r = 9;
+    } else if ((n % 3) == 0) {
+      r = 3;
+      // fftFactor(r, facbuf, small_factors_offset);
+      // small_stage_count = 2;
+      // std::cout<< "r1=3, r2=3"<< std::endl;
+      // set small factors
+
+      // factors[small_factors_offset+5*j+0]: radix
+      // factors[small_factors_offset+5*j+1]: section_num
+      // factors[small_factors_offset+5*j+2]: butterfly_num
+      // factors[small_factors_offset+5*j+3]: in_stride
+      // factors[small_factors_offset+5*j+4]: tw_offset
+    } else {
+      // prime
+      r = n;
+
+      // large_radix = 1;
+      // while (n > 1 || large_radix < MaxLargeRadix)
+      // {
+      //   if ((n % 1024) == 0)
+      //   {
+      //     r = 1024;
+      //     // set small factors
+      //   }
+      //   else if ((n % 512) == 0)
+      //   {
+      //     r = 512;
+      //     // set small factors
+      //   }
+      //   else
+      //   {
+      //     r =n;
+      //   }
+      // }
+    }
+
+    // printf("radix%d = %d\n", stage_num+1, r);
+    n /= r;
+    in_stride = _n / r;
+    section_num = n;
+    stage_num++;
+
+    facbuf[5 * stage_num + 0] = r;
+    facbuf[5 * stage_num + 1] = section_num;
+    facbuf[5 * stage_num + 2] = out_stride;
+    facbuf[5 * stage_num + 3] = in_stride;
+    facbuf[5 * stage_num + 4] = small_factors_offset;
+
+    fftFactor(r, facbuf, small_factors_offset);
+    // facbuf[6*stage_num+4] = small_stage_count;
+    // facbuf[6*stage_num+5] = small_factors_offset;
+
+    // facbuf[4 * stage_num] = r;
+    // facbuf[4 * stage_num + 1] = section_num;
+    // facbuf[4 * stage_num + 2] = out_stride;
+    // facbuf[4 * stage_num + 3] = in_stride;
+
+    out_stride *= r;
+  }
+
+  facbuf[0] = stage_num;
+  facbuf[1] = _n;
+  facbuf[2] = 0;
+  facbuf[3] = 0;
+  facbuf[4] = 0;
+
+  VLOG(5) << "stage_num: " << stage_num << " _n: " << _n;
+
+  if (stage_num > 21) {
+    // Since nfft is openfft_int32_t, stage_num can never be greater than 21,
+    // because 3^21 > 2^32 printf("ERROR, unsupported length for int32 type.
+    // __FILE__: %s, __LINE__: %d. \n", __FILE__, __LINE__); exit(1);
+  }
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+mluOpStatus_t MLUOP_WIN_API
+mluOpAllocateC2C1D(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
+                   mluOpTensorDescriptor_t input_desc,
+                   mluOpTensorDescriptor_t output_desc, const int nfft) {
+  const std::string make_plan_api = "[mluOpAllocateC2C1D]";
+  size_t workspace_size = 0;
+  size_t reservespace_size = 0;
+
+  size_t CPX_TYPE_SIZE = 0;
+
+  switch (fft_plan->fft_type) {
+    case CNFFT_COMPLEX_HALF2COMPLEX_HALF: {
+      CPX_TYPE_SIZE = 2 * 2;
+    } break;
+    case CNFFT_COMPLEX_FLOAT2COMPLEX_FLOAT: {
+      CPX_TYPE_SIZE = 4 * 2;
+    }; break;
+    default: {
+      LOG(ERROR) << make_plan_api << ": invalid c2c 1d fft type.";
+      return MLUOP_STATUS_BAD_PARAM;
+    }
+  }
+
+  int batch = fft_plan->batch;
+
+  size_t buffer_size = batch * sizeof(CPX_TYPE_SIZE) * nfft;
+
+  workspace_size = buffer_size * 3;
+
+  // reservespace_size = batch * sizeof(mluOpFFTPlan_t) + sizeof(int) *
+  // (FFT_MAXFACTORS) /* factors */
+  //                              + sizeof(CPX_TYPE_SIZE) * nfft * 2 /* twiddles
+  //                              */
+  //                             );
+
+  size_t twiddles_size = sizeof(CPX_TYPE_SIZE) * nfft * 2;
+  reservespace_size = sizeof(int) * (FFT_MAXFACTORS)    /* factors */
+                      + twiddles_size + DFT_TABLE_SIZE; /* twiddles */
+
+  fft_plan->workspace_size = workspace_size;
+  fft_plan->reservespace_size = reservespace_size;
+
+  // std::cout << "workspace_size: " << workspace_size << "bytes" << std::endl;
+  // std::cout << "reservespace_size: " << reservespace_size << "bytes" <<
+  // std::endl; CNAME(openfft_generate_twiddles)(st->twiddles, st->factors,
+  // nfft, st->dir);
+
+  return MLUOP_STATUS_SUCCESS;
+}
+
+/**
+ * @degroup C2C_PLAN Floating Complex-to-Complex FFT plan
+ */
+
+mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanC2C1D(
+    mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
+    mluOpTensorDescriptor_t input_desc, mluOpTensorDescriptor_t output_desc,
+    const int rank, const int *n, const int direction) {
+  // reservespace_addr_ = mlu_runtime_.allocate(reservespace_size_)
+  // st = CNAME(openfft_allocate_c2c_plan_1d)(nfft, fin, fout, dir);
+
+  // std::cout<< "mluOpAllocateC2C1D"<<std::endl;
+  mluOpAllocateC2C1D(handle, fft_plan, input_desc, output_desc, n[0]);
+  // std::cout<< "mluOpAllocateC2C1D"<<std::endl;
+  fftTwoStepFactor(n[0], fft_plan->factors);
+  // result = openfft_factor(nfft, st->factors);
+  // if (result == OPENFFT_ERR)
+  // {
+  //     openfft_aligned_free(st);
+  //     return NULL;
+  // }
+
+  switch (fft_plan->fft_type) {
+    case CNFFT_FLOAT2COMPLEX_FLOAT:
+    case CNFFT_COMPLEX_FLOAT2FLOAT:
+    case CNFFT_COMPLEX_FLOAT2COMPLEX_FLOAT:
+      fftGenerateTwiddles<float>(fft_plan->twiddles, fft_plan->factors, n[0],
+                                 direction);
+      fftGenerateDftMatrix<float>(fft_plan->dft_matrix, fft_plan->factors, n[0],
+                                  direction);
+      break;
+    case CNFFT_HALF2COMPLEX_HALF:
+    case CNFFT_COMPLEX_HALF2HALF:
+    case CNFFT_COMPLEX_HALF2COMPLEX_HALF:
+      // fftGenerateTwiddles<half>(fft_plan->twiddles,
+      //                           fft_plan->factors,
+      //                           n[0],
+      //                           direction);
+
+      // TODO(zrg): need to copy twiddles to device, and convert to half.
+      fftGenerateTwiddles<float>(fft_plan->twiddles, fft_plan->factors, n[0],
+                                 direction);
+      fftGenerateDftMatrix<float>(fft_plan->dft_matrix, fft_plan->factors, n[0],
+                                  direction);
+      break;
+    default:
+      break;
+  }
+
+  // if(fft_plan->twiddles == NULL){
+  //   std::cout<<" \n\n\n fft_plan->twiddles == NULL \n\n\n"<<std::endl;
+  // }
+  // CNAME(openfft_generate_twiddles)(st->twiddles, st->factors, nfft, st->dir);
+
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -89,7 +677,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
     mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
     mluOpTensorDescriptor_t input_desc, mluOpTensorDescriptor_t output_desc,
     const int rank, const int *n, size_t *reservespace_size,
-    size_t *workspace_size) {
+    size_t *workspace_size, const int direction) {
   // bad param check
   const std::string make_plan_api = "[mluOpMakeFFTPlanMany]";
   // plan NULL check
@@ -296,7 +884,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
     case CNFFT_COMPLEX_FLOAT2COMPLEX_FLOAT:
     case CNFFT_COMPLEX_FLOAT2FLOAT: {
       if (supportFloatConv(handle)) {
-        if (execution_dtype != f_r_dtype) {
+        if (!(execution_dtype == f_r_dtype ||
+              execution_dtype == MLUOP_DTYPE_INT31)) {
+          LOG(ERROR) << make_plan_api << ": invalid execution dtype "
+                     << mluOpGetNameOfDataType(fft_plan->execution_dtype)
+                     << ".";
+          return MLUOP_STATUS_BAD_PARAM;
+        }
+      } else {
+        if (!(execution_dtype == MLUOP_DTYPE_INT31)) {
           LOG(ERROR) << make_plan_api << ": invalid execution dtype "
                      << mluOpGetNameOfDataType(fft_plan->execution_dtype)
                      << ".";
@@ -333,20 +929,23 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
   // create input and output descriptor for gen_case
   // because mluOpExecFFT don't have input and output descriptor
   mluOpTensorDescriptor_t fft_input_desc, fft_output_desc;
-  CHECK_RETURN(make_plan_api, mluOpCreateTensorDescriptor(&fft_input_desc));
-  CHECK_RETURN(make_plan_api, mluOpCreateTensorDescriptor(&fft_output_desc));
-  CHECK_RETURN(make_plan_api,
+  INTERNAL_CHECK(make_plan_api, mluOpCreateTensorDescriptor(&fft_input_desc) ==
+                                    MLUOP_STATUS_SUCCESS);
+  INTERNAL_CHECK(make_plan_api, mluOpCreateTensorDescriptor(&fft_output_desc) ==
+                                    MLUOP_STATUS_SUCCESS);
+  INTERNAL_CHECK(make_plan_api,
                  mluOpSetTensorDescriptorEx_v2(
                      fft_input_desc, input_desc->layout, input_desc->dtype,
                      input_desc->dim, input_desc->dims,
-                     input_desc->strides));
-  CHECK_RETURN(make_plan_api, mluOpSetTensorDescriptorOnchipDataType(
-                                    fft_input_desc, input_desc->onchip_dtype));
-  CHECK_RETURN(make_plan_api,
+                     input_desc->strides) == MLUOP_STATUS_SUCCESS);
+  INTERNAL_CHECK(make_plan_api, mluOpSetTensorDescriptorOnchipDataType(
+                                    fft_input_desc, input_desc->onchip_dtype) ==
+                                    MLUOP_STATUS_SUCCESS);
+  INTERNAL_CHECK(make_plan_api,
                  mluOpSetTensorDescriptorEx_v2(
                      fft_output_desc, output_desc->layout, output_desc->dtype,
                      output_desc->dim, output_desc->dims,
-                     output_desc->strides));
+                     output_desc->strides) == MLUOP_STATUS_SUCCESS);
   fft_plan->input_desc = fft_input_desc;
   fft_plan->output_desc = fft_output_desc;
 
@@ -374,7 +973,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
     case CNFFT_COMPLEX_FLOAT2COMPLEX_FLOAT: {
       if (rank == 1) {
         VLOG(5) << "into make FFT1d Policy";
-        status = makeFFT1dPolicy(handle, fft_plan);
+        // status = makeFFT1dPolicy(handle, fft_plan);
+        // C2C 1D
+        status = mluOpMakeFFTPlanC2C1D(handle, fft_plan, input_desc,
+                                       output_desc, rank, n, direction);
       }
     }; break;
   }
@@ -392,13 +994,23 @@ mluOpStatus_t MLUOP_WIN_API mluOpDestroyFFTPlan(mluOpFFTPlan_t fft_plan) {
   const std::string destroy_api = "[mluOpDestroyFFTPlan]";
   PARAM_CHECK_NE("[mluOpDestroyFFTPlan]", fft_plan, NULL);
   if (fft_plan->input_desc != NULL) {
-    CHECK_RETURN(destroy_api,
-                   mluOpDestroyTensorDescriptor(fft_plan->input_desc));
+    INTERNAL_CHECK(destroy_api,
+                   mluOpDestroyTensorDescriptor(fft_plan->input_desc) ==
+                       MLUOP_STATUS_SUCCESS);
   }
   if (fft_plan->output_desc != NULL) {
-    CHECK_RETURN(destroy_api,
-                   mluOpDestroyTensorDescriptor(fft_plan->output_desc));
+    INTERNAL_CHECK(destroy_api,
+                   mluOpDestroyTensorDescriptor(fft_plan->output_desc) ==
+                       MLUOP_STATUS_SUCCESS);
   }
+  if (fft_plan->factors != NULL) {
+    delete fft_plan->factors;
+  }
+
+  if (fft_plan->twiddles != NULL) {
+    delete (char *)fft_plan->twiddles;
+  }
+
   delete fft_plan;
   return MLUOP_STATUS_SUCCESS;
 }
@@ -427,7 +1039,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpSetFFTReserveArea(mluOpHandle_t handle,
     case CNFFT_COMPLEX_HALF2COMPLEX_HALF:
     case CNFFT_COMPLEX_FLOAT2COMPLEX_FLOAT: {
       if (fft_plan->rank == 1) {
-        status = setFFT1dReserveArea(handle, fft_plan, api);
+        // status = setFFT1dReserveArea(handle, fft_plan, api);
+        status = setFFT1dReserveArea_v2(handle, fft_plan, api);
       } else {
         status = MLUOP_STATUS_NOT_SUPPORTED;
       }
@@ -469,7 +1082,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpExecFFT(
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {
-    GEN_CASE_START("fft", "FFT");
+    GEN_CASE_START("fft");
     GEN_CASE_HANDLE(handle);
     GEN_CASE_DATA(true, "input", input, fft_plan->input_desc, 1, 0);
     GEN_CASE_DATA(false, "output", output, fft_plan->output_desc, 0, 0);

--- a/kernels/fft/fft_optm_device/fft_butterfly_ops.h
+++ b/kernels/fft/fft_optm_device/fft_butterfly_ops.h
@@ -1,0 +1,91 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#pragma once
+
+#define fft_swap_ptr_macro(X, Y)         \
+  {                                      \
+    X = ((intptr_t)(X) ^ (intptr_t)(Y)); \
+    Y = ((intptr_t)(X) ^ (intptr_t)(Y)); \
+    X = ((intptr_t)(X) ^ (intptr_t)(Y)); \
+  }
+
+#define FFT_SWAP_PTR(A, B) \
+  {                        \
+    DT *tmp = A;           \
+    A = B;                 \
+    B = tmp;               \
+  }
+
+#define MLU_CPX_ADD(Z, A, B, VL)   \
+  {                                \
+    __bang_add(Z.r, A.r, B.r, VL); \
+    __bang_add(Z.i, A.i, B.i, VL); \
+  }
+
+#define MLU_CPX_SUB(Z, A, B, VL)   \
+  {                                \
+    __bang_sub(Z.r, A.r, B.r, VL); \
+    __bang_sub(Z.i, A.i, B.i, VL); \
+  }
+
+// #define MLU_CPX_MLA_INPLACE(OUT, IN, TWI, VL) \
+//     { \
+//       __bang_fusion(FUSION_FMA, OUT.r, OUT.r, TWI, IN.r, VL, VL);\
+//       __bang_fusion(FUSION_FMA, OUT.i, OUT.i, TWI, IN.i, VL, VL);\
+//     }
+
+#define MLU_CPX_MLA_INPLACE(OUT, IN, TWI, TEMP, VL) \
+  {                                                 \
+    MLU_CPX_MUL_S(TEMP, IN, TWI, VL)                \
+    MLU_CPX_ADD(OUT, OUT, TEMP, VL)                 \
+  }
+
+#define MLU_CPX_MLA_OUTPLACE(OUT, IN1, IN2, TWR, VL)             \
+  {                                                              \
+    __bang_fusion(FUSION_FMA, OUT.r, IN2.r, TWR, IN1.r, VL, VL); \
+    __bang_fusion(FUSION_FMA, OUT.i, IN2.i, TWR, IN1.i, VL, VL); \
+  }
+
+#define MLU_CPX_MUL_S(OUT, IN, TWI, VL)      \
+  {                                          \
+    __bang_mul_scalar(OUT.r, IN.r, TWI, VL); \
+    __bang_mul_scalar(OUT.i, IN.i, TWI, VL); \
+  }
+
+#define MLU_CPX_ODD_OUT(HEAD, TAIL, _A, _B, VL) \
+  {                                             \
+    __bang_sub(HEAD.r, _A.r, _B.i, VL);         \
+    __bang_add(HEAD.i, _A.i, _B.r, VL);         \
+    __bang_add(TAIL.r, _A.r, _B.i, VL);         \
+    __bang_sub(TAIL.i, _A.i, _B.r, VL);         \
+  }
+
+#define MLU_CPX_MUL(Z, A, B, RR, II, RI, IR, VL) \
+  {                                              \
+    __bang_mul(RR, A.r, B.r, VL);                \
+    __bang_mul(II, A.i, B.i, VL);                \
+    __bang_mul(RI, A.r, B.i, VL);                \
+    __bang_mul(IR, A.i, B.r, VL);                \
+    __bang_sub(Z.r, RR, II, VL);                 \
+    __bang_add(Z.i, RI, IR, VL);                 \
+  }

--- a/kernels/fft/fft_optm_device/fft_cooley-tukey_ux_device.mlu
+++ b/kernels/fft/fft_optm_device/fft_cooley-tukey_ux_device.mlu
@@ -59,7 +59,16 @@ __mlu_func__ void genWVec1(float *w_r, float *w_i, float *w_tmp1, float *w_tmp2,
     float *tmp_offset_addr = offset_addr + L_align * i;
     float *tmp_inc_addr = inc_addr + L_align * i;
     float start_value = L * i;
-    __mluop_get_indices(tmp_inc_addr, start_value, L_align);
+#if __BANG_ARCH__ >= 372
+    __mluop_get_indices(L_align, start_value, tmp_inc_addr, nullptr,
+                        tmp_inc_addr, nullptr);
+#else
+    float *int32_temp_addr = tmp_cos_addr;
+    float *float2int_dst_ad = tmp_sin_addr;
+    float *float2int_src128B = w_tmp3;
+    __mluop_get_indices(L_align, start_value, int32_temp_addr,
+                        float2int_src128B, tmp_inc_addr, float2int_dst_ad);
+#endif
     float scale =
         2.0 * M_PI / (n / L_align * L * 2.0) * (fft_flag != IRFFT ? -1 : 1);
     scale *= ((fft_flag == FFT_IFFT && direction == FFT_INVERSE) ? -1 : 1);
@@ -90,7 +99,16 @@ __mlu_func__ void genWVec2(float *w_r, float *w_i, float *w_tmp1, float *w_tmp2,
   float scale = 2.0 * M_PI / (n_tmp * 2.0) * (fft_flag != IRFFT ? -1 : 1);
   scale *= ((fft_flag == FFT_IFFT && direction == FFT_INVERSE) ? -1 : 1);
   float start_value = ri * op_size;
-  __mluop_get_indices(inc_addr, start_value, op_size_align);
+#if __BANG_ARCH__ >= 372
+  __mluop_get_indices(op_size_align, start_value, inc_addr, nullptr, inc_addr,
+                      nullptr);
+#else
+  float *int32_temp_addr = cos_addr;
+  float *float2int_dst_ad = sin_addr;
+  float *float2int_src128B = w_tmp3;
+  __mluop_get_indices(op_size_align, start_value, int32_temp_addr,
+                      float2int_src128B, inc_addr, float2int_dst_ad);
+#endif
   __bang_mul_scalar(offset_addr, inc_addr, scale, op_size_align);
   __bang_cos(cos_addr, offset_addr, op_size);
   if (n <= 48000) {
@@ -487,7 +505,7 @@ __mlu_func__ void computeMutiLayerOnchip(
     DT *matmul_im_mul_im_addr, DT *output, int batch, int n, int m, int l,
     int s, int fft_flag, int direction) {
   // load subgraph from workspace data: X[C, batch_id, 2^s * core_offset, L]
-  // ->(C x 1 x 2^s x L) each mlu core deals with 2 sub graph
+  // ->(C x 1 x 2^s x L) each ipu core deals with 2 sub graph
   int repeat_remain_flag = (param.op_group_num_x_batch % taskDimX);
   int repeat_plus_one = repeat_remain_flag > 0 ? 1 : 0;
   int repeat_for_each_core =
@@ -558,9 +576,9 @@ __mlu_func__ void computeLayerByLayer(const AddrNode<DT> &addr,
            repeat_for_each_core);
     for (int repeat_id = 0; repeat_id < repeat_for_each_core; repeat_id++) {
       int continue_flag_for_each_core =
-          // all mlu cores will be used the same times
+          // all ipu cores will be used the same times
           repeat_remain_flag == 0
-          // assume that all mlu cores just less one than others at most
+          // assume that all ipu cores just less one than others at most
           || (repeat_id != repeat_for_each_core - 1) ||
           (repeat_id == repeat_for_each_core - 1 &&
            taskId < repeat_remain_flag);

--- a/kernels/fft/fft_optm_device/fft_stockham_u1_device.mlu
+++ b/kernels/fft/fft_optm_device/fft_stockham_u1_device.mlu
@@ -25,21 +25,35 @@
 #include "kernels/kernel.h"
 #include "kernels/utils/common.h"
 #include "kernels/fft/fft.h"
-
+#include "kernels/fft/fft_optm_device/fft_butterfly_ops.h"
+#include "kernels/fft/fft_optm_device/fft_twiddle_factors.h"
 // direction: 1 means IFFT, used to distinguish FFT and IFFT.
 #define FFT_INVERSE 1
 
 // Two split dimemsion(batch && L) trversal orders can be selected via
 // "L_FIRST". By default "L" is preferred, then "batch".
 #define L_FIRST 1
-
+// #define DFTMTX_TLB_SIZE (32 * 16 * 2)
 __nram__ char nram_buffer[MAX_NRAM_SIZE + REM_FOR_STACK - 32 * 1024];
+// __mlu_shared__ char sram_buffer[8192];  // radix-1024
+__mlu_shared__ char sram_large_tw[8192];  // radix-1024
+__wram__ char wram_buffer[MAX_WRAM_SIZE];
+template <typename DT>
+struct FFT_CPX_T {
+  DT *r;
+  DT *i;
+};
+
+// struct DFT_TLB_ENTRY {
+//   DT *gdram_addr;
+//   DT *nram_addr;
+// };
 
 // Generate w vector.
 template <typename DT>
-__mlu_func__ void genWSc1_opt(DT* w_r, DT* w_i, DT* tmp, DT* seq_addr,
-                              const int& L, const int& L_sub, const int& part,
-                              const int& unit_size, float scale, int n) {
+__mlu_func__ void genWSc1_opt(DT *w_r, DT *w_i, DT *tmp, DT *seq_addr,
+                              const int &L, const int &L_sub, const int &part,
+                              const int &unit_size, float scale, int n) {
   float inc_value = part * L_sub;
   int size_tmp_bytes = L_sub * unit_size;
   scale = scale / unit_size;
@@ -47,12 +61,12 @@ __mlu_func__ void genWSc1_opt(DT* w_r, DT* w_i, DT* tmp, DT* seq_addr,
   __bang_mul_scalar(tmp, tmp, scale, size_tmp_bytes);
 
 #if __BANG_ARCH__ >= 372
-  __bang_cos((float*)w_r, (float*)tmp, size_tmp_bytes);
+  __bang_cos((float *)w_r, (float *)tmp, size_tmp_bytes);
   if (n <= 48000) {
-    __bang_sin((float*)w_i, (float*)tmp, size_tmp_bytes);
+    __bang_sin((float *)w_i, (float *)tmp, size_tmp_bytes);
   } else {
     // This function has higher precision, and the actual test determined n.
-    __cn_vector_sin_f32(size_tmp_bytes, (float*)w_i, (float*)tmp);
+    __cn_vector_sin_f32(size_tmp_bytes, (float *)w_i, (float *)tmp);
   }
 #endif
 }
@@ -73,15 +87,15 @@ __mlu_func__ void genWSc1_opt(DT* w_r, DT* w_i, DT* tmp, DT* seq_addr,
 // Some temporarily unused space is used to ensure opertions such as
 // "half2float" in "compute()" function.
 template <typename DT>
-__mlu_func__ void load(DT* y_in_r, DT* y_in_i, DT* z_in_r, DT* z_in_i,
-                       DT* x_out1_r, DT* x_out1_i, DT* x_out2_r, DT* x_out2_i,
-                       DT* wz_rr, DT* wz_ir, DT* matmul_re_mul_re_addr,
-                       const int& n, const int& L, const int& L_sub,
-                       const int& part_num, const int& pow_2_m,
-                       const int& pow_2_m_half, const int& batch_x_part,
-                       const int& fft_flag, const int& batch,
-                       const int& op_size_align_via_L_dt,
-                       const int& ping_pong) {
+__mlu_func__ void load(DT *y_in_r, DT *y_in_i, DT *z_in_r, DT *z_in_i,
+                       DT *x_out1_r, DT *x_out1_i, DT *x_out2_r, DT *x_out2_i,
+                       DT *wz_rr, DT *wz_ir, DT *matmul_re_mul_re_addr,
+                       const int &n, const int &L, const int &L_sub,
+                       const int &part_num, const int &pow_2_m,
+                       const int &pow_2_m_half, const int &batch_x_part,
+                       const int &fft_flag, const int &batch,
+                       const int &op_size_align_via_L_dt,
+                       const int &ping_pong) {
 #if L_FIRST
   int b = batch_x_part / part_num;
   int part = batch_x_part % part_num;
@@ -127,7 +141,7 @@ __mlu_func__ void load(DT* y_in_r, DT* y_in_i, DT* z_in_r, DT* z_in_i,
     int src_offset = L_sub * pow_2_m * part + b * n * 2;
     int data_size_bytes = pow_2_m * sizeof(DT);
     int total_data_size_bytes = L_deal * data_size_bytes;
-    int distance_bytes = int((char*)x_out1_i - (char*)x_out1_r);
+    int distance_bytes = int((char *)x_out1_i - (char *)x_out1_r);
     if (part < part_num / 2 || part_num == 1) {
       __memcpy_async(x_out1_r, matmul_re_mul_re_addr + src_offset,
                      total_data_size_bytes, GDRAM2NRAM, distance_bytes,
@@ -154,7 +168,7 @@ __mlu_func__ void load(DT* y_in_r, DT* y_in_i, DT* z_in_r, DT* z_in_i,
     }
   } else if (fft_flag == IRFFT) {
     int total_data_size_bytes = L_deal * pow_2_m * sizeof(DT);
-    DT* x[4] = {x_out1_r, x_out1_i, y_in_r, y_in_i};
+    DT *x[4] = {x_out1_r, x_out1_i, y_in_r, y_in_i};
     for (int addr_i = 0; addr_i < 4; addr_i++) {
       int complex_in = addr_i / 2;
       int complex_w = addr_i % 2;
@@ -177,22 +191,22 @@ __mlu_func__ void load(DT* y_in_r, DT* y_in_i, DT* z_in_r, DT* z_in_i,
 }
 
 template <typename DT, typename YT>
-__mlu_func__ void preProcessRFFT(YT* y_in_r, YT* y_in_i, YT* x_out1_r,
-                                 YT* x_out1_i, YT* wz_ir, const int& L_sub,
-                                 const int& part_num, const int& pow_2_m,
-                                 const int& part) {
+__mlu_func__ void preProcessRFFT(YT *y_in_r, YT *y_in_i, YT *x_out1_r,
+                                 YT *x_out1_i, YT *wz_ir, const int &L_sub,
+                                 const int &part_num, const int &pow_2_m,
+                                 const int &part) {
   if (sizeof(DT) == sizeof(half)) {
     if (part >= part_num / 2 && part_num > 1) {
       // According to conjugate symmetry, it need to multiply the second half of
       // the imag part by -1.
-      __bang_mul_scalar((DT*)wz_ir, (DT*)wz_ir, -1.0, pow_2_m * L_sub);
+      __bang_mul_scalar((DT *)wz_ir, (DT *)wz_ir, -1.0, pow_2_m * L_sub);
     }
     // Transpose L_sub to the lowest dimension for easy vector operations.
-    __bang_transpose((DT*)x_out1_r, (DT*)y_in_i, L_sub, pow_2_m);
-    __bang_transpose((DT*)x_out1_i, (DT*)wz_ir, L_sub, pow_2_m);
+    __bang_transpose((DT *)x_out1_r, (DT *)y_in_i, L_sub, pow_2_m);
+    __bang_transpose((DT *)x_out1_i, (DT *)wz_ir, L_sub, pow_2_m);
     // Convert to float, prepare for bitwidth promition calculation.
-    __bang_half2float((float*)y_in_r, (half*)x_out1_r, L_sub * pow_2_m);
-    __bang_half2float((float*)y_in_i, (half*)x_out1_i, L_sub * pow_2_m);
+    __bang_half2float((float *)y_in_r, (half *)x_out1_r, L_sub * pow_2_m);
+    __bang_half2float((float *)y_in_i, (half *)x_out1_i, L_sub * pow_2_m);
   } else {
     if (part >= part_num / 2 && part_num > 1) {
       // According to conjugate symmetry, it need to multiply the second half of
@@ -206,24 +220,24 @@ __mlu_func__ void preProcessRFFT(YT* y_in_r, YT* y_in_i, YT* x_out1_r,
 }
 
 template <typename DT, typename YT>
-__mlu_func__ void preProcessFFT_IFFT(YT* y_in_r, YT* y_in_i, YT* z_in_r,
-                                     YT* x_out1_r, YT* x_out1_i, YT* wz_rr,
-                                     YT* wz_ri, YT* wz_ir, const int& L_sub,
-                                     const int& pow_2_m) {
+__mlu_func__ void preProcessFFT_IFFT(YT *y_in_r, YT *y_in_i, YT *z_in_r,
+                                     YT *x_out1_r, YT *x_out1_i, YT *wz_rr,
+                                     YT *wz_ri, YT *wz_ir, const int &L_sub,
+                                     const int &pow_2_m) {
   if (sizeof(DT) == sizeof(half)) {
     // Transpose L_sub to the lowest dimension for easy vector operations.
-    __bang_transpose((DT*)y_in_r, (DT*)y_in_i, L_sub * pow_2_m, 2);
-    __bang_transpose((DT*)wz_rr, (DT*)wz_ir, L_sub * pow_2_m, 2);
+    __bang_transpose((DT *)y_in_r, (DT *)y_in_i, L_sub * pow_2_m, 2);
+    __bang_transpose((DT *)wz_rr, (DT *)wz_ir, L_sub * pow_2_m, 2);
     // Compute the real part: src_in(real * real) - src_in(imag * imag).
-    __bang_sub((DT*)y_in_r, (DT*)y_in_r, (DT*)wz_ri, L_sub * pow_2_m);
+    __bang_sub((DT *)y_in_r, (DT *)y_in_r, (DT *)wz_ri, L_sub * pow_2_m);
     // Compute the imag part: src_in(real * imag) - src_in(imag * real).
-    __bang_add((DT*)wz_rr, (DT*)wz_rr, (DT*)z_in_r, L_sub * pow_2_m);
+    __bang_add((DT *)wz_rr, (DT *)wz_rr, (DT *)z_in_r, L_sub * pow_2_m);
     // Transpose L_sub to the lowest dimension for easy vector operations.
-    __bang_transpose((DT*)y_in_i, (DT*)y_in_r, L_sub, pow_2_m);
-    __bang_transpose((DT*)wz_ir, (DT*)wz_rr, L_sub, pow_2_m);
+    __bang_transpose((DT *)y_in_i, (DT *)y_in_r, L_sub, pow_2_m);
+    __bang_transpose((DT *)wz_ir, (DT *)wz_rr, L_sub, pow_2_m);
     // Convert to float, prepare for bitwidth promition calculation.
-    __bang_half2float((float*)y_in_r, (half*)y_in_i, L_sub * pow_2_m);
-    __bang_half2float((float*)y_in_i, (half*)wz_ir, L_sub * pow_2_m);
+    __bang_half2float((float *)y_in_r, (half *)y_in_i, L_sub * pow_2_m);
+    __bang_half2float((float *)y_in_i, (half *)wz_ir, L_sub * pow_2_m);
   } else {
     // Transpose the read and imag parts to the highest dimension for easy
     // vector operations.
@@ -240,21 +254,21 @@ __mlu_func__ void preProcessFFT_IFFT(YT* y_in_r, YT* y_in_i, YT* z_in_r,
 }
 
 template <typename DT, typename YT>
-__mlu_func__ void preProcessIRFFT(YT* y_in_r, YT* y_in_i, YT* z_in_r,
-                                  YT* z_in_i, YT* x_out1_r, YT* x_out1_i,
-                                  YT* x_out2_r, YT* x_out2_i, YT* wz_ir,
-                                  const int& L_sub, const int& pow_2_m) {
+__mlu_func__ void preProcessIRFFT(YT *y_in_r, YT *y_in_i, YT *z_in_r,
+                                  YT *z_in_i, YT *x_out1_r, YT *x_out1_i,
+                                  YT *x_out2_r, YT *x_out2_i, YT *wz_ir,
+                                  const int &L_sub, const int &pow_2_m) {
   if (sizeof(DT) == sizeof(half)) {
     // Compute the real part: src_in(real * real) - src_in(imag * imag).
-    __bang_sub((DT*)x_out2_r, (DT*)x_out2_r, (DT*)z_in_i, L_sub * pow_2_m);
+    __bang_sub((DT *)x_out2_r, (DT *)x_out2_r, (DT *)z_in_i, L_sub * pow_2_m);
     // Compute the imag part: src_in(real * imag) - src_in(imag * real).
-    __bang_add((DT*)x_out2_i, (DT*)x_out2_i, (DT*)z_in_r, L_sub * pow_2_m);
+    __bang_add((DT *)x_out2_i, (DT *)x_out2_i, (DT *)z_in_r, L_sub * pow_2_m);
     // Transpose L_sub to the lowest dimension for easy vector operations.
-    __bang_transpose((DT*)z_in_r, (DT*)x_out2_r, L_sub, pow_2_m);
-    __bang_transpose((DT*)wz_ir, (DT*)x_out2_i, L_sub, pow_2_m);
+    __bang_transpose((DT *)z_in_r, (DT *)x_out2_r, L_sub, pow_2_m);
+    __bang_transpose((DT *)wz_ir, (DT *)x_out2_i, L_sub, pow_2_m);
     // Convert to float, prepare for bitwidth promition calculation.
-    __bang_half2float((float*)y_in_r, (half*)z_in_r, L_sub * pow_2_m);
-    __bang_half2float((float*)y_in_i, (half*)wz_ir, L_sub * pow_2_m);
+    __bang_half2float((float *)y_in_r, (half *)z_in_r, L_sub * pow_2_m);
+    __bang_half2float((float *)y_in_i, (half *)wz_ir, L_sub * pow_2_m);
   } else {
     // Compute the real part: src_in(real * real) - src_in(imag * imag).
     __bang_sub(x_out1_r, x_out1_r, y_in_i, L_sub * pow_2_m);
@@ -269,36 +283,36 @@ __mlu_func__ void preProcessIRFFT(YT* y_in_r, YT* y_in_i, YT* z_in_r,
 // Perform preprocessing for "compute()" function, including merging of real and
 // imag parts, transposition and data types conversion, etc.
 template <typename DT, typename YT>
-__mlu_func__ void preProcess(YT* y_in_r, YT* y_in_i, YT* z_in_r, YT* z_in_i,
-                             YT* x_out1_r, YT* x_out1_i, YT* x_out2_r,
-                             YT* x_out2_i, YT* wz_rr, YT* wz_ri, YT* wz_ir,
-                             const int& fft_flag, const int& L_sub,
-                             const int& part_num, const int& pow_2_m,
-                             const int& part) {
+__mlu_func__ void preProcess(YT *y_in_r, YT *y_in_i, YT *z_in_r, YT *z_in_i,
+                             YT *x_out1_r, YT *x_out1_i, YT *x_out2_r,
+                             YT *x_out2_i, YT *wz_rr, YT *wz_ri, YT *wz_ir,
+                             const int &fft_flag, const int &L_sub,
+                             const int &part_num, const int &pow_2_m,
+                             const int &part) {
   if (fft_flag == RFFT) {
-    preProcessRFFT<DT, float>((float*)y_in_r, (float*)y_in_i, (float*)x_out1_r,
-                              (float*)x_out1_i, (float*)wz_ir, L_sub, part_num,
-                              pow_2_m, part);
+    preProcessRFFT<DT, float>((float *)y_in_r, (float *)y_in_i,
+                              (float *)x_out1_r, (float *)x_out1_i,
+                              (float *)wz_ir, L_sub, part_num, pow_2_m, part);
   } else if (fft_flag == FFT_IFFT) {
-    preProcessFFT_IFFT<DT, float>((float*)y_in_r, (float*)y_in_i,
-                                  (float*)z_in_r, (float*)x_out1_r,
-                                  (float*)x_out1_i, (float*)wz_rr,
-                                  (float*)wz_ri, (float*)wz_ir, L_sub, pow_2_m);
+    preProcessFFT_IFFT<DT, float>(
+        (float *)y_in_r, (float *)y_in_i, (float *)z_in_r, (float *)x_out1_r,
+        (float *)x_out1_i, (float *)wz_rr, (float *)wz_ri, (float *)wz_ir,
+        L_sub, pow_2_m);
   } else if (fft_flag == IRFFT) {
-    preProcessIRFFT<DT, float>((float*)y_in_r, (float*)y_in_i, (float*)z_in_r,
-                               (float*)z_in_i, (float*)x_out1_r,
-                               (float*)x_out1_i, (float*)x_out2_r,
-                               (float*)x_out2_i, (float*)wz_ir, L_sub, pow_2_m);
+    preProcessIRFFT<DT, float>(
+        (float *)y_in_r, (float *)y_in_i, (float *)z_in_r, (float *)z_in_i,
+        (float *)x_out1_r, (float *)x_out1_i, (float *)x_out2_r,
+        (float *)x_out2_i, (float *)wz_ir, L_sub, pow_2_m);
   }
 }
 
 template <typename DT, typename YT>
-__mlu_func__ void computeOneLayer(YT* y_in_r, YT* y_in_i, YT* z_in_r,
-                                  YT* z_in_i, YT* x_out1_r, YT* x_out1_i,
-                                  YT* w_r, YT* w_i, YT* wz_rr, YT* wz_ri,
-                                  YT* wz_ir, YT* wz_ii, const int& fft_flag,
-                                  const int& L_sub, const int& part,
-                                  const int& pow_2_m_half, const int& layer_num,
+__mlu_func__ void computeOneLayer(YT *y_in_r, YT *y_in_i, YT *z_in_r,
+                                  YT *z_in_i, YT *x_out1_r, YT *x_out1_i,
+                                  YT *w_r, YT *w_i, YT *wz_rr, YT *wz_ri,
+                                  YT *wz_ir, YT *wz_ii, const int &fft_flag,
+                                  const int &L_sub, const int &part,
+                                  const int &pow_2_m_half, const int &layer_num,
                                   int ln, int ln_pow2) {
   int basic_size = L_sub * ln_pow2;
   int group_size = basic_size * 2;
@@ -316,12 +330,12 @@ __mlu_func__ void computeOneLayer(YT* y_in_r, YT* y_in_i, YT* z_in_r,
 
   for (int bgn = 0; bgn < basic_group_num; bgn++) {
     int bgn_offset = basic_size * bgn;
-    YT* y_r = y_in_r + bgn_offset;
-    YT* y_i = y_in_i + bgn_offset;
-    YT* x_r = x_out1_r + group_size * bgn;
-    YT* x_i = x_out1_i + group_size * bgn;
-    YT* wz_rr_tmp = wz_rr + bgn_offset;
-    YT* wz_ri_tmp = wz_ri + bgn_offset;
+    YT *y_r = y_in_r + bgn_offset;
+    YT *y_i = y_in_i + bgn_offset;
+    YT *x_r = x_out1_r + group_size * bgn;
+    YT *x_i = x_out1_i + group_size * bgn;
+    YT *wz_rr_tmp = wz_rr + bgn_offset;
+    YT *wz_ri_tmp = wz_ri + bgn_offset;
     // Compute x_out1 = y_in + w * z_in.
     __bang_add(x_r, y_r, wz_rr_tmp, basic_size);
     __bang_add(x_i, y_i, wz_ri_tmp, basic_size);
@@ -333,8 +347,8 @@ __mlu_func__ void computeOneLayer(YT* y_in_r, YT* y_in_i, YT* z_in_r,
       } else if (part == 0) {
         // According to conjugate symmetrym the last layer does not need to
         // calculate the second half part, except the point (n/2 + 1).
-        *((YT*)x_r + basic_size) = *((YT*)y_r) - *((YT*)wz_rr_tmp);
-        *((YT*)x_i + basic_size) = *((YT*)y_i) - *((YT*)wz_ri_tmp);
+        *((YT *)x_r + basic_size) = *((YT *)y_r) - *((YT *)wz_rr_tmp);
+        *((YT *)x_i + basic_size) = *((YT *)y_i) - *((YT *)wz_ri_tmp);
       }
     } else {
       // Compute x_out2 = y_in - w * z_in.
@@ -370,17 +384,17 @@ __mlu_func__ void computeOneLayer(YT* y_in_r, YT* y_in_i, YT* z_in_r,
 // total number of points, flag represents FFT type, 1 for RFFT and FFT, -1 for
 // IRFFT and IFFT.
 template <typename DT, typename YT>
-__mlu_func__ void compute(YT* y_in_r, YT* y_in_i, YT* z_in_r, YT* z_in_i,
-                          YT* x_out1_r, YT* x_out1_i, YT* x_out2_r,
-                          YT* x_out2_i, YT* w_r, YT* w_i, YT* wz_rr, YT* wz_ri,
-                          YT* wz_ir, YT* wz_ii, YT* seq_addr,
-                          const int& fft_flag, const int& direction,
-                          const int& n, const int& L, const int& L_sub,
-                          const int& part_num, const int& pow_2_m,
-                          const int& pow_2_m_half, const int& layer_num,
-                          const int& op_size_align_via_L_dt, float scale,
-                          const float scale_factor, const int& batch_x_part,
-                          const int& batch, int ping_pong) {
+__mlu_func__ void compute(YT *y_in_r, YT *y_in_i, YT *z_in_r, YT *z_in_i,
+                          YT *x_out1_r, YT *x_out1_i, YT *x_out2_r,
+                          YT *x_out2_i, YT *w_r, YT *w_i, YT *wz_rr, YT *wz_ri,
+                          YT *wz_ir, YT *wz_ii, YT *seq_addr,
+                          const int &fft_flag, const int &direction,
+                          const int &n, const int &L, const int &L_sub,
+                          const int &part_num, const int &pow_2_m,
+                          const int &pow_2_m_half, const int &layer_num,
+                          const int &op_size_align_via_L_dt, float scale,
+                          const float scale_factor, const int &batch_x_part,
+                          const int &batch, int ping_pong) {
 #if L_FIRST
   int part = batch_x_part % part_num;
 #else
@@ -406,11 +420,11 @@ __mlu_func__ void compute(YT* y_in_r, YT* y_in_i, YT* z_in_r, YT* z_in_i,
   wz_ri += pingpong_offset;
   wz_ir += pingpong_offset;
   wz_ii += pingpong_offset;
-  preProcess<DT, float>((float*)y_in_r, (float*)y_in_i, (float*)z_in_r,
-                        (float*)z_in_i, (float*)x_out1_r, (float*)x_out1_i,
-                        (float*)x_out2_r, (float*)x_out2_i, (float*)wz_rr,
-                        (float*)wz_ri, (float*)wz_ir, fft_flag, L_sub, part_num,
-                        pow_2_m, part);
+  preProcess<DT, float>((float *)y_in_r, (float *)y_in_i, (float *)z_in_r,
+                        (float *)z_in_i, (float *)x_out1_r, (float *)x_out1_i,
+                        (float *)x_out2_r, (float *)x_out2_i, (float *)wz_rr,
+                        (float *)wz_ri, (float *)wz_ir, fft_flag, L_sub,
+                        part_num, pow_2_m, part);
 
   // Calculate layer by layer as shown in the example.
   for (int ln = 0; ln < layer_num; ln++) {
@@ -419,17 +433,17 @@ __mlu_func__ void compute(YT* y_in_r, YT* y_in_i, YT* z_in_r, YT* z_in_i,
     genWSc1_opt<YT>(w_r, w_i, wz_ii, seq_addr, L, L_sub, part, ln_pow2, scale,
                     n);
     computeOneLayer<DT, float>(
-        (float*)y_in_r, (float*)y_in_i, (float*)z_in_r, (float*)z_in_i,
-        (float*)x_out1_r, (float*)x_out1_i, (float*)w_r, (float*)w_i,
-        (float*)wz_rr, (float*)wz_ri, (float*)wz_ir, (float*)wz_ii, fft_flag,
-        L_sub, part, pow_2_m_half, layer_num, ln, ln_pow2);
+        (float *)y_in_r, (float *)y_in_i, (float *)z_in_r, (float *)z_in_i,
+        (float *)x_out1_r, (float *)x_out1_i, (float *)w_r, (float *)w_i,
+        (float *)wz_rr, (float *)wz_ri, (float *)wz_ir, (float *)wz_ii,
+        fft_flag, L_sub, part, pow_2_m_half, layer_num, ln, ln_pow2);
 
     // In order to avoid the data movement, the addr of input and output are
     // exchanged here.
-    YT* tmp_y_r = y_in_r;
-    YT* tmp_y_i = y_in_i;
-    YT* tmp_z_r = z_in_r;
-    YT* tmp_z_i = z_in_i;
+    YT *tmp_y_r = y_in_r;
+    YT *tmp_y_i = y_in_i;
+    YT *tmp_z_r = z_in_r;
+    YT *tmp_z_i = z_in_i;
     y_in_r = x_out1_r;
     y_in_i = x_out1_i;
     z_in_r = x_out2_r;
@@ -450,19 +464,19 @@ __mlu_func__ void compute(YT* y_in_r, YT* y_in_i, YT* z_in_r, YT* z_in_i,
     __bang_mul_scalar(y_in_r, y_in_r, scale_factor, L_sub * 2 * pow_2_m);
   }
   if (sizeof(DT) == sizeof(half)) {
-    __mluop_float2half((half*)y_in_r, (float*)y_in_r, L_sub * 2 * pow_2_m);
+    __mluop_float2half((half *)y_in_r, (float *)y_in_r, L_sub * 2 * pow_2_m);
   }
 }
 
 // Store the calculation result to output. The difference between RFFT, IRFFT
 // and FFT_IFFT can see in the description of "load()" function.
 template <typename DT>
-__mlu_func__ void store(DT* output, DT* y_in_r, DT* x_out1_r,
-                        const int& pow_2_m, const int& pow_2_m_half,
-                        const int& m, const int& L, const int& L_sub,
-                        const int& part_num, const int& n, const int& out_n,
-                        const int& batch_x_part, const int& batch,
-                        const int& fft_flag, const int& ping_pong) {
+__mlu_func__ void store(DT *output, DT *y_in_r, DT *x_out1_r,
+                        const int &pow_2_m, const int &pow_2_m_half,
+                        const int &m, const int &L, const int &L_sub,
+                        const int &part_num, const int &n, const int &out_n,
+                        const int &batch_x_part, const int &batch,
+                        const int &fft_flag, const int &ping_pong) {
 #if L_FIRST
   int b = batch_x_part / part_num;
   int part = batch_x_part % part_num;
@@ -474,7 +488,7 @@ __mlu_func__ void store(DT* output, DT* y_in_r, DT* x_out1_r,
   int L_re = L % L_sub;
   int L_deal = part < (part_num - 1) ? L_sub : (L_re != 0 ? L_re : L_sub);
   int dst_offset = part * L_sub * 2;
-  DT* out_nram = m % 2 == 0 ? y_in_r : x_out1_r;
+  DT *out_nram = m % 2 == 0 ? y_in_r : x_out1_r;
   out_nram += pingpong_offset;
   if (fft_flag == RFFT) {
     int output_block = pow_2_m_half - 1;
@@ -494,7 +508,6 @@ __mlu_func__ void store(DT* output, DT* y_in_r, DT* x_out1_r,
     __memcpy_async(output + dst_offset + b * out_n, out_nram,
                    L_deal * sizeof(DT), NRAM2GDRAM, L * sizeof(DT),
                    L_sub * sizeof(DT), output_block);
-
   } else if (fft_flag == FFT_IFFT) {
     int output_block = pow_2_m - 1;
     __memcpy_async(output + dst_offset + b * out_n * 2, out_nram,
@@ -514,17 +527,17 @@ __mlu_func__ void store(DT* output, DT* y_in_r, DT* x_out1_r,
 //     2. perform sin && cos operation with scale on the incermental sequence.
 // where, the sequence generated by step1 can be reused. Therefore, we save it
 // in seq_addr.
-__mlu_func__ void generateIncSequence(float* seq_addr, float* tmp_addr, int L,
+__mlu_func__ void generateIncSequence(float *seq_addr, float *tmp_addr, int L,
                                       int L_sub, int pow_2_m_half) {
-  __mluop_get_indices((float*)seq_addr, (float)0.0,
-                      PAD_UP(L_sub, NFU_ALIGN_SIZE));
+  __mluop_get_indices(PAD_UP(L_sub, NFU_ALIGN_SIZE), (float)0.0,
+                      (float *)tmp_addr, nullptr, (float *)seq_addr, nullptr);
   // reduce call times of "__mluop_get_indices", which time is longer, by
   // using "for loop" and
   // "__bang_add_scalar".
   for (size_t i = 1; i < pow_2_m_half; i++) {
     int offset = i * L_sub;
     int init_value = i * L;
-    __bang_add_scalar((float*)seq_addr + offset, (float*)seq_addr, init_value,
+    __bang_add_scalar((float *)seq_addr + offset, (float *)seq_addr, init_value,
                       L_sub);
   }
 }
@@ -545,12 +558,12 @@ __mlu_func__ void generateIncSequence(float* seq_addr, float* tmp_addr, int L,
 //    3. Store output data. See the "store()" function for details.
 template <typename DT>
 __mlu_func__ void computeMutiLayerOnchip(
-    const AddrNode<DT>& addr, DT* matmul_re_mul_re_addr, DT* output,
-    DT* seq_addr, int batch, int n, int m, int L, int fft_flag, int direction,
+    const AddrNode<DT> &addr, DT *matmul_re_mul_re_addr, DT *output,
+    DT *seq_addr, int batch, int n, int m, int L, int fft_flag, int direction,
     int op_size_align_via_L_dt, int pow_2_m, int pow_2_m_half, int L_sub,
     const float scale_factor, int ping_pong) {
   // Generate an incremental sequence
-  generateIncSequence((float*)seq_addr, (float*)addr.y_in_r, L, L_sub,
+  generateIncSequence((float *)seq_addr, (float *)addr.y_in_r, L, L_sub,
                       pow_2_m_half);
   // Calculate the fixed part of W scale.
   float scale = M_PI / L;
@@ -613,14 +626,14 @@ __mlu_func__ void computeMutiLayerOnchip(
       // Compute data layer by layer according to the Stockham rules.
       if (t >= t_start + 1 && t < t_end + 1) {
         compute<DT, float>(
-            (float*)addr.y_in_r, (float*)addr.y_in_i, (float*)addr.z_in_r,
-            (float*)addr.z_in_i, (float*)addr.x_out1_r, (float*)addr.x_out1_i,
-            (float*)addr.x_out2_r, (float*)addr.x_out2_i, (float*)addr.w_r,
-            (float*)addr.w_i, (float*)addr.wz_rr, (float*)addr.wz_ri,
-            (float*)addr.wz_ir, (float*)addr.wz_ii, (float*)seq_addr, fft_flag,
-            direction, n, L, L_sub, part_num, pow_2_m, pow_2_m_half, m,
-            op_size_align_via_L_dt, scale, scale_factor, t - 1, batch,
-            ping_pong);
+            (float *)addr.y_in_r, (float *)addr.y_in_i, (float *)addr.z_in_r,
+            (float *)addr.z_in_i, (float *)addr.x_out1_r,
+            (float *)addr.x_out1_i, (float *)addr.x_out2_r,
+            (float *)addr.x_out2_i, (float *)addr.w_r, (float *)addr.w_i,
+            (float *)addr.wz_rr, (float *)addr.wz_ri, (float *)addr.wz_ir,
+            (float *)addr.wz_ii, (float *)seq_addr, fft_flag, direction, n, L,
+            L_sub, part_num, pow_2_m, pow_2_m_half, m, op_size_align_via_L_dt,
+            scale, scale_factor, t - 1, batch, ping_pong);
       }
       // Load input data.
       if (t < t_end) {
@@ -638,7 +651,7 @@ __mlu_func__ void computeMutiLayerOnchip(
 // Divide the space size and call the onchip iterative calculation of Stockham
 // algorithm.
 template <typename DT>
-__mlu_func__ void fftStockham(DT* matmul_re_mul_re_addr, DT* output,
+__mlu_func__ void fftStockham(DT *matmul_re_mul_re_addr, DT *output,
                               int fft_flag, int direction, int n, int batch,
                               int L, int m, int L_sub,
                               const float scale_factor) {
@@ -664,7 +677,7 @@ __mlu_func__ void fftStockham(DT* matmul_re_mul_re_addr, DT* output,
   AddrNode<DT> addr;
 
   // Input vector addr.
-  addr.y_in_r = (DT*)nram_buffer;
+  addr.y_in_r = (DT *)nram_buffer;
   addr.z_in_r = addr.y_in_r + op_size_align_via_L_dt;
   addr.y_in_i = addr.z_in_r + op_size_align_via_L_dt;
   addr.z_in_i = addr.y_in_i + op_size_align_via_L_dt;
@@ -687,19 +700,19 @@ __mlu_func__ void fftStockham(DT* matmul_re_mul_re_addr, DT* output,
   // three-stage pipeline operation.
   int ping_pong = op_size_align_via_L_dt * 14;
   // The public space stores the incremental sequence shared by ping_pong.
-  DT* seq_addr = (DT*)nram_buffer + ping_pong * 2;
+  DT *seq_addr = (DT *)nram_buffer + ping_pong * 2;
 
   computeMutiLayerOnchip(addr, matmul_re_mul_re_addr, output, seq_addr, batch,
                          n, m, L, fft_flag, direction, op_size_align_via_L_dt,
                          pow_2_m, pow_2_m_half, L_sub, scale_factor, ping_pong);
 }
 
-__mlu_global__ void MLUKernelFFTStockham(void* matmul_re_mul_re_addr,
-                                         void* output, int fft_flag,
+__mlu_global__ void MLUKernelFFTStockham(void *matmul_re_mul_re_addr,
+                                         void *output, int fft_flag,
                                          int direction, int n, int batch, int L,
                                          int m, int L_sub, int dtype_size,
                                          const float scale_factor) {
-  if (__is_mpu()) return;
+  // if (__is_mpu()) return;
   switch (dtype_size) {
     default: {
       MLULOG("mluOpFFT Not Implemented.");
@@ -707,14 +720,14 @@ __mlu_global__ void MLUKernelFFTStockham(void* matmul_re_mul_re_addr,
     case (MLUOP_DTYPE_COMPLEX_FLOAT):
     case (MLUOP_DTYPE_FLOAT): {
       MLULOG("MLUOP_DTYPE_COMPLEX_FLOAT: MLUOP_DTYPE_FLOAT\n");
-      fftStockham<float>((float*)matmul_re_mul_re_addr, (float*)output,
+      fftStockham<float>((float *)matmul_re_mul_re_addr, (float *)output,
                          fft_flag, direction, n, batch, L, m, L_sub,
                          scale_factor);
     }; break;
     case (MLUOP_DTYPE_COMPLEX_HALF):
     case (MLUOP_DTYPE_HALF): {
       MLULOG("MLUOP_DTYPE_COMPLEX_HALF: MLUOP_DTYPE_HALF\n");
-      fftStockham<half>((half*)matmul_re_mul_re_addr, (half*)output, fft_flag,
+      fftStockham<half>((half *)matmul_re_mul_re_addr, (half *)output, fft_flag,
                         direction, n, batch, L, m, L_sub, scale_factor);
     }; break;
   }
@@ -732,5 +745,2894 @@ kernelFFTStockham(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
       direction,  // direction, -1 means invalid(only FFT_IFFT use).
       fft_plan->n[0], fft_plan->batch, fft_plan->L, fft_plan->m,
       fft_plan->L_sub, fft_plan->output_dtype, scale_factor)));
+  return MLUOP_STATUS_SUCCESS;
+}
+
+template <typename DT>
+__mlu_func__ void fft_swap_ptr(DT **X, DT **Y) {
+  DT *Z = *X;
+  *X = *Y;
+  *Y = Z;
+}
+
+// __nram__ uint8_t* _A[4096];
+
+template <typename DT>
+__mlu_func__ void computeRadix3ButterflyFirststage_v1(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, int section_num, int butterfly_num, int in_stride,
+    int dir) {
+  // outplace(nram)
+
+  // DT * scratch_in_r0 = nram_in_r;
+  // DT * scratch_in_r1 = &nram_in_r[3];
+  // DT * scratch_in_r2 = &nram_in_r[6];
+
+  // DT * scratch_in_i0 = nram_in_i;
+  // DT * scratch_in_i1 = &nram_in_i[3];
+  // DT * scratch_in_i2 = &nram_in_i[6];
+
+  const int sign = (dir == FFT_FORWARD) ? 1 : -1;
+  const DT tw3_1i = sign * TW3_1I_F;
+
+  DT *Fin_r[3] = {nram_in_r, &nram_in_r[butterfly_num],
+                  &nram_in_r[butterfly_num * 2]};
+  DT *Fin_i[3] = {nram_in_i, &nram_in_i[butterfly_num],
+                  &nram_in_i[butterfly_num * 2]};
+  DT *scratch_r[4] = {nram_scratch, &nram_scratch[butterfly_num],
+                      &nram_scratch[butterfly_num * 2],
+                      &nram_scratch[butterfly_num * 3]};
+  DT *scratch_i[4] = {
+      &nram_scratch[butterfly_num * 4], &nram_scratch[butterfly_num * 5],
+      &nram_scratch[butterfly_num * 6], &nram_scratch[butterfly_num * 7]};
+
+  DT *Fout_r[3] = {&nram_scratch[butterfly_num * 8],
+                   &nram_scratch[butterfly_num * 9],
+                   &nram_scratch[butterfly_num * 10]};
+  DT *Fout_i[3] = {&nram_scratch[butterfly_num * 11],
+                   &nram_scratch[butterfly_num * 12],
+                   &nram_scratch[butterfly_num * 13]};
+
+  DT *_A_r = &nram_scratch[butterfly_num * 14];
+  DT *_A_i = &nram_scratch[butterfly_num * 15];
+  DT *_B_r = &nram_scratch[butterfly_num * 16];
+  DT *_B_i = &nram_scratch[butterfly_num * 17];
+  // CPX_ADD
+  __bang_add(scratch_r[0], Fin_r[1], Fin_r[2], butterfly_num);
+  __bang_add(scratch_i[0], Fin_i[1], Fin_i[2], butterfly_num);
+
+  // CPX_SUB
+  __bang_sub(scratch_r[1], Fin_r[1], Fin_r[2], butterfly_num);
+  __bang_sub(scratch_i[1], Fin_i[1], Fin_i[2], butterfly_num);
+
+  // CPX_ADD
+  __bang_add(Fout_r[0], scratch_r[0], Fin_r[0], butterfly_num);
+  __bang_add(Fout_i[0], scratch_i[0], Fin_i[0], butterfly_num);
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("Fin_r r: %f.\n", Fin_r[0][j]);
+  // }
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("Fin_i i: %f.\n", Fin_i[0][j]);
+  // }
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("Fin_r r: %f.\n", Fin_r[1][j]);
+  // }
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("Fin_i i: %f.\n", Fin_i[1][j]);
+  // }
+
+  // CPX_MLA_OUTPLACE
+  __bang_fusion(FUSION_FMA, _A_r, scratch_r[0], TW3_1R_F, Fin_r[0],
+                butterfly_num, butterfly_num);
+  __bang_fusion(FUSION_FMA, _A_i, scratch_i[0], TW3_1R_F, Fin_i[0],
+                butterfly_num, butterfly_num);
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("_A_r r: %f.\n", _A_r[j]);
+  // }
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("_A_i i: %f.\n", _A_i[j]);
+  // }
+  // CPX_MUL_S
+  __bang_mul_scalar(_B_r, scratch_r[1], tw3_1i, butterfly_num);
+  __bang_mul_scalar(_B_i, scratch_i[1], tw3_1i, butterfly_num);
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("_B_r r: %f.\n", _B_r[j]);
+  // }
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("_B_i i: %f.\n", _B_i[j]);
+  // }
+  // OPENFFT_CPX_ODD_OUT
+  __bang_sub(Fout_r[1], _A_r, _B_i, butterfly_num);
+  __bang_add(Fout_i[1], _A_i, _B_r, butterfly_num);
+  __bang_add(Fout_r[2], _A_r, _B_i, butterfly_num);
+  __bang_sub(Fout_i[2], _A_i, _B_r, butterfly_num);
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("Fout_r r: %f.\n", Fout_r[j]);
+  // }
+
+  // for (int j = 0; j < 15; j++) {
+  //   MLULOG("Fout_i i: %f.\n", Fout_i[j]);
+  // }
+
+  // output
+  __bang_transpose(nram_out_r, Fout_r[0], 3, butterfly_num);
+  __bang_transpose(nram_out_i, Fout_i[0], 3, butterfly_num);
+
+  // MLULOG("butterfly_num---------: %d.\n", butterfly_num);
+  // for (int j = 0; j < 3*butterfly_num; j++) {
+  //   MLULOG("Fout[%d]: (%f, %f)\n", j, nram_out_r[j], nram_out_i[j]);
+  // }
+
+  // __memcpy(scratch_in_r0, nram_out_r, butterfly_num* sizeof(DT))
+
+  // __nram__ FFT_CPX_T<DT>* _A[butterfly_num];
+  // __nram__ FFT_CPX_T<DT>* _B[butterfly_num];
+
+  // for (; butterfly_num > 0; --butterfly_num)
+  // {
+
+  // scratch_in[0] = Fin[0];
+  // scratch_in[1] = Fin[in_stride];
+  // scratch_in[2] = Fin[2 * in_stride];
+
+  // _CRADIX(R3_KERNEL)(scratch_out, scratch_in, tw3_1i);
+
+  // Fout[0] = scratch_out[0];
+  // Fout[1] = scratch_out[1];
+  // Fout[2] = scratch_out[2];
+
+  // Fin += offset;
+  // Fout += 3;
+
+  // input += in_stride;
+  // output += 3;
+  // }
+}
+
+template <typename DT>
+__mlu_func__ void computeRadix3ButterflyFirststage(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, int section_num, int butterfly_num, int in_stride,
+    int dir) {
+  // outplace(nram)
+
+  const int sign = (dir == FFT_FORWARD) ? 1 : -1;
+  const DT tw3_1i = sign * TW3_1I_F;
+
+  FFT_CPX_T<DT> scratch[4];
+  int nram_scratch_offset = 0;
+  for (int i = 0; i < 4; i++) {
+    scratch[i].r = &nram_scratch[nram_scratch_offset];
+    nram_scratch_offset += butterfly_num;
+    scratch[i].i = &nram_scratch[nram_scratch_offset];
+    nram_scratch_offset += butterfly_num;
+  }
+
+  FFT_CPX_T<DT> Fin[3];
+  int nram_in_offset = 0;
+  for (int i = 0; i < 3; i++) {
+    Fin[i].r = &nram_in_r[nram_in_offset];
+    Fin[i].i = &nram_in_i[nram_in_offset];
+    nram_in_offset += butterfly_num;
+  }
+
+  FFT_CPX_T<DT> Fout[3];
+  // int nram_out_offset = nram_scratch_offset;
+
+  // seperate the space for: Fout[i].r  Fout[i].i
+  for (int i = 0; i < 3; i++) {
+    Fout[i].r = &nram_scratch[nram_scratch_offset];
+    Fout[i].i = &nram_scratch[nram_scratch_offset + butterfly_num * 3];
+    nram_scratch_offset += butterfly_num;
+  }
+  nram_scratch_offset += (butterfly_num * 3);
+
+  // __sync();
+  FFT_CPX_T<DT> _A = {&nram_scratch[nram_scratch_offset],
+                      &nram_scratch[nram_scratch_offset + butterfly_num]};
+  FFT_CPX_T<DT> _B = {&nram_scratch[nram_scratch_offset + butterfly_num * 2],
+                      &nram_scratch[nram_scratch_offset + butterfly_num * 3]};
+
+  // FFT_CPX_T<DT> in_0 = {&nram_scratch[nram_scratch_offset + butterfly_num *
+  // 4],
+  //                       &nram_scratch[nram_scratch_offset + butterfly_num *
+  //                       5]};
+  nram_scratch_offset += (butterfly_num * 6);
+  // FFT_CPX_T<DT> in_0 = Fin[0];
+  //   MLU_CPX_ADD(scratch[0], Fin[1], Fin[2], butterfly_num);
+  //   MLU_CPX_SUB(scratch[1], Fin[1], Fin[2], butterfly_num);
+
+  //   MLU_CPX_ADD(Fout[0], scratch[0], in_0, butterfly_num);
+
+  //   MLU_CPX_MLA_OUTPLACE(_A, in_0, scratch[0], TW3_1R_F, butterfly_num);
+  //   MLU_CPX_MUL_S(_B, scratch[1],  tw3_1i, butterfly_num);
+  //   MLU_CPX_ODD_OUT(Fout[1], Fout[2], _A, _B, butterfly_num);
+
+  MLU_CPX_ADD(scratch[0], Fin[1], Fin[2], butterfly_num);
+  MLU_CPX_SUB(scratch[1], Fin[1], Fin[2], butterfly_num);
+
+  MLU_CPX_ADD(Fout[0], scratch[0], Fin[0], butterfly_num);
+
+  MLU_CPX_MLA_OUTPLACE(_A, Fin[0], scratch[0], TW3_1R_F, butterfly_num);
+  MLU_CPX_MUL_S(_B, scratch[1], tw3_1i, butterfly_num);
+  MLU_CPX_ODD_OUT(Fout[1], Fout[2], _A, _B, butterfly_num);
+
+  // output
+  // __bang_transpose(nram_out_r, Fout_r[0], 3, butterfly_num);
+  // __bang_transpose(nram_out_i, Fout_i[0], 3, butterfly_num);
+  __bang_transpose(nram_out_r, Fout[0].r, 3, butterfly_num);
+  __bang_transpose(nram_out_i, Fout[0].i, 3, butterfly_num);
+}
+
+template <typename DT>
+__mlu_func__ void computeRadix9ButterflyFirststage(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, int section_num, int butterfly_num, int in_stride,
+    int dir) {
+  // outplace(nram)
+
+  const int sign = (dir == FFT_FORWARD) ? 1 : -1;
+  const DT tw9_1i = sign * TW9_1I_F;
+  const DT tw9_2i = sign * TW9_2I_F;
+  const DT tw9_3i = sign * TW9_3I_F;
+  const DT tw9_4i = sign * TW9_4I_F;
+
+  FFT_CPX_T<DT> scratch[10];
+  int nram_scratch_offset = 0;
+  for (int i = 0; i < 10; i++) {
+    scratch[i].r = &nram_scratch[nram_scratch_offset];
+    nram_scratch_offset += butterfly_num;
+    scratch[i].i = &nram_scratch[nram_scratch_offset];
+    nram_scratch_offset += butterfly_num;
+  }
+
+  FFT_CPX_T<DT> Fin[9];
+  int nram_in_offset = 0;
+  for (int i = 0; i < 9; i++) {
+    Fin[i].r = &nram_in_r[nram_in_offset];
+    Fin[i].i = &nram_in_i[nram_in_offset];
+    nram_in_offset += butterfly_num;
+  }
+
+  FFT_CPX_T<DT> Fout[9];
+  // int nram_out_offset = nram_scratch_offset;
+
+  // seperate the space for: Fout[i].r  Fout[i].i
+  for (int i = 0; i < 9; i++) {
+    Fout[i].r = &nram_scratch[nram_scratch_offset];
+    Fout[i].i = &nram_scratch[nram_scratch_offset + butterfly_num * 9];
+    nram_scratch_offset += butterfly_num;
+  }
+  nram_scratch_offset += (butterfly_num * 9);
+
+  FFT_CPX_T<DT> _A = {&nram_scratch[nram_scratch_offset],
+                      &nram_scratch[nram_scratch_offset + butterfly_num]};
+  FFT_CPX_T<DT> _B = {&nram_scratch[nram_scratch_offset + butterfly_num * 2],
+                      &nram_scratch[nram_scratch_offset + butterfly_num * 3]};
+
+  FFT_CPX_T<DT> in_0 = {&nram_scratch[nram_scratch_offset + butterfly_num * 4],
+                        &nram_scratch[nram_scratch_offset + butterfly_num * 5]};
+  nram_scratch_offset += (butterfly_num * 6);
+
+  FFT_CPX_T<DT> _A_TEMP = {&nram_scratch[nram_scratch_offset],
+                           &nram_scratch[nram_scratch_offset + butterfly_num]};
+  FFT_CPX_T<DT> _B_TEMP = {
+      &nram_scratch[nram_scratch_offset + butterfly_num * 2],
+      &nram_scratch[nram_scratch_offset + butterfly_num * 3]};
+
+  __bang_move(in_0.r, Fin[0].r, butterfly_num * sizeof(DT));
+  __bang_move(in_0.i, Fin[0].i, butterfly_num * sizeof(DT));
+
+  MLU_CPX_ADD(scratch[0], Fin[1], Fin[8], butterfly_num);
+  MLU_CPX_SUB(scratch[1], Fin[1], Fin[8], butterfly_num);
+  MLU_CPX_ADD(scratch[2], Fin[2], Fin[7], butterfly_num);
+  MLU_CPX_SUB(scratch[3], Fin[2], Fin[7], butterfly_num);
+  MLU_CPX_ADD(scratch[4], Fin[3], Fin[6], butterfly_num);
+  MLU_CPX_SUB(scratch[5], Fin[3], Fin[6], butterfly_num);
+  MLU_CPX_ADD(scratch[6], Fin[4], Fin[5], butterfly_num);
+  MLU_CPX_SUB(scratch[7], Fin[4], Fin[5], butterfly_num);
+
+  MLU_CPX_ADD(scratch[9], scratch[0], scratch[2], butterfly_num);
+  MLU_CPX_ADD(scratch[9], scratch[4], scratch[9], butterfly_num);
+  MLU_CPX_ADD(scratch[9], scratch[6], scratch[9], butterfly_num);
+  MLU_CPX_ADD(Fout[0], scratch[9], in_0, butterfly_num);
+
+  MLU_CPX_MLA_OUTPLACE(_A, in_0, scratch[0], TW9_1R_F, butterfly_num);
+  MLU_CPX_MUL_S(_B, scratch[1], tw9_1i, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[2], TW9_2R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[3], tw9_2i, _B_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[4], TW9_3R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[5], tw9_3i, _B_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[6], TW9_4R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[7], tw9_4i, _B_TEMP, butterfly_num);
+  MLU_CPX_ODD_OUT(Fout[1], Fout[8], _A, _B, butterfly_num);
+
+  MLU_CPX_MLA_OUTPLACE(_A, in_0, scratch[0], TW9_2R_F, butterfly_num);
+  MLU_CPX_MUL_S(_B, scratch[1], tw9_2i, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[2], TW9_4R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[3], tw9_4i, _B_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[4], TW9_3R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[5], -tw9_3i, _B_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[6], TW9_1R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[7], -tw9_1i, _B_TEMP, butterfly_num);
+  MLU_CPX_ODD_OUT(Fout[2], Fout[7], _A, _B, butterfly_num);
+
+  MLU_CPX_ADD(_A, in_0, scratch[4], butterfly_num);
+  MLU_CPX_ADD(_B, scratch[0], scratch[2], butterfly_num);
+  MLU_CPX_ADD(_B, scratch[6], _B, butterfly_num);
+  MLU_CPX_MLA_OUTPLACE(_A, _A, _B, TW9_3R_F, butterfly_num);
+  MLU_CPX_SUB(_B, scratch[1], scratch[3], butterfly_num);
+  MLU_CPX_ADD(_B, scratch[7], _B, butterfly_num);
+  MLU_CPX_MUL_S(_B, _B, tw9_3i, butterfly_num);
+  MLU_CPX_ODD_OUT(Fout[3], Fout[6], _A, _B, butterfly_num);
+
+  MLU_CPX_MLA_OUTPLACE(_A, in_0, scratch[0], TW9_4R_F, butterfly_num);
+  MLU_CPX_MUL_S(_B, scratch[1], tw9_4i, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[2], TW9_1R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[3], -tw9_1i, _B_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[4], TW9_3R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[5], tw9_3i, _B_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_A, scratch[6], TW9_2R_F, _A_TEMP, butterfly_num);
+  MLU_CPX_MLA_INPLACE(_B, scratch[7], -tw9_2i, _B_TEMP, butterfly_num);
+  MLU_CPX_ODD_OUT(Fout[4], Fout[5], _A, _B, butterfly_num);
+
+  // output
+  __bang_transpose(nram_out_r, Fout[0].r, 9, butterfly_num);
+  __bang_transpose(nram_out_i, Fout[0].i, 9, butterfly_num);
+}
+
+template <typename DT>
+__mlu_func__ void computeRadix9ButterflyFirststageMat(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, DT *nram_dftmtx, int section_num, int butterfly_num,
+    int in_stride, int dir) {
+  // outplace(nram)
+  const int radix = 9;
+  int nram_scratch_offset = 0;
+  int wram_scratch_offset = 0;
+  DT *wram_sratch = (DT *)wram_buffer;
+
+  const int align_radix = 16;
+  FFT_CPX_T<DT> in_trans_wram = {
+      &wram_sratch[wram_scratch_offset],
+      &wram_sratch[wram_scratch_offset + butterfly_num * align_radix]};
+
+  wram_scratch_offset += (butterfly_num * radix * 2);
+
+  FFT_CPX_T<DT> in_trans = {
+      &nram_scratch[nram_scratch_offset],
+      &nram_scratch[nram_scratch_offset + butterfly_num * radix]};
+  FFT_CPX_T<DT> out = in_trans;
+  nram_scratch_offset += (butterfly_num * radix * 2);
+
+  FFT_CPX_T<DT> in_trans_align = {
+      &nram_scratch[nram_scratch_offset],
+      &nram_scratch[nram_scratch_offset + butterfly_num * align_radix]};
+  nram_scratch_offset += (butterfly_num * align_radix * 2);
+  // FFT_CPX_T<DT> out = in_trans;
+
+  FFT_CPX_T<DT> dftmtx = {nram_dftmtx, &nram_dftmtx[radix * radix]};
+
+  // for(int i=0; i<9; i++){
+  //   for(int j=0; j<9; j++){
+  //     MLULOG("nram_dftmtx[%d][%d]: (%f, %f) ", i,j, nram_dftmtx[i*9+j],
+  //     nram_dftmtx[i*9+j+81]);
+  //   }
+  //   MLULOG("\n");
+  // }
+
+  DT *RR = &nram_scratch[nram_scratch_offset];  // (9-1)*butterfly_num
+  DT *RI = &nram_scratch[nram_scratch_offset +
+                         butterfly_num * radix];  // (9-1)*butterfly_num
+  DT *IR = &nram_scratch[nram_scratch_offset +
+                         butterfly_num * radix * 2];  // (9-1)*butterfly_num
+  DT *II = &nram_scratch[nram_scratch_offset +
+                         butterfly_num * radix * 3];  // (9-1)*butterfly_num
+
+  nram_scratch_offset += (butterfly_num * 4 * radix);
+
+  __bang_transpose(in_trans.r, nram_in_r, align_radix, butterfly_num);
+  __bang_transpose(in_trans.i, nram_in_i, align_radix, butterfly_num);
+  // __bang_xor(in_trans_align.r, in_trans_align)
+  __bang_write_zero(in_trans_align.r, align_radix * butterfly_num * 2);
+
+  __memcpy(in_trans_align.r, nram_in_r, radix * sizeof(DT), NRAM2NRAM,
+           align_radix * sizeof(DT), radix * sizeof(DT), butterfly_num * 2 - 1);
+
+  // __memcpy(in_trans_wram.r, in_trans.r, radix * butterfly_num * sizeof(DT) *
+  // 2, NRAM2WRAM);
+
+  __memcpy(in_trans_wram.r, in_trans_align.r,
+           align_radix * butterfly_num * sizeof(DT), NRAM2WRAM);
+  __memcpy(in_trans_wram.i, in_trans_align.i,
+           align_radix * butterfly_num * sizeof(DT), NRAM2WRAM);
+  // __bang_transpose(in_trans_wram.i, in_trans.i, radix, butterfly_num);
+
+  __bang_matmul((float *)RR, (float *)dftmtx.r, (float *)in_trans_wram.r, radix,
+                align_radix, butterfly_num);
+  __bang_matmul((float *)RI, (float *)dftmtx.r, (float *)in_trans_wram.i, radix,
+                align_radix, butterfly_num);
+  __bang_matmul((float *)IR, (float *)dftmtx.i, (float *)in_trans_wram.r, radix,
+                align_radix, butterfly_num);
+  __bang_matmul((float *)II, (float *)dftmtx.i, (float *)in_trans_wram.i, radix,
+                align_radix, butterfly_num);
+
+  __bang_sub(out.r, RR, II, butterfly_num * radix);
+  __bang_add(out.i, RI, IR, butterfly_num * radix);
+
+  //  for(int i=0; i<9; i++){
+  //   for(int j=0; j<9; j++){
+  //     MLULOG("out[%d][%d]: (%f, %f) ", i,j, out.r[i*9+j],
+  //     out.i[i*9+j+butterfly_num*radix]);
+  //   }
+  //   MLULOG("\n");
+  // }
+
+  // output
+  __bang_transpose(nram_out_r, out.r, radix, butterfly_num);
+  __bang_transpose(nram_out_i, out.i, radix, butterfly_num);
+}
+
+template <typename DT>
+__mlu_func__ void computeRadix9ButterflyOtherstages(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, DT *nram_tw, int section_num, int butterfly_num,
+    int in_stride, int dir) {
+  const int radix = 9;
+  const int sign = (dir == FFT_FORWARD) ? 1 : -1;
+  const DT tw9_1i = sign * TW9_1I_F;
+  const DT tw9_2i = sign * TW9_2I_F;
+  const DT tw9_3i = sign * TW9_3I_F;
+  const DT tw9_4i = sign * TW9_4I_F;
+
+  // const int out_stride = butterfly_num;
+  int Fin_stride = 0, Fout_stride = 0;
+  int sec_count;
+
+  FFT_CPX_T<DT> scratch[10];
+  int nram_scratch_offset = 0;
+  for (int i = 0; i < 10; i++) {
+    scratch[i].r = &nram_scratch[nram_scratch_offset];
+    nram_scratch_offset += butterfly_num;
+    scratch[i].i = &nram_scratch[nram_scratch_offset];
+    nram_scratch_offset += butterfly_num;
+  }
+
+  FFT_CPX_T<DT> _A = {&nram_scratch[nram_scratch_offset],
+                      &nram_scratch[nram_scratch_offset + butterfly_num]};
+  FFT_CPX_T<DT> _B = {&nram_scratch[nram_scratch_offset + butterfly_num * 2],
+                      &nram_scratch[nram_scratch_offset + butterfly_num * 3]};
+
+  FFT_CPX_T<DT> in_0 = {&nram_scratch[nram_scratch_offset + butterfly_num * 4],
+                        &nram_scratch[nram_scratch_offset + butterfly_num * 5]};
+  nram_scratch_offset += (butterfly_num * 6);
+
+  FFT_CPX_T<DT> _A_TEMP = {&nram_scratch[nram_scratch_offset],
+                           &nram_scratch[nram_scratch_offset + butterfly_num]};
+  FFT_CPX_T<DT> _B_TEMP = {
+      &nram_scratch[nram_scratch_offset + butterfly_num * 2],
+      &nram_scratch[nram_scratch_offset + butterfly_num * 3]};
+  nram_scratch_offset += (butterfly_num * 4);
+  FFT_CPX_T<DT> scratch_tw = {nram_tw, &nram_tw[butterfly_num * (radix - 1)]};
+
+  DT *RR = &nram_scratch[nram_scratch_offset];  // (9-1)*butterfly_num
+  DT *RI = &nram_scratch[nram_scratch_offset +
+                         butterfly_num * (radix - 1)];  // (9-1)*butterfly_num
+  DT *IR = &nram_scratch[nram_scratch_offset + butterfly_num * (radix - 1) *
+                                                   2];  // (9-1)*butterfly_num
+  DT *II = &nram_scratch[nram_scratch_offset + butterfly_num * (radix - 1) *
+                                                   3];  // (9-1)*butterfly_num
+  nram_scratch_offset += (butterfly_num * 4 * (radix - 1));
+
+  FFT_CPX_T<DT> scratch_in;
+  FFT_CPX_T<DT> Fin[radix];
+  FFT_CPX_T<DT> Fout[radix];
+
+  // __memcpy(scratch_tw_r, sram_tw, butterfly_num * (3 - 1) * 2, SRAM2NRAM);
+
+  for (sec_count = 0; sec_count < section_num; ++sec_count) {
+    for (int i = 0; i < radix; i++) {
+      Fout[i].r = &nram_out_r[Fout_stride + butterfly_num * i];
+      Fout[i].i = &nram_out_i[Fout_stride + butterfly_num * i];
+    }
+
+    if (section_num == 1) {
+      scratch_in = FFT_CPX_T<DT>{nram_in_r, nram_in_i};
+    } else {
+      // nram_scratch
+      scratch_in.r = &nram_scratch[nram_scratch_offset];
+      scratch_in.i = &nram_scratch[nram_scratch_offset + 9 * butterfly_num];
+      __memcpy(scratch_in.r, nram_in_r + Fin_stride, sizeof(DT) * butterfly_num,
+               NRAM2NRAM, sizeof(DT) * butterfly_num, in_stride * sizeof(DT),
+               radix - 1);
+      __memcpy(scratch_in.i, nram_in_i + Fin_stride, sizeof(DT) * butterfly_num,
+               NRAM2NRAM, sizeof(DT) * butterfly_num, in_stride * sizeof(DT),
+               radix - 1);
+    }
+
+    int nram_in_offset = 0;
+    for (int i = 0; i < radix; i++) {
+      Fin[i].r = &scratch_in.r[nram_in_offset];
+      Fin[i].i = &scratch_in.i[nram_in_offset];
+      nram_in_offset += butterfly_num;
+    }
+
+    // rotate
+    MLU_CPX_MUL(Fin[1], Fin[1], scratch_tw, RR, II, RI, IR,
+                butterfly_num * (radix - 1));
+
+    // butterfly compute
+
+    __bang_move(in_0.r, Fin[0].r, butterfly_num * sizeof(DT));
+    __bang_move(in_0.i, Fin[0].i, butterfly_num * sizeof(DT));
+
+    MLU_CPX_ADD(scratch[0], Fin[1], Fin[8], butterfly_num);
+    MLU_CPX_SUB(scratch[1], Fin[1], Fin[8], butterfly_num);
+    MLU_CPX_ADD(scratch[2], Fin[2], Fin[7], butterfly_num);
+    MLU_CPX_SUB(scratch[3], Fin[2], Fin[7], butterfly_num);
+    MLU_CPX_ADD(scratch[4], Fin[3], Fin[6], butterfly_num);
+    MLU_CPX_SUB(scratch[5], Fin[3], Fin[6], butterfly_num);
+    MLU_CPX_ADD(scratch[6], Fin[4], Fin[5], butterfly_num);
+    MLU_CPX_SUB(scratch[7], Fin[4], Fin[5], butterfly_num);
+
+    MLU_CPX_ADD(scratch[9], scratch[0], scratch[2], butterfly_num);
+    MLU_CPX_ADD(scratch[9], scratch[4], scratch[9], butterfly_num);
+    MLU_CPX_ADD(scratch[9], scratch[6], scratch[9], butterfly_num);
+    MLU_CPX_ADD(Fout[0], scratch[9], in_0, butterfly_num);
+
+    MLU_CPX_MLA_OUTPLACE(_A, in_0, scratch[0], TW9_1R_F, butterfly_num);
+    MLU_CPX_MUL_S(_B, scratch[1], tw9_1i, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[2], TW9_2R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[3], tw9_2i, _B_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[4], TW9_3R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[5], tw9_3i, _B_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[6], TW9_4R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[7], tw9_4i, _B_TEMP, butterfly_num);
+    MLU_CPX_ODD_OUT(Fout[1], Fout[8], _A, _B, butterfly_num);
+
+    MLU_CPX_MLA_OUTPLACE(_A, in_0, scratch[0], TW9_2R_F, butterfly_num);
+    MLU_CPX_MUL_S(_B, scratch[1], tw9_2i, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[2], TW9_4R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[3], tw9_4i, _B_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[4], TW9_3R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[5], -tw9_3i, _B_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[6], TW9_1R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[7], -tw9_1i, _B_TEMP, butterfly_num);
+    MLU_CPX_ODD_OUT(Fout[2], Fout[7], _A, _B, butterfly_num);
+
+    MLU_CPX_ADD(_A, in_0, scratch[4], butterfly_num);
+    MLU_CPX_ADD(_B, scratch[0], scratch[2], butterfly_num);
+    MLU_CPX_ADD(_B, scratch[6], _B, butterfly_num);
+    MLU_CPX_MLA_OUTPLACE(_A, _A, _B, TW9_3R_F, butterfly_num);
+    MLU_CPX_SUB(_B, scratch[1], scratch[3], butterfly_num);
+    MLU_CPX_ADD(_B, scratch[7], _B, butterfly_num);
+    MLU_CPX_MUL_S(_B, _B, tw9_3i, butterfly_num);
+    MLU_CPX_ODD_OUT(Fout[3], Fout[6], _A, _B, butterfly_num);
+
+    MLU_CPX_MLA_OUTPLACE(_A, in_0, scratch[0], TW9_4R_F, butterfly_num);
+    MLU_CPX_MUL_S(_B, scratch[1], tw9_4i, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[2], TW9_1R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[3], -tw9_1i, _B_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[4], TW9_3R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[5], tw9_3i, _B_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_A, scratch[6], TW9_2R_F, _A_TEMP, butterfly_num);
+    MLU_CPX_MLA_INPLACE(_B, scratch[7], -tw9_2i, _B_TEMP, butterfly_num);
+    MLU_CPX_ODD_OUT(Fout[4], Fout[5], _A, _B, butterfly_num);
+
+    Fin_stride += butterfly_num;
+    Fout_stride += radix * butterfly_num;
+  }
+}
+
+template <typename DT>
+__mlu_func__ void computeRadix9ButterflyLaststage(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, DT *nram_tw, int section_num, int butterfly_num,
+    int in_stride, int dir) {
+  computeRadix9ButterflyOtherstages(nram_out_r, nram_out_i, nram_in_r,
+                                    nram_in_i, nram_scratch, nram_tw,
+                                    section_num, butterfly_num, in_stride, dir);
+}
+
+// template <typename DT>
+// __mlu_func__ void load_input_gdram2nram()
+
+template <typename DT>
+__mlu_func__ void computeRadix3ButterflyOtherstages(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, DT *nram_tw, int section_num, int butterfly_num,
+    int in_stride, int dir) {
+  // MLULOG("computeRadix3ButterflyOtherstages\n");
+  const int sign = (dir == FFT_FORWARD) ? 1 : -1;
+  const DT tw3_1i = sign * TW3_1I_F;
+
+  // const int out_stride = butterfly_num;
+  int Fin_stride = 0, Fout_stride = 0;
+  int sec_count;
+
+  DT *scratch_r[4] = {nram_scratch, &nram_scratch[butterfly_num],
+                      &nram_scratch[butterfly_num * 2],
+                      &nram_scratch[butterfly_num * 3]};
+  DT *scratch_i[4] = {
+      &nram_scratch[butterfly_num * 4], &nram_scratch[butterfly_num * 5],
+      &nram_scratch[butterfly_num * 6], &nram_scratch[butterfly_num * 7]};
+
+  DT *_A_r = &nram_scratch[butterfly_num * 8];
+  DT *_A_i = &nram_scratch[butterfly_num * 9];
+  DT *_B_r = &nram_scratch[butterfly_num * 10];
+  DT *_B_i = &nram_scratch[butterfly_num * 11];
+
+  // DT *scratch_tw_r = &nram_scratch[butterfly_num * 12]; //
+  // (3-1)*butterfly_num DT *scratch_tw_i = &nram_scratch[butterfly_num * 14];
+  DT *scratch_tw_r = nram_tw;  // (3-1)*butterfly_num
+  DT *scratch_tw_i = &nram_tw[butterfly_num * (3 - 1)];
+
+  DT *CPX_MUL_RR = &nram_scratch[butterfly_num * 16];  // (3-1)*butterfly_num
+  DT *CPX_MUL_RI = &nram_scratch[butterfly_num * 18];  // (3-1)*butterfly_num
+  DT *CPX_MUL_IR = &nram_scratch[butterfly_num * 20];  // (3-1)*butterfly_num
+  DT *CPX_MUL_II = &nram_scratch[butterfly_num * 22];  // (3-1)*butterfly_num
+
+  DT *scratch_in_r;
+  DT *scratch_in_i;
+
+  // __memcpy(scratch_tw_r, sram_tw, butterfly_num * (3 - 1) * 2, SRAM2NRAM);
+
+  for (sec_count = 0; sec_count < section_num; ++sec_count) {
+    DT *Fout_r[3] = {&nram_out_r[Fout_stride],
+                     &nram_out_r[butterfly_num + Fout_stride],
+                     &nram_out_r[butterfly_num * 2 + Fout_stride]};
+    DT *Fout_i[3] = {&nram_out_i[Fout_stride],
+                     &nram_out_i[butterfly_num + Fout_stride],
+                     &nram_out_i[butterfly_num * 2 + Fout_stride]};
+
+    if (section_num == 1) {
+      scratch_in_r = nram_in_r;
+      scratch_in_i = nram_in_i;
+      // scratch_in_r = nram_in_r + Fin_stride;
+      // scratch_in_i = nram_in_i + Fin_stride;
+    } else {
+      // nram_scratch
+      scratch_in_r = &nram_scratch[butterfly_num * 24];
+      scratch_in_i = &nram_scratch[butterfly_num * (24 + 3)];
+      __memcpy(scratch_in_r, nram_in_r + Fin_stride, sizeof(DT) * butterfly_num,
+               NRAM2NRAM, sizeof(DT) * butterfly_num, in_stride * sizeof(DT),
+               3 - 1);
+      __memcpy(scratch_in_i, nram_in_i + Fin_stride, sizeof(DT) * butterfly_num,
+               NRAM2NRAM, sizeof(DT) * butterfly_num, in_stride * sizeof(DT),
+               3 - 1);
+    }
+
+    // CNAME(r3_other_stages_kernel)
+    // (Fout + Fout_stride, Fin + Fin_stride, twiddles, tw3_1i, in_stride,
+    // out_stride, butterfly_num);
+    DT *Fin_r[3] = {scratch_in_r, &scratch_in_r[butterfly_num],
+                    &scratch_in_r[butterfly_num * 2]};
+    DT *Fin_i[3] = {scratch_in_i, &scratch_in_i[butterfly_num],
+                    &scratch_in_i[butterfly_num * 2]};
+
+    // rotate
+    __bang_mul(CPX_MUL_RR, Fin_r[1], scratch_tw_r, butterfly_num * (3 - 1));
+    __bang_mul(CPX_MUL_II, Fin_i[1], scratch_tw_i, butterfly_num * (3 - 1));
+    __bang_mul(CPX_MUL_RI, Fin_r[1], scratch_tw_i, butterfly_num * (3 - 1));
+    __bang_mul(CPX_MUL_IR, Fin_i[1], scratch_tw_r, butterfly_num * (3 - 1));
+
+    __bang_sub(Fin_r[1], CPX_MUL_RR, CPX_MUL_II, butterfly_num * (3 - 1));
+    __bang_add(Fin_i[1], CPX_MUL_RI, CPX_MUL_IR, butterfly_num * (3 - 1));
+
+    // butterfly compute
+
+    // CPX_ADD
+    __bang_add(scratch_r[0], Fin_r[1], Fin_r[2], butterfly_num);
+    __bang_add(scratch_i[0], Fin_i[1], Fin_i[2], butterfly_num);
+
+    // CPX_SUB
+    __bang_sub(scratch_r[1], Fin_r[1], Fin_r[2], butterfly_num);
+    __bang_sub(scratch_i[1], Fin_i[1], Fin_i[2], butterfly_num);
+
+    // CPX_ADD
+    __bang_add(Fout_r[0], scratch_r[0], Fin_r[0], butterfly_num);
+    __bang_add(Fout_i[0], scratch_i[0], Fin_i[0], butterfly_num);
+
+    // CPX_MLA_OUTPLACE
+    __bang_fusion(FUSION_FMA, _A_r, scratch_r[0], TW3_1R_F, Fin_r[0],
+                  butterfly_num, butterfly_num);
+    __bang_fusion(FUSION_FMA, _A_i, scratch_i[0], TW3_1R_F, Fin_i[0],
+                  butterfly_num, butterfly_num);
+
+    // CPX_MUL_S
+    __bang_mul_scalar(_B_r, scratch_r[1], tw3_1i, butterfly_num);
+    __bang_mul_scalar(_B_i, scratch_i[1], tw3_1i, butterfly_num);
+
+    // OPENFFT_CPX_ODD_OUT
+    __bang_sub(Fout_r[1], _A_r, _B_i, butterfly_num);
+    __bang_add(Fout_i[1], _A_i, _B_r, butterfly_num);
+    __bang_add(Fout_r[2], _A_r, _B_i, butterfly_num);
+    __bang_sub(Fout_i[2], _A_i, _B_r, butterfly_num);
+
+    Fin_stride += butterfly_num;
+    Fout_stride += 3 * butterfly_num;
+  }
+}
+
+template <typename DT>
+__mlu_func__ void computeRadix3ButterflyLaststage(
+    DT *nram_out_r, DT *nram_out_i, DT *nram_in_r, DT *nram_in_i,
+    DT *nram_scratch, DT *nram_tw, int section_num, int butterfly_num,
+    int in_stride, int dir) {
+  computeRadix3ButterflyOtherstages(nram_out_r, nram_out_i, nram_in_r,
+                                    nram_in_i, nram_scratch, nram_tw,
+                                    section_num, butterfly_num, in_stride, dir);
+}
+
+#define MAX_BUTTERFLY_ON_CHIP 32
+#define NRAM_BUFFER_SIZE 1024
+template <typename DT>
+__mlu_func__ void computeLargeButterflyFirststage_v1(
+    DT *output, DT *input, int large_in_stride, int section_num,
+    const DT *twiddles, const DT *dft_matrix, void *nram_buf,
+    const int *small_factors, int dir, int nfft, int last_stage) {
+  int radix, small_in_stride, small_stage_count, large_radix,
+      _small_stage_count;
+  int small_section_num, small_butterfly_num, value_mul;
+
+  // int is_two_stages = 0; // the variable for twostages
+  // const int is_in_place = (input == output);
+  int tw_offset;
+
+  _small_stage_count = small_factors[0];
+  large_radix = small_factors[1];
+  tw_offset = small_factors[2];
+
+  const DT *small_twiddles = twiddles + tw_offset * 2;  // complex
+
+  // TODO(zrg): save nram space.
+  // __nram__ DT nram_space[MAX_BUTTERFLY_ON_CHIP * 2];
+  // 0 1 2 3 4 5
+  // 0   1   3
+  // DT *nram_buf_end = (DT*)&((uint8_t*)nram_buf)[NRAM_BUFFER_SIZE];
+  // FFT_CPX_T<DT> *nram_in = (FFT_CPX_T<DT> *)nram_buffer;
+  // FFT_CPX_T<DT> *nram_out = &nram_in[large_radix];
+  // FFT_CPX_T<DT> *nram_buf = &nram_in[large_radix * 2];
+
+  const int max_para_ldst_num = 32;
+
+  // assign nram space
+  int nram_buf_offset = 0;
+  DT *nram_in_r = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_in_i = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_out_r = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_out_i = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *_nram_tw = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix << 1;  // complex
+
+  // parallel load/store space
+  DT *nram_para_ldst = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  // transpose space: [radix, 2 * parrallel] -> [parrallel * 2, radix]
+  DT *nram_transpose = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  DT *nram_scratch = (DT *)nram_buf + nram_buf_offset;
+
+  if (nram_buf == NULL) {
+    MLULOG("nram_buf: NULL.\n");
+  }
+  if (input == NULL) {
+    MLULOG("input: NULL.\n");
+  }
+  if (output == NULL) {
+    MLULOG("output: NULL.\n");
+  }
+
+  const int para_num = 1;
+  int para_ldst_num;
+  for (int i = 0; i < section_num; i += para_num) {
+    radix = small_factors[4];
+    small_section_num = small_factors[5];
+    small_in_stride = small_factors[7];
+    small_stage_count = _small_stage_count;
+    // load_input_gdram2nram
+
+    // __memcpy(nram_transpose, input + i * 2, large_radix * sizeof(DT) * 2,
+    // GDRAM2NRAM);
+
+    if (i % max_para_ldst_num == 0) {
+      para_ldst_num = (max_para_ldst_num > (section_num - i))
+                          ? (section_num - i)
+                          : max_para_ldst_num;
+
+      __memcpy(nram_para_ldst, input + i * 2, sizeof(DT) * 2 * para_ldst_num,
+               GDRAM2NRAM, sizeof(DT) * 2 * para_ldst_num,
+               large_in_stride * sizeof(DT) * 2, large_radix - 1);
+
+      __bang_transpose(nram_transpose, nram_para_ldst, large_radix,
+                       2 * para_ldst_num);
+    }
+
+    // load real & imag
+    __memcpy(nram_in_r,
+             nram_transpose + (i % max_para_ldst_num) * large_radix * 2,
+             large_radix * sizeof(DT) * 2, NRAM2NRAM);
+
+    // for (int j = 0; j < large_radix; j++) {
+    //   MLULOG("input r: %f.\n", nram_in_r[j]);
+    // }
+
+    // for (int j = 0; j < large_radix; j++) {
+    //   MLULOG("input i: %f.\n", nram_in_i[j]);
+    // }
+
+    // stage is odd or even, place is in or out
+    // if (_stage_count != 1 && (is_in_place || _stage_count % 2 != 0))
+    // fft_swap_ptr(&nram_out, &nram_in); // test
+
+    // first stage
+
+    // twiddles: GDRAM -> SRAM
+    // loadNextStageTwiddles();
+    // switch (radix)
+    // {
+    // case 2:
+    //   computeRadix2ButterflyFirststage(Fout, Fin, section_num, section_num,
+    //   1, dir); break;
+    // case 3:
+    //   computeRadix3ButterflyFirststage(Fout, Fin, section_num, section_num,
+    //   1, dir); break;
+    // default:
+    //   computeGenericButterflyFirststage(Fout, buffer, twiddles, radix,
+    //   section_num, butterfly_num, in_stride, 0, dir); break;
+    // }
+
+    switch (radix) {
+      case 2:
+        // computeRadix2ButterflyFirststage(Fout, Fin, section_num, section_num,
+        // 1, dir);
+        break;
+      case 3:
+        computeRadix3ButterflyFirststage(
+            nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+            small_section_num, small_section_num, 1, dir);
+        break;
+      default:
+        // computeGenericButterflyFirststage(Fout, buffer, twiddles, radix,
+        // section_num, butterfly_num, in_stride, 0, dir);
+        break;
+    }
+    __sync();
+
+    small_stage_count--;
+    if (small_stage_count == 0) {
+      // nram to gdram
+
+      if (last_stage) {
+        __memcpy(nram_para_ldst + ((i % max_para_ldst_num) * 2) * large_radix,
+                 nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+        __memcpy(
+            nram_para_ldst + ((i % max_para_ldst_num) * 2 + 1) * large_radix,
+            nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+
+        __bang_transpose(
+            nram_transpose + ((i % max_para_ldst_num) * 2) * large_radix,
+            nram_para_ldst + ((i % max_para_ldst_num) * 2) * large_radix, 2,
+            large_radix);
+
+        if (i % max_para_ldst_num == (para_ldst_num - 1)) {
+          // __bang_transpose(nram_transpose, nram_para_ldst, 2 * para_ldst_num,
+          // large_radix);
+
+          // __memcpy(output + (i * large_radix) * 2, nram_transpose,
+          //         large_radix * sizeof(DT) * 2, NRAM2GDRAM);
+          __memcpy(output + (i - para_ldst_num + 1) * 2, nram_transpose,
+                   sizeof(DT) * 2 * para_ldst_num * large_radix, NRAM2GDRAM);
+        }
+
+      } else {
+        // __bang_transpose(nram_transpose, nram_out_r, 2, large_radix);
+
+        // // real
+        // __memcpy(output + i * large_radix, nram_out_r, large_radix *
+        // sizeof(DT),
+        //          NRAM2GDRAM);
+        // // imag
+        // __memcpy(output + i * large_radix + nfft, nram_out_i,
+        //          large_radix * sizeof(DT), NRAM2GDRAM);
+
+        __memcpy(nram_para_ldst + (i % max_para_ldst_num) * large_radix,
+                 nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+        __memcpy(nram_para_ldst +
+                     (i % max_para_ldst_num + max_para_ldst_num) * large_radix,
+                 nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+        __sync();
+        if (i % max_para_ldst_num == (para_ldst_num - 1)) {
+          // real
+          __memcpy(output + (i - para_ldst_num + 1) * large_radix,
+                   nram_para_ldst, para_ldst_num * large_radix * sizeof(DT),
+                   NRAM2GDRAM);
+          // imag
+          __memcpy(output + (i - para_ldst_num + 1) * large_radix + nfft,
+                   nram_para_ldst + max_para_ldst_num * large_radix,
+                   para_ldst_num * large_radix * sizeof(DT), NRAM2GDRAM);
+        }
+
+        // if(i> 27){
+        //   for (int j = 0; j < 15; j++) {
+        //     MLULOG("input r: %f.\n", nram_out_r[j]);
+        //   }
+
+        //   for (int j = 0; j < 15; j++) {
+        //     MLULOG("input i: %f.\n", nram_out_i[j]);
+        //   }
+        // }
+        fft_swap_ptr(&nram_out_r, &nram_in_r);
+        fft_swap_ptr(&nram_out_i, &nram_in_i);
+      }
+
+      continue;
+    }
+
+    // DT *sram_tw = (DT *)sram_buffer;
+    DT *nram_tw = _nram_tw;
+
+    for (; small_stage_count > 1; small_stage_count--) {
+      fft_swap_ptr(&nram_out_r, &nram_in_r);
+      fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+      // __memcpy(input2NRAM_tmp, input2SRAM + ROUND * coreId * k, k * ROUND *
+      // sizeof(int8_t), SRAM2NRAM);
+
+      // twiddles: GDRAM -> SRAM
+      // loadNextStageTwiddles();
+
+      // swap_ptr(buffer, Fout);
+
+      // if (is_two_stages && is_in_place)
+      // {
+      //   if (_stage_count % 2 == 0)
+      //   {
+      //     if ((_stage_count - stage_count) == 2)
+      //       swap_ptr(odd_extra_buffer, Fout);
+      //   }
+      //   else
+      //   {
+      //     if ((_stage_count - stage_count) == 3)
+      //       swap_ptr(odd_extra_buffer, Fout);
+      //   }
+      // }
+
+      value_mul = (_small_stage_count - small_stage_count + 1) * 4;
+      // // update parameter
+      radix = small_factors[value_mul];
+      small_section_num = small_factors[value_mul + 1];
+      small_butterfly_num = small_factors[value_mul + 2];
+      small_in_stride = small_factors[value_mul + 3];
+
+      // radix = small_factors[4 * _small_stage_count];
+      // small_section_num = small_factors[4 * _small_stage_count + 1];
+      // small_butterfly_num = small_factors[4 * _small_stage_count + 2];
+      // small_in_stride = small_factors[4 * _small_stage_count + 3];
+
+      // copy GDRAM2SRAM
+
+      if (i == 0) {
+        // if (1) {
+        // __memcpy(sram_tw, twiddles,
+        //          small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+        //          GDRAM2SRAM);
+        // small_twiddles += small_butterfly_num * (radix - 1) * 2;  // 2 means
+        // (r, i)
+        // __sync_cluster();
+        __memcpy(nram_tw, small_twiddles,
+                 small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                 GDRAM2NRAM);
+        small_twiddles += small_butterfly_num * (radix - 1) * 2;  // 2 means
+      }
+
+      switch (radix) {
+        case 2:
+          // computeRadix2ButterflyOtherstages(Fout, Fin, section_num,
+          // section_num, 1, dir);
+          break;
+        case 3:
+          computeRadix3ButterflyOtherstages(
+              nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+              nram_tw, small_section_num, small_butterfly_num, small_in_stride,
+              dir);
+          break;
+        case 9:
+          computeRadix9ButterflyOtherstages(
+              nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+              nram_tw, small_section_num, small_butterfly_num, small_in_stride,
+              dir);
+          break;
+        default:
+          // computeGenericButterflyOtherstages(Fout, buffer, twiddles, radix,
+          // section_num, butterfly_num, in_stride, 0, dir);
+          break;
+      }
+
+      nram_tw += small_butterfly_num * (radix - 1) * 2;
+      // __sync();
+      // __sync_cluster();  // sync barrier
+    }  // for (stage_count)
+
+    // MLULOG("butterfly id: %d\n", i);
+    // last stage
+    {
+      // if ((_stage_count % 2 == 0) && is_in_place && !is_two_stages)
+      // {
+      //   swap_ptr(buffer, Fout);
+      // }
+      // else
+      // {
+      //   buffer = Fout;
+
+      //   if (is_in_place && _stage_count == 3 && is_two_stages)
+      //     swap_ptr(odd_extra_buffer, Fout);
+      // }
+
+      fft_swap_ptr(&nram_out_r, &nram_in_r);
+      fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+      // copy GDRAM2SRAM
+
+      // update parameter
+      radix = small_factors[4 * _small_stage_count];
+      small_section_num = small_factors[4 * _small_stage_count + 1];
+      small_butterfly_num = small_factors[4 * _small_stage_count + 2];
+      small_in_stride = small_factors[4 * _small_stage_count + 3];
+
+      // MLULOG("small_section_num: %d\n", small_section_num);
+      // MLULOG("small_butterfly_num: %d\n", small_butterfly_num);
+      // MLULOG("small_in_stride: %d\n", small_in_stride);
+      // MLULOG("1320\n");
+      if (i == 0) {
+        // if (1) {
+        // __memcpy(sram_tw, twiddles,
+        //          small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+        //          GDRAM2SRAM);
+        __memcpy(nram_tw, small_twiddles,
+                 small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                 GDRAM2NRAM);
+        // __sync_cluster();
+      }
+      // MLULOG("1326\n");
+      // for (int j = 0; j < 6; j++)
+      // {
+      //   MLULOG("twiddles i: (%f, %f).\n", small_twiddles[j],
+      //   small_twiddles[j+6]);
+      // }
+      switch (radix) {
+        case 2:
+          // computeRadix2ButterflyLaststage(Fout, Fin, section_num,
+          // section_num, 1, dir);
+          break;
+        case 3:
+          // MLULOG("computeRadix3ButterflyLaststage\n");
+          computeRadix3ButterflyLaststage(
+              nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+              nram_tw, small_section_num, small_butterfly_num, small_in_stride,
+              dir);
+          break;
+        case 9:
+          // MLULOG("computeRadix3ButterflyLaststage\n");
+          computeRadix9ButterflyLaststage(
+              nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+              nram_tw, small_section_num, small_butterfly_num, small_in_stride,
+              dir);
+          break;
+        default:
+          // computeGenericButterflyLaststage(Fout, buffer, twiddles, radix,
+          // section_num, butterfly_num, in_stride, 0, dir);
+          break;
+      }
+
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("output i: (%f, %f).\n", nram_out_r[j], nram_out_i[j]);
+      // }
+      __sync();
+
+      if (last_stage) {
+        // __bang_transpose(nram_transpose, nram_out_r, 2, large_radix);
+        // __memcpy(output, nram_transpose, large_radix * sizeof(DT) * 2,
+        //          NRAM2GDRAM);
+
+        __memcpy(nram_para_ldst + ((i % max_para_ldst_num) * 2) * large_radix,
+                 nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+        __memcpy(
+            nram_para_ldst + ((i % max_para_ldst_num) * 2 + 1) * large_radix,
+            nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+
+        __bang_transpose(
+            nram_transpose + ((i % max_para_ldst_num) * 2) * large_radix,
+            nram_para_ldst + ((i % max_para_ldst_num) * 2) * large_radix, 2,
+            large_radix);
+
+        if (i % max_para_ldst_num == (para_ldst_num - 1)) {
+          // __bang_transpose(nram_transpose, nram_para_ldst, 2 * para_ldst_num,
+          // large_radix);
+
+          // __memcpy(output + (i * large_radix) * 2, nram_transpose,
+          //         large_radix * sizeof(DT) * 2, NRAM2GDRAM);
+          __memcpy(output + (i - para_ldst_num + 1) * 2, nram_transpose,
+                   sizeof(DT) * 2 * para_ldst_num * large_radix, NRAM2GDRAM);
+        }
+
+      } else {
+        // __bang_transpose(nram_transpose, nram_out_r, 2, large_radix);
+
+        // // real
+        // __memcpy(output + i * large_radix, nram_out_r, large_radix *
+        // sizeof(DT),
+        //          NRAM2GDRAM);
+        // // imag
+        // __memcpy(output + i * large_radix + nfft, nram_out_i,
+        //          large_radix * sizeof(DT), NRAM2GDRAM);
+
+        __memcpy(nram_para_ldst + (i % max_para_ldst_num) * large_radix,
+                 nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+        __memcpy(nram_para_ldst +
+                     (i % max_para_ldst_num + max_para_ldst_num) * large_radix,
+                 nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+        __sync();
+        if (i % max_para_ldst_num == (para_ldst_num - 1)) {
+          // real
+          __memcpy(output + (i - para_ldst_num + 1) * large_radix,
+                   nram_para_ldst, para_ldst_num * large_radix * sizeof(DT),
+                   NRAM2GDRAM);
+          // imag
+          __memcpy(output + (i - para_ldst_num + 1) * large_radix + nfft,
+                   nram_para_ldst + max_para_ldst_num * large_radix,
+                   para_ldst_num * large_radix * sizeof(DT), NRAM2GDRAM);
+        }
+
+        fft_swap_ptr(&nram_out_r, &nram_in_r);
+        fft_swap_ptr(&nram_out_i, &nram_in_i);
+      }
+      __sync();
+    }
+  }
+}
+
+template <typename DT>
+__mlu_func__ void computeLargeButterflyFirststage(
+    DT *output, DT *input, int large_in_stride, int section_num,
+    const DT *twiddles, const DT *dft_matrix, void *nram_buf,
+    const int *small_factors, int dir, int nfft, int last_stage) {
+  // constant
+  // const int max_para_ldst_num = 3;
+  const dft_table_entry *dft_table = (const dft_table_entry *)dft_matrix;
+  // test
+  // for(int i =0; i<3; i++){
+  //   MLULOG("entry: %d, dft_table.radix: %d, dft_table.offset: %d.\n",
+  //    i, dft_table[i].radix, dft_table[i].offset);
+  // }
+  // network info
+  int radix, small_in_stride, small_stage_count, large_radix,
+      _small_stage_count;
+  int small_section_num, small_butterfly_num, value_mul;
+  int tw_offset;
+  // int max_radix = small_factors[4];
+  _small_stage_count = small_factors[0];
+  large_radix = small_factors[1];
+  tw_offset = small_factors[2];
+
+  // for (int i=2; i<= _small_stage_count; i++) {
+
+  //   max_radix = max(small_factors[i*4], max_radix);
+
+  // }
+
+  const int max_para_ldst_num = 6561 / large_radix;
+  // const int max_para_ldst_num = 1;
+  const DT *small_twiddles = twiddles + tw_offset * 2;  // complex
+
+  // TODO(zrg): save nram space.
+  // assign nram space
+  int nram_buf_offset = 0;
+  DT *nram_in_r = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_in_i = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_out_r = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_out_i = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *_nram_tw = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * 2;  // complex
+
+  // parallel load/store space
+  DT *nram_para_load_ping = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  DT *nram_para_load_pong = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  DT *nram_para_store_ping = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  DT *nram_para_store_pong = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  // transpose space: [radix, 2 * parrallel] -> [parrallel * 2, radix]
+  DT *nram_transpose_load = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+  // nram_buf_offset += max_radix * max_radix * 2;  // complex
+
+  // DT *nram_dftmtx_ping = (DT *)nram_buf + nram_buf_offset;
+  // nram_buf_offset += max_radix * max_radix * 2;  // complex
+
+  // DT *nram_dftmtx_pong = (DT *)nram_buf + nram_buf_offset;
+  // nram_buf_offset += max_radix * max_radix * 2;  // complex
+  // nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  // DT *nram_transpose_store = (DT *)nram_buf + nram_buf_offset;
+  // nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  DT *nram_dftmtx = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += 9 * 9 * 2;  // complex
+
+  for (int entry = 0;; entry++) {
+    if (dft_table[entry].radix == 9) {
+      __memcpy(nram_dftmtx, &dft_matrix[dft_table[entry].offset * 2],
+               sizeof(DT) * 2 * 9 * 9, GDRAM2NRAM);
+      break;
+    }
+  }
+
+  DT *nram_scratch = (DT *)nram_buf + nram_buf_offset;
+
+  DT *nram_transpose_temp = nram_scratch;
+
+  if (nram_buf == NULL) {
+    MLULOG("nram_buf: NULL.\n");
+  }
+  if (input == NULL) {
+    MLULOG("input: NULL.\n");
+  }
+  if (output == NULL) {
+    MLULOG("output: NULL.\n");
+  }
+
+  // const int para_num = 1;
+  // int para_ldst_num;
+  // int para_load_num;
+  // int para_store_num;
+
+  int repeat_num = (section_num + max_para_ldst_num - 1) / max_para_ldst_num;
+
+  for (int repeat_id = 0; repeat_id < repeat_num + 2; ++repeat_id) {
+    // pipeline: store-stage
+    if (repeat_id >= 2) {
+      // MLULOG("pipeline: store-stage.\n");
+      int i = max_para_ldst_num * (repeat_id - 2);
+
+      int para_store_num = (max_para_ldst_num > (section_num - i))
+                               ? (section_num - i)
+                               : max_para_ldst_num;
+
+      DT *nram_para_store =
+          (repeat_id % 2 == 0) ? nram_para_store_ping : nram_para_store_pong;
+
+      if (last_stage) {
+        if (section_num == 1) {
+          __memcpy_async(output, nram_para_store, sizeof(DT) * 2 * large_radix,
+                         NRAM2GDRAM);
+        } else {
+          __memcpy_async(output + i * large_radix * 2, nram_para_store,
+                         sizeof(DT) * 2 * para_store_num * large_radix,
+                         NRAM2GDRAM);
+        }
+      } else {
+        // real
+        __memcpy_async(output + i * large_radix, nram_para_store,
+                       para_store_num * large_radix * sizeof(DT), NRAM2GDRAM);
+        // imag
+        __memcpy_async(output + i * large_radix + nfft,
+                       nram_para_store + max_para_ldst_num * large_radix,
+                       para_store_num * large_radix * sizeof(DT), NRAM2GDRAM);
+      }
+    }
+    // __sync();
+    // pipeline: compute-stage
+
+    if (repeat_id >= 1 && repeat_id < repeat_num + 1) {
+      // MLULOG("pipeline: compute-stage.\n");
+      int i = max_para_ldst_num * (repeat_id - 1);
+
+      DT *nram_para_load =
+          (repeat_id % 2 != 0) ? nram_para_load_ping : nram_para_load_pong;
+      DT *nram_para_store =
+          (repeat_id % 2 != 0) ? nram_para_store_ping : nram_para_store_pong;
+
+      int para_ldst_num = (max_para_ldst_num > (section_num - i))
+                              ? (section_num - i)
+                              : max_para_ldst_num;
+
+      __bang_transpose(nram_transpose_load, nram_para_load, large_radix,
+                       2 * para_ldst_num);
+
+      for (int compute_id = 0; compute_id < para_ldst_num; compute_id++) {
+        // load real & imag
+
+        radix = small_factors[4];
+        small_section_num = small_factors[5];
+        small_in_stride = small_factors[7];
+        small_stage_count = _small_stage_count;
+
+        // __memcpy(nram_in_r,
+        //         nram_transpose_load + compute_id * large_radix * 2,
+        //          large_radix * sizeof(DT) * 2, NRAM2NRAM);
+
+        // first stage
+        switch (radix) {
+          case 2:
+            break;
+          case 3:
+            computeRadix3ButterflyFirststage(
+                nram_out_r, nram_out_i,
+                nram_transpose_load + compute_id * large_radix * 2,
+                nram_transpose_load + (compute_id * 2 + 1) * large_radix,
+                nram_scratch, small_section_num, small_section_num, 1, dir);
+            break;
+          case 9:
+            MLULOG("computeRadix9ButterflyFirststage.\n");
+            computeRadix9ButterflyFirststage(
+                nram_out_r, nram_out_i,
+                nram_transpose_load + compute_id * large_radix * 2,
+                nram_transpose_load + (compute_id * 2 + 1) * large_radix,
+                nram_scratch, small_section_num, small_section_num, 1, dir);
+
+            // computeRadix9ButterflyFirststageMat(
+            //     nram_out_r, nram_out_i,
+            //     nram_transpose_load + compute_id * large_radix * 2,
+            //     nram_transpose_load + (compute_id * 2 + 1) * large_radix,
+            //     nram_scratch, nram_dftmtx,
+            //     small_section_num, small_section_num, 1, dir);
+            break;
+          default:
+            // computeGenericButterflyFirststage(Fout, buffer, twiddles, radix,
+            // section_num, butterfly_num, in_stride, 0, dir);
+            break;
+        }
+        //           for (int j = 0; j < large_radix; j++) {
+        //   MLULOG("output i: (%f, %f).\n", nram_out_r[j], nram_out_i[j]);
+        // }
+        small_stage_count--;
+        if (small_stage_count == 0) {
+          // nram to gdram
+
+          if (last_stage) {
+            __memcpy(nram_transpose_temp + (compute_id * 2) * large_radix,
+                     nram_out_r, large_radix * sizeof(DT) * 2, NRAM2NRAM);
+            // __memcpy(nram_transpose_temp + (compute_id * 2 + 1) *
+            // large_radix,
+            //          nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+
+            __bang_transpose(
+                nram_para_store + (compute_id * 2) * large_radix,
+                nram_transpose_temp + (compute_id * 2) * large_radix, 2,
+                large_radix);
+
+          } else {
+            __memcpy(nram_para_store + compute_id * large_radix, nram_out_r,
+                     large_radix * sizeof(DT), NRAM2NRAM);
+            __memcpy(nram_para_store +
+                         (compute_id + max_para_ldst_num) * large_radix,
+                     nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+          }
+
+          continue;
+        }
+
+        // DT *sram_tw = (DT *)sram_buffer;
+        DT *nram_tw = _nram_tw;
+
+        for (; small_stage_count > 1; small_stage_count--) {
+          fft_swap_ptr(&nram_out_r, &nram_in_r);
+          fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+          value_mul = (_small_stage_count - small_stage_count + 1) * 4;
+          // // update parameter
+          radix = small_factors[value_mul];
+          small_section_num = small_factors[value_mul + 1];
+          small_butterfly_num = small_factors[value_mul + 2];
+          small_in_stride = small_factors[value_mul + 3];
+          // copy GDRAM2SRAM
+
+          if (compute_id == 0 && repeat_id == 1) {
+            __memcpy(nram_tw, small_twiddles,
+                     small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                     GDRAM2NRAM);
+            small_twiddles += small_butterfly_num * (radix - 1) * 2;
+          }
+
+          switch (radix) {
+            case 2:
+              // computeRadix2ButterflyOtherstages(Fout, Fin, section_num,
+              // section_num, 1, dir);
+              break;
+            case 3:
+              computeRadix3ButterflyOtherstages(
+                  nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                  nram_tw, small_section_num, small_butterfly_num,
+                  small_in_stride, dir);
+              break;
+            case 9:
+              computeRadix9ButterflyOtherstages(
+                  nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                  nram_tw, small_section_num, small_butterfly_num,
+                  small_in_stride, dir);
+              break;
+            default:
+              // computeGenericButterflyOtherstages(Fout, buffer, twiddles,
+              // radix, section_num, butterfly_num, in_stride, 0, dir);
+              break;
+          }
+
+          nram_tw += small_butterfly_num * (radix - 1) * 2;
+        }  // for (stage_count)
+
+        //           for (int j = 0; j < large_radix; j++) {
+        //   MLULOG("output i: (%f, %f).\n", nram_out_r[j], nram_out_i[j]);
+        // }
+
+        // MLULOG("butterfly id: %d\n", i);
+        // last stage
+        {
+          fft_swap_ptr(&nram_out_r, &nram_in_r);
+          fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+          // copy GDRAM2SRAM
+
+          // update parameter
+          radix = small_factors[4 * _small_stage_count];
+          small_section_num = small_factors[4 * _small_stage_count + 1];
+          small_butterfly_num = small_factors[4 * _small_stage_count + 2];
+          small_in_stride = small_factors[4 * _small_stage_count + 3];
+
+          if (compute_id == 0 && repeat_id == 1) {
+            __memcpy(nram_tw, small_twiddles,
+                     small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                     GDRAM2NRAM);
+          }
+
+          switch (radix) {
+            case 2:
+              break;
+            case 3:
+              computeRadix3ButterflyLaststage(
+                  nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                  nram_tw, small_section_num, small_butterfly_num,
+                  small_in_stride, dir);
+              break;
+            case 9:
+              computeRadix9ButterflyLaststage(
+                  nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                  nram_tw, small_section_num, small_butterfly_num,
+                  small_in_stride, dir);
+              break;
+            default:
+              // computeGenericButterflyLaststage(Fout, buffer, twiddles, radix,
+              // section_num, butterfly_num, in_stride, 0, dir);
+              break;
+          }
+
+          if (last_stage) {
+            // __memcpy(nram_transpose_temp + (compute_id * 2) * large_radix,
+            //          nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+            // __memcpy(nram_transpose_temp
+            // + (compute_id * 2 + 1) * large_radix,
+            //          nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+            __memcpy(nram_transpose_temp + (compute_id * 2) * large_radix,
+                     nram_out_r, large_radix * sizeof(DT) * 2, NRAM2NRAM);
+            __bang_transpose(
+                nram_para_store + (compute_id * 2) * large_radix,
+                nram_transpose_temp + (compute_id * 2) * large_radix, 2,
+                large_radix);
+
+          } else {
+            __memcpy(nram_para_store + compute_id * large_radix, nram_out_r,
+                     large_radix * sizeof(DT), NRAM2NRAM);
+            __memcpy(nram_para_store +
+                         (compute_id + max_para_ldst_num) * large_radix,
+                     nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+          }
+        }
+      }
+    }
+    // __sync();
+    // pipeline: load-stage
+
+    if (repeat_id < repeat_num) {
+      // MLULOG("pipeline: load-stage.\n");
+      int i = max_para_ldst_num * repeat_id;
+      DT *nram_para_load =
+          (repeat_id % 2 == 0) ? nram_para_load_ping : nram_para_load_pong;
+
+      // DT *nram_dftmtx =
+      //     (repeat_id % 2 == 0) ? nram_dftmtx_ping : nram_dftmtx_pong;
+      int para_load_num = (max_para_ldst_num > (section_num - i))
+                              ? (section_num - i)
+                              : max_para_ldst_num;
+      if (section_num == 1) {
+        __memcpy_async(nram_para_load, input, sizeof(DT) * 2 * large_radix,
+                       GDRAM2NRAM);
+      } else {
+        __memcpy_async(nram_para_load, input + i * 2,
+                       sizeof(DT) * 2 * para_load_num, GDRAM2NRAM,
+                       sizeof(DT) * 2 * para_load_num,
+                       large_in_stride * sizeof(DT) * 2, large_radix - 1);
+      }
+    }
+
+    __sync();
+  }
+}
+
+template <typename DT>
+__mlu_func__ void computeLargeButterflyOtherstages_v1(
+    DT *output, DT *input, const DT *cur_large_twiddles, const DT *_twiddles,
+    int large_section_num, int large_butterfly_num, int large_in_stride,
+    void *nram_buf, const int *small_factors, int nfft, int dir,
+    int last_stage) {
+  int radix, small_in_stride, small_stage_count, large_radix,
+      _small_stage_count;
+  int small_section_num, small_butterfly_num, value_mul;
+
+  // int is_two_stages = 0; // the variable for twostages
+  // const int is_in_place = (input == output);
+  const int large_out_stride = large_butterfly_num;
+  int tw_offset;
+
+  _small_stage_count = small_factors[0];
+  large_radix = small_factors[1];
+  tw_offset = small_factors[2];
+
+  const DT *_small_twiddles = _twiddles + tw_offset * 2;  // complex
+  const DT *small_twiddles;                               // complex
+
+  // MLULOG("small_section_num:      %d.\n\n\n", small_section_num);
+  // max num for parallel  load/store
+  const int max_para_ldst_num = 3;
+  int para_ldst_num;
+  // TODO(zrg): save nram space.
+  // __nram__ DT nram_space[MAX_BUTTERFLY_ON_CHIP * 2];
+  // 0 1 2 3 4 5
+  // 0   1   3
+  // DT *nram_buf_end = (DT*)&((uint8_t*)nram_buf)[NRAM_BUFFER_SIZE];
+  // FFT_CPX_T<DT> *nram_in = (FFT_CPX_T<DT> *)nram_buffer;
+  // FFT_CPX_T<DT> *nram_out = &nram_in[large_radix];
+  // FFT_CPX_T<DT> *nram_buf = &nram_in[large_radix * 2];
+  DT *nram_in_r = (DT *)nram_buf;
+  DT *nram_in_i = &nram_in_r[large_radix];
+  DT *nram_out_r = &nram_in_r[large_radix * 2];
+  DT *nram_out_i = &nram_in_i[large_radix * 2];
+  DT *nram_para_ldst_r = &nram_out_i[large_radix];  // para_load_num
+  DT *nram_para_ldst_i =
+      &nram_para_ldst_r[large_radix * max_para_ldst_num];  // para_load_num
+  DT *nram_para_transpose_r =
+      &nram_para_ldst_r[large_radix * 2 * max_para_ldst_num];
+  DT *nram_para_transpose_i =
+      &nram_para_transpose_r[large_radix * max_para_ldst_num];  // para_load_num
+  DT *nram_twiddles =
+      &nram_para_transpose_r[large_radix * 2 * max_para_ldst_num];
+  DT *_nram_tw = &nram_twiddles[large_radix * 2];
+  DT *nram_scratch = &_nram_tw[large_radix * 2];
+
+  // temp overlap with "nram_scratch"
+  DT *CPX_MUL_RR = nram_scratch;
+  DT *CPX_MUL_RI = &CPX_MUL_RR[large_radix * max_para_ldst_num];
+  DT *CPX_MUL_IR = &CPX_MUL_RI[large_radix * max_para_ldst_num];
+  DT *CPX_MUL_II = &CPX_MUL_IR[large_radix * max_para_ldst_num];
+
+  // size: (large_radix - 1) * max_para_ldst_num
+  DT *scratch_tw_r = &CPX_MUL_II[large_radix * max_para_ldst_num];
+  DT *scratch_tw_i = &scratch_tw_r[(large_radix - 1) * max_para_ldst_num];
+
+  if (nram_buf == NULL) {
+    MLULOG("nram_buf: NULL.\n");
+  }
+  if (input == NULL) {
+    MLULOG("input: NULL.\n");
+  }
+  if (output == NULL) {
+    MLULOG("output: NULL.\n");
+  }
+
+  if (cur_large_twiddles == NULL) {
+    MLULOG("twiddles: NULL.\n");
+  }
+
+  // __nram__ DT *nram_buf = &nram_space[MAX_BUTTERFLY_ON_CHIP*2];
+
+  // DT *odd_extra_buffer = buffer + nfft*2; // for in_place temp buffer
+
+  const int para_num = 1;
+  int Fin_stride = 0, Fout_stride = 0;
+  int sec_count;
+
+  MLULOG("large_section_num: %d.\n", large_section_num);
+  MLULOG("large_butterfly_num: %d.\n", large_butterfly_num);
+  // MLULOG("small_section_num!!!!! %d.\n", small_section_num);
+
+  for (sec_count = 0; sec_count < large_section_num; ++sec_count) {
+    // for (int i = 0; i < large_butterfly_num; i += para_num) {
+    for (int i = 0; i < large_butterfly_num; i += para_num) {
+      radix = small_factors[4];
+      small_section_num = small_factors[5];
+      small_in_stride = small_factors[7];
+
+      small_stage_count = _small_stage_count;
+      small_twiddles = _small_twiddles;
+      // MLULOG("butterfly id: %d\n", i);
+      // load_input_gdram2nram
+
+      if (i % max_para_ldst_num == 0) {
+        para_ldst_num = (max_para_ldst_num > (large_butterfly_num - i))
+                            ? (large_butterfly_num - i)
+                            : max_para_ldst_num;
+
+        // MLULOG("para_ldst_num: %d\n", para_ldst_num);
+        if (para_ldst_num != 1) {
+          __memcpy(nram_para_ldst_r, input + Fin_stride + i,
+                   sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+                   sizeof(DT) * para_ldst_num, large_in_stride * sizeof(DT),
+                   large_radix - 1);
+          __memcpy(nram_para_ldst_i, input + nfft + Fin_stride + i,
+                   sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+                   sizeof(DT) * para_ldst_num, large_in_stride * sizeof(DT),
+                   large_radix - 1);
+
+          // for (int j = 0; j < large_radix; j++) {
+          //   MLULOG("input r: %f.\n", nram_in_r[j]);
+          // }
+
+          // for (int j = 0; j < large_radix; j++) {
+          //   MLULOG("input i: %f.\n", nram_in_i[j]);
+          // }
+
+#if 1
+          __memcpy(scratch_tw_r, cur_large_twiddles + i,
+                   sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+                   sizeof(DT) * para_ldst_num, large_out_stride * sizeof(DT),
+                   large_radix - 2);
+          __memcpy(
+              scratch_tw_i,
+              cur_large_twiddles + large_butterfly_num * (large_radix - 1) + i,
+              sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+              sizeof(DT) * para_ldst_num, large_out_stride * sizeof(DT),
+              large_radix - 2);
+#else
+
+          __memcpy(scratch_tw_r, cur_large_twiddles + i,
+                   sizeof(DT) * para_ldst_num, SRAM2NRAM,
+                   sizeof(DT) * para_ldst_num, large_out_stride * sizeof(DT),
+                   large_radix - 2);
+          __memcpy(
+              scratch_tw_i,
+              cur_large_twiddles + large_butterfly_num * (large_radix - 1) + i,
+              sizeof(DT) * para_ldst_num, SRAM2NRAM, sizeof(DT) * para_ldst_num,
+              large_out_stride * sizeof(DT), large_radix - 2);
+
+#endif
+          // for (int j = 0; j < para_ldst_num * (large_radix - 1); j++) {
+          //   MLULOG("scratch_tw_r j: %f, %d.\n", scratch_tw_r[j], j);
+          // }
+
+          // for (int j = 0; j < para_ldst_num * (large_radix - 1); j++) {
+          //   MLULOG("scratch_tw_i j: %f, %d.\n", scratch_tw_i[j], j);
+          // }
+
+          // __sync();
+          // MLULOG("butterfly id: %d\n", i);
+          // rotate
+          __bang_mul(CPX_MUL_RR, nram_para_ldst_r + para_ldst_num, scratch_tw_r,
+                     para_ldst_num * (large_radix - 1));
+          __bang_mul(CPX_MUL_II, nram_para_ldst_i + para_ldst_num, scratch_tw_i,
+                     para_ldst_num * (large_radix - 1));
+          __bang_mul(CPX_MUL_RI, nram_para_ldst_r + para_ldst_num, scratch_tw_i,
+                     para_ldst_num * (large_radix - 1));
+          __bang_mul(CPX_MUL_IR, nram_para_ldst_i + para_ldst_num, scratch_tw_r,
+                     para_ldst_num * (large_radix - 1));
+
+          // __sync();
+
+          __bang_sub(nram_para_ldst_r + para_ldst_num, CPX_MUL_RR, CPX_MUL_II,
+                     para_ldst_num * (large_radix - 1));
+          __bang_add(nram_para_ldst_i + para_ldst_num, CPX_MUL_RI, CPX_MUL_IR,
+                     para_ldst_num * (large_radix - 1));
+
+          __bang_transpose(nram_para_transpose_r, nram_para_ldst_r, large_radix,
+                           para_ldst_num);
+          __bang_transpose(nram_para_transpose_i, nram_para_ldst_i, large_radix,
+                           para_ldst_num);
+
+        } else {
+          // TODO(zrg): copy for no parallel
+        }
+      }
+
+      __memcpy(nram_in_r,
+               nram_para_transpose_r + (i % max_para_ldst_num) * large_radix,
+               large_radix * sizeof(DT), NRAM2NRAM);
+      __memcpy(nram_in_i,
+               nram_para_transpose_i + (i % max_para_ldst_num) * large_radix,
+               large_radix * sizeof(DT), NRAM2NRAM);
+
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("input r: %f.\n", nram_in_r[j]);
+      // }
+
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("input i: %f.\n", nram_in_i[j]);
+      // }
+
+      // stage is odd or even, place is in or out
+      // if (_stage_count != 1 && (is_in_place || _stage_count % 2 != 0))
+      // fft_swap_ptr(&nram_out, &nram_in); // test
+
+      // first stage
+
+      // twiddles: GDRAM -> SRAM
+      // loadNextStageTwiddles();
+      // switch (radix)
+      // {
+      // case 2:
+      //   computeRadix2ButterflyFirststage(Fout, Fin, section_num, section_num,
+      //   1, dir); break;
+      // case 3:
+      //   computeRadix3ButterflyFirststage(Fout, Fin, section_num, section_num,
+      //   1, dir); break;
+      // default:
+      //   computeGenericButterflyFirststage(Fout, buffer, twiddles, radix,
+      //   section_num, butterfly_num, in_stride, 0, dir); break;
+      // }
+
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("input %d: (%f, %f).\n", i, nram_in_r[j], nram_in_i[j]);
+      // }
+
+      //   computeRadix3ButterflyFirststage(
+      //       nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+      //       small_section_num, small_section_num, 1, dir);
+      //       __sync();
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("output %d: (%f, %f).\n", i, nram_out_r[j], nram_out_i[j]);
+      // }
+
+      switch (radix) {
+        case 2:
+          // computeRadix2ButterflyFirststage(Fout, Fin, section_num,
+          // section_num, 1, dir);
+          break;
+        case 3:
+
+          computeRadix3ButterflyFirststage(
+              nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+              small_section_num, small_section_num, 1, dir);
+          __sync();
+          // for (int j = 0; j < large_radix; j++) {
+          //   MLULOG("output %d: (%f, %f).\n", i, nram_out_r[j],
+          //   nram_out_i[j]);
+          // }
+          break;
+        case 9:
+
+          computeRadix9ButterflyFirststage(
+              nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+              small_section_num, small_section_num, 1, dir);
+
+          break;
+        default:
+          // computeGenericButterflyFirststage(Fout, buffer, twiddles, radix,
+          // section_num, butterfly_num, in_stride, 0, dir);
+          break;
+      }
+
+      // __sync();
+
+      // MLULOG("small_stage_count(Large other/last stage): %d\n",
+      // small_stage_count);
+
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("nram_out_r %d: %f.\n", j, nram_out_r[j]);
+      // }
+
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("nram_out_i %d: %f.\n", j, nram_out_i[j]);
+      // }
+
+      small_stage_count--;
+      if (small_stage_count == 0) {
+        // nram to gdram
+
+        // temp store to nram
+        __memcpy(nram_para_ldst_r + (i % max_para_ldst_num) * large_radix,
+                 nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+        __memcpy(nram_para_ldst_i + (i % max_para_ldst_num) * large_radix,
+                 nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+        __sync();
+        // transpose before store to GDRAM
+        if (i % max_para_ldst_num == (para_ldst_num - 1)) {
+          // transpose: [para_ldst_num, large_radix] -> [large_radix,
+          // para_ldst_num]
+
+          // real
+          __bang_transpose(nram_para_transpose_r, nram_para_ldst_r,
+                           para_ldst_num, large_radix);
+          // imag
+          // __bang_transpose(nram_para_transpose_i, nram_para_ldst_i,
+          //                  para_ldst_num, large_radix);
+          __bang_transpose(nram_para_transpose_r + large_radix * para_ldst_num,
+                           nram_para_ldst_i, para_ldst_num, large_radix);
+          if (last_stage) {
+            // [2, nfft] -> [nfft, 2]
+            __bang_transpose(nram_para_ldst_r, nram_para_transpose_r, 2,
+                             large_radix * para_ldst_num);
+            __memcpy(output + (Fout_stride + i - para_ldst_num + 1) * 2,
+                     nram_para_ldst_r, sizeof(DT) * 2 * para_ldst_num,
+                     NRAM2GDRAM, large_out_stride * 2 * sizeof(DT),
+                     sizeof(DT) * 2 * para_ldst_num, large_radix - 1);
+
+          } else {
+            // real
+            __memcpy(output + (Fout_stride + i - para_ldst_num + 1),
+                     nram_para_transpose_r, para_ldst_num * sizeof(DT),
+                     NRAM2GDRAM, large_out_stride * sizeof(DT),
+                     sizeof(DT) * para_ldst_num, large_radix - 1);
+            // imag
+            __memcpy(output + (Fout_stride + i - para_ldst_num + 1) + nfft,
+                     nram_para_transpose_r + large_radix * para_ldst_num,
+                     para_ldst_num * sizeof(DT), NRAM2GDRAM,
+                     large_out_stride * sizeof(DT), sizeof(DT) * para_ldst_num,
+                     large_radix - 1);
+
+            fft_swap_ptr(&nram_out_r, &nram_in_r);
+            fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+            // __bang_transpose(nram_transpose, nram_out_r, 2, large_radix);
+            // real
+            // __memcpy(output + Fout_stride, nram_transpose,
+            //          large_radix * sizeof(DT), NRAM2GDRAM);
+
+            // imag
+            // __memcpy(output + Fout_stride + nfft,
+            //          nram_transpose + large_radix, large_radix * sizeof(DT),
+            //          NRAM2GDRAM);
+            // __memcpy(nram_para_ldst_r, input + Fin_stride + i,
+            //          sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+            //          sizeof(DT) * para_ldst_num, large_in_stride *
+            //          sizeof(DT), large_radix - 1);
+            // __memcpy(nram_para_ldst_i, input + nfft + Fin_stride + i,
+            //          sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+            //          sizeof(DT) * para_ldst_num, large_in_stride *
+            //          sizeof(DT), large_radix - 1);
+          }
+
+          // for (int j = 0; j < large_radix; j++) {
+          //   MLULOG("nram_out_r %d: %f.\n", j, *(output + (Fout_stride + i +
+          //   j*large_out_stride) * 2));
+          // }
+
+          // for (int j = 0; j < large_radix; j++) {
+          //   MLULOG("nram_out_i %d: %f.\n", j, *(output + (Fout_stride + i +
+          //   j*large_out_stride) * 2));
+          // }
+        }
+        // __sync();
+        continue;
+      }
+
+      // MLULOG("butterfly id: %d\n", i);
+
+      // DT *sram_tw = (DT *)sram_buffer;
+      DT *nram_tw = _nram_tw;
+
+      for (; small_stage_count > 1; small_stage_count--) {
+        fft_swap_ptr(&nram_out_r, &nram_in_r);
+        fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+        // __memcpy(input2NRAM_tmp, input2SRAM + ROUND * coreId * k, k * ROUND *
+        // sizeof(int8_t), SRAM2NRAM);
+
+        // twiddles: GDRAM -> SRAM
+        // loadNextStageTwiddles();
+
+        // swap_ptr(buffer, Fout);
+
+        // if (is_two_stages && is_in_place)
+        // {
+        //   if (_stage_count % 2 == 0)
+        //   {
+        //     if ((_stage_count - stage_count) == 2)
+        //       swap_ptr(odd_extra_buffer, Fout);
+        //   }
+        //   else
+        //   {
+        //     if ((_stage_count - stage_count) == 3)
+        //       swap_ptr(odd_extra_buffer, Fout);
+        //   }
+        // }
+
+        value_mul = (_small_stage_count - small_stage_count + 1) * 4;
+        // // update parameter
+        radix = small_factors[value_mul];
+        small_section_num = small_factors[value_mul + 1];
+        small_butterfly_num = small_factors[value_mul + 2];
+        small_in_stride = small_factors[value_mul + 3];
+
+        // radix = small_factors[4 * _small_stage_count];
+        // small_section_num = small_factors[4 * _small_stage_count + 1];
+        // small_butterfly_num = small_factors[4 * _small_stage_count + 2];
+        // small_in_stride = small_factors[4 * _small_stage_count + 3];
+
+        // copy GDRAM2SRAM
+
+        if (i == 0 && sec_count == 0) {
+          // if (1) {
+          // __memcpy(sram_tw, twiddles,
+          //          small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+          //          GDRAM2SRAM);
+          // small_twiddles += small_butterfly_num * (radix - 1) * 2;  // 2
+          // means (r, i)
+          // __sync_cluster();
+          __memcpy(nram_tw, small_twiddles,
+                   small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                   GDRAM2NRAM);
+          small_twiddles += small_butterfly_num * (radix - 1) * 2;  // 2 means
+        }
+
+        switch (radix) {
+          case 2:
+            // computeRadix2ButterflyOtherstages(Fout, Fin, section_num,
+            // section_num, 1, dir);
+            break;
+          case 3:
+            computeRadix3ButterflyOtherstages(
+                nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                nram_tw, small_section_num, small_butterfly_num,
+                small_in_stride, dir);
+            break;
+          case 9:
+            computeRadix9ButterflyOtherstages(
+                nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                nram_tw, small_section_num, small_butterfly_num,
+                small_in_stride, dir);
+            break;
+          default:
+            // computeGenericButterflyOtherstages(Fout, buffer, twiddles, radix,
+            // section_num, butterfly_num, in_stride, 0, dir);
+            break;
+        }
+
+        nram_tw += small_butterfly_num * (radix - 1) * 2;
+        // __sync();
+        // __sync_cluster();  // sync barrier
+      }  // for (stage_count)
+
+      // for (int j = 0; j < large_radix; j++) {
+      //   MLULOG("output %d: (%f, %f).\n", i, nram_out_r[j], nram_out_i[j]);
+      // }
+
+      // last stage
+      {
+        // if ((_stage_count % 2 == 0) && is_in_place && !is_two_stages)
+        // {
+        //   swap_ptr(buffer, Fout);
+        // }
+        // else
+        // {
+        //   buffer = Fout;
+
+        //   if (is_in_place && _stage_count == 3 && is_two_stages)
+        //     swap_ptr(odd_extra_buffer, Fout);
+        // }
+
+        fft_swap_ptr(&nram_out_r, &nram_in_r);
+        fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+        // copy GDRAM2SRAM
+
+        // update parameter
+        radix = small_factors[4 * _small_stage_count];
+        small_section_num = small_factors[4 * _small_stage_count + 1];
+        small_butterfly_num = small_factors[4 * _small_stage_count + 2];
+        small_in_stride = small_factors[4 * _small_stage_count + 3];
+
+        // MLULOG("small_section_num: %d\n", small_section_num);
+        // MLULOG("small_butterfly_num: %d\n", small_butterfly_num);
+        // MLULOG("small_in_stride: %d\n", small_in_stride);
+        // MLULOG("1320\n");
+        if (i == 0 && sec_count == 0) {
+          // if (1) {
+          // __memcpy(sram_tw, twiddles,
+          //          small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+          //          GDRAM2SRAM);
+          __memcpy(nram_tw, small_twiddles,
+                   small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                   GDRAM2NRAM);
+          // __sync_cluster();
+        }
+        // MLULOG("1326\n");
+        // for (int j = 0; j < 6; j++)
+        // {
+        //   MLULOG("twiddles i: (%f, %f).\n", small_twiddles[j],
+        //   small_twiddles[j+6]);
+        // }
+        switch (radix) {
+          case 2:
+            // computeRadix2ButterflyLaststage(Fout, Fin, section_num,
+            // section_num, 1, dir);
+            break;
+          case 3:
+            // MLULOG("computeRadix3ButterflyLaststage\n");
+            computeRadix3ButterflyLaststage(
+                nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                nram_tw, small_section_num, small_butterfly_num,
+                small_in_stride, dir);
+            break;
+          case 9:
+            // MLULOG("computeRadix3ButterflyLaststage\n");
+            computeRadix9ButterflyLaststage(
+                nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                nram_tw, small_section_num, small_butterfly_num,
+                small_in_stride, dir);
+            break;
+          default:
+            // computeGenericButterflyLaststage(Fout, buffer, twiddles, radix,
+            // section_num, butterfly_num, in_stride, 0, dir);
+            break;
+        }
+
+        // for (int j = 0; j < large_radix; j++) {
+        //   MLULOG("output %d: (%f, %f).\n", i, nram_out_r[j], nram_out_i[j]);
+        // }
+
+        // for (int j = 0; j < 3; j++) {
+        // for (int k = 0; k < 3; large_radix++) {
+        //   MLULOG("output[%d] r: %f\n", i-2+j, nram_para_transpose_r[j]);
+        //   MLULOG("output[%d] i: %f\n", i-2+j, (nram_para_transpose_r +
+        //   large_radix * para_ldst_num)[j]);
+        // }
+        // }
+
+        // temp store to nram
+        __memcpy(nram_para_ldst_r + (i % max_para_ldst_num) * large_radix,
+                 nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+        __memcpy(nram_para_ldst_i + (i % max_para_ldst_num) * large_radix,
+                 nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+
+        // transpose before store to GDRAM
+        if (i % max_para_ldst_num == (para_ldst_num - 1)) {
+          // transpose: [para_ldst_num, large_radix] -> [large_radix,
+          // para_ldst_num]
+
+          // real
+          __bang_transpose(nram_para_transpose_r, nram_para_ldst_r,
+                           para_ldst_num, large_radix);
+          // imag
+          // __bang_transpose(nram_para_transpose_i, nram_para_ldst_i,
+          //                  para_ldst_num, large_radix);
+          __bang_transpose(nram_para_transpose_r + large_radix * para_ldst_num,
+                           nram_para_ldst_i, para_ldst_num, large_radix);
+
+          if (last_stage) {
+            // [2, nfft] -> [nfft, 2]
+            __bang_transpose(nram_para_ldst_r, nram_para_transpose_r, 2,
+                             large_radix * para_ldst_num);
+            __memcpy(output + (Fout_stride + (i - para_ldst_num + 1)) * 2,
+                     nram_para_ldst_r, sizeof(DT) * 2 * para_ldst_num,
+                     NRAM2GDRAM, large_out_stride * 2 * sizeof(DT),
+                     sizeof(DT) * 2 * para_ldst_num, large_radix - 1);
+            // MLULOG("Fout_stride + i: %d\n", Fout_stride + i-para_ldst_num+1);
+
+          } else {
+            // real
+            __memcpy(output + (Fout_stride + i - para_ldst_num + 1),
+                     nram_para_transpose_r, para_ldst_num * sizeof(DT),
+                     NRAM2GDRAM, large_out_stride * sizeof(DT),
+                     sizeof(DT) * para_ldst_num, large_radix - 1);
+            // imag
+            __memcpy(output + (Fout_stride + i - para_ldst_num + 1) + nfft,
+                     nram_para_transpose_r + large_radix * para_ldst_num,
+                     para_ldst_num * sizeof(DT), NRAM2GDRAM,
+                     large_out_stride * sizeof(DT), sizeof(DT) * para_ldst_num,
+                     large_radix - 1);
+
+            fft_swap_ptr(&nram_out_r, &nram_in_r);
+            fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+            // __bang_transpose(nram_transpose, nram_out_r, 2, large_radix);
+            // real
+            // __memcpy(output + Fout_stride, nram_transpose,
+            //          large_radix * sizeof(DT), NRAM2GDRAM);
+
+            // imag
+            // __memcpy(output + Fout_stride + nfft,
+            //          nram_transpose + large_radix, large_radix * sizeof(DT),
+            //          NRAM2GDRAM);
+            // __memcpy(nram_para_ldst_r, input + Fin_stride + i,
+            //          sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+            //          sizeof(DT) * para_ldst_num, large_in_stride *
+            //          sizeof(DT), large_radix - 1);
+            // __memcpy(nram_para_ldst_i, input + nfft + Fin_stride + i,
+            //          sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+            //          sizeof(DT) * para_ldst_num, large_in_stride *
+            //          sizeof(DT), large_radix - 1);
+          }
+        }
+        // MLULOG("butterfly id: %d\n", i);
+        // store to GDRAM
+
+        // __sync();
+      }
+    }
+
+    Fin_stride += large_butterfly_num;
+    Fout_stride += large_radix * large_butterfly_num;
+  }
+}
+
+template <typename DT>
+__mlu_func__ void computeLargeButterflyOtherstages(
+    DT *output, DT *input, const DT *cur_large_twiddles, const DT *_twiddles,
+    int large_section_num, int large_butterfly_num, int large_in_stride,
+    void *nram_buf, const int *small_factors, int nfft, int dir,
+    int last_stage) {
+  int radix, small_in_stride, small_stage_count, large_radix,
+      _small_stage_count;
+  int small_section_num, small_butterfly_num, value_mul;
+
+  const int large_out_stride = large_butterfly_num;
+  int tw_offset;
+
+  _small_stage_count = small_factors[0];
+  large_radix = small_factors[1];
+  tw_offset = small_factors[2];
+
+  const DT *small_twiddles = _twiddles + tw_offset * 2;  // complex
+  // const DT *small_twiddles;                               // complex
+
+  // MLULOG("small_section_num:      %d.\n\n\n", small_section_num);
+  // max num for parallel  load/store
+  const int max_para_ldst_num = 6561 / large_radix;
+  // int para_ldst_num;
+  // TODO(zrg): save nram space.
+  // __nram__ DT nram_space[MAX_BUTTERFLY_ON_CHIP * 2];
+  // 0 1 2 3 4 5
+  // 0   1   3
+  // DT *nram_buf_end = (DT*)&((uint8_t*)nram_buf)[NRAM_BUFFER_SIZE];
+  // FFT_CPX_T<DT> *nram_in = (FFT_CPX_T<DT> *)nram_buffer;
+  // FFT_CPX_T<DT> *nram_out = &nram_in[large_radix];
+  // FFT_CPX_T<DT> *nram_buf = &nram_in[large_radix * 2];
+  int nram_buf_offset = 0;
+  DT *nram_in_r = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_in_i = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_out_r = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  DT *nram_out_i = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix;
+
+  // parallel load/store space
+  FFT_CPX_T<DT> nram_para_load_in_ping = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  FFT_CPX_T<DT> nram_para_load_in_pong = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  FFT_CPX_T<DT> nram_para_load_tw_ping = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  FFT_CPX_T<DT> nram_para_load_tw_pong = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  FFT_CPX_T<DT> nram_para_store_ping = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  FFT_CPX_T<DT> nram_para_store_pong = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  FFT_CPX_T<DT> nram_transpose_temp;
+  // temp out-space before transpose
+  // if last-stage:
+  //                compute_id 0 r
+  //                compute_id 0 i
+  //                compute_id 1 r
+  //                compute_id 1 i
+  // else:
+  //                compute_id 0 r
+  //                compute_id 1 i
+  //                compute_id 0 r
+  //                compute_id 1 i
+  nram_transpose_temp = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * ((int)last_stage) +
+          large_radix * (1 - (int)last_stage) * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  DT *_nram_tw = (DT *)nram_buf + nram_buf_offset;
+  nram_buf_offset += large_radix * 2;  // complex
+
+  // transpose space: [radix, 2 * parrallel] -> [parrallel * 2, radix]
+  FFT_CPX_T<DT> nram_transpose_load = {
+      (DT *)nram_buf + nram_buf_offset,
+      (DT *)nram_buf + nram_buf_offset + large_radix * max_para_ldst_num};
+  nram_buf_offset += large_radix * max_para_ldst_num * 2;  // complex
+
+  DT *nram_scratch = (DT *)nram_buf + nram_buf_offset;
+
+  // temp overlap with "nram_scratch"
+  DT *CPX_MUL_RR = nram_scratch;
+  DT *CPX_MUL_RI = &CPX_MUL_RR[large_radix * max_para_ldst_num];
+  DT *CPX_MUL_IR = &CPX_MUL_RI[large_radix * max_para_ldst_num];
+  DT *CPX_MUL_II = &CPX_MUL_IR[large_radix * max_para_ldst_num];
+
+  nram_buf_offset += large_radix * max_para_ldst_num * 4;  // complex
+
+  // size: (large_radix - 1) * max_para_ldst_num
+  // DT *scratch_tw_r = &CPX_MUL_II[large_radix * max_para_ldst_num];
+  // DT *scratch_tw_i = &scratch_tw_r[(large_radix - 1) * max_para_ldst_num];
+
+  if (nram_buf == NULL) {
+    MLULOG("nram_buf: NULL.\n");
+  }
+  if (input == NULL) {
+    MLULOG("input: NULL.\n");
+  }
+  if (output == NULL) {
+    MLULOG("output: NULL.\n");
+  }
+
+  if (cur_large_twiddles == NULL) {
+    MLULOG("twiddles: NULL.\n");
+  }
+
+  // __nram__ DT *nram_buf = &nram_space[MAX_BUTTERFLY_ON_CHIP*2];
+
+  // DT *odd_extra_buffer = buffer + nfft*2; // for in_place temp buffer
+
+  // const int para_num = 1;
+  int Fin_stride = 0, Fout_stride = 0;
+  int sec_count;
+  int repeat_num =
+      (large_butterfly_num + max_para_ldst_num - 1) / max_para_ldst_num;
+  for (sec_count = 0; sec_count < large_section_num; ++sec_count) {
+    for (int repeat_id = 0; repeat_id < repeat_num + 2; ++repeat_id) {
+      // small_twiddles = _small_twiddles;
+      // pipeline: store-stage
+      if (repeat_id >= 2) {
+        // MLULOG("pipeline: store-stage.\n");
+        int i = max_para_ldst_num * (repeat_id - 2);
+
+        int para_store_num = (max_para_ldst_num > (large_butterfly_num - i))
+                                 ? (large_butterfly_num - i)
+                                 : max_para_ldst_num;
+
+        FFT_CPX_T<DT> nram_para_store =
+            (repeat_id % 2 == 0) ? nram_para_store_ping : nram_para_store_pong;
+
+        if (last_stage) {
+          // __memcpy_async(
+          //     output + (Fout_stride + i * large_radix) * 2,
+          //     nram_para_store.r,
+          //     sizeof(DT) * 2 * para_store_num * large_radix, NRAM2GDRAM);
+
+          __memcpy_async(output + (Fout_stride + i) * 2, nram_para_store.r,
+                         sizeof(DT) * 2 * para_store_num, NRAM2GDRAM,
+                         large_out_stride * 2 * sizeof(DT),
+                         sizeof(DT) * 2 * para_store_num, large_radix - 1);
+
+        } else {
+          // // real
+          // __memcpy_async(output + Fout_stride + i * large_radix,
+          //                nram_para_store.r,
+          //                para_store_num * large_radix * sizeof(DT),
+          //                NRAM2GDRAM);
+          // // imag
+          // __memcpy_async(output + Fout_stride + i * large_radix + nfft,
+          //                nram_para_store.i,
+          //                para_store_num * large_radix * sizeof(DT),
+          //                NRAM2GDRAM);
+          // real
+          __memcpy_async(output + Fout_stride + i, nram_para_store.r,
+                         para_store_num * sizeof(DT), NRAM2GDRAM,
+                         large_out_stride * sizeof(DT),
+                         sizeof(DT) * para_store_num, large_radix - 1);
+          // imag
+          __memcpy_async(output + Fout_stride + i + nfft, nram_para_store.i,
+                         para_store_num * sizeof(DT), NRAM2GDRAM,
+                         large_out_stride * sizeof(DT),
+                         sizeof(DT) * para_store_num, large_radix - 1);
+        }
+      }
+      // __sync();
+      // pipeline: compute-stage
+
+      if (repeat_id >= 1 && repeat_id < repeat_num + 1) {
+        // MLULOG("pipeline: compute-stage.\n");
+        int i = max_para_ldst_num * (repeat_id - 1);
+
+        FFT_CPX_T<DT> nram_para_load_in = (repeat_id % 2 != 0)
+                                              ? nram_para_load_in_ping
+                                              : nram_para_load_in_pong;
+
+        FFT_CPX_T<DT> nram_para_load_tw = (repeat_id % 2 != 0)
+                                              ? nram_para_load_tw_ping
+                                              : nram_para_load_tw_pong;
+
+        FFT_CPX_T<DT> nram_para_store =
+            (repeat_id % 2 != 0) ? nram_para_store_ping : nram_para_store_pong;
+
+        int para_ldst_num = (max_para_ldst_num > (large_butterfly_num - i))
+                                ? (large_butterfly_num - i)
+                                : max_para_ldst_num;
+
+        // __bang_transpose(nram_transpose_load, nram_para_load, large_radix,
+        //                  2 * para_ldst_num);
+
+        // rotation-large
+        __bang_mul(CPX_MUL_RR, nram_para_load_in.r + para_ldst_num,
+                   nram_para_load_tw.r, para_ldst_num * (large_radix - 1));
+        __bang_mul(CPX_MUL_II, nram_para_load_in.i + para_ldst_num,
+                   nram_para_load_tw.i, para_ldst_num * (large_radix - 1));
+        __bang_mul(CPX_MUL_RI, nram_para_load_in.r + para_ldst_num,
+                   nram_para_load_tw.i, para_ldst_num * (large_radix - 1));
+        __bang_mul(CPX_MUL_IR, nram_para_load_in.i + para_ldst_num,
+                   nram_para_load_tw.r, para_ldst_num * (large_radix - 1));
+
+        __bang_sub(nram_para_load_in.r + para_ldst_num, CPX_MUL_RR, CPX_MUL_II,
+                   para_ldst_num * (large_radix - 1));
+        __bang_add(nram_para_load_in.i + para_ldst_num, CPX_MUL_RI, CPX_MUL_IR,
+                   para_ldst_num * (large_radix - 1));
+
+        __bang_transpose(nram_transpose_load.r, nram_para_load_in.r,
+                         large_radix, para_ldst_num);
+        __bang_transpose(nram_transpose_load.i, nram_para_load_in.i,
+                         large_radix, para_ldst_num);
+
+        for (int compute_id = 0; compute_id < para_ldst_num; compute_id++) {
+          // load real & imag
+
+          radix = small_factors[4];
+          small_section_num = small_factors[5];
+          small_in_stride = small_factors[7];
+          small_stage_count = _small_stage_count;
+
+          // __memcpy(nram_in_r,
+          //         nram_transpose_load + compute_id * large_radix * 2,
+          //          large_radix * sizeof(DT) * 2, NRAM2NRAM);
+
+          // first stage
+          // if(0)
+          switch (radix) {
+            case 2:
+              break;
+            case 3:
+              computeRadix3ButterflyFirststage(
+                  nram_out_r, nram_out_i,
+                  nram_transpose_load.r + compute_id * large_radix,
+                  nram_transpose_load.i + compute_id * large_radix,
+                  nram_scratch, small_section_num, small_section_num, 1, dir);
+              break;
+            case 9:
+              MLULOG("computeRadix9ButterflyFirststage.\n");
+              computeRadix9ButterflyFirststage(
+                  nram_out_r, nram_out_i,
+                  nram_transpose_load.r + compute_id * large_radix,
+                  nram_transpose_load.i + compute_id * large_radix,
+                  nram_scratch, small_section_num, small_section_num, 1, dir);
+
+              // computeRadix9ButterflyFirststageMat(
+              //     nram_out_r, nram_out_i,
+              //     nram_transpose_load + compute_id * large_radix * 2,
+              //     nram_transpose_load + (compute_id * 2 + 1) * large_radix,
+              //     nram_scratch, nram_dftmtx,
+              //     small_section_num, small_section_num, 1, dir);
+              break;
+            default:
+              // computeGenericButterflyFirststage(Fout, buffer, twiddles,
+              // radix, section_num, butterfly_num, in_stride, 0, dir);
+              break;
+          }
+          //           for (int j = 0; j < large_radix; j++) {
+          //   MLULOG("output i: (%f, %f).\n", nram_out_r[j], nram_out_i[j]);
+          // }
+          small_stage_count--;
+          if (small_stage_count == 0) {
+            // if last-stage: stride = large_radix * 2
+            //                compute_id 0 r
+            //                compute_id 0 i
+            //                compute_id 1 r
+            //                compute_id 1 i
+            // else: stride = large_radix
+            //                compute_id 0 r
+            //                compute_id 1 i
+            //                compute_id 0 r
+            //                compute_id 1 i
+
+            __memcpy(nram_transpose_temp.r +
+                         compute_id * large_radix * (1 + (int)last_stage),
+                     nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+            __memcpy(nram_transpose_temp.i +
+                         compute_id * large_radix * (1 + (int)last_stage),
+                     nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+
+            // __bang_transpose(nram_para_store, nram_transpose_temp.r,
+            //                  max_para_ldst_num * 2, large_radix);
+            continue;
+          }
+
+          // DT *sram_tw = (DT *)sram_buffer;
+          DT *nram_tw = _nram_tw;
+
+          for (; small_stage_count > 1; small_stage_count--) {
+            fft_swap_ptr(&nram_out_r, &nram_in_r);
+            fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+            value_mul = (_small_stage_count - small_stage_count + 1) * 4;
+            // // update parameter
+            radix = small_factors[value_mul];
+            small_section_num = small_factors[value_mul + 1];
+            small_butterfly_num = small_factors[value_mul + 2];
+            small_in_stride = small_factors[value_mul + 3];
+            // copy GDRAM2SRAM
+
+            if (sec_count == 0 && compute_id == 0 && repeat_id == 1) {
+              __memcpy(nram_tw, small_twiddles,
+                       small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                       GDRAM2NRAM);
+              small_twiddles += small_butterfly_num * (radix - 1) * 2;
+            }
+
+            switch (radix) {
+              case 2:
+                // computeRadix2ButterflyOtherstages(Fout, Fin, section_num,
+                // section_num, 1, dir);
+                break;
+              case 3:
+                computeRadix3ButterflyOtherstages(
+                    nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                    nram_tw, small_section_num, small_butterfly_num,
+                    small_in_stride, dir);
+                break;
+              case 9:
+                computeRadix9ButterflyOtherstages(
+                    nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                    nram_tw, small_section_num, small_butterfly_num,
+                    small_in_stride, dir);
+                break;
+              default:
+                // computeGenericButterflyOtherstages(Fout, buffer, twiddles,
+                // radix, section_num, butterfly_num, in_stride, 0, dir);
+                break;
+            }
+
+            nram_tw += small_butterfly_num * (radix - 1) * 2;
+          }  // for (stage_count)
+
+          //           for (int j = 0; j < large_radix; j++) {
+          //   MLULOG("output i: (%f, %f).\n", nram_out_r[j], nram_out_i[j]);
+          // }
+
+          // MLULOG("butterfly id: %d\n", i);
+          // last stage
+          {
+            fft_swap_ptr(&nram_out_r, &nram_in_r);
+            fft_swap_ptr(&nram_out_i, &nram_in_i);
+
+            // copy GDRAM2SRAM
+
+            // update parameter
+            radix = small_factors[4 * _small_stage_count];
+            small_section_num = small_factors[4 * _small_stage_count + 1];
+            small_butterfly_num = small_factors[4 * _small_stage_count + 2];
+            small_in_stride = small_factors[4 * _small_stage_count + 3];
+
+            if (sec_count == 0 && compute_id == 0 && repeat_id == 1) {
+              __memcpy(nram_tw, small_twiddles,
+                       small_butterfly_num * (radix - 1) * sizeof(DT) * 2,
+                       GDRAM2NRAM);
+            }
+
+            switch (radix) {
+              case 2:
+                break;
+              case 3:
+                computeRadix3ButterflyLaststage(
+                    nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                    nram_tw, small_section_num, small_butterfly_num,
+                    small_in_stride, dir);
+                break;
+              case 9:
+                computeRadix9ButterflyLaststage(
+                    nram_out_r, nram_out_i, nram_in_r, nram_in_i, nram_scratch,
+                    nram_tw, small_section_num, small_butterfly_num,
+                    small_in_stride, dir);
+                break;
+              default:
+                // computeGenericButterflyLaststage(Fout, buffer, twiddles,
+                // radix, section_num, butterfly_num, in_stride, 0, dir);
+                break;
+            }
+
+            // if last-stage: stride = large_radix * 2
+            //                compute_id 0 r
+            //                compute_id 0 i
+            //                compute_id 1 r
+            //                compute_id 1 i
+            // else: stride = large_radix
+            //                compute_id 0 r
+            //                compute_id 1 i
+            //                compute_id 0 r
+            //                compute_id 1 i
+            __memcpy(nram_transpose_temp.r +
+                         compute_id * large_radix * (1 + (int)last_stage),
+                     nram_out_r, large_radix * sizeof(DT), NRAM2NRAM);
+            __memcpy(nram_transpose_temp.i +
+                         compute_id * large_radix * (1 + (int)last_stage),
+                     nram_out_i, large_radix * sizeof(DT), NRAM2NRAM);
+
+            // __bang_transpose(nram_para_store, nram_transpose_temp.r,
+            //                  max_para_ldst_num * 2, large_radix);
+          }
+        }
+
+        if (last_stage) {
+          __bang_transpose(nram_para_store.r, nram_transpose_temp.r,
+                           para_ldst_num * 2, large_radix);
+        } else {
+          __bang_transpose(nram_para_store.r, nram_transpose_temp.r,
+                           para_ldst_num, large_radix);
+          __bang_transpose(nram_para_store.i, nram_transpose_temp.i,
+                           para_ldst_num, large_radix);
+        }
+      }
+      // __sync();
+      // pipeline: load-stage
+
+      if (repeat_id < repeat_num) {
+        // MLULOG("pipeline: load-stage.\n");
+        int i = max_para_ldst_num * repeat_id;
+        FFT_CPX_T<DT> nram_para_load_in = (repeat_id % 2 == 0)
+                                              ? nram_para_load_in_ping
+                                              : nram_para_load_in_pong;
+
+        FFT_CPX_T<DT> nram_para_load_tw = (repeat_id % 2 == 0)
+                                              ? nram_para_load_tw_ping
+                                              : nram_para_load_tw_pong;
+
+        int para_load_num = (max_para_ldst_num > (large_butterfly_num - i))
+                                ? (large_butterfly_num - i)
+                                : max_para_ldst_num;
+        if (para_load_num != 1) {
+          __memcpy_async(nram_para_load_in.r, input + Fin_stride + i,
+                         sizeof(DT) * para_load_num, GDRAM2NRAM,
+                         sizeof(DT) * para_load_num,
+                         large_in_stride * sizeof(DT), large_radix - 1);
+          __memcpy_async(nram_para_load_in.i, input + nfft + Fin_stride + i,
+                         sizeof(DT) * para_load_num, GDRAM2NRAM,
+                         sizeof(DT) * para_load_num,
+                         large_in_stride * sizeof(DT), large_radix - 1);
+          __memcpy_async(nram_para_load_tw.r, cur_large_twiddles + i,
+                         sizeof(DT) * para_load_num, GDRAM2NRAM,
+                         sizeof(DT) * para_load_num,
+                         large_out_stride * sizeof(DT), large_radix - 2);
+          __memcpy_async(
+              nram_para_load_tw.i,
+              cur_large_twiddles + large_butterfly_num * (large_radix - 1) + i,
+              sizeof(DT) * para_load_num, GDRAM2NRAM,
+              sizeof(DT) * para_load_num, large_out_stride * sizeof(DT),
+              large_radix - 2);
+        }
+      }
+
+      __sync();
+    }
+    Fin_stride += large_butterfly_num;
+    Fout_stride += large_radix * large_butterfly_num;
+  }
+}
+
+template <typename DT>
+__mlu_func__ void computeLargeButterflyLaststage(
+    DT *output, DT *input, const DT *cur_large_twiddles, const DT *_twiddles,
+    int large_section_num, int large_butterfly_num, int large_in_stride,
+    void *nram_buf, const int *small_factors, int nfft, int dir) {
+  computeLargeButterflyOtherstages(output, input, cur_large_twiddles, _twiddles,
+                                   large_section_num, large_butterfly_num,
+                                   large_in_stride, nram_buf, small_factors,
+                                   nfft, dir, 1);
+}
+
+template <typename DT>
+__mlu_func__ void computeMutiStageOnchip(DT *input, DT *output, int *factors,
+                                         const DT *twiddles,
+                                         const DT *dft_matrix, DT *buffer,
+                                         int batch, int fft_flag,
+                                         int direction) {
+  int total_num = batch;
+  int repeat_num = total_num / taskDim;
+  int remain_num = total_num % taskDim;
+  // MLULOG("\n\n\ntaskId: %d, taskDim: %d, coreId: %d\n\n\n", taskId, taskDim,
+  //        coreId);
+
+  // if (taskId % 4 == 0) {
+  //   MLULOG("\n\n\n__is_mpu\n\n\n");
+  // }
+
+  // return;
+  // __sync_cluster();
+  // __nram__ uint8_t *nram_buf[NRAM_BUFFER_SIZE];
+  char *nram_buf = nram_buffer;
+
+  // Each core needs to process "t_len" blocks, "remain_num" is evenly
+  // assigned to the previous "remian_num" cores.
+  int t_len = repeat_num + ((remain_num > 0 && taskId < remain_num) ? 1 : 0);
+  // Calculate the offset of the block at each core.
+  int t_start = taskId - remain_num <= 0 ? taskId * (repeat_num + 1)
+                                         : (remain_num * (repeat_num + 1) +
+                                            (taskId - remain_num) * repeat_num);
+  int t_end = (t_start + t_len);
+
+  MLULOG(
+      "taskId: %d, repeat_num: %d, "
+      "remain_num: %d, t_len: %d, t_start: %d, t_end: %d\n",
+      taskId, repeat_num, remain_num, t_len, t_start, t_end);
+
+  int radix, section_num, butterfly_num, in_stride, stage_count, value_mul,
+      small_factors_offset;
+  // const int is_two_stages = (stage_count == 2);  // the variable for
+  // twostages
+  // const int is_in_place = (input == output);
+  const DT *_twiddles = twiddles;
+  int *small_factors;
+  const int _stage_count = factors[0];
+  const int nfft = factors[1];
+
+  // first stage
+  radix = factors[5 + 0];
+  section_num = factors[5 + 1];
+  in_stride = factors[5 + 3];
+  small_factors_offset = factors[5 + 4];
+
+  small_factors = factors + small_factors_offset;
+
+  // FFT_CPX_T<DT> *odd_extra_buffer = (FFT_CPX_T<DT> *)buffer + batch * nfft;
+  // // for in_place temp buffer
+  DT *odd_extra_buffer =
+      buffer + batch * (nfft * 2);  // for in_place temp buffer
+  // out_place: input -> output (1 stage)
+  //            input -> buffer -> output (2 stage)
+  //            input -> buffer -> odd_extra_buffer -> output (3 stage)
+  //            input -> buffer -> output -> buffer -> output (4 stage)
+  //            input -> buffer -> output -> buffer -> odd_extra_buffer ->
+  //            output (5 stage)
+
+  // _stage_count = stage_count;
+
+  stage_count = _stage_count;
+  int last_stage = (stage_count == 1);
+
+  if (_stage_count != 1) FFT_SWAP_PTR(buffer, output);
+
+  if (__is_ipu()) {
+    if (repeat_num > 0 || taskId < remain_num) {
+      for (int t = t_start; t < t_end; t++) {
+        // MLULOG("taskId: %d, batchId: %d\n", taskId, t);
+        DT *input_batch = input + t * (nfft * 2);
+        DT *output_batch = output + t * (nfft * 2);
+        // DT *buffer_batch = buffer + t * (nfft * 2);
+        // DT *odd_extra_buffer_batch = odd_extra_buffer + t * (nfft * 2);
+
+        // first stage
+
+        computeLargeButterflyFirststage<DT>(
+            output_batch, input_batch, in_stride, section_num, twiddles,
+            dft_matrix, (void *)nram_buf, small_factors, direction, nfft,
+            last_stage);
+      }
+    }
+    // __sync();
+  }
+
+  // sram_large_tw
+  stage_count--;
+  if (stage_count == 0) {
+    // continue;
+    return;
+  }
+
+  // sram_large_tw
+
+  for (; stage_count > 1; stage_count--) {
+    // fft_swap_ptr<DT>(&buffer, &output);
+    // FFT_SWAP_PTR(buffer, output);
+    FFT_SWAP_PTR(buffer, output);
+
+    // if (is_two_stages && is_in_place) {
+    //   if (_stage_count % 2 == 0) {
+    //     if ((_stage_count - stage_count) == 2)
+    //       fft_swap_ptr<DT>(&odd_extra_buffer, &output);
+    //   } else {
+    //     if ((_stage_count - stage_count) == 3)
+    //       fft_swap_ptr<DT>(&odd_extra_buffer, &output);
+    //   }
+    // }
+
+    if (stage_count == 2 && _stage_count % 2) {
+      // fft_swap_ptr<DT>(&odd_extra_buffer, &output);
+      FFT_SWAP_PTR(odd_extra_buffer, output);
+    }
+
+    value_mul = (_stage_count - stage_count + 1) * 5;
+    // update parameter
+    radix = factors[value_mul];
+    section_num = factors[value_mul + 1];
+    butterfly_num = factors[value_mul + 2];
+    in_stride = factors[value_mul + 3];
+    small_factors_offset = factors[value_mul + 4];
+
+    small_factors = factors + small_factors_offset;
+
+    if (__is_ipu()) {
+      // MLULOG("other stage radix: %d \n", radix);
+      if (repeat_num > 0 || taskId < remain_num) {
+        for (int t = t_start; t < t_end; t++) {
+          DT *output_batch = output + t * (nfft * 2);
+          DT *buffer_batch = buffer + t * (nfft * 2);
+
+          computeLargeButterflyOtherstages<DT>(
+              output_batch, buffer_batch, (DT *)twiddles, _twiddles,
+              section_num, butterfly_num, in_stride, (void *)nram_buf,
+              small_factors, nfft, direction, 0);
+
+          __sync();
+        }
+      }
+    }
+    twiddles += butterfly_num * (radix - 1) * 2;  // 2 for complex
+  }                                               // for (stage_count)
+
+  // __mlu_shared__ DT *sram_tw[2048];  // radix-1024
+  // __mlu_shared__ DT *sram_tw[64];  // radix-1024
+  // last stage
+  {
+    if ((_stage_count % 2 == 1)) {
+      FFT_SWAP_PTR(odd_extra_buffer, buffer);
+    }
+
+    // fft_swap_ptr<DT>(&buffer, &output);
+    FFT_SWAP_PTR(buffer, output);
+
+    // update parameter
+    radix = factors[5 * _stage_count];
+    section_num = factors[5 * _stage_count + 1];
+    butterfly_num = factors[5 * _stage_count + 2];
+    in_stride = factors[5 * _stage_count + 3];
+    small_factors_offset = factors[5 * _stage_count + 4];
+
+    small_factors = factors + small_factors_offset;
+
+    MLULOG("last stage radix: %d, section_num: %d\n", radix, section_num);
+
+    // DT * sram_la = sram_large_tw
+
+    // if (taskId == 0) {
+    // if (__is_mpu()) {
+    //   __memcpy(sram_tw, twiddles, sizeof(DT) * 2 * butterfly_num * (radix -
+    //   1),
+    //            GDRAM2SRAM);
+    // }
+
+    // __sync_cluster();
+    // // imag
+    // __memcpy(
+    //     sram_large_tw + butterfly_num * (radix - 1),
+    //     twiddles + + butterfly_num * (radix - 1),
+    //     sizeof(DT) * para_ldst_num, GDRAM2NRAM,
+    //     sizeof(DT) * para_ldst_num, large_out_stride * sizeof(DT),
+    //     large_radix - 2);
+
+    if (__is_ipu()) {
+      if (repeat_num > 0 || taskId < remain_num) {
+        for (int t = t_start; t < t_end; t++) {
+          DT *output_batch = output + t * (nfft * 2);
+          DT *buffer_batch = buffer + t * (nfft * 2);
+
+          computeLargeButterflyLaststage<DT>(
+              output_batch, buffer_batch, (DT *)twiddles, _twiddles,
+              section_num, butterfly_num, in_stride, (void *)nram_buf,
+              small_factors, nfft, direction);
+        }
+      }
+    }
+  }
+}
+
+__mlu_global__ void MLUKernelFFTButterfly(void *input, void *output,
+                                          int *factors, void *twiddles,
+                                          void *dft_matrix, void *buffer,
+                                          int batch, int fft_flag,
+                                          int direction, int dtype_size) {
+  // if (__is_mpu()) return;
+  // if (coreId == 0x80) {
+  //     MLULOG("\n\n\nmemcore\n\n");
+  // }
+  // if (taskId == 0) {
+  //     MLULOG("\n\n\nmemcore\n\n");
+  // }
+  switch (dtype_size) {
+    case (MLUOP_DTYPE_COMPLEX_FLOAT):
+    case (MLUOP_DTYPE_FLOAT): {
+      // MLULOG("MLUOP_DTYPE_COMPLEX_FLOAT: MLUOP_DTYPE_FLOAT\n");
+      computeMutiStageOnchip<float>(
+          (float *)input, (float *)output, factors, (float *)twiddles,
+          (float *)dft_matrix, (float *)buffer, batch, fft_flag, direction);
+    }; break;
+    case (MLUOP_DTYPE_COMPLEX_HALF):
+    case (MLUOP_DTYPE_HALF): {
+      // MLULOG("MLUOP_DTYPE_COMPLEX_HALF: MLUOP_DTYPE_HALF\n");
+      computeMutiStageOnchip<half>((half *)input, (half *)output, factors,
+                                   (half *)twiddles, (half *)dft_matrix,
+                                   (half *)buffer, batch, fft_flag, direction);
+    }; break;
+
+    default: {
+      MLULOG("mluOpFFT Not Implemented.");
+    }
+  }
+}
+
+mluOpStatus_t MLUOP_WIN_API kernelFFTButterfly(cnrtDim3_t k_dim,
+                                               cnrtFunctionType_t k_type,
+                                               cnrtQueue_t queue,
+                                               mluOpFFTPlan_t fft_plan,
+                                               int direction, FFTFlag flag) {
+  VLOG(5) << "Launch Kernel kernelFFTButterfly <<Union" << k_type / CORE_DIM
+          << ", " << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";
+  KERNEL_CHECK((MLUKernelFFTButterfly<<<k_dim, k_type, queue>>>(
+      fft_plan->mlu_addrs.input, fft_plan->mlu_addrs.output,
+      fft_plan->mlu_addrs.factors, fft_plan->mlu_addrs.twiddles,
+      fft_plan->mlu_addrs.dft_matrix, fft_plan->mlu_addrs.buffer_buf,
+      fft_plan->batch, flag,
+      direction,  // direction, -1 means invalid(only FFT_IFFT use).
+      fft_plan->output_dtype)));
   return MLUOP_STATUS_SUCCESS;
 }

--- a/kernels/fft/fft_optm_device/fft_twiddle_factors.h
+++ b/kernels/fft/fft_optm_device/fft_twiddle_factors.h
@@ -1,0 +1,72 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#pragma once
+
+#define COS_PI_2_3 -0.49999999999999978
+#define TW3_1R_F COS_PI_2_3
+#define TW3_1I_F -0.86602540378443871
+
+#define COS_PI_2_9 \
+  0.76604444311897801  //  cos(2 * pi * 1 / 9) and cos(2 * pi * 8 / 9)
+#define COS_PI_4_9 \
+  0.17364817766693041  //  cos(2 * pi * 2 / 9) and cos(2 * pi * 7 / 9)
+#define COS_PI_6_9 \
+  -0.49999999999999978  //  cos(2 * pi * 3 / 9) and cos(2 * pi * 6 / 9)
+#define COS_PI_8_9 \
+  -0.93969262078590832  //  cos(2 * pi * 4 / 9) and cos(2 * pi * 5 / 9)
+#define NEG_SIN_PI_2_9 \
+  -0.64278760968653925  //  -sin(2 * pi * 1 / 9) and sin(2 * pi * 8 / 9)
+#define NEG_SIN_PI_4_9 \
+  -0.98480775301220802  //  -sin(2 * pi * 2 / 9) and sin(2 * pi * 7 / 9)
+#define NEG_SIN_PI_6_9 \
+  -0.86602540378443871  //  -sin(2 * pi * 3 / 9) and sin(2 * pi * 6 / 9)
+#define NEG_SIN_PI_8_9 \
+  -0.34202014332566888  //  -sin(2 * pi * 4 / 9) and sin(2 * pi * 5 / 9)
+#define SIN_PI_2_9 \
+  0.64278760968653925  //  sin(2 * pi * 1 / 9) and -sin(2 * pi * 8 / 9)
+#define SIN_PI_4_9 \
+  0.98480775301220802  //  sin(2 * pi * 2 / 9) and -sin(2 * pi * 7 / 9)
+#define SIN_PI_6_9 \
+  0.86602540378443871  //  sin(2 * pi * 3 / 9) and -sin(2 * pi * 6 / 9)
+#define SIN_PI_8_9 \
+  0.34202014332566888  //  sin(2 * pi * 4 / 9) and -sin(2 * pi * 5 / 9)
+#define NEG_SIN_PI_6_9_X2 -1.732050807568877293527446341505872366942805254
+
+/* Twiddles used in Radix-9 FFT */
+#define TW9_1R_F COS_PI_2_9
+#define TW9_2R_F COS_PI_4_9
+#define TW9_3R_F COS_PI_6_9
+#define TW9_4R_F COS_PI_8_9
+#define TW9_1I_F NEG_SIN_PI_2_9
+#define TW9_2I_F NEG_SIN_PI_4_9
+#define TW9_3I_F NEG_SIN_PI_6_9
+#define TW9_4I_F NEG_SIN_PI_8_9
+#define TW9_1I_F_NEG SIN_PI_2_9
+#define TW9_2I_F_NEG SIN_PI_4_9
+#define TW9_3I_F_NEG SIN_PI_6_9
+#define TW9_4I_F_NEG SIN_PI_8_9
+#define TW9_3I_X2_F NEG_SIN_PI_6_9_X2
+#define TW91_SUB_TW94_R 1.705737063904886419256501927880148143872040591
+#define TW92_ADD_TW94_R -1.113340798452838732905825904094046265936583811
+#define TW94_SUB_TW91_I 0.300767466360870593278543795225003852144476517
+#define TW92_ADD_TW94_I 1.326827896337876792410842639271782594433726619

--- a/kernels/fft/irfft/irfft_host.cpp
+++ b/kernels/fft/irfft/irfft_host.cpp
@@ -49,7 +49,8 @@ static mluOpStatus_t selectIRFFT1dStrategy(mluOpHandle_t handle,
 mluOpStatus_t makeIRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
   std::string api = "[mluOpMakeFFTPlanMany]";
   mluOpStatus_t status = MLUOP_STATUS_SUCCESS;
-  CHECK_RETURN(api, selectIRFFT1dStrategy(handle, fft_plan));
+  INTERNAL_CHECK(
+      api, selectIRFFT1dStrategy(handle, fft_plan) == MLUOP_STATUS_SUCCESS);
 
   mluOpDataType_t in_c_dtype = fft_plan->input_dtype;
   mluOpDataType_t in_r_dtype = (in_c_dtype == MLUOP_DTYPE_COMPLEX_HALF)
@@ -507,15 +508,15 @@ mluOpStatus_t setIRFFT1dReserveArea(mluOpHandle_t handle,
       int dft_mat_num = dft_mat_times * dim0 * dim1;
       kernelGenerateIRFFTHalfDFTMatrix(k_dim, k_type, handle->queue, fft_plan,
                                        in_r_dtype, n);
-      CHECK_RETURN(
-          "[mluOpSetFFTReserveArea]",
-          fftQuantizePositionScale(
-              handle, dft_mat_num, in_r_dtype, in_e_dtype,
-              fft_plan->matmul_addrs.dft_matrix_addr,
-              fft_plan->matmul_addrs.dft_pos_addr,
-              fft_plan->matmul_addrs.dft_scale_addr,
-              fft_plan->matmul_addrs.dft_quantize_workspace_addr,
-              fft_plan->matmul_addrs.dft_quantize_workspace_size, api));
+      status = fftQuantizePositionScale(
+          handle, dft_mat_num, in_r_dtype, in_e_dtype,
+          fft_plan->matmul_addrs.dft_matrix_addr,
+          fft_plan->matmul_addrs.dft_pos_addr,
+          fft_plan->matmul_addrs.dft_scale_addr,
+          fft_plan->matmul_addrs.dft_quantize_workspace_addr,
+          fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
+      INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
+                     status == MLUOP_STATUS_SUCCESS);
     }; break;
     case CNFFT_FUNC_COOLEY_TUKEY:
     case CNFFT_FUNC_STOCKHAM: {
@@ -527,15 +528,15 @@ mluOpStatus_t setIRFFT1dReserveArea(mluOpHandle_t handle,
       kernelGenerateIRFFTFullDFTMatrix(k_dim, k_type, handle->queue, fft_plan,
                                        in_r_dtype, L);
 
-      CHECK_RETURN(
-          "[mluOpSetFFTReserveArea]",
-          fftQuantizePositionScale(
-              handle, dft_mat_num, in_r_dtype, in_e_dtype,
-              fft_plan->matmul_addrs.dft_matrix_addr,
-              fft_plan->matmul_addrs.dft_pos_addr,
-              fft_plan->matmul_addrs.dft_scale_addr,
-              fft_plan->matmul_addrs.dft_quantize_workspace_addr,
-              fft_plan->matmul_addrs.dft_quantize_workspace_size, api));
+      status = fftQuantizePositionScale(
+          handle, dft_mat_num, in_r_dtype, in_e_dtype,
+          fft_plan->matmul_addrs.dft_matrix_addr,
+          fft_plan->matmul_addrs.dft_pos_addr,
+          fft_plan->matmul_addrs.dft_scale_addr,
+          fft_plan->matmul_addrs.dft_quantize_workspace_addr,
+          fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
+      INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
+                     status == MLUOP_STATUS_SUCCESS);
     }; break;
     default: {
       status = MLUOP_STATUS_NOT_SUPPORTED;
@@ -696,20 +697,23 @@ static mluOpStatus_t makeIRFFT1dContiguousInput(mluOpHandle_t handle,
   if (!fft_plan->is_input_contiguous) {
     VLOG(5) << "launch mluOpContiguous for irfft1d input";
     mluOpTensorDescriptor_t input_desc;
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&input_desc));
+    status = mluOpCreateTensorDescriptor(&input_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     const int in_dim_num = 2;
     int64_t dims[in_dim_num] = {fft_plan->batch, fft_plan->inembed[0]};
     int64_t strides[in_dim_num] = {fft_plan->idist, fft_plan->istride};
-    CHECK_RETURN(api, mluOpSetTensorDescriptorEx_v2(
-                          input_desc, MLUOP_LAYOUT_ARRAY, fft_plan->input_dtype,
-                          in_dim_num, dims, strides));
+    status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
+                                           fft_plan->input_dtype, in_dim_num,
+                                           dims, strides);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-    CHECK_RETURN(api,
-                 mluOpContiguous(handle, input_desc, input,
-                                 fft_plan->matmul_addrs.input_contiguous_addr));
+    status = mluOpContiguous(handle, input_desc, input,
+                             fft_plan->matmul_addrs.input_contiguous_addr);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-    CHECK_RETURN(api, mluOpDestroyTensorDescriptor(input_desc));
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   }
   return status;
 }
@@ -732,19 +736,21 @@ static mluOpStatus_t padIRFFT1dContiguousInput(mluOpHandle_t handle,
   if (need_pad) {
     VLOG(5) << "launch cnnlOpPad for input pad";
     mluOpTensorDescriptor_t input_desc, padded_input_desc;
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&input_desc));
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&padded_input_desc));
+    status = mluOpCreateTensorDescriptor(&input_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    status = mluOpCreateTensorDescriptor(&padded_input_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     const int in_dim_num = 2;
     int64_t dims[in_dim_num] = {batch, fft_plan->inembed[0] * COMPLEX};
-    CHECK_RETURN(api,
-                 mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
-                                             in_r_dtype, in_dim_num, dims));
+    status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
+                                         in_r_dtype, in_dim_num, dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     int64_t padded_dims[in_dim_num] = {batch, FFT_HALF(n) * COMPLEX};
-    CHECK_RETURN(
-        api, mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
-                                         in_r_dtype, in_dim_num, padded_dims));
+    status = mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
+                                         in_r_dtype, in_dim_num, padded_dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     const int pad_dim_num = 4;
     int paddings[pad_dim_num] = {
@@ -824,30 +830,32 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
     int trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
     int trans_permute[trans_dim_num] = {1, 0};
 
-    CHECK_RETURN(
-        api,
+    status =
         fftTranspose(handle, trans_dim_num, trans_input_dims, trans_output_dims,
                      trans_permute, fft_plan->matmul_addrs.input_pad_addr,
                      fft_plan->matmul_addrs.input_transed_addr, in_r_dtype,
                      fft_plan->matmul_addrs.internal_workspace_addr,
-                     fft_plan->matmul_addrs.internal_workspace_size, api));
+                     fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // stridedslice: [a, b, c, d]    --> [d, c, b]
     // stridedslice: [a, b, c, d, e] --> [d, c, b]
     VLOG(5) << "launch mluOpStridedSlice for input";
     mluOpTensorDescriptor_t ss_input_desc, ss_output_desc;
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&ss_input_desc));
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&ss_output_desc));
+    status = mluOpCreateTensorDescriptor(&ss_input_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    status = mluOpCreateTensorDescriptor(&ss_output_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     const int ss_dim_num = 2;
     int64_t ss_in_dims[ss_dim_num] = {COMPLEX * batch, FFT_HALF(n)};
-    CHECK_RETURN(
-        api, mluOpSetTensorDescriptor_v2(ss_input_desc, MLUOP_LAYOUT_ARRAY,
-                                         in_r_dtype, ss_dim_num, ss_in_dims));
+    status = mluOpSetTensorDescriptor_v2(ss_input_desc, MLUOP_LAYOUT_ARRAY,
+                                         in_r_dtype, ss_dim_num, ss_in_dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
     int64_t ss_out_dims[ss_dim_num] = {COMPLEX * batch, (n - FFT_HALF(n))};
-    CHECK_RETURN(
-        api, mluOpSetTensorDescriptor_v2(ss_output_desc, MLUOP_LAYOUT_ARRAY,
-                                         in_r_dtype, ss_dim_num, ss_out_dims));
+    status = mluOpSetTensorDescriptor_v2(ss_output_desc, MLUOP_LAYOUT_ARRAY,
+                                         in_r_dtype, ss_dim_num, ss_out_dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     int dim1_begin = (n % 2) ? -1 : -2;
     int dim1_end = -FFT_HALF(n);
@@ -878,24 +886,25 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
         (uint8_t *)fft_plan->matmul_addrs.input_reversed_addr +
         in_r_dtype_size * reversed_input_num;
 
-    CHECK_RETURN(
-        api, fftOptensor(handle, reversed_input_num, input_reversed_im_addr,
+    status = fftOptensor(handle, reversed_input_num, input_reversed_im_addr,
                          input_reversed_re_addr, input_reversed_im_addr, -1.0,
                          0.0, 0.0, in_r_dtype, CNNL_OP_TENSOR_ADD,
                          fft_plan->matmul_addrs.internal_workspace_addr,
-                         fft_plan->matmul_addrs.internal_workspace_size, api));
+                         fft_plan->matmul_addrs.internal_workspace_size, api);
 
     // conat: [a, b, c, d]    + [d, c, b] --> [a, b, c, d, d, c, b]
     // conat: [a, b, c, d, e] + [d, c, b] --> [a, b, c, d, e, d, c, b]
     VLOG(5) << "launch mluOpConcat for input";
     mluOpTensorDescriptor_t concat_output_desc;
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&concat_output_desc));
+    status = mluOpCreateTensorDescriptor(&concat_output_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     const int concat_dim_num = 2;
     int64_t concat_out_dims[concat_dim_num] = {COMPLEX * batch, n};
-    CHECK_RETURN(api, mluOpSetTensorDescriptor_v2(
-                          concat_output_desc, MLUOP_LAYOUT_ARRAY, in_r_dtype,
-                          concat_dim_num, concat_out_dims));
+    status = mluOpSetTensorDescriptor_v2(concat_output_desc, MLUOP_LAYOUT_ARRAY,
+                                         in_r_dtype, concat_dim_num,
+                                         concat_out_dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // convert to cnnl_tensor_descriptor
     DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(concat_output_desc,
@@ -971,13 +980,13 @@ static mluOpStatus_t transposeIRFFT1dPaddedInput(mluOpHandle_t handle,
     int trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
     int trans_permute[trans_dim_num] = {1, 0};
 
-    CHECK_RETURN(
-        api,
+    status =
         fftTranspose(handle, trans_dim_num, trans_input_dims, trans_output_dims,
                      trans_permute, fft_plan->matmul_addrs.input_pad_addr,
                      fft_plan->matmul_addrs.input_re_addr, in_r_dtype,
                      fft_plan->matmul_addrs.internal_workspace_addr,
-                     fft_plan->matmul_addrs.internal_workspace_size, api));
+                     fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     VLOG(5) << "launch mluOpTranspose for input COOLEY_TUKEY";
     int L = fft_plan->L;
@@ -989,13 +998,13 @@ static mluOpStatus_t transposeIRFFT1dPaddedInput(mluOpHandle_t handle,
     int trans_output_dims[trans_dim_num] = {COMPLEX * batch, m, L};
     int trans_permute[trans_dim_num] = {0, 2, 1};
 
-    CHECK_RETURN(
-        api,
+    status =
         fftTranspose(handle, trans_dim_num, trans_input_dims, trans_output_dims,
                      trans_permute, fft_plan->matmul_addrs.input_merged_addr,
                      fft_plan->matmul_addrs.input_re_addr, in_r_dtype,
                      fft_plan->matmul_addrs.internal_workspace_addr,
-                     fft_plan->matmul_addrs.internal_workspace_size, api));
+                     fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   }
   return status;
 }
@@ -1015,13 +1024,13 @@ static mluOpStatus_t quantizeIRFFT1dPaddedInput(mluOpHandle_t handle,
   mluOpDataType_t in_e_dtype = fft_plan->execution_dtype;
   int padded_input_num = fft_plan->batch * FFT_HALF(fft_plan->n[0]);
 
-  CHECK_RETURN(api, fftQuantizePositionScale(
-                        handle, COMPLEX * padded_input_num, in_r_dtype,
-                        in_e_dtype, fft_plan->matmul_addrs.input_pad_addr,
-                        fft_plan->matmul_addrs.input_pos_addr,
-                        fft_plan->matmul_addrs.input_scale_addr,
-                        fft_plan->matmul_addrs.internal_workspace_addr,
-                        fft_plan->matmul_addrs.internal_workspace_size, api));
+  status = fftQuantizePositionScale(
+      handle, COMPLEX * padded_input_num, in_r_dtype, in_e_dtype,
+      fft_plan->matmul_addrs.input_pad_addr,
+      fft_plan->matmul_addrs.input_pos_addr,
+      fft_plan->matmul_addrs.input_scale_addr,
+      fft_plan->matmul_addrs.internal_workspace_addr,
+      fft_plan->matmul_addrs.internal_workspace_size, api);
 
   return status;
 }
@@ -1078,123 +1087,120 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
   if (fft_plan->fft_strategy == CNFFT_FUNC_MATMUL) {
     VLOG(5) << "into computeIRFFT1dMatmulResult CNFFT_FUNC_MATMUL";
     // input real matmul dft real
-    CHECK_RETURN(
-        api,
-        fftQuantMatMul(
-            handle, batch, FFT_HALF(n), n, fft_plan->matmul_addrs.input_re_addr,
-            fft_plan->matmul_addrs.input_pos_addr,
-            fft_plan->matmul_addrs.input_scale_addr,
-            fft_plan->matmul_addrs.dft_re_matrix_addr,
-            fft_plan->matmul_addrs.dft_pos_addr,
-            fft_plan->matmul_addrs.dft_scale_addr,
-            fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, true,
-            scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
-            fft_plan->matmul_addrs.internal_workspace_addr,
-            fft_plan->matmul_addrs.internal_workspace_size, api));
+    status = fftQuantMatMul(
+        handle, batch, FFT_HALF(n), n, fft_plan->matmul_addrs.input_re_addr,
+        fft_plan->matmul_addrs.input_pos_addr,
+        fft_plan->matmul_addrs.input_scale_addr,
+        fft_plan->matmul_addrs.dft_re_matrix_addr,
+        fft_plan->matmul_addrs.dft_pos_addr,
+        fft_plan->matmul_addrs.dft_scale_addr,
+        fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, true, scale_factor,
+        0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+        fft_plan->matmul_addrs.internal_workspace_addr,
+        fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // input imag matmul dft imag
-    CHECK_RETURN(
-        api,
-        fftQuantMatMul(
-            handle, batch, FFT_HALF(n), n, fft_plan->matmul_addrs.input_im_addr,
-            fft_plan->matmul_addrs.input_pos_addr,
-            fft_plan->matmul_addrs.input_scale_addr,
-            fft_plan->matmul_addrs.dft_im_matrix_addr,
-            fft_plan->matmul_addrs.dft_pos_addr,
-            fft_plan->matmul_addrs.dft_scale_addr,
-            fft_plan->matmul_addrs.matmul_im_mul_im_addr, false, true,
-            scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
-            fft_plan->matmul_addrs.internal_workspace_addr,
-            fft_plan->matmul_addrs.internal_workspace_size, api));
+    status = fftQuantMatMul(
+        handle, batch, FFT_HALF(n), n, fft_plan->matmul_addrs.input_im_addr,
+        fft_plan->matmul_addrs.input_pos_addr,
+        fft_plan->matmul_addrs.input_scale_addr,
+        fft_plan->matmul_addrs.dft_im_matrix_addr,
+        fft_plan->matmul_addrs.dft_pos_addr,
+        fft_plan->matmul_addrs.dft_scale_addr,
+        fft_plan->matmul_addrs.matmul_im_mul_im_addr, false, true, scale_factor,
+        0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+        fft_plan->matmul_addrs.internal_workspace_addr,
+        fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // real mul real add imag mul imag
     int per_matmul_output_num = batch * n;
-    CHECK_RETURN(
-        api, fftOptensor(handle, per_matmul_output_num,
+    status = fftOptensor(handle, per_matmul_output_num,
                          fft_plan->matmul_addrs.matmul_re_mul_re_addr,
                          fft_plan->matmul_addrs.matmul_im_mul_im_addr,
                          fft_plan->matmul_addrs.output_contiguous_addr, 1.0,
                          1.0, 0.0, in_r_dtype, CNNL_OP_TENSOR_ADD,
                          fft_plan->matmul_addrs.internal_workspace_addr,
-                         fft_plan->matmul_addrs.internal_workspace_size, api));
+                         fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     VLOG(5) << "into computeIRFFT1dMatmulResult CNFFT_FUNC_COOLEY_TUKEY";
     int L = fft_plan->L;
     int m = (1 << fft_plan->m);
 
     // input real matmul dft real
-    CHECK_RETURN(
-        api, fftQuantMatMul(
-                 handle, batch * m, L, L, fft_plan->matmul_addrs.input_re_addr,
-                 fft_plan->matmul_addrs.input_pos_addr,
-                 fft_plan->matmul_addrs.input_scale_addr,
-                 fft_plan->matmul_addrs.dft_re_matrix_addr,
-                 fft_plan->matmul_addrs.dft_pos_addr,
-                 fft_plan->matmul_addrs.dft_scale_addr,
-                 fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, true,
-                 scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
-                 fft_plan->matmul_addrs.internal_workspace_addr,
-                 fft_plan->matmul_addrs.internal_workspace_size, api));
+    status = fftQuantMatMul(
+        handle, batch * m, L, L, fft_plan->matmul_addrs.input_re_addr,
+        fft_plan->matmul_addrs.input_pos_addr,
+        fft_plan->matmul_addrs.input_scale_addr,
+        fft_plan->matmul_addrs.dft_re_matrix_addr,
+        fft_plan->matmul_addrs.dft_pos_addr,
+        fft_plan->matmul_addrs.dft_scale_addr,
+        fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, true, scale_factor,
+        0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+        fft_plan->matmul_addrs.internal_workspace_addr,
+        fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // input imag matmul dft imag
-    CHECK_RETURN(
-        api, fftQuantMatMul(
-                 handle, batch * m, L, L, fft_plan->matmul_addrs.input_im_addr,
-                 fft_plan->matmul_addrs.input_pos_addr,
-                 fft_plan->matmul_addrs.input_scale_addr,
-                 fft_plan->matmul_addrs.dft_im_matrix_addr,
-                 fft_plan->matmul_addrs.dft_pos_addr,
-                 fft_plan->matmul_addrs.dft_scale_addr,
-                 fft_plan->matmul_addrs.matmul_im_mul_im_addr, false, true,
-                 scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
-                 fft_plan->matmul_addrs.internal_workspace_addr,
-                 fft_plan->matmul_addrs.internal_workspace_size, api));
+    status = fftQuantMatMul(
+        handle, batch * m, L, L, fft_plan->matmul_addrs.input_im_addr,
+        fft_plan->matmul_addrs.input_pos_addr,
+        fft_plan->matmul_addrs.input_scale_addr,
+        fft_plan->matmul_addrs.dft_im_matrix_addr,
+        fft_plan->matmul_addrs.dft_pos_addr,
+        fft_plan->matmul_addrs.dft_scale_addr,
+        fft_plan->matmul_addrs.matmul_im_mul_im_addr, false, true, scale_factor,
+        0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+        fft_plan->matmul_addrs.internal_workspace_addr,
+        fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // input real matmul dft imag
-    CHECK_RETURN(
-        api, fftQuantMatMul(
-                 handle, batch * m, L, L, fft_plan->matmul_addrs.input_re_addr,
-                 fft_plan->matmul_addrs.input_pos_addr,
-                 fft_plan->matmul_addrs.input_scale_addr,
-                 fft_plan->matmul_addrs.dft_im_matrix_addr,
-                 fft_plan->matmul_addrs.dft_pos_addr,
-                 fft_plan->matmul_addrs.dft_scale_addr,
-                 fft_plan->matmul_addrs.matmul_re_mul_im_addr, false, true,
-                 scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
-                 fft_plan->matmul_addrs.internal_workspace_addr,
-                 fft_plan->matmul_addrs.internal_workspace_size, api));
+    status = fftQuantMatMul(
+        handle, batch * m, L, L, fft_plan->matmul_addrs.input_re_addr,
+        fft_plan->matmul_addrs.input_pos_addr,
+        fft_plan->matmul_addrs.input_scale_addr,
+        fft_plan->matmul_addrs.dft_im_matrix_addr,
+        fft_plan->matmul_addrs.dft_pos_addr,
+        fft_plan->matmul_addrs.dft_scale_addr,
+        fft_plan->matmul_addrs.matmul_re_mul_im_addr, false, true, scale_factor,
+        0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+        fft_plan->matmul_addrs.internal_workspace_addr,
+        fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // input imag matmul dft real
-    CHECK_RETURN(
-        api, fftQuantMatMul(
-                 handle, batch * m, L, L, fft_plan->matmul_addrs.input_im_addr,
-                 fft_plan->matmul_addrs.input_pos_addr,
-                 fft_plan->matmul_addrs.input_scale_addr,
-                 fft_plan->matmul_addrs.dft_re_matrix_addr,
-                 fft_plan->matmul_addrs.dft_pos_addr,
-                 fft_plan->matmul_addrs.dft_scale_addr,
-                 fft_plan->matmul_addrs.matmul_im_mul_re_addr, false, true,
-                 scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
-                 fft_plan->matmul_addrs.internal_workspace_addr,
-                 fft_plan->matmul_addrs.internal_workspace_size, api));
+    status = fftQuantMatMul(
+        handle, batch * m, L, L, fft_plan->matmul_addrs.input_im_addr,
+        fft_plan->matmul_addrs.input_pos_addr,
+        fft_plan->matmul_addrs.input_scale_addr,
+        fft_plan->matmul_addrs.dft_re_matrix_addr,
+        fft_plan->matmul_addrs.dft_pos_addr,
+        fft_plan->matmul_addrs.dft_scale_addr,
+        fft_plan->matmul_addrs.matmul_im_mul_re_addr, false, true, scale_factor,
+        0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+        fft_plan->matmul_addrs.internal_workspace_addr,
+        fft_plan->matmul_addrs.internal_workspace_size, api);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_STOCKHAM) {
     int L = fft_plan->L;
     int m = (1 << fft_plan->m);
 
     // W[2 * L, L] * in[batch * 2, L, 2^m] -> out[batch, 2, 2, L, 2^m]
-    CHECK_RETURN(api,
-                 fftBatchMatMulBcast(
-                     handle, 2 * L, L, m, batch * 2,
-                     fft_plan->matmul_addrs.dft_re_matrix_addr,
-                     fft_plan->matmul_addrs.dft_pos_addr,
-                     fft_plan->matmul_addrs.dft_scale_addr,
-                     fft_plan->matmul_addrs.input_merged_addr,
-                     fft_plan->matmul_addrs.input_pos_addr,
-                     fft_plan->matmul_addrs.input_scale_addr,
-                     fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, false,
-                     scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
-                     fft_plan->matmul_addrs.internal_workspace_addr,
-                     fft_plan->matmul_addrs.internal_workspace_size, api));
+    status = fftBatchMatMulBcast(
+        handle, 2 * L, L, m, batch * 2,
+        fft_plan->matmul_addrs.dft_re_matrix_addr,
+        fft_plan->matmul_addrs.dft_pos_addr,
+        fft_plan->matmul_addrs.dft_scale_addr,
+        fft_plan->matmul_addrs.input_merged_addr,
+        fft_plan->matmul_addrs.input_pos_addr,
+        fft_plan->matmul_addrs.input_scale_addr,
+        fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, false,
+        scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+        fft_plan->matmul_addrs.internal_workspace_addr,
+        fft_plan->matmul_addrs.internal_workspace_size, api);
   }
 
   return status;
@@ -1272,19 +1278,22 @@ static mluOpStatus_t makeIRFFT1dContiguousOutput(mluOpHandle_t handle,
     mluOpDataType_t out_r_dtype = fft_plan->output_dtype;
     // create tensor desc
     mluOpTensorDescriptor_t copy_src_desc, copy_dst_desc;
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&copy_src_desc));
-    CHECK_RETURN(api, mluOpCreateTensorDescriptor(&copy_dst_desc));
+    status = mluOpCreateTensorDescriptor(&copy_src_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    status = mluOpCreateTensorDescriptor(&copy_dst_desc);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // set up tensor desc
     const int out_dim_num = 2;
     int64_t dims[out_dim_num] = {fft_plan->batch, fft_plan->onembed[0]};
     int64_t strides[out_dim_num] = {fft_plan->odist, fft_plan->ostride};
-    CHECK_RETURN(api,
-                 mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
-                                             out_r_dtype, out_dim_num, dims));
-    CHECK_RETURN(api, mluOpSetTensorDescriptorEx_v2(
-                          copy_dst_desc, MLUOP_LAYOUT_ARRAY, out_r_dtype,
-                          out_dim_num, dims, strides));
+    status = mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
+                                         out_r_dtype, out_dim_num, dims);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    status =
+        mluOpSetTensorDescriptorEx_v2(copy_dst_desc, MLUOP_LAYOUT_ARRAY,
+                                      out_r_dtype, out_dim_num, dims, strides);
+    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
     // copy
     void *copy_src_addr = fft_plan->matmul_addrs.output_contiguous_addr;
@@ -1315,20 +1324,28 @@ mluOpStatus_t execIRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
   configureIRFFT1dMatmulWorkspaceAddrs(handle, fft_plan, (void *)input,
                                        workspace, output);
 
-  CHECK_RETURN(api, makeIRFFT1dContiguousInput(handle, fft_plan, input));
+  status = makeIRFFT1dContiguousInput(handle, fft_plan, input);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-  CHECK_RETURN(api, padIRFFT1dContiguousInput(handle, fft_plan));
+  status = padIRFFT1dContiguousInput(handle, fft_plan);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-  CHECK_RETURN(api, mergeIRFFT1dInput(handle, fft_plan));
+  status = mergeIRFFT1dInput(handle, fft_plan);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-  CHECK_RETURN(api, transposeIRFFT1dPaddedInput(handle, fft_plan));
+  status = transposeIRFFT1dPaddedInput(handle, fft_plan);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-  CHECK_RETURN(api, quantizeIRFFT1dPaddedInput(handle, fft_plan));
+  status = quantizeIRFFT1dPaddedInput(handle, fft_plan);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-  CHECK_RETURN(api, computeIRFFT1dMatmulResult(handle, fft_plan, scale_factor));
+  status = computeIRFFT1dMatmulResult(handle, fft_plan, scale_factor);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-  CHECK_RETURN(api, mergeIRFFT1dOutput(handle, fft_plan, scale_factor));
+  status = mergeIRFFT1dOutput(handle, fft_plan, scale_factor);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-  CHECK_RETURN(api, makeIRFFT1dContiguousOutput(handle, fft_plan, output));
+  status = makeIRFFT1dContiguousOutput(handle, fft_plan, output);
+  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
   return status;
 }

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -27,9 +27,9 @@
  * MLU-OPS: Cambricon Open Source operator library for Network
  ******************************************************************************/
 
-#define MLUOP_MAJOR 1
-#define MLUOP_MINOR 1
-#define MLUOP_PATCHLEVEL 1
+#define MLUOP_MAJOR 0
+#define MLUOP_MINOR 11
+#define MLUOP_PATCHLEVEL 0
 
 /*********************************************************************************
  * MLUOP_VERSION is deprecated and not recommended. To get the version of MLUOP, use
@@ -417,7 +417,7 @@ typedef struct mluOpContext *mluOpHandle_t;
  */
 typedef struct mluOpTensorSetStruct *mluOpTensorSetDescriptor_t;
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Initializes the MLU-OPS library and creates a handle \b handle to a struct
  * that holds the MLU-OPS library context. It allocates hardware resources on the host
@@ -456,7 +456,7 @@ typedef struct mluOpTensorSetStruct *mluOpTensorSetDescriptor_t;
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreate(mluOpHandle_t *handle);
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Updates the MLU-OPS context information that is held by \b handle. This function
  * should be called if you call CNDrv API cnSetCtxConfigParam to set the context information.
@@ -494,7 +494,7 @@ mluOpCreate(mluOpHandle_t *handle);
 mluOpStatus_t MLUOP_WIN_API
 mluOpUpdateContextInformation(mluOpHandle_t handle);
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Releases the resources of the specified MLU-OPS handle \b handle that was
  * created by ::mluOpCreate. It is usually the last call to destroy
@@ -530,7 +530,7 @@ mluOpUpdateContextInformation(mluOpHandle_t handle);
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroy(mluOpHandle_t handle);
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Sets the runtime queue \b queue in the handle \b handle. The queue is used to
  * launch kernels or to synchronize to this queue.
@@ -571,7 +571,7 @@ mluOpDestroy(mluOpHandle_t handle);
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetQueue(mluOpHandle_t handle, cnrtQueue_t queue);
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Retrieves the queue \b queue that was previously set to the handle \b handle.
  *
@@ -608,7 +608,7 @@ mluOpSetQueue(mluOpHandle_t handle, cnrtQueue_t queue);
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetQueue(mluOpHandle_t handle, cnrtQueue_t *queue);
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Converts the MLU-OPS enumerated status code to ASCIIZ static string and returns
  * a pointer to the MLU memory that holds information about ASCIIZ static string with
@@ -646,7 +646,7 @@ mluOpGetQueue(mluOpHandle_t handle, cnrtQueue_t *queue);
 const char *
 mluOpGetErrorString(mluOpStatus_t status);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Gets the size of a data type in ::mluOpDataType_t.
  *
@@ -682,7 +682,7 @@ mluOpGetErrorString(mluOpStatus_t status);
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetSizeOfDataType(mluOpDataType_t data_type, size_t *size);
 
-// Group: Version Management
+// Group:Version Management
 /*!
  * @brief Retrieves the version of MLU-OPS library. The version of MLU-OPS
  * is composed of \b major, \b minor, and \b patch. For instance, major = 1,
@@ -722,7 +722,7 @@ mluOpGetSizeOfDataType(mluOpDataType_t data_type, size_t *size);
 void
 mluOpGetLibVersion(int *major, int *minor, int *patch);
 
-// Group: QuantizeRoundMode
+// Group:QuantizeRoundMode
 /*!
  * @brief Updates the specific rounding mode of MLU-OPS context information that is held by the \b
  * handle. This function should be called if you want to change the MLU-OPS rounding mode that
@@ -763,7 +763,7 @@ mluOpGetLibVersion(int *major, int *minor, int *patch);
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetQuantizeRoundMode(mluOpHandle_t handle, mluOpQuantizeRoundMode_t round_mode);
 
-// Group: QuantizeRoundMode
+// Group:QuantizeRoundMode
 /*!
  * @brief Retrieves the rounding mode of a specific MLU-OPS context.
  *
@@ -800,7 +800,7 @@ mluOpSetQuantizeRoundMode(mluOpHandle_t handle, mluOpQuantizeRoundMode_t round_m
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetQuantizeRoundMode(mluOpHandle_t handle, mluOpQuantizeRoundMode_t *round_mode);
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Updates the specific atomics mode of MLU-OPS context information that is held by the
  * \b handle. This function should be called if you want to change the atomics mode that is
@@ -839,7 +839,7 @@ mluOpGetQuantizeRoundMode(mluOpHandle_t handle, mluOpQuantizeRoundMode_t *round_
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetAtomicsMode(mluOpHandle_t handle, mluOpAtomicsMode_t atomics_mode);
 
-// Group: Runtime Management
+// Group:Runtime Management
 /*!
  * @brief Retrieves the atomics mode of a specific MLU-OPS context.
  *
@@ -895,200 +895,15 @@ typedef struct mluOpTensorStruct *mluOpTensorDescriptor_t;
  * layout, data type, sequence length, padding fill, position, and scale.
  * The total size of the tensor descriptor supports up to 2 Giga elements.
  * Call ::mluOpCreateSeqDataDescriptor to create a descriptor, and
- * call ::mluOpSetSeqDataDescriptor_v2 to set the sequence data information to the descriptor.
+ * call ::mluOpSetSeqDataDescriptor to set the sequence data information to the descriptor.
  * If the sequence data is in fixed-point data type, call ::mluOpSetSeqDataDescriptorPositionAndScale
  * to set the position and scale of the sequence data.
  * To destroy the descriptor, call ::mluOpDestroySeqDataDescriptor.
  */
 typedef struct mluOpSeqDataStruct *mluOpSeqDataDescriptor_t;
 
-// Group: SeqData
-/*!
- *  @brief Creates a sequence data instance \p seq_data_desc that holds the dimensions, data type,
- *  sequence lengths, padding fill and layout of sequence data on the host memory.
- *
- *  Use ::mluOpSetSeqDataDescriptor_v2 to configure the descriptor and ::mluOpDestroySeqDataDescriptor
- *  function to destroy the sequence data descriptor.
- *
- *  @param[out] seq_data_desc
- *  Pointer to the host memory that holds information about
- *  the struct of the sequence data descriptor.
- *
- *  @par Return
- *  - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
- *
- *  @note
- *  - None.
- *
- *  @par Requirements
- *  - None.
- *
- *  @par Example
- *  - None.
- *
- *  @par Reference
- *  - None.
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpCreateSeqDataDescriptor(mluOpSeqDataDescriptor_t *seq_data_desc);
-
-// Group: SeqData
-/*!
- * @brief Sets the sequence data descriptor \p seq_data_desc that holds the dimensions,
- * data type, sequence lengths, padding fill and layout of the sequence data.
- *
- * The number of dimensions in the \p dimSize[] is defined by \p dimNb. For example,
- * if the layout of the sequence data is set to ::MLUOP_SEQDATA_NC, the \p dimNb is 2,
- * with \p dimSize={batch, embedding}.
- *
- * The ::mluOpSeqDataDescriptor_t container is a collection of fixed-length sequential
- * vectors, similar to the words constructing sentences. The T dimension described in the
- * ::mluOpSeqDataLayout_t is the time dimension. Different sequences are bundled together to a
- * batch. The beam dimension described in the ::mluOpSeqDataLayout_t is
- * different candidates presenting a similar meaning in a typical translation task. The original
- * sentence can be translated to several versions before picking the optimal one, and the number
- * of candidates is beam.
- *
- * Note that different sentences have different sequence lengths, even inside a beam.
- * \p seqLengthArray is to record the real sequence lengths before padding to the maximum sequence
- * length. The value of \p seqLengthArray should follow a batch-beam order, in despite of
- * sequence data layout. Take a sequence of batch=3, beam=2 for example, the \p seqLengthArray
- * should be as follows:
-   @verbatim
-   {batch_idx = 0, beam_idx = 0}
-   {batch_idx = 0, beam_idx = 1}
-   {batch_idx = 1, beam_idx = 0}
-   {batch_idx = 1, beam_idx = 1}
-   {batch_idx = 2, beam_idx = 0}
-   {batch_idx = 2, beam_idx = 1}
-   @endverbatim
- * If the real sequence lengths are not requested, pass NULL to \p seqLengthArray in this function.
- *
- * The \p seqLengthArraySize should be batch * beam, which is 6 in the example above.
- *
- * The \p PaddingFill describes whether the sequence data needs to be padded using a
- * specified value. In the multi-head attention operation, the padding part should be zero before
- * entering the attention part to ensure the result validity. If the sequence data is padding
- * zero in advance, pass NULL to \p PaddingFill in this function. Otherwise, pass a pointer to padding
- * value (e.g. float a = 0, &a) to \p PaddingFill to indicate this function that extra padding are
- * needed.
- *
- * @param[in,out] seq_data_desc
- *   Input/output. The descriptor of the sequence data. For detailed information,
- *   see ::mluOpSeqDataDescriptor_t.
- * @param[in] layout
- *   The layout of the sequence data. See ::mluOpSeqDataLayout_t for the description of the
- *   enumeration type.
- * @param[in] dtype
- *   The data type of the sequence data. See ::mluOpDataType_t for the description of the
- *   enumeration type.
- * @param[in] dimNb
- *   The number of dimensions of the sequence data.
- * @param[in] dimSize
- *   An array that contains the size of the sequence data for each dimension.
- * @param[in] seqLengthArraySize
- *   Number of elements in sequence length array, \p seqLengthArray[]. It should be
- *   batch * beam. The batch and beam are described in the ::mluOpSeqDataLayout_t.
- * @param[in] seqLengthArray
- *   An integer array recording the length of all sequences. Note that the array should be
- *   set in the batch-beam order, in despite of sequence data layout. Set this parameter to NULL
- *   when sequence length array is not requested.
- * @param[in] paddingFill
- *   A host pointer to the data type \p dtype to fill up the padding vectors within
- *   the valid length of each sequence. Use NULL when extra padding is not requested.
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
- *
- * @par API Dependency
- * - Before calling this function, ::mluOpCreateSeqDataDescriptor should be called.
- *
- * @note
- * - dimSize[0] represents the highest dimension, and dimSize[dimNb - 1] represents
- *   the lowest dimension.
- *
- * @par Requirements
- * - None.
- *
- * @par Example
- * - None.
- *
- * @par Reference
- * - None.
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpSetSeqDataDescriptor_v2(mluOpSeqDataDescriptor_t seq_data_desc,
-                             mluOpSeqDataLayout_t layout,
-                             mluOpDataType_t dtype,
-                             int dimNb,
-                             const int64_t dimSize[],
-                             int seqLengthArraySize,
-                             const int seqLengthArray[],
-                             void *paddingFill);
-
-// Group: SeqData
-/*!
- * @brief Destroys a sequence data descriptor \p seq_data_desc that was created by
- * ::mluOpCreateSeqDataDescriptor.
- *
- * @param[in] seq_data_desc
- * A sequence data descriptor created by ::mluOpCreateSeqDataDescriptor.
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
- *
- * @note
- * - None.
- *
- * @par Requirements
- * - None.
- *
- * @par Example
- *  - None.
- *
- *  @par Reference
- *  - None.
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpDestroySeqDataDescriptor(mluOpSeqDataDescriptor_t seq_data_desc);
-
-// Group: SeqData
-/*!
- * @brief Sets the position \p position and scale \p scale factors used in fixed-point quantization.
- * It is only used if you have quantized the input data with the symmetric fixed-point
- * quantization with scale factor quantization method. For more information about quantization,
- * see "Cambricon MLU-OPS User Guide".
- *
- * @param[in] seq_data_desc
- * The descriptor of the sequence data. For detailed information,
- * see ::mluOpSeqDataDescriptor_t.
- * @param[in] position
- * An integer of fixed position factor that is used for quantization.
- * @param[in] scale
- * A scalar of scale factor that is used for quantization.
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
- *
- * @par API Dependency
- * - Before calling this function, ::mluOpCreateSeqDataDescriptor, ::mluOpSetSeqDataDescriptor_v2
- *   should be called.
- *
- * @note
- * - If the sequence data is in fixed-point data type, you need to call this function.
- *   This function is only used in the inference mode.
- * - The \p position should be limited in [-128, 127], otherwise the result is undefined.
- *
- * @par Requirements
- * - None.
- *
- * @par Example
- *  - None.
- *
- *  @par Reference
- *  - None.
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpSetSeqDataDescriptorPositionAndScale(mluOpSeqDataDescriptor_t seq_data_desc, int position, float scale);
-
-// Group: SeqData
+// Group:Common Interface
+// Subgroup:SeqData
 /*!
  * @brief Retrieves the sequence data descriptor \p seq_data_desc that holds the dimensions,
  * data type, layout, padding fill, and the sequence lengths of the input sequence data.
@@ -1179,7 +994,7 @@ typedef struct cnnlRoiAlignStruct *mluOpRoiAlignForwardDescriptor_t;
  *
  * You need to call the ::mluOpCreateDCNDescriptor function to create a descriptor, and call the
  * ::mluOpSetDCNDescriptor function to set the information of the deformable convolution operation
- * to the descriptor. Also, you need to destroy the Cambricon MLU-OPS context at the end with the
+ * to the descriptor. Also, you need to destroy the Cambricon CNNL context at the end with the
  * ::mluOpDestroyDCNDescriptor function.*/
 typedef struct cnnlDCNStruct *mluOpDCNDescriptor_t;
 
@@ -1195,7 +1010,7 @@ typedef struct cnnlDCNStruct *mluOpDCNDescriptor_t;
  */
 typedef struct mluOpCarafeStruct *mluOpCarafeDescriptor_t;
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Creates a tensor descriptor pointed by \b desc that holds the dimensions, data type,
  * and layout of input tensor. If the input tensor is in fixed-point data type,
@@ -1235,7 +1050,7 @@ typedef struct mluOpCarafeStruct *mluOpCarafeDescriptor_t;
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateTensorDescriptor(mluOpTensorDescriptor_t *desc);
 
-// Group: SparseConv
+// Group:GetIndicePairs
 /*!
  * @brief Creates a tensor descriptor pointed by \b desc that holds the dimensions, pad, stride,
  * dilation, sub_m, transpose, inverse and layout of input filter and output tensor shape.
@@ -1274,7 +1089,7 @@ mluOpCreateTensorDescriptor(mluOpTensorDescriptor_t *desc);
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateSparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t *desc);
 
-// Group: SparseConv
+// Group:GetIndicePairs
 /*!
  * @brief Destroys a convolution descriptor \b desc that was previously created with the
  * ::mluOpCreateSparseConvolutionDescriptor function.
@@ -1313,7 +1128,7 @@ mluOpCreateSparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t *desc)
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroySparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t desc);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Creates a group of tensor descriptor stored by \b group_desc that holds the
  * dimensions, data_type, and layout of input tensors. If the input tensor is in
@@ -1355,7 +1170,7 @@ mluOpDestroySparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t desc)
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateGroupTensorDescriptors(mluOpTensorDescriptor_t *group_desc[], const int desc_num);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Initializes the tensor descriptor pointed by \b desc that was previously created
  * with ::mluOpCreateTensorDescriptor, and sets the information about the
@@ -1409,7 +1224,8 @@ mluOpStatus_t MLUOP_WIN_API
 mluOpSetTensorDescriptor(
     mluOpTensorDescriptor_t desc, mluOpTensorLayout_t layout, mluOpDataType_t dtype, int dimNb, const int dimSize[]);
 
-// Group: Tensor
+// Group:Common Interface
+// Subgroup:Tensor
 /*!
  * @brief Sets the pointer mode \p pointer_mode factor for the input tensor descriptor \p desc.
  *
@@ -1434,7 +1250,8 @@ mluOpSetTensorDescriptor(
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetTensorDescriptorPointerMode(mluOpTensorDescriptor_t desc, mluOpPointerMode_t pointer_mode);
 
-// Group: Tensor
+// Group:Common Interface
+// Subgroup:Tensor
 /*!
  * @brief Retrieves the pointer mode of the input tensor descriptor \p desc set by
  * ::mluOpSetTensorDescriptorPointerMode.
@@ -1460,7 +1277,7 @@ mluOpSetTensorDescriptorPointerMode(mluOpTensorDescriptor_t desc, mluOpPointerMo
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetTensorDescriptorPointerMode(mluOpTensorDescriptor_t desc, mluOpPointerMode_t *pointer_mode);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Initializes the tensor descriptor pointed by \b desc that was previously created
  * with ::mluOpCreateTensorDescriptor, and sets the information about the
@@ -1517,7 +1334,7 @@ mluOpSetTensorDescriptor_v2(mluOpTensorDescriptor_t desc,
                             int dimNb,
                             const int64_t dimSize[]);
 
-// Group: SparseConv
+// Group:GetIndicePairs
 /*!
  * @brief Initializes the sparse convolution descriptor \b desc that was previously created
  * with ::mluOpCreateSparseConvolutionDescriptor, and sets the information
@@ -1620,7 +1437,7 @@ mluOpSetSparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t desc,
                                     const int transpose,
                                     const int inverse);
 
-// Group: SparseConv
+// Group:GetIndicePairs
 /*!
  * @brief Obtains the parameter num_act_out from ::mluOpSparseConvolutionDescriptor_t.
  *
@@ -1656,7 +1473,7 @@ mluOpSetSparseConvolutionDescriptor(mluOpSparseConvolutionDescriptor_t desc,
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetSparseConvolutionNumActOut(mluOpSparseConvolutionDescriptor_t desc, int *num_act_out);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Initializes the group of tensor descriptors stored by \b group_desc that was
  * previously created with ::mluOpCreateTensorDescriptor or
@@ -1723,7 +1540,7 @@ mluOpSetGroupTensorDescriptors(mluOpTensorDescriptor_t *group_desc[],
                                const int group_dimSize[],
                                const int desc_num);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Resets the tensor descriptor pointed by \b desc that was previously created with
  *  ::mluOpCreateTensorDescriptor. If ::mluOpResetTensorDescriptor is called,
@@ -1763,7 +1580,7 @@ mluOpSetGroupTensorDescriptors(mluOpTensorDescriptor_t *group_desc[],
 mluOpStatus_t MLUOP_WIN_API
 mluOpResetTensorDescriptor(mluOpTensorDescriptor_t desc);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Initializes the tensor descriptor pointed by \b desc that was previously created
  * with ::mluOpCreateTensorDescriptor, and sets the information about the
@@ -1822,7 +1639,7 @@ mluOpSetTensorDescriptorEx(mluOpTensorDescriptor_t desc,
                            const int dimSize[],
                            const int dimStride[]);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Initializes the tensor descriptor pointed by \b desc that was previously created
  * with ::mluOpCreateTensorDescriptor, and sets the information about the
@@ -1881,7 +1698,7 @@ mluOpSetTensorDescriptorEx_v2(mluOpTensorDescriptor_t desc,
                               const int64_t dimSize[],
                               const int64_t dimStride[]);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Sets the \b dimNb and \b dimSize factors to the input tensor descriptor.
  * If ::mluOpSetTensorDescriptorDim is called, you do not need to specify the strides of all
@@ -1925,7 +1742,7 @@ mluOpSetTensorDescriptorEx_v2(mluOpTensorDescriptor_t desc,
 mluOpStatus_t
 mluOpSetTensorDescriptorDim(mluOpTensorDescriptor_t desc, int dimNb, const int *dimSize);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Sets the \b dimNb and \b dimSize factors to the input tensor descriptor.
  * If ::mluOpSetTensorDescriptorDim_v2 is called, you do not need to specify the strides of all
@@ -1969,7 +1786,7 @@ mluOpSetTensorDescriptorDim(mluOpTensorDescriptor_t desc, int dimNb, const int *
 mluOpStatus_t
 mluOpSetTensorDescriptorDim_v2(mluOpTensorDescriptor_t desc, int dimNb, const int64_t *dimSize);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Sets the on-chip data type to the descriptor of a tensor \b desc. The on-chip
  * data type \b onchip_dtype can be different from the off-chip data type of the tensor.
@@ -2011,7 +1828,7 @@ mluOpSetTensorDescriptorDim_v2(mluOpTensorDescriptor_t desc, int dimNb, const in
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetTensorDescriptorOnchipDataType(mluOpTensorDescriptor_t desc, mluOpDataType_t onchip_dtype);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Sets the \b position factor to the descriptor \b desc of fixed-point data in
  * fixed-point quantization. It is used in ::MLUOP_QUANTIZE_POSITION mode.
@@ -2048,7 +1865,7 @@ mluOpSetTensorDescriptorOnchipDataType(mluOpTensorDescriptor_t desc, mluOpDataTy
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetTensorDescriptorPosition(mluOpTensorDescriptor_t desc, int position);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Sets the \b position and \b scale factors to the descriptor of fixed-point
  * data in fixed-point quantization. It is used in ::MLUOP_QUANTIZE_POSITION_SCALE mode.
@@ -2087,7 +1904,7 @@ mluOpSetTensorDescriptorPosition(mluOpTensorDescriptor_t desc, int position);
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetTensorDescriptorPositionAndScale(mluOpTensorDescriptor_t desc, int position, float scale);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Sets the \b position , \b scale , and \b offset factors to the descriptor of fixed-point
  * data in fixed-point quantization. It is used in ::MLUOP_QUANTIZE_POSITION_SCALE_OFFSET mode.
@@ -2128,7 +1945,7 @@ mluOpSetTensorDescriptorPositionAndScale(mluOpTensorDescriptor_t desc, int posit
 mluOpStatus_t MLUOP_WIN_API
 mluOpSetTensorDescriptorPositionScaleAndOffset(mluOpTensorDescriptor_t desc, int position, float scale, int offset);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Retrieves a tensor descriptor \b desc that was previously created with
  * ::mluOpCreateTensorDescriptor, and sets the information about the dimensions,
@@ -2176,7 +1993,7 @@ mluOpStatus_t MLUOP_WIN_API
 mluOpGetTensorDescriptor(
     const mluOpTensorDescriptor_t desc, mluOpTensorLayout_t *layout, mluOpDataType_t *dtype, int *dimNb, int dimSize[]);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Retrieves a tensor descriptor \b desc that was previously created with
  * ::mluOpCreateTensorDescriptor, and sets the information about the dimensions,
@@ -2227,7 +2044,7 @@ mluOpGetTensorDescriptor_v2(const mluOpTensorDescriptor_t desc,
                             int *dimNb,
                             int64_t dimSize[]);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Retrieves a tensor descriptor \b desc that was previously created with the
  * ::mluOpCreateTensorDescriptor and sets the information about the dimensions, data type,
@@ -2281,7 +2098,7 @@ mluOpGetTensorDescriptorEx(const mluOpTensorDescriptor_t desc,
                            int dimSize[],
                            int dimStride[]);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Retrieves a tensor descriptor \b desc that was previously created with the
  * ::mluOpCreateTensorDescriptor and sets the information about the dimensions, data type,
@@ -2335,7 +2152,7 @@ mluOpGetTensorDescriptorEx_v2(const mluOpTensorDescriptor_t desc,
                               int64_t dimSize[],
                               int64_t dimStride[]);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Retrieves the number of elements according to the input descriptor \b desc. You
  * need to call ::mluOpSetTensorDescriptor first to create a tensor descriptor
@@ -2379,7 +2196,7 @@ mluOpGetTensorDescriptorEx_v2(const mluOpTensorDescriptor_t desc,
 size_t MLUOP_WIN_API
 mluOpGetTensorElementNum(const mluOpTensorDescriptor_t desc);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Retrieves the on-chip data type of a tensor descriptor \b desc set by
  * ::mluOpSetTensorDescriptorOnchipDataType. If the on-chip data type is not set
@@ -2420,7 +2237,7 @@ mluOpGetTensorElementNum(const mluOpTensorDescriptor_t desc);
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetTensorDescriptorOnchipDataType(const mluOpTensorDescriptor_t desc, mluOpDataType_t *onchip_dtype);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Gets the \b position factor to the descriptor \b desc of fixed-point data in
  * fixed-point quantization.
@@ -2457,7 +2274,7 @@ mluOpGetTensorDescriptorOnchipDataType(const mluOpTensorDescriptor_t desc, mluOp
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetTensorDescriptorPosition(const mluOpTensorDescriptor_t desc, int *position);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Gets the position and scale factors of a tensor descriptor \b desc used in
  * fixed-point quantization.
@@ -2496,7 +2313,7 @@ mluOpGetTensorDescriptorPosition(const mluOpTensorDescriptor_t desc, int *positi
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetTensorDescriptorPositionAndScale(const mluOpTensorDescriptor_t desc, int *position, float *scale);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Gets the \b position, \b scale and \b offset factors to the descriptor \b desc of
  * fixed-point data in fixed-point quantization.
@@ -2541,7 +2358,7 @@ mluOpGetTensorDescriptorPositionScaleAndOffset(const mluOpTensorDescriptor_t des
                                                float *scale,
                                                int *offset);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Destroys a tensor descriptor that was created by ::mluOpCreateTensorDescriptor.
  *
@@ -2575,7 +2392,7 @@ mluOpGetTensorDescriptorPositionScaleAndOffset(const mluOpTensorDescriptor_t des
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyTensorDescriptor(mluOpTensorDescriptor_t desc);
 
-// Group: Tensor
+// Group:Tensor
 /*!
  * @brief Destroys a group of tensor descriptors that were created by
  * ::mluOpCreateTensorDescriptor or ::mluOpCreateGroupTensorDescriptors.
@@ -2613,7 +2430,7 @@ mluOpDestroyTensorDescriptor(mluOpTensorDescriptor_t desc);
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyGroupTensorDescriptors(mluOpTensorDescriptor_t *group_desc[], const int desc_num);
 
-// Group: TensorSet
+// Group:TensorSet
 /*!
  * @brief Creates a descriptor \b tensorSetDesc of tensor set that holds a series of tensors.
  * The number of tensors of tensor set is jointly determined by \b setDimNb and \b setDimSize.
@@ -2656,7 +2473,7 @@ mluOpDestroyGroupTensorDescriptors(mluOpTensorDescriptor_t *group_desc[], const 
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateTensorSetDescriptor(mluOpTensorSetDescriptor_t *tensorSetDesc, const int setDimNb, const int setDimSize[]);
 
-// Group: TensorSet
+// Group:TensorSet
 /*!
  * @brief Retrieves a tensor set descriptor \b tensorSetDesc that was previously created
  * with ::mluOpCreateTensorSetDescriptor.
@@ -2696,7 +2513,7 @@ mluOpCreateTensorSetDescriptor(mluOpTensorSetDescriptor_t *tensorSetDesc, const 
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetTensorSetDescriptor(mluOpTensorSetDescriptor_t tensorSetDesc, int *setDimNb, int setDimSize[]);
 
-// Group: TensorSet
+// Group:TensorSet
 /*!
  * @brief Destroys a tensor set descriptor \b tensorSetDesc that was previously created by
  * ::mluOpCreateTensorSetDescriptor.
@@ -2732,7 +2549,7 @@ mluOpGetTensorSetDescriptor(mluOpTensorSetDescriptor_t tensorSetDesc, int *setDi
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyTensorSetDescriptor(mluOpTensorSetDescriptor_t tensorSetDesc);
 
-// Group: TensorSet
+// Group:TensorSet
 /*!
  * @brief Initializes a member tensor in the tensor set descriptors pointed by
  * \b desc that was previously created with ::mluOpCreateTensorSetDescriptor,
@@ -2796,7 +2613,7 @@ mluOpInitTensorSetMemberDescriptor(mluOpTensorSetDescriptor_t tensorSetDesc,
                                    const int dimNb,
                                    const int dimSize[]);
 
-// Group: TensorSet
+// Group:TensorSet
 /*!
  * @brief Sets the position and scale factors used in fixed-point quantization.
  * It is only used if you have quantized the input data with the symmetric
@@ -2854,7 +2671,7 @@ mluOpInitTensorSetMemberDescriptorPositionAndScale(mluOpTensorSetDescriptor_t te
                                                    const int position,
                                                    const float scale);
 
-// Group: TensorSet
+// Group:TensorSet
 /*!
  * @brief Retrieves the size of tensor set according to the input descriptor \b
  * tensorSetDesc. You need to call ::mluOpInitTensorSetMemberDescriptor
@@ -2895,7 +2712,7 @@ mluOpInitTensorSetMemberDescriptorPositionAndScale(mluOpTensorSetDescriptor_t te
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetTensorSetDescriptorSize(mluOpTensorSetDescriptor_t tensorSetDesc, int *sizeInBytes);
 
-// Group: TensorSet
+// Group:TensorSet
 /*!
  * @brief Retrieves the tensor descriptor in the tensor set and the corresponding offset
  * address based on the entire block of MLU memory through the index \b tensorIndex.
@@ -2948,7 +2765,7 @@ mluOpGetTensorAndDataFromTensorSet(mluOpTensorSetDescriptor_t tensorSetDesc,
                                    mluOpTensorDescriptor_t *tensorDesc,
                                    void **dataAddrInDevice);
 
-// Group: Abs
+// Group:Abs
 /*!
  * @brief Computes the absolute value for every element of the input tensor \b x
  * and returns results in \b y.
@@ -3011,7 +2828,7 @@ mluOpAbs(mluOpHandle_t handle,
          const mluOpTensorDescriptor_t y_desc,
          void *y);
 
-// Group: Log
+// Group:Log
 /*!
  * @brief Computes logarithm of input tensor \b x, and returns the results in
  * the output tensor \b y.
@@ -3073,7 +2890,7 @@ mluOpLog(mluOpHandle_t handle,
          const mluOpTensorDescriptor_t y_desc,
          void *y);
 
-// Group: Carafe
+// Group:Carafe
 /*!
  * @brief Creates a descriptor pointed by \b carafe_desc for CARAFE upsampling forward and backward operations,
  * and allocates memory holding the configuration parameters.The information is defined in ::mluOpCarafeDescriptor_t.
@@ -3114,7 +2931,7 @@ mluOpLog(mluOpHandle_t handle,
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateCarafeDescriptor(mluOpCarafeDescriptor_t *carafe_desc);
 
-// Group: Carafe
+// Group:Carafe
 /*!
  * @brief Initializes the CARAFE descriptor \b carafe_desc that was previously created with
  * ::mluOpCreateCarafeDescriptor, and sets the information about the
@@ -3165,7 +2982,7 @@ mluOpSetCarafeDescriptor(mluOpCarafeDescriptor_t carafe_desc,
                          const int group_size,
                          const int scale_factor);
 
-// Group: Carafe
+// Group:Carafe
 /*!
  * @brief Destroys a CARAFE descriptor \b carafe_desc that was previously created by
  * ::mluOpCreateCarafeDescriptor.
@@ -3207,7 +3024,7 @@ mluOpSetCarafeDescriptor(mluOpCarafeDescriptor_t carafe_desc,
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyCarafeDescriptor(mluOpCarafeDescriptor_t carafe_desc);
 
-// Group: Carafe
+// Group:Carafe
 /*!
  * @brief Performs the CARAFE upsampling operation on the input feature maps \b input using
  * weighted combination, where the filter is set with \b mask. The upsampled feature maps
@@ -3315,7 +3132,7 @@ mluOpCarafeForward(mluOpHandle_t handle,
                    const mluOpTensorDescriptor_t output_desc,
                    void *output);
 
-// Group: Carafe
+// Group:Carafe
 /*!
  * @brief Performs the back-propagation of CARAFE.
  * operation to compute the gradient with respect to input \b grad_input and
@@ -3420,7 +3237,7 @@ mluOpCarafeBackward(mluOpHandle_t handle,
                     const mluOpTensorDescriptor_t grad_mask_desc,
                     void *grad_mask);
 
-// Group: Div
+// Group:Div
 /*!
  * @brief Computes division on input tensors \b x and \b y, and returns the
  * results in the output tensor \b output.
@@ -3487,7 +3304,7 @@ mluOpDiv(mluOpHandle_t handle,
          const mluOpTensorDescriptor_t z_desc,
          void *z);
 
-// Group: DynamicPointToVoxel
+// Group:DynamicPointToVoxelBackward
 /*!
  * @brief Gets extra space size for the DynamicPointToVoxelBackward operation.
  *
@@ -3551,7 +3368,7 @@ mluOpGetDynamicPointToVoxelBackwardWorkspaceSize(const mluOpHandle_t handle,
                                                  const mluOpTensorDescriptor_t voxel_num_desc,
                                                  size_t *workspace_size);
 
-// Group: DynamicPointToVoxel
+// Group:DynamicPointToVoxelBackward
 /*!
  * @brief Performs the back-propagation of DynamicPointToVoxelForward
  * operation to compute the gradient for input \b grad_voxel_feats
@@ -3633,7 +3450,7 @@ mluOpGetDynamicPointToVoxelBackwardWorkspaceSize(const mluOpHandle_t handle,
  *   - 2C * sizeof(datatype of \b feats) + (N + 3C + 1) * sizeof(int) + N
  *     must be less than or equal to 640KB on MLU300 series.
  *   - 2C * sizeof(datatype of \b feats) + (N + 3C + 1) * sizeof(int) + N
- *     must be less than or equal to 380KB on series higher than MLU300 series.
+ *     must be less than or equal to 380KB on MLU500 series.
  *
  * @par API Dependency
  * - Before calling this function, you need to get the size of workspace by
@@ -3641,9 +3458,9 @@ mluOpGetDynamicPointToVoxelBackwardWorkspaceSize(const mluOpHandle_t handle,
  *
  * @par Note
  * - This function is only supported on MLU300 series or above platforms.
- * - On MLU300 series and above, the inputs \b point2voxel_map, \b voxel_points_count, and \b voxel_num with NaN or
- *   infinity are not supported.
- * - On MLU300 series and above, the inputs \b grad_voxel_feats, \b feats and \b voxel_feats with NaN or infinity
+ * - On MLU300 and MLU500, the inputs \b point2voxel_map, \b voxel_points_count, and \b voxel_num with NaN or infinity
+ *   are not supported.
+ * - On MLU300 and MLU500, the inputs \b grad_voxel_feats, \b feats and \b voxel_feats with NaN or infinity
  *   are supported.
  *
  * @par Example
@@ -3672,7 +3489,7 @@ mluOpDynamicPointToVoxelBackward(const mluOpHandle_t handle,
                                  const mluOpTensorDescriptor_t grad_feats_desc,
                                  void *grad_feats);
 
-// Group: DynamicPointToVoxel
+// Group:DynamicPointToVoxel
 /*!
  * @brief Gets extra space size that is needed in the DynamicPointToVoxelForward operation.
  *
@@ -3718,7 +3535,7 @@ mluOpGetDynamicPointToVoxelForwardWorkspaceSize(mluOpHandle_t handle,
                                                 const mluOpTensorDescriptor_t coors_desc,
                                                 size_t *workspace_size);
 
-// Group: DynamicPointToVoxel
+// Group:DynamicPointToVoxel
 /*!
  * @brief Scatters points features into voxels, used in the voxel encoder with
  * dynamic voxelization.
@@ -3801,8 +3618,8 @@ mluOpGetDynamicPointToVoxelForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Note
  * - This function is only supported on MLU300 series or above platforms.
- * - On MLU300 series and above, the input \b coors with NaN or infinity is not supported.
- * - On MLU300 series and above, the input \b feats with NaN or infinity is supported.
+ * - On MLU300 and MLU500, the input \b coors with NaN or infinity is not supported.
+ * - On MLU300 and MLU500, the input \b feats with NaN or infinity is supported.
  *
  * @par Example
  * - None.
@@ -3830,7 +3647,7 @@ mluOpDynamicPointToVoxelForward(const mluOpHandle_t handle,
                                 const mluOpTensorDescriptor_t voxel_num_desc,
                                 void *voxel_num);
 
-// Group: GenerateProposalsV2
+// Group:GenerateProposalsV2
 /*!
  * @brief Gets extra space size that is needed in the GenerateProposalsV2 operation.
  *
@@ -3870,7 +3687,7 @@ mluOpDynamicPointToVoxelForward(const mluOpHandle_t handle,
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetGenerateProposalsV2WorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescriptor_t scores_desc, size_t *size);
 
-// Group: GenerateProposalsV2
+// Group:GenerateProposalsV2
 /*!
  * @brief Generates bounding box proposals for Faster Region-CNN.
  * This operation is the second version of generate_proposals op.
@@ -4037,7 +3854,7 @@ mluOpGenerateProposalsV2(mluOpHandle_t handle,
                          void *rpn_rois_num,
                          void *rpn_rois_batch_size);
 
-// Group: PolyNms
+// Group:PolyNms
 /*!
  * @brief Gets extra space size that is needed in the poly_nms operation.
  *
@@ -4077,7 +3894,7 @@ mluOpGenerateProposalsV2(mluOpHandle_t handle,
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetPolyNmsWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescriptor_t boxes_desc, size_t *size);
 
-// Group: PolyNms
+// Group:PolyNms
 /*!
  * @brief Computes the NMS (Non-Maximum Suppression) of polygon.
  *
@@ -4159,7 +3976,7 @@ mluOpPolyNms(mluOpHandle_t handle,
              void *output,
              void *output_size);
 
-// Group: Nms
+// Group:Nms
 /*!
  * @brief Creates a descriptor pointed to \b desc for ::mluOpNms, and allocates
  * memory for holding the information about the Nms function. The information
@@ -4188,7 +4005,7 @@ mluOpPolyNms(mluOpHandle_t handle,
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateNmsDescriptor(mluOpNmsDescriptor_t *desc);
 
-// Group: Nms
+// Group:Nms
 /*!
  *
  * @brief Destroys an Nms descriptor \b desc that was previously created with
@@ -4217,7 +4034,7 @@ mluOpCreateNmsDescriptor(mluOpNmsDescriptor_t *desc);
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyNmsDescriptor(mluOpNmsDescriptor_t desc);
 
-// Group: Nms
+// Group:Nms
 /*!
  * @brief Initializes the Nms descriptor \b nms_desc that was previously created with
  * ::mluOpCreateNmsDescriptor, and sets the information about the Nms operation
@@ -4309,7 +4126,7 @@ mluOpSetNmsDescriptor(mluOpNmsDescriptor_t nms_desc,
                       const int input_layout,
                       const bool pad_to_max_output_size);
 
-// Group: Nms
+// Group:Nms
 /*!
  * @brief Calculates the subset of input tensor \b boxes with the scores of \b confidence, and returns
  * the results in the output tensors \b output and \b output_size.
@@ -4420,7 +4237,7 @@ mluOpNms(mluOpHandle_t handle,
          void *output,
          void *output_size);
 
-// Group: Nms
+// Group:Nms
 /*!
  * @brief Returns in \b size the size of the MLU memory that is used as an extra workspace
  * needed in Nms operation.
@@ -4476,7 +4293,7 @@ mluOpGetNmsWorkspaceSize(mluOpHandle_t handle,
                          const mluOpTensorDescriptor_t confidence_desc,
                          size_t *size);
 
-// Group: PriorBox
+// Group:PriorBox
 /*!
  * @brief Generates prior boxes for SSD (Single Shot MultiBox Detector) algorithm.
  *
@@ -4627,7 +4444,7 @@ mluOpPriorBox(mluOpHandle_t handle,
               const mluOpTensorDescriptor_t var_desc,
               void *var);
 
-// Group: PsRoiPool
+// Group:PsRoiPool
 /*!
  * @brief Generates fixed size feature map for each ROI (Regions of Interest).
  *
@@ -4735,7 +4552,7 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
                       const mluOpTensorDescriptor_t mapping_channel_desc,
                       void *mapping_channel);
 
-// Group: PsRoiPool
+// Group:PsRoiPool
 /*!
  * @brief Computes the gradients of feature map \b bottom_grad based on the
  * inputs \b top_grad , \b rois , and \b mapping_channel to perform the backpropagation
@@ -4834,7 +4651,7 @@ mluOpPsRoiPoolBackward(mluOpHandle_t handle,
                        const mluOpTensorDescriptor_t bottom_grad_desc,
                        void *bottom_grad);
 
-// Group: RoiAlign
+// Group:RoiAlignForward
 /*!
  * @brief Creates a descriptor pointed by \b desc for ::mluOpRoiAlignForward_v2,
  * and allocates memory for holding the information about the function.
@@ -4872,7 +4689,7 @@ mluOpPsRoiPoolBackward(mluOpHandle_t handle,
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateRoiAlignForwardDescriptor(mluOpRoiAlignForwardDescriptor_t *desc);
 
-// Group: RoiAlign
+// Group:RoiAlignForward
 /*!
  * @brief Initializes the descriptor \b desc that was previously created with
  * ::mluOpCreateRoiAlignForwardDescriptor function, and sets RoiAlign information
@@ -4932,7 +4749,7 @@ mluOpSetRoiAlignForwardDescriptor_v2(mluOpRoiAlignForwardDescriptor_t roialign_d
                                      const int pool_mode,
                                      const bool aligned);
 
-// Group: RoiAlign
+// Group:RoiAlignForward
 /*!
  * @brief Destroys a RoiAlign descriptor \b desc that was previously created
  * with ::mluOpCreateRoiAlignForwardDescriptor function.
@@ -4972,7 +4789,7 @@ mluOpSetRoiAlignForwardDescriptor_v2(mluOpRoiAlignForwardDescriptor_t roialign_d
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyRoiAlignForwardDescriptor(mluOpRoiAlignForwardDescriptor_t desc);
 
-// Group: RoiAlign
+// Group:RoiAlignForward
 /*!
  * @brief Computes the output feature map \b output based on the input feature map \b input
  * and bounding boxes \b boxes to perform this function. This function supports
@@ -5096,7 +4913,7 @@ mluOpRoiAlignForward_v2(mluOpHandle_t handle,
                         const mluOpTensorDescriptor_t argmax_y_desc,
                         void *argmax_y);
 
-// Group: RoiAlignRotated
+// Group:RoiAlignRotated
 /*!
  * @brief Extracts the corresponding \b features information to \b output by bilinear interpolation
  * according to the \b rois with rotation.
@@ -5206,7 +5023,7 @@ mluOpRoiAlignRotatedForward(mluOpHandle_t handle,
                             const mluOpTensorDescriptor_t output_desc,
                             void *output);
 
-// Group: RoiAlignRotated
+// Group:RoiAlignRotated
 /*!
  * @brief Computes the gradients of feature map \b bottom_grad based on the input \b top_grad and
  * \b rois to perform the backpropagation of ::mluOpRoiAlignRotatedForward.
@@ -5315,7 +5132,7 @@ mluOpRoiAlignRotatedBackward(mluOpHandle_t handle,
                              const mluOpTensorDescriptor_t bottom_grad_desc,
                              void *bottom_grad);
 
-// Group: RoiCrop
+// Group:RoiCrop
 /*!
  * @brief Generates fixed size feature map for each grid. Each value in the
  * feature map is interpolated by bilinear sampling.
@@ -5373,7 +5190,7 @@ mluOpRoiAlignRotatedBackward(mluOpHandle_t handle,
  *
  * @par Note
  * - On MLU300, the input \b grid with NaN or infinity is not supported.
- * - On series higher than MLU300 series, the inputs \b grid and \b input with NaN or infinity are supported.
+ * - On MLU500, the inputs \b grid and \b input with NaN or infinity are supported.
  *
  * @par Example
  * - None.
@@ -5390,7 +5207,7 @@ mluOpRoiCropForward(mluOpHandle_t handle,
                     const mluOpTensorDescriptor_t output_desc,
                     void *output);
 
-// Group: RoiCrop
+// Group:RoiCrop
 /*!
  * @brief Computes the gradients of images \b grad_input based on the gradients
  * \b grad_output and coordinates mapping parameter \b grid to perform the
@@ -5455,7 +5272,7 @@ mluOpRoiCropForward(mluOpHandle_t handle,
  *
  * @par Note
  * - On MLU300, the input \b grid with NaN or infinity is not supported.
- * - On series higher than MLU300 series, the inputs \b grid and \b grad_output with NaN or infinity are supported.
+ * - On MLU500, the inputs \b grid and \b grad_output with NaN or infinity are supported.
  *
  * @par Example
  * - None.
@@ -5472,7 +5289,7 @@ mluOpRoiCropBackward(mluOpHandle_t handle,
                      const mluOpTensorDescriptor_t grad_input_desc,
                      void *grad_input);
 
-// Group: RotatedFeatureAlign
+// Group:RotatedFeatureAlign
 /*!
  * @brief Uses the feature interpolation to obtain the position information corresponding to the
  * refined rotate anchors \b bboxes and reconstructs the feature maps \b output in pixel-wise
@@ -5564,7 +5381,7 @@ mluOpRotatedFeatureAlignForward(const mluOpHandle_t handle,
                                 const mluOpTensorDescriptor_t output_desc,
                                 void *output);
 
-// Group: RotatedFeatureAlign
+// Group:RotatedFeatureAlign
 /*!
  * @brief Computes the gradients of feature map \b bottom_input based on the inputs \b top_output
  * and \b bboxes to perform the backpropagation of ::mluOpRotatedFeatureAlignForward.
@@ -5644,7 +5461,7 @@ mluOpRotatedFeatureAlignBackward(const mluOpHandle_t handle,
                                  const mluOpTensorDescriptor_t bottom_input_desc,
                                  void *bottom_input);
 
-// Group: Sqrt
+// Group:Sqrt
 /*!
  * @brief Computes sqrt on input tensor \b x, and returns the results in the
  * output tensor \b y.
@@ -5704,7 +5521,7 @@ mluOpSqrt(mluOpHandle_t handle,
           const mluOpTensorDescriptor_t y_desc,
           void *y);
 
-// Group: Sqrt
+// Group:Sqrt
 
 /*!
  * @brief Computes gradient of sqrt on input tensor \b y and \b diff_y, and
@@ -5769,7 +5586,7 @@ mluOpSqrtBackward(mluOpHandle_t handle,
                   const mluOpTensorDescriptor_t dx_desc,
                   void *diff_x);
 
-// Group: Voxelization
+// Group:Voxelization
 /*!
  * @brief Gets extra space size that is needed in voxelization operation.
  *
@@ -5853,7 +5670,7 @@ mluOpGetVoxelizationWorkspaceSize(mluOpHandle_t handle,
                                   const mluOpTensorDescriptor_t voxel_num_desc,
                                   size_t *size);
 
-// Group: Voxelization
+// Group:Voxelization
 /*!
  * @brief Generates voxelization of input tensor \b points. Output tensor
  * \b voxels contains points in voxels; \b coors is the voxel coordinates;
@@ -5970,7 +5787,7 @@ mluOpVoxelization(mluOpHandle_t handle,
                   const mluOpTensorDescriptor_t voxel_num_desc,
                   void *voxel_num);
 
-// Group: YoloBox
+// Group:YoloBox
 /*!
  * @brief Computes bounding box information from the backbone output of the
  * detected network.
@@ -6083,7 +5900,7 @@ mluOpYoloBox(mluOpHandle_t handle,
              const mluOpTensorDescriptor_t scores_desc,
              void *scores);
 
-// Group: VoxelPooling
+// Group:VoxelPooling
 /*!
  * @brief Adds the eigenvalues of all the channels on the same x and y coordinates,
  * and then pools them to all the channels in the bev 2D area on the corresponding coordinates.
@@ -6182,7 +5999,7 @@ mluOpVoxelPoolingForward(mluOpHandle_t handle,
                          const mluOpTensorDescriptor_t pos_memo_desc,
                          void *pos_memo);
 
-// Group: BoxIouRotated
+// Group:BoxIouRotated
 /*!
  * @brief Computes the intersection-over-union (Jaccard index, IOU) of rotated
  * bounding-boxes. If \b aligned is false, then calculates the IOU
@@ -6280,7 +6097,7 @@ mluOpBoxIouRotated(mluOpHandle_t handle,
                    const mluOpTensorDescriptor_t ious_desc,
                    void *ious);
 
-// Group: NmsRotated
+// Group:NmsRotated
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize ::mluOpNmsRotated.
@@ -6311,7 +6128,7 @@ mluOpBoxIouRotated(mluOpHandle_t handle,
 mluOpStatus_t MLUOP_WIN_API
 mluOpGetNmsRotatedWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescriptor_t boxes_desc, size_t *workspace_size);
 
-// Group: NmsRotated
+// Group:NmsRotated
 /*!
  * @brief Computes the index of nms with IOU of rotated bounding boxes.
  *
@@ -6388,7 +6205,7 @@ mluOpNmsRotated(mluOpHandle_t handle,
                 void *output,
                 int32_t *result_num);
 
-// Group: BboxOverlaps
+// Group:BboxOverlaps
 /*!
  * @brief Computes the IOUs or IOFs between two sets of
  * bounding-boxes. If \b aligned is false, this operation calculates the IOU of each row between each bounding-box
@@ -6685,7 +6502,7 @@ mluOpThreeInterpolateBackward(mluOpHandle_t handle,
                               const mluOpTensorDescriptor_t grad_features_desc,
                               void *grad_features);
 
-// Group: BallQuery
+// Group:Ballquery
 /*!
  * @brief Takes the point's index in the \b new_xyz set as the center of the sphere,
  * uses \b min_radius and \b max_radius as the radius, and returns the \b idx of
@@ -6777,7 +6594,7 @@ mluOpBallQuery(mluOpHandle_t handle,
                const mluOpTensorDescriptor_t idx_desc,
                void *idx);
 
-// Group: FocalLossSigmoid
+// Group:FocalLossSigmoid
 /*!
  * @brief Computes cross entropy loss with weighting factor and focusing factor
  * to reduce the filter of samples which are easy to classify.
@@ -6888,7 +6705,7 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
                              const mluOpTensorDescriptor_t output_desc,
                              void *output);
 
-// Group: FocalLossSigmoid
+// Group:FocalLossSigmoid
 /*!
  * @brief Computes the gradients of ::mluOpFocalLossSigmoidBackward with \b input tensor,
  * \b target tensor, \b weight tensor, and returns the results in
@@ -6970,8 +6787,8 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  *   \b weight is NULL on MLU300 series. The length of C should be in the range of [0, 14848] when
  *   \b weight is not NULL on MLU300 series.
  * - If the shape of \b input is set to [N, C], the length of C should be in the range of [0, 9785] when
- *   \b weight is NULL on series higher than MLU300 series. The length of C should be in the range of [0, 8864] when
- *   \b weight is not NULL on series higher than MLU300 series.
+ *   \b weight is NULL on MLU500 series. The length of C should be in the range of [0, 8864] when
+ *   \b weight is not NULL on MLU500 series.
  * - \b weight does not support positive infinity and negative infinity currently.
  * - \b gamma should be in the range of [0, 10000].
  *
@@ -6996,7 +6813,7 @@ mluOpFocalLossSigmoidBackward(mluOpHandle_t handle,
                               const mluOpTensorDescriptor_t grad_input_desc,
                               void *grad_input);
 
-// Group: MaskedIm2col
+// Group:MaskedIm2col
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra workspace to
  * optimize ::mluOpMaskedIm2colForward.
@@ -7058,7 +6875,7 @@ mluOpGetMaskedIm2colForwardWorkspaceSize(mluOpHandle_t handle,
                                          const mluOpTensorDescriptor_t data_col_desc,
                                          size_t *workspace_size);
 
-// Group: MaskedIm2col
+// Group:MaskedIm2col
 /*!
  * @brief Copies the data of the input tensor \b feature covered by mask to the output tensor \b data_col.
  * The area of mask that is out of \b feature is padded with 0. This function firstly generates mask coordinates
@@ -7173,7 +6990,7 @@ mluOpMaskedIm2colForward(mluOpHandle_t handle,
                          const mluOpTensorDescriptor_t data_col_desc,
                          void *data_col);
 
-// Group: MoeDispatch
+// Group:MoeDispatchBackwardData
 /*!
  * @brief Calculates the inverse gradient of \b input tensor, and returns the results in the output
  * tensor \b grad_input.
@@ -7280,7 +7097,7 @@ mluOpMoeDispatchBackwardData(mluOpHandle_t handle,
                              const mluOpTensorDescriptor_t grad_input_desc,
                              void *grad_input);
 
-// Group: MsDeformAttn
+// Group:MsDeformAttn
 /*!
  * @brief Computes the gradient of the input tensors of ::mluOpMsDeformAttnForward.
  *
@@ -7363,7 +7180,7 @@ mluOpMoeDispatchBackwardData(mluOpHandle_t handle,
  * @par Note
  * - The input \b sampling_loc that contains NaN or infinity is not supported.
  * - The \b value, \b sampling_loc, \b with attn_weight and \b grad_output contain NaN or infinity are not
- *   supported on series higher than MLU300 series currently.
+ *   supported ON MLU500 series currently.
  * - The function does not support MLU200 series.
  *
  * @par Example
@@ -7395,7 +7212,7 @@ mluOpMsDeformAttnBackward(mluOpHandle_t handle,
                           const mluOpTensorDescriptor_t grad_attn_weight_desc,
                           void *grad_attn_weight);
 
-// Group: MutualInformation
+// Group:MutualInformationBackward
 /*!
  * @brief Returns the size of the MLU memory as an extra workspace
  * to optimize ::mluOpMutualInformationBackward.
@@ -7457,7 +7274,7 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
                                                const bool overwrite_ans_grad,
                                                size_t *workspace_size);
 
-// Group: MutualInformation
+// Group:MutualInformationBackward
 /*!
  * @brief Computes the gradients of tensor \b px and tensor \b py.
  *
@@ -7575,7 +7392,7 @@ mluOpMutualInformationBackward(mluOpHandle_t handle,
                                const mluOpTensorDescriptor_t py_grad_desc,
                                void *py_grad);
 
-// Group: MutualInformation
+// Group:MutualInformationForward
 /*!
  * @brief Returns the size of the MLU memory as an extra workspace
  * to optimize ::mluOpMutualInformationForward.
@@ -7634,7 +7451,7 @@ mluOpGetMutualInformationForwardWorkspaceSize(mluOpHandle_t handle,
                                               const mluOpTensorDescriptor_t ans_desc,
                                               size_t *workspace_size);
 
-// Group: MutualInformation
+// Group:MutualInformationForward
 /*!
  * @brief Computes mutual information between tensor \b px and tensor \b py.
  *
@@ -7728,7 +7545,7 @@ mluOpMutualInformationForward(mluOpHandle_t handle,
                               const mluOpTensorDescriptor_t ans_desc,
                               void *ans);
 
-// Group: Deprecated APIs
+// Group:RoiAwarePool3d
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize ::mluOpRoiAwarePool3dForward.
@@ -7737,7 +7554,7 @@ mluOpMutualInformationForward(mluOpHandle_t handle,
  * including the input tensor descriptors \b pts_desc.
  *
  * @par Deprecated
- * - ::mluOpGetRoiawarePool3dForwardWorkspaceSize is deprecated and will be removed in the future
+ * - :: mluOpGetRoiawarePool3dForwardWorkspaceSize is deprecated and will be removed in the future
  *   release. It is recommended to use ::mluOpGetRoiAwarePool3dForwardWorkspaceSize instead.
  *
  * @param[in] handle
@@ -7784,7 +7601,7 @@ mluOpGetRoiawarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
                                            const mluOpTensorDescriptor_t pts_feature_desc,
                                            size_t *workspace_size);
 
-// Group: RoiAwarePool3d
+// Group:RoiAwarePool3d
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize ::mluOpRoiAwarePool3dForward.
@@ -7836,7 +7653,7 @@ mluOpGetRoiAwarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
                                            const mluOpTensorDescriptor_t pts_feature_desc,
                                            size_t *workspace_size);
 
-// Group: Deprecated APIs
+// Group:RoiAwarePool3d
 /*!
  * @brief Returns \b argmax, \b pts_idx_of_voxels and \b pooled_features calculated by
  * this operator.
@@ -7845,10 +7662,6 @@ mluOpGetRoiAwarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * of points in boxes are named as voxels and recorded as \b pts_idx_of_voxels. The operator
  * also performs max pooling or average pooling on the voxels and results in \b argmax
  * and \b pooled_features.
- *
- * @par Deprecated
- * - ::mluOpRoiawarePool3dForward is deprecated and will be removed in the future
- *   release. It is recommended to use ::mluOpRoiAwarePool3dForward instead.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
@@ -7971,7 +7784,7 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
                            const mluOpTensorDescriptor_t pooled_features_desc,
                            void *pooled_features);
 
-// Group: RoiAwarePool3d
+// Group:RoiAwarePool3d
 /*!
  * @brief Returns \b argmax, \b pts_idx_of_voxels and \b pooled_features calculated by
  * this operator.
@@ -8102,13 +7915,13 @@ mluOpRoiAwarePool3dForward(mluOpHandle_t handle,
                            const mluOpTensorDescriptor_t pooled_features_desc,
                            void *pooled_features);
 
-// Group: Deprecated APIs
+// Group:RoiAwarePool3d
 /*!
  * @brief Returns \b pts_idx_of_voxels, \b argmax, \b grad_out and \b grad_in by
  * performing the backpropagation of ::mluOpRoiAwarePool3dForward.
  *
  * @par Deprecated
- * - ::mluOpRoiawarePool3dBackward is deprecated and will be removed in the future
+ * - :: mluOpRoiawarePool3dBackward is deprecated and will be removed in the future
  *   release. It is recommended to use ::mluOpRoiAwarePool3dBackward instead.
  *
  * @param[in] handle
@@ -8199,7 +8012,7 @@ mluOpRoiawarePool3dBackward(mluOpHandle_t handle,
                             const mluOpTensorDescriptor_t grad_in_desc,
                             void *grad_in);
 
-// Group: RoiAwarePool3d
+// Group:RoiAwarePool3d
 /*!
  * @brief Returns \b pts_idx_of_voxels, \b argmax, \b grad_out and \b grad_in by
  * performing the backpropagation of ::mluOpRoiAwarePool3dForward.
@@ -8292,7 +8105,7 @@ mluOpRoiAwarePool3dBackward(mluOpHandle_t handle,
                             const mluOpTensorDescriptor_t grad_in_desc,
                             void *grad_in);
 
-// Group: Psamask
+// Group:Psamask
 /*!
  * @brief Moves the \b x tensor to \b y tensor according to \b h_mask , \b w_mask , and \b psa_type.
  *
@@ -8371,7 +8184,7 @@ mluOpPsamaskForward(mluOpHandle_t handle,
                     const mluOpTensorDescriptor_t y_desc,
                     void *y);
 
-// Group: Psamask
+// Group:Psamask
 /*!
  * @brief Computes the gradients of input tensor \b dx with the gradients of output tensor \b dy
  * according to \b h_mask , \b w_mask , and \b psa_type.
@@ -8450,7 +8263,7 @@ mluOpPsamaskBackward(mluOpHandle_t handle,
                      const mluOpTensorDescriptor_t dx_desc,
                      void *dx);
 
-// Group: SparseConv
+// Group:GetIndicePairs
 /*!
  * @brief Computes the get_indice_paris operation, then returns the results in the output
  * tensor \b out_indices , \b indice_pairs and \b ind, ice_num.
@@ -8549,7 +8362,7 @@ mluOpGetIndicePairs(mluOpHandle_t handle,
                     const mluOpTensorDescriptor_t indice_num_desc,
                     void *indice_num);
 
-// Group: SparseConv
+// Group:GetIndicePairs
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra workspace
  * to optimize the get_indice_pairs operation.
@@ -8620,7 +8433,7 @@ mluOpGetIndicePairsWorkspaceSize(mluOpHandle_t handle,
                                  const mluOpTensorDescriptor_t indice_num_desc,
                                  size_t *workspace_size);
 
-// Group: ActiveRotatedFilter
+// Group:ActiveRotatedFilterForward
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize ::mluOpActiveRotatedFilterForward. The size of the extra
@@ -8666,7 +8479,7 @@ mluOpGetActiveRotatedFilterForwardWorkspaceSize(const mluOpHandle_t handle,
                                                 const mluOpTensorDescriptor_t input_desc,
                                                 size_t *workspace_size);
 
-// Group: ActiveRotatedFilter
+// Group:ActiveRotatedFilterForward
 /*!
  * @brief Rotates \b input according to \b indices. This function encodes
  * the orientation information and generates orientation-sensitive features.
@@ -8755,229 +8568,7 @@ mluOpActiveRotatedFilterForward(const mluOpHandle_t handle,
                                 const mluOpTensorDescriptor_t output_desc,
                                 void *output);
 
-/*!
- * @brief Enumeration variables describing the attributes of the AdamW computation.
- */
-typedef enum {
-  MLUOP_ADAMW_WEIGHT_DECAY = 0,
-  /*!< Set the weight_decay attribute for the AdamW operation. */
-  MLUOP_ADAMW_GRAD_SCALE = 1,
-  /*!< Set the grad_scale attribute for the AdamW operation. */
-  MLUOP_ADAMW_USE_NESTEROV = 2,
-  /*!< Specifies whether to use nesterov on the AdamW operation. */
-} mluOpAdamWDescAttribute_t;
-
-typedef struct mluOpAdamWStruct *mluOpAdamWDescriptor_t;
-
-// Group: AdamW
-/*!
- * @brief Updates each attribute by using AdamW.
- *
- * @param[in] handle
- * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices
- * and queues in the AdamW operation. For detailed information,
- * see ::mluOpHandle_t.
- * @param[in] adamw_desc
- * A host pointer to the AdamW descriptor that holds information about the AdamW operation.
- * @param[in] param_desc
- * The descriptor of the tensor, which contains the dimension and layout of param.
- * For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] param
- * Pointer to the MLU memory that stores the param tensor.
- * @param[in] paramh_desc
- * The descriptor of the tensor, which contains the dimension and layout of param_h.
- * For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] param_h
- * Pointer to the MLU memory that stores the param_h tensor.
- * @param[in] momentum_desc
- * The descriptor of the tensor, which contains the dimension and layout of momentum.
- * For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] momentum
- * Pointer to the MLU memory that stores the momentum tensor.
- * @param[in] velocity_desc
- * The descriptor of the tensor, which contains the dimension and layout of velocity.
- * For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] velocity
- * Pointer to the MLU memory that stores the velocity tensor.
- * @param[in] grad_desc
- * The descriptor of the tensor, which contains the dimension and layout of grad.
- * For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] grad
- * Pointer to the MLU memory that stores the grad tensor.
- * @param[in] lr
- * A scalar of lr factor that is used for AdamW.
- * @param[in] beta1
- * A scalar of beta1 factor that is used for AdamW.
- * @param[in] beta2
- * A scalar of beta2 factor that is used for AdamW.
- * @param[in] bias1
- * A scalar of bias1 factor that is used for AdamW.
- * @param[in] bias2
- * A scalar of bias2 factor that is used for AdamW.
- * @param[in] epsilon
- * A scalar of epsilon factor that is used for AdamW.
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ARCH_MISMATCH
- *
- * @par Data Type
- * - The supported data types of input and output tensors are as follows:
- *   - param tensor: float
- *   - param_h tensor: bfloat16
- *   - momentum tensor: float
- *   - velocity tensor: float
- *   - grad tensor: bfloat16
- *
- * @par Data Layout
- * - The supported data layouts of \b param tensor, \b param_h tensor, \b momentum tensor, \b velocity tensor, and \b
- * grad tensor are as follows:
- *   - param tensor: \p MLUOP_LAYOUT_ARRAY
- *   - param_h tensor: \p MLUOP_LAYOUT_ARRAY
- *   - momentum tensor: \p MLUOP_LAYOUT_ARRAY
- *   - velocity tensor: \p MLUOP_LAYOUT_ARRAY
- *   - grad tensor: \p MLUOP_LAYOUT_ARRAY
- *
- * @par Scale Limitation
- * - None.
- *
- * @par API Dependency
- * - None.
- *
- * @par Note
- * - None.
- *
- * @par Example
- * - None.
- *
- * @par Reference
- * - https://github.com/OpenBMB/BMTrain/blob/6abcf772aa1e120192f7656e55c4adbcde53c886/csrc/cuda/adam_cuda.cu
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpAdamW(mluOpHandle_t handle,
-           mluOpAdamWDescriptor_t adamw_desc,
-           const mluOpTensorDescriptor_t param_desc,
-           void *param,
-           const mluOpTensorDescriptor_t paramh_desc,
-           void *param_h,
-           const mluOpTensorDescriptor_t momentum_desc,
-           void *momentum,
-           const mluOpTensorDescriptor_t velocity_desc,
-           void *velocity,
-           const mluOpTensorDescriptor_t grad_desc,
-           void *grad,
-           const float lr,
-           const float beta1,
-           const float beta2,
-           const float bias1,
-           const float bias2,
-           const float epsilon);
-
-// Group: AdamW
-/*!
- * @brief Creates a descriptor pointed by \p adamw_desc for AdamW operation.
- * The information is defined in ::mluOpAdamWDescriptor_t.
- * For more information about the descriptor, see "Cambricon MLU-OPS User Guide".
- *
- * @param[out] adamw_desc
- * A host pointer to the AdamW descriptor that holds information about the
- * AdamW operation.
- *
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ALLOC_FAILED
- *
- * @par API Dependency
- * - After calling this function, call ::mluOpSetAdamWDescAttr function to initialize
- *   and set the information to the AdamW descriptor.
- *
- * @par Note
- * - None.
- *
- * @par Requirements
- * - None.
- *
- * @par Example
- * - None.
- *
- * @par Reference
- * - None.
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpCreateAdamWDescriptor(mluOpAdamWDescriptor_t *adamw_desc);
-
-// Group: AdamW
-/*!
- * @brief Initializes the descriptor \b adamw_desc that was previously created with
- * ::mluOpCreateAdamWDescriptor function, and sets AdamW information
- * to the descriptor \b adamw_desc. The information includes \b weight_decay , \b grad_scale
- * and \b use_nesterov for AdamW operation.
- *
- * @param[in] adamw_desc
- * The descriptor of the AdamW operation. For detailed information,
- * see ::mluOpAdamWDescriptor_t.
- * @param[in] attr
- * Attribute of AdamW descriptor to be set. For detailed information,
- * see ::mluOpAdamWDescAttribute_t.
- * @param[in] buf
- * A host pointer to the attribute value set by this function.
- * @param[in] size_in_bytes
- * Buffer in bytes for verification.
- *
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
- *
- * @par Data Type
- * - None.
- *
- * @par Data Layout
- * - None.
- *
- * @par Scale Limitation
- * - None.
- *
- * @par API Dependency
- * - This function should be called after ::mluOpCreateAdamWDescriptor.
- *
- * @par Note
- * - None.
- *
- * @par Example
- * - None.
- *
- * @par Reference
- * - None.
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpSetAdamWDescAttr(mluOpAdamWDescriptor_t adamw_desc,
-                      mluOpAdamWDescAttribute_t attr,
-                      const void *buf,
-                      const size_t size_in_bytes);
-
-// Group: AdamW
-/*!
- * @brief Destroys the AdamW descriptor \p adamw_desc that was previously created by
- * ::mluOpCreateAdamWDescriptor.
- *
- * @param[in] adamw_desc
- *   The AdamW descriptor to be destroyed.
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
- *
- * @par Note
- * - Call this function after calling ::mluOpAdamW.
- * - It is necessary to call this function to destroy the AdamW descriptor to avoid memory leak.
- *
- * @par Requirements
- * - None.
- *
- * @par Example
- * - None.
- *
- * @par Reference
- * - None
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpDestroyAdamWDescriptor(mluOpAdamWDescriptor_t adamw_desc);
-
-// Group: DeformRoiPool
+// Group:DeformRoiPool
 /*!
  * @brief Computes deformable roi pooling over \b input tensor. This function firstly divides the obtained
  * candidate region into regions with the same size according to the specified pooling width and pooling height,
@@ -9088,7 +8679,7 @@ mluOpDeformRoiPoolForward(const mluOpHandle_t handle,
                           const mluOpTensorDescriptor_t output_desc,
                           void *output);
 
-// Group: DeformRoiPool
+// Group:DeformRoiPool
 /*!
  * @brief Computes the gradient of input \b grad_input and the gradient of offset \b grad_offset
  * based on the gradient of output \b grad_output , input \b input , ROI \b rois , and offset \b offset.
@@ -9206,7 +8797,7 @@ mluOpDeformRoiPoolBackward(const mluOpHandle_t handle,
                            const mluOpTensorDescriptor_t grad_offset_desc,
                            void *grad_offset);
 
-// Group: BorderAlign
+// Group:BorderAlign
 /*!
  * @brief Extracts the border features of \b input based on the bounding boxes
  * to compute the maximum border features of \b input with the maximum pooling.
@@ -9355,7 +8946,7 @@ mluOpBorderAlignForward(mluOpHandle_t handle,
                         const mluOpTensorDescriptor_t argmax_idx_desc,
                         void *argmax_idx);
 
-// Group: BorderAlign
+// Group:BorderAlign
 /*!
  * @brief Computes the gradient of the input tensor of ::mluOpBorderAlignForward
  * according to the output gradient \b grad_output , the maximum pooling index \b
@@ -9498,7 +9089,7 @@ mluOpBorderAlignBackward(mluOpHandle_t handle,
                          const mluOpTensorDescriptor_t grad_input_desc,
                          void *grad_input);
 
-// Group: SparseConv
+// Group:IndiceConvolutionBackwardData
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as
  * an extra workspace to optimize the indice convolution backward data operation.
@@ -9571,7 +9162,7 @@ mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(mluOpHandle_t handle,
                                                    const int64_t inverse,
                                                    size_t *workspace_size);
 
-// Group: SparseConv
+// Group:IndiceConvolutionBackwardData
 /*!
  * @brief Performs the back propagation of an indice convolution operation to
  * compute the gradient of input \b input_grad based on the gradient of response
@@ -9711,7 +9302,7 @@ mluOpIndiceConvolutionBackwardData(mluOpHandle_t handle,
                                    const mluOpTensorDescriptor_t input_grad_desc,
                                    void *input_grad);
 
-// Group: SparseConv
+// Group:IndiceConvolutionBackwardFilter
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra workspace
  * to optimize the indice_convolution_backward_filter operation.
@@ -9784,7 +9375,7 @@ mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(mluOpHandle_t handle,
                                                      const int64_t sub_m,
                                                      size_t *workspace_size);
 
-// Group: SparseConv
+// Group:IndiceConvolutionBackwardFilter
 /*!
  * @brief Computes the indice_convolution_backward_filter operation, then returns the results in the output
  * tensor \b filters_grad.
@@ -9885,7 +9476,7 @@ mluOpIndiceConvolutionBackwardFilter(mluOpHandle_t handle,
                                      const mluOpTensorDescriptor_t filters_grad_desc,
                                      void *filters_grad);
 
-// Group: RoiPointPool3d
+// Group:RoiPointPool3d
 /*!
  * @brief Returns in \b size the size of the MLU memory in bytes that is used as
  * an extra workspace to optimize ::mluOpRoiPointPool3d.
@@ -9964,7 +9555,7 @@ mluOpGetRoiPointPool3dWorkspaceSize(mluOpHandle_t handle,
                                     const mluOpTensorDescriptor_t pooled_empty_flag_desc,
                                     size_t *size);
 
-// Group: RoiPointPool3d
+// Group:RoiPointPool3d
 /*!
  * @brief Implements a linear interpolation of two tensors \b a and \b b based on
  * a scalar or tensor \b w and returns the results in \b d tensor.
@@ -10065,7 +9656,7 @@ mluOpRoiPointPool3d(mluOpHandle_t handle,
                     const mluOpTensorDescriptor_t pooled_empty_flag_desc,
                     void *pooled_empty_flag);
 
-// Group: ThreeNN
+// Group:ThreeNNForward
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize ::mluOpThreeNNForward. The size of the extra workspace is
@@ -10111,7 +9702,7 @@ mluOpGetThreeNNForwardWorkspaceSize(const mluOpHandle_t handle,
                                     const mluOpTensorDescriptor_t known_desc,
                                     size_t *workspace_size);
 
-// Group: ThreeNN
+// Group:ThreeNNForward
 /*!
  * @brief Finds the closest 3 points of \b unknown among \b known, and outputs \b dist and index
  * \b idx tensor. This function firstly computes dist of each known point to a unknown point, and
@@ -10193,7 +9784,7 @@ mluOpThreeNNForward(const mluOpHandle_t handle,
                     const mluOpTensorDescriptor_t idx_desc,
                     void *idx);
 
-// Group: SparseConv
+// Group:IndiceConvolutionForward
 /*!
  * @brief Returns in \b workspace_size of the MLU memory which is used as an extra workspace
  * to boost up indice_convolution_forward computation.
@@ -10269,7 +9860,7 @@ mluOpGetIndiceConvolutionForwardWorkspaceSize(mluOpHandle_t handle,
                                               const int64_t sub_m,
                                               size_t *workspace_size);
 
-// Group: SparseConv
+// Group:IndiceConvolutionForward
 /*!
  * @brief Performs convolution on input sparse tensor \b features with kernel \b filters,
  * then returns the output sparse tensor \b features_out.
@@ -10386,7 +9977,7 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
                               const mluOpTensorDescriptor_t features_out_desc,
                               void *features_out);
 
-// Group: MoeDispatch
+// Group:MoeDispatchForward
 /*!
  * @brief Dispatches the order of \b input tensor, and returns the
  * results in the output tensor \b dispatch in the MoE algorithm.
@@ -10492,7 +10083,7 @@ mluOpMoeDispatchForward(mluOpHandle_t handle,
                         const mluOpTensorDescriptor_t dispatch_desc,
                         void *dispatch);
 
-// Group: MoeDispatch
+// Group:MoeDispatchBackwardGate
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra workspace
  * to optimize the moe_dispatch_backward_gate operation.
@@ -10539,7 +10130,7 @@ mluOpGetMoeDispatchBackwardGateWorkspaceSize(mluOpHandle_t handle,
                                              const mluOpTensorDescriptor_t input_desc,
                                              size_t *workspace_size);
 
-// Group: MoeDispatch
+// Group:MoeDispatchBackwardGate
 /*!
  * @brief Calculates the inverse gradient of \b gates tensor, and returns the results in the output
  * tensor \b grad_gates.
@@ -10654,7 +10245,7 @@ mluOpMoeDispatchBackwardGate(mluOpHandle_t handle,
                              const mluOpTensorDescriptor_t grad_gates_desc,
                              void *grad_gates);
 
-// Group: PointsInBoxes
+// Group:PointsInBoxes
 /*!
  * @brief Detects the first 3D box that each point belongs to in given points cloud data.
  *
@@ -10695,7 +10286,7 @@ mluOpMoeDispatchBackwardGate(mluOpHandle_t handle,
  *
  * @par Scale Limitation
  * - On MLU370, the number of boxes cannot exceed 23404;
- *   On series higher than MLU300 series, the number of boxes cannot exceed 14042.
+ *   On MLU590, the number of boxes cannot exceed 14042.
  *
  * @par API Dependency
  * - None.
@@ -10719,7 +10310,7 @@ mluOpPointsInBoxes(mluOpHandle_t handle,
                    const mluOpTensorDescriptor_t points_indices_desc,
                    void *points_indices);
 
-// Group: RoiAlign
+// Group:RoiAlignBackward
 /*!
  * @brief Computes the gradients of images \b grads_image using the gradients \b grads and
  * bounding boxes \b boxes to perform the backpropagation of ::mluOpRoiAlignForward_v2
@@ -10815,7 +10406,7 @@ mluOpRoiAlignBackward(mluOpHandle_t handle,
                       const mluOpTensorDescriptor_t grads_image_desc,
                       void *grads_image);
 
-// Group: RoiAlign
+// Group:RoiAlignBackward
 /*!
  * @brief Computes the gradients of images \b grads_image based on the gradients \b grads,
  * bounding boxes \b boxes, the coordinate of x axis \b argmax_x, and the coordinate of y axis
@@ -10953,7 +10544,7 @@ mluOpRoiAlignBackward_v2(mluOpHandle_t handle,
                          const mluOpTensorDescriptor_t grads_image_desc,
                          void *grads_image);
 
-// Group: MsDeformAttn
+// Group:MsDeformAttnForward
 /*!
  * @brief Implements a multi-scale deformable attention module used in Deformable-Detr.
  * For detailed information about Deformable-Detr, see "Deformable DETR: Deformable
@@ -11032,7 +10623,7 @@ mluOpMsDeformAttnForward(mluOpHandle_t handle,
                          const mluOpTensorDescriptor_t data_col_desc,
                          void *data_col);
 
-// Group: TinShift
+// Group:TinShift
 /*!
  * @brief Shifts gradients from \b grad_output according to shift information in \b shifts and stores the
  * result into \b grad_input.
@@ -11096,7 +10687,7 @@ mluOpTinShiftBackward(mluOpHandle_t handle,
                       const mluOpTensorDescriptor_t grad_input_desc,
                       void *grad_input);
 
-// Group: TinShift
+// Group:TinShift
 /*!
  * @brief Shifts datas from \b input according to shift information in \b shifts and stores the
  * result into \b output.
@@ -11160,7 +10751,7 @@ mluOpTinShiftForward(mluOpHandle_t handle,
                      const mluOpTensorDescriptor_t output_desc,
                      void *output);
 
-// Group: MaskedIm2col
+// Group:MaskedCol2im
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra workspace to
  * optimize the MaskedCol2imForward operation.
@@ -11215,7 +10806,7 @@ mluOpGetMaskedCol2imForwardWorkspaceSize(mluOpHandle_t handle,
                                          const mluOpTensorDescriptor_t im_desc,
                                          size_t *workspace_size);
 
-// Group: MaskedIm2col
+// Group:MaskedCol2im
 /*!
  * @brief  Copies the data of the input tensor \b col to the special coordinates by combining \b mask_h_idx tensor
  * and \b mask_w_idx tensor of output tensor \b im.
@@ -11307,7 +10898,7 @@ mluOpMaskedCol2imForward(mluOpHandle_t handle,
                          const mluOpTensorDescriptor_t im_desc,
                          void *im);
 
-// Group: DiffIouRotatedSortVertices
+// Group:DiffIouRotatedSortVerticesForward
 /*!
  * @brief Sorts the effective vertices of the polygon formed by the intersection of two boxes,
  * and outputs the sorted vertex index.
@@ -11379,7 +10970,7 @@ mluOpDiffIouRotatedSortVerticesForward(mluOpHandle_t handle,
                                        const mluOpTensorDescriptor_t idx_desc,
                                        void *idx);
 
-// Group: RoiPooling
+// Group:RoiPoolingForward
 /*!
  * @brief Generates a fixed size feature map and input feature index
  * of argmax for each ROI (Regions of Interest) to perform ::mluOpRoiPoolingForward operation.
@@ -11526,7 +11117,7 @@ mluOpRoiPoolingForward(mluOpHandle_t handle,
                        void *output,
                        int *argmax);
 
-// Group: RoiPooling
+// Group:RoiPoolingBackward
 /*!
  * @brief Computes the gradients of image \b grads_image based on the gradients \b grads and
  * region proposals \b rois to perform the backpropagation of ::mluOpRoiPoolingForward operation.
@@ -11628,7 +11219,7 @@ mluOpRoiPoolingBackward(mluOpHandle_t handle,
                         const mluOpTensorDescriptor_t grads_image_desc,
                         void *grads_image);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchNormStats
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize ::mluOpSyncBatchNormStats_v2 operation.
@@ -11676,7 +11267,7 @@ mluOpGetSyncBatchNormStatsWorkspaceSize(mluOpHandle_t handle,
                                         const mluOpTensorDescriptor_t x_desc,
                                         size_t *workspace_size);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchNormStats
 /*!
  * @brief Computes the local mean and the local inverse standard deviation for each channel
  * across a batch of data in the training scenario.
@@ -11771,7 +11362,7 @@ mluOpSyncBatchNormStats_v2(mluOpHandle_t handle,
                            const mluOpTensorDescriptor_t invstd_desc,
                            void *invstd);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchNormStats
 /*!
  * @brief Computes the local mean and the local inverse standard deviation for each channel
  * across a batch of data in the training scenario.
@@ -11855,7 +11446,7 @@ mluOpSyncBatchNormStats(mluOpHandle_t handle,
                         const mluOpTensorDescriptor_t invstd_desc,
                         void *invstd);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchNormGatherStatsWithCounts
 /*!
  * @brief Computes the global mean and the global inverse standard deviation across aggregation
  * of the local mean and local inverse standard deviation of multiple MLU devices.
@@ -11984,7 +11575,7 @@ mluOpSyncBatchNormGatherStatsWithCounts(mluOpHandle_t handle,
                                         const mluOpTensorDescriptor_t invstd_desc,
                                         void *invstd);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchNormElemt
 /*!
  * @brief Applies Batch Normalization for each channel across a batch of data with the given mean,
  *        inverse variance and scaling factors.
@@ -12098,13 +11689,13 @@ mluOpSyncBatchNormElemt(mluOpHandle_t handle,
                         const mluOpTensorDescriptor_t y_desc,
                         void *y);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchnormBackwardReduce
 /*!
  * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize the sync_batchnorm_backward_reduce operation.
  *
  * The size of extra workspace is based on the given information of
- * ::mluOpSyncBatchNormBackwardReduce_v2 operation, including the input tensor descriptor \b x_desc.
+ * ::mluOpSyncBatchnormBackwardReduce_v2 operation, including the input tensor descriptor \b x_desc.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in the mse_loss
@@ -12114,7 +11705,7 @@ mluOpSyncBatchNormElemt(mluOpHandle_t handle,
  * ::mluOpTensorDescriptor_t.
  * @param[out] workspace_size
  * Pointer to the returned size of the extra workspace in bytes that is used in
- * ::mluOpSyncBatchNormBackwardReduce_v2 operation.
+ * ::mluOpSyncBatchnormBackwardReduce_v2 operation.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
@@ -12132,61 +11723,8 @@ mluOpSyncBatchNormElemt(mluOpHandle_t handle,
  * - None.
  *
  * @par note
- * - This API is only used along with ::mluOpSyncBatchNormBackwardReduce_v2.
- * - ::mluOpSyncBatchNormBackwardReduce does not require this API.
- *
- * @par Example
- * - None.
- *
- * @par Reference
- * - None.
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpGetSyncBatchNormBackwardReduceWorkspaceSize(mluOpHandle_t handle,
-                                                 const mluOpTensorDescriptor_t x_desc,
-                                                 size_t *workspace_size);
-
-// Group: Deprecated APIs
-/*!
- * @brief Returns in \b workspace_size the size of the MLU memory that is used as an extra
- * workspace to optimize the sync_batchnorm_backward_reduce operation.
- *
- * The size of extra workspace is based on the given information of
- * ::mluOpSyncBatchNormBackwardReduce_v2 operation, including the input tensor descriptor \b x_desc.
- *
- * @par Deprecated
- * - ::mluOpGetSyncBatchnormBackwardReduceWorkspaceSize is deprecated and will be
- *   removed in the future release. It is recommended to use
- *   ::mluOpGetSyncBatchNormBackwardReduceWorkspaceSize instead.
- *
- * @param[in] handle
- * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in the mse_loss
- * operation. For detailed information, see ::mluOpHandle_t.
- * @param[in] x_desc
- * The descriptor of the input tensor. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[out] workspace_size
- * Pointer to the returned size of the extra workspace in bytes that is used in
- * ::mluOpSyncBatchNormBackwardReduce_v2 operation.
- *
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
- *
- * @par Data Type
- * - None.
- *
- * @par Data Layout
- * - None.
- *
- * @par Scale Limitation
- * - None.
- *
- * @par API Dependency
- * - None.
- *
- * @par note
- * - This API is only used along with ::mluOpSyncBatchNormBackwardReduce_v2.
- * - ::mluOpSyncBatchNormBackwardReduce does not require this API.
+ * - This API is only used along with ::mluOpSyncBatchnormBackwardReduce_v2.
+ * - ::mluOpSyncBatchnormBackwardReduce does not require this API.
  *
  * @par Example
  * - None.
@@ -12199,7 +11737,7 @@ mluOpGetSyncBatchnormBackwardReduceWorkspaceSize(mluOpHandle_t handle,
                                                  const mluOpTensorDescriptor_t x_desc,
                                                  size_t *workspace_size);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchnormBackwardReduce
 /*!
  * @brief Applies Synchronized Batch Normalization Reduce operator to backwardly compute grad
  * filters, grad bias, sum_dy and sum_dy_xmu on each MLU device.
@@ -12207,13 +11745,13 @@ mluOpGetSyncBatchnormBackwardReduceWorkspaceSize(mluOpHandle_t handle,
  * Batch Normalization is used in convolution network, including but not limited to
  * ResNet (Residual Network), Yolo (You Only Look Once) and R-CNN (Regions with CNN features).
  *
- * Compared with ::mluOpSyncBatchNormBackwardReduce, this function allows you to allocate some extra
+ * Compared with ::mluOpSyncBatchnormBackwardReduce, this function allows you to allocate some extra
  * workspace as an input parameter. If you just set \b workspace to NULL and \b workspace_size to 0,
- * this function will perform as same as ::mluOpSyncBatchNormBackwardReduce.
+ * this function will perform as same as ::mluOpSyncBatchnormBackwardReduce.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
- * ::mluOpSyncBatchNormBackwardReduce_v2 operation. For detailed information, see ::mluOpHandle_t.
+ * ::mluOpSyncBatchnormBackwardReduce_v2 operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] desc_dz
  * The descriptor of the input tensor \b dz. For detailed information, see
  * ::mluOpTensorDescriptor_t.
@@ -12237,11 +11775,11 @@ mluOpGetSyncBatchnormBackwardReduceWorkspaceSize(mluOpHandle_t handle,
  * standard deviation of input \b x.
  * @param[in] workspace
  * Pointer to the MLU memory that is used as an extra workspace for
- * ::mluOpSyncBatchNormBackwardReduce_v2.
+ * ::mluOpSyncBatchnormBackwardReduce_v2.
  * @param[in] workspace_size
  * The size of the extra workspace in bytes that needs to be used in
- * the ::mluOpSyncBatchNormBackwardReduce_v2. You can get the size of the workspace with
- * the ::mluOpGetSyncBatchNormBackwardReduceWorkspaceSize function.
+ * the ::mluOpSyncBatchnormBackwardReduce_v2. You can get the size of the workspace with
+ * the ::mluOpGetSyncBatchnormBackwardReduceWorkspaceSize function.
  * @param[out] desc_dfilter
  * The descriptor of \b dfilters tensor. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] dfilter
@@ -12309,8 +11847,8 @@ mluOpGetSyncBatchnormBackwardReduceWorkspaceSize(mluOpHandle_t handle,
  * - None.
  *
  * @par API Dependency
- * - Before calling this function to perform ::mluOpSyncBatchNormBackwardReduce_v2, you need to get
- *   the size of workspace by ::mluOpGetSyncBatchNormBackwardReduceWorkspaceSize.
+ * - Before calling this function to perform ::mluOpSyncBatchnormBackwardReduce_v2, you need to get
+ *   the size of workspace by ::mluOpGetSyncBatchnormBackwardReduceWorkspaceSize.
  *
  * @par note
  * - The \b mean, \b invstd, \b dfilter, \b bias, \b sum_dy and \b sum_dy_xmu must be 1D tensors
@@ -12319,184 +11857,7 @@ mluOpGetSyncBatchnormBackwardReduceWorkspaceSize(mluOpHandle_t handle,
  * - The length of each dimension of \b x and \b dz must be the same.
  *
  * @par Example
- * - The example of ::mluOpSyncBatchNormBackwardReduce_v2 operation is as follows:
-     @verbatim
-      input four arrays by 1 * 2 * 3 * 2, 2, 2, 2 and 2
-      --> dz: [[[[6.0, 6.0],[6.0, 6.0],[6.0, 6.0]],
-               [[6.0, 6.0],[6.0, 6.0],[6.0, 6.0]]]]
-
-      --> x: [[[[3.0, 3.0],[3.0, 3.0],[3.0, 3.0]],
-               [[3.0, 3.0],[3.0, 3.0],[3.0, 3.0]]]]
-
-      --> mean: [1, 1]
-
-      --> invstd: [0.8, 0.8]
-
-      output array by 2
-      --> dfilter: [57.6, 57.6]
-
-      --> dbias: [36.0, 36.0]
-
-      --> sum_dy: [36.0, 36.0]
-
-      --> sum_dy_xmu: [72.0, 72.0]
-     @endverbatim
- *
- * @par Reference
- * - Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift,
- *   Sergey Ioffe, 2015.
- *
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpSyncBatchNormBackwardReduce_v2(mluOpHandle_t handle,
-                                    const mluOpTensorDescriptor_t desc_dz,
-                                    const void *dz,
-                                    const mluOpTensorDescriptor_t desc_x,
-                                    const void *x,
-                                    const mluOpTensorDescriptor_t desc_mean,
-                                    const void *mean,
-                                    const mluOpTensorDescriptor_t desc_invstd,
-                                    const void *invstd,
-                                    void *workspace,
-                                    size_t workspace_size,
-                                    const mluOpTensorDescriptor_t desc_dfilter,
-                                    void *dfilter,
-                                    const mluOpTensorDescriptor_t desc_dbias,
-                                    void *dbias,
-                                    const mluOpTensorDescriptor_t desc_sum_dy,
-                                    void *sum_dy,
-                                    const mluOpTensorDescriptor_t desc_sum_dy_xmu,
-                                    void *sum_dy_xmu,
-                                    const bool needs_input_grad0,
-                                    const bool needs_input_grad1,
-                                    const bool needs_input_grad2);
-
-// Group: Deprecated APIs
-/*!
- * @brief Applies Synchronized Batch Normalization Reduce operator to backwardly compute grad
- * filters, grad bias, sum_dy and sum_dy_xmu on each MLU device.
- *
- * Batch Normalization is used in convolution network, including but not limited to
- * ResNet (Residual Network), Yolo (You Only Look Once) and R-CNN (Regions with CNN features).
- *
- * Compared with ::mluOpSyncBatchNormBackwardReduce, this function allows you to allocate some extra
- * workspace as an input parameter. If you just set \b workspace to NULL and \b workspace_size to 0,
- * this function will perform as same as ::mluOpSyncBatchNormBackwardReduce.
- *
- * @par Deprecated
- * - ::mluOpSyncBatchnormBackwardReduce_v2 is deprecated and will be
- *   removed in the future release. It is recommended to use
- *   ::mluOpSyncBatchNormBackwardReduce_v2 instead.
- *
- * @param[in] handle
- * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
- * ::mluOpSyncBatchNormBackwardReduce_v2 operation. For detailed information, see ::mluOpHandle_t.
- * @param[in] desc_dz
- * The descriptor of the input tensor \b dz. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[in] dz
- * Pointer to the MLU memory that stores the tensor \b dz, which denotes the partial
- * derivative of batch normalization forward output.
- * @param[in] desc_x
- * The descriptor of the input tensor \b x. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[in] x
- * Pointer to the MLU memory that stores the input tensor \b x.
- * @param[in] desc_mean
- * The descriptor of \b mean tensor. For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] mean
- * Pointer to the MLU memory that stores the tensor \b mean, which denotes the average
- * result of input \b x.
- * @param[in] desc_invstd
- * The descriptor of \b invstd tensor. For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] invstd
- * Pointer to the MLU memory that stores the tensor \b invstd, which denotes the inversed
- * standard deviation of input \b x.
- * @param[in] workspace
- * Pointer to the MLU memory that is used as an extra workspace for
- * ::mluOpSyncBatchNormBackwardReduce_v2.
- * @param[in] workspace_size
- * The size of the extra workspace in bytes that needs to be used in
- * the ::mluOpSyncBatchNormBackwardReduce_v2. You can get the size of the workspace with
- * the ::mluOpGetSyncBatchNormBackwardReduceWorkspaceSize function.
- * @param[out] desc_dfilter
- * The descriptor of \b dfilters tensor. For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[out] dfilter
- * Pointer to the MLU memory that stores the input tensor \b dfilters, which denotes
- * partial derivative of filter in sync batch normalization forward training. It will be computed
- * only if booleanvariable \b needs_input_grad1 is true.
- * @param[out] desc_dbias
- * The descriptor of the sync batch normalization output tensor \b dbias. For detailed
- * information, see ::mluOpTensorDescriptor_t.
- * @param[out] dbias
- * Pointer to the MLU memory that stores the output tensor \b dbias, which denotes partial
- * derivative of bias in sync batch normalization forward training. It will be computed
- * only if \b needs_input_grad2 is true.
- * @param[out] desc_sum_dy
- * The descriptor of the sync batch normalization output tensor \b sum_dy. For detailed
- * information, see ::mluOpTensorDescriptor_t.
- * @param[out] sum_dy
- * Pointer to the MLU memory that stores the output tensor \b sum_dy, which denotes the
- * summation of dz and is also an intermediate variable to compute the partial derivative of
- * input x. Moreover, it will be computed only if boolean variable \b needs_input_grad0 is true.
- * @param[out] desc_sum_dy_xmu
- * The descriptor of the sync batch normalization output tensor \b sum_dy_xmu. For detailed
- * information, see ::mluOpTensorDescriptor_t.
- * @param[out] sum_dy_xmu
- * Pointer to the MLU memory that stores the output tensor \b sum_dy_xmu, which denotes
- * sum{dz(x-mean)}. It is also an intermediate variable to compute the partial derivative of
- * input \b x. Moreover, it will be computed only if boolean variable \b needs_input_grad0 is
- * true.
- * @param[in] needs_input_grad0
- * A boolean variable that determines whether to compute \b sum_dy and \b sum_dy_xmu.
- * When \b needs_input_grad0 is true, \b sum_dy and \b sum_dy_xmu will be computed.
- * When \b needs_input_grad0 is false, \b sum_dy and \b sum_dy_xmu will be NULL.
- * @param[in] needs_input_grad1
- * A boolean variable that determines whether to compute \b dfilters.
- * When \b needs_input_grad1 is true, \b dfilters will be computed.
- * When \b needs_input_grad1 is false, \b dfilter will be NULL.
- * @param[in] needs_input_grad2
- * A boolean variable that determines whether to compute \b dbias.
- * When \b needs_input_grad2 is true, \b dbias will be computed.
- * When \b needs_input_grad2 is false, \b dbias will be NULL.
- *
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_BAD_PARAM
- *
- * @par Data Type
- * - The supported combinations of data types are shown below with the following order:
- *   - dz_tensor - x_tensor - mean_tensor - invstd_tensor - dfilter_tensor - dbias_tensor -
- *   sum_dy_tensor - sum_dy_xmu_tensor
- *   - float - float - float - float - float - float - float - float.
- *   - half - half - float - float - float - float - float - float.
- *
- * @par Data Layout
- * - The supported data layout of \b dz, \b x, \b mean, \b invstd, \b dfilter, \b dbias, \b sum_dy
- *   and \b sum_dy_xmu is as follows:
- *   - dz tensor: \p MLUOP_LAYOUT_NDHWC, \p MLUOP_LAYOUT_NHWC, \p MLUOP_LAYOUT_NLC, \p MLUOP_LAYOUT_NC.
- *   - x tensor: \p MLUOP_LAYOUT_NDHWC, \p MLUOP_LAYOUT_NHWC, \p MLUOP_LAYOUT_NLC, \p MLUOP_LAYOUT_NC.
- *   - mean tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - invstd tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - dfilter tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - dbias tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - sum_dy tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - sum_dy_xmu tensor: \p MLUOP_LAYOUT_ARRAY.
- *
- * @par Scale Limitation
- * - None.
- *
- * @par API Dependency
- * - Before calling this function to perform ::mluOpSyncBatchNormBackwardReduce_v2, you need to get
- *   the size of workspace by ::mluOpGetSyncBatchNormBackwardReduceWorkspaceSize.
- *
- * @par note
- * - The \b mean, \b invstd, \b dfilter, \b bias, \b sum_dy and \b sum_dy_xmu must be 1D tensors
- *   and the length of the dimensions of these tensors should be the same as the length of
- *   the lowest dimension of \b x.
- * - The length of each dimension of \b x and \b dz must be the same.
- *
- * @par Example
- * - The example of ::mluOpSyncBatchNormBackwardReduce_v2 operation is as follows:
+ * - The example of ::mluOpSyncBatchnormBackwardReduce_v2 operation is as follows:
      @verbatim
       input four arrays by 1 * 2 * 3 * 2, 2, 2, 2 and 2
       --> dz: [[[[6.0, 6.0],[6.0, 6.0],[6.0, 6.0]],
@@ -12548,7 +11909,7 @@ mluOpSyncBatchnormBackwardReduce_v2(mluOpHandle_t handle,
                                     const bool needs_input_grad1,
                                     const bool needs_input_grad2);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchnormBackwardReduce
 /*!
  * @brief Applies Synchronized Batch Normalization Reduce operator to backwardly compute grad filters,
  * grad bias, sum_dy and sum_dy_xmu on each MLU device.
@@ -12558,7 +11919,7 @@ mluOpSyncBatchnormBackwardReduce_v2(mluOpHandle_t handle,
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in the
- * ::mluOpSyncBatchNormBackwardReduce operation. For detailed information, see ::mluOpHandle_t.
+ * ::mluOpSyncBatchnormBackwardReduce operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] desc_dz
  * The descriptor of the input tensor \b dz. For detailed information, see
  * ::mluOpTensorDescriptor_t.
@@ -12653,167 +12014,7 @@ mluOpSyncBatchnormBackwardReduce_v2(mluOpHandle_t handle,
  * - The length of each dimension of \b x and \b dz must be the same.
  *
  * @par Example
- * - The example of ::mluOpSyncBatchNormBackwardReduce operation is as follows:
-     @verbatim
-      input four arrays by 1 * 2 * 3 * 2, 2, 2, 2 and 2
-      --> dz: [[[[6.0, 6.0],[6.0, 6.0],[6.0, 6.0]],
-               [[6.0, 6.0],[6.0, 6.0],[6.0, 6.0]]]]
-
-      --> x: [[[[3.0, 3.0],[3.0, 3.0],[3.0, 3.0]],
-               [[3.0, 3.0],[3.0, 3.0],[3.0, 3.0]]]]
-
-      --> mean: [1, 1]
-
-      --> invstd: [0.8, 0.8]
-
-      output array by 2
-      --> dfilter: [57.6, 57.6]
-
-      --> dbias: [36.0, 36.0]
-
-      --> sum_dy: [36.0, 36.0]
-
-      --> sum_dy_xmu: [72.0, 72.0]
-     @endverbatim
- *
- * @par Reference
- * - Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift,
- *   Sergey Ioffe, 2015.
- *
- */
-mluOpStatus_t MLUOP_WIN_API
-mluOpSyncBatchNormBackwardReduce(mluOpHandle_t handle,
-                                 const mluOpTensorDescriptor_t desc_dz,
-                                 const void *dz,
-                                 const mluOpTensorDescriptor_t desc_x,
-                                 const void *x,
-                                 const mluOpTensorDescriptor_t desc_mean,
-                                 const void *mean,
-                                 const mluOpTensorDescriptor_t desc_invstd,
-                                 const void *invstd,
-                                 const mluOpTensorDescriptor_t desc_dfilter,
-                                 void *dfilter,
-                                 const mluOpTensorDescriptor_t desc_dbias,
-                                 void *dbias,
-                                 const mluOpTensorDescriptor_t desc_sum_dy,
-                                 void *sum_dy,
-                                 const mluOpTensorDescriptor_t desc_sum_dy_xmu,
-                                 void *sum_dy_xmu,
-                                 const bool needs_input_grad0,
-                                 const bool needs_input_grad1,
-                                 const bool needs_input_grad2);
-
-// Group: Deprecated APIs
-/*!
- * @brief Applies Synchronized Batch Normalization Reduce operator to backwardly compute grad filters,
- * grad bias, sum_dy and sum_dy_xmu on each MLU device.
- *
- * Batch Normalization is used in CNN, including but not limited to
- * ResNet (Residual Network), Yolo (You Only Look Once) and R-CNN (Regions with CNN features).
- *
- * @par Deprecated
- * - ::mluOpSyncBatchnormBackwardReduce is deprecated and will be
- *   removed in the future release. It is recommended to use
- *   ::mluOpSyncBatchNormBackwardReduce instead.
- *
- * @param[in] handle
- * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in the
- * ::mluOpSyncBatchNormBackwardReduce operation. For detailed information, see ::mluOpHandle_t.
- * @param[in] desc_dz
- * The descriptor of the input tensor \b dz. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[in] dz
- * Pointer to the MLU memory that stores the tensor \b dz, which denotes the partial derivative of
- * batch normalization forward output.
- * @param[in] desc_x
- * The descriptor of the input tensor \b x. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[in] x
- * Pointer to the MLU memory that stores the input tensor \b x.
- * @param[in] desc_mean
- * The descriptor of \b mean tensor. For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] mean
- * Pointer to the MLU memory that stores the tensor \b mean, which denotes the average result of
- * input \b x.
- * @param[in] desc_invstd
- * The descriptor of \b invstd tensor. For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[in] invstd
- * Pointer to the MLU memory that stores the tensor \b invstd, which denotes the inversed standard deviation
- * of input \b x.
- * @param[out] desc_dfilter
- * The descriptor of \b dfilter tensor. For detailed information, see ::mluOpTensorDescriptor_t.
- * @param[out] dfilter
- * Pointer to the MLU memory that stores the input tensor \b dfilter, which denotes partial derivative
- * of filter in sync batch normalization forward training. It will be computed only if boolean variable
- * \b needs_input_grad1 is true.
- * @param[out] desc_dbias
- * The descriptor of the sync batch normalization output tensor \b dbias. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[out] dbias
- * Pointer to the MLU memory that stores the output tensor \b dbias, which denotes partial derivative of
- * bias in sync batch normalization forward training. It will be computed only if \b needs_input_grad2 is true.
- * @param[out] desc_sum_dy
- * The descriptor of the sync batch normalization output tensor \b sum_dy. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[out] sum_dy
- * Pointer to the MLU memory that stores the output tensor \b sum_dy, which denotes the summation of dz
- * and is also an intermediate variable to compute the partial derivative of input x. Moreover, it will be
- * computed only if boolean variable \b needs_input_grad0 is true.
- * @param[out] desc_sum_dy_xmu
- * The descriptor of the sync batch normalization output tensor \b sum_dy_xmu. For detailed information, see
- * ::mluOpTensorDescriptor_t.
- * @param[out] sum_dy_xmu
- * Pointer to the MLU memory that stores the output tensor \b sum_dy_xmu, which denotes sum{dz(x-mean)}.
- * It is also an intermediate variable to compute the partial derivative of
- * input \b x. Moreover, it will be computed only if boolean variable \b needs_input_grad0 is true.
- * @param[in] needs_input_grad0
- * A boolean variable that determines whether to compute \b sum_dy and \b sum_dy_xmu.
- * When \b needs_input_grad0 is true, \b sum_dy and \b sum_dy_xmu will be computed.
- * When \b needs_input_grad0 is false, \b sum_dy and \b sum_dy_xmu will be NULL.
- * @param[in] needs_input_grad1
- * A boolean variable that determines whether to compute \b dfilters.
- * When \b needs_input_grad1 is true, \b dfilters will be computed.
- * When \b needs_input_grad1 is false, \b dfilter will be NULL.
- * @param[in] needs_input_grad2
- * A boolean variable that determines whether to compute \b dbias.
- * When \b needs_input_grad2 is true, \b dbias will be computed.
- * When \b needs_input_grad2 is false, \b dbias will be NULL.
- *
- * @par Return
- * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_ARCH_MISMATCH, ::MLUOP_STATUS_BAD_PARAM
- *
- * @par Data Type
- * - The supported combinations of data types are shown below with the following order:
- *   - dz_tensor - x_tensor - mean_tensor - invstd_tensor - dfilter_tensor - dbias_tensor - sum_dy_tensor
- *   - sum_dy_xmu_tensor
- *   - float - float - float - float - float - float - float - float.
- *   - half - half - float - float - float - float - float - float.
- *
- * @par Data Layout
- * - The supported data layout of \b dz, \b x, \b mean, \b invstd, \b dfilter, \b dbias, \b sum_dy and
- *   \b sum_dy_xmu is as follows:
- *   - dz tensor: \p MLUOP_LAYOUT_NDHWC, \p MLUOP_LAYOUT_NHWC, \p MLUOP_LAYOUT_NLC, \p MLUOP_LAYOUT_NC.
- *   - x tensor: \p MLUOP_LAYOUT_NDHWC, \p MLUOP_LAYOUT_NHWC, \p MLUOP_LAYOUT_NLC, \p MLUOP_LAYOUT_NC.
- *   - mean tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - invstd tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - dfilter tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - dbias tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - sum_dy tensor: \p MLUOP_LAYOUT_ARRAY.
- *   - sum_dy_xmu tensor: \p MLUOP_LAYOUT_ARRAY.
- *
- * @par Scale Limitation
- * - None.
- *
- * @par API Dependency
- * - None.
- *
- * @par note
- * - The \b mean, \b invstd, \b dfilter, \b bias, \b sum_dy and \b sum_dy_xmu must be 1D tensors and the
- *   length of the dimensions of these tensors should be the same as the length of the lowest dimension of \b x.
- * - The length of each dimension of \b x and \b dz must be the same.
- *
- * @par Example
- * - The example of ::mluOpSyncBatchNormBackwardReduce operation is as follows:
+ * - The example of ::mluOpSyncBatchnormBackwardReduce operation is as follows:
      @verbatim
       input four arrays by 1 * 2 * 3 * 2, 2, 2, 2 and 2
       --> dz: [[[[6.0, 6.0],[6.0, 6.0],[6.0, 6.0]],
@@ -12863,7 +12064,7 @@ mluOpSyncBatchnormBackwardReduce(mluOpHandle_t handle,
                                  const bool needs_input_grad1,
                                  const bool needs_input_grad2);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchNormBackwardElemt
 /*!
  * @brief Computes the gradients of input in the training scenario.
  *
@@ -12991,7 +12192,7 @@ mluOpSyncBatchNormBackwardElemt(mluOpHandle_t handle,
                                 const mluOpTensorDescriptor_t diff_x_desc,
                                 void *diff_x);
 
-// Group: SyncBatchNorm
+// Group:SyncBatchNormBackwardElemt
 /*!
  * @brief Computes the gradients of input in the training scenario.
  *
@@ -13131,7 +12332,7 @@ mluOpSyncBatchNormBackwardElemtV2(mluOpHandle_t handle,
                                   const mluOpTensorDescriptor_t diff_x_desc,
                                   void *diff_x);
 
-// Group: Debugging
+// Group:Debugging
 /*!
  * @brief Sets the mode of a Cambricon MLU-OPS debugging tool that can generate operator
  * information files for all the operators that are called. The generated file
@@ -13173,7 +12374,7 @@ mluOpSyncBatchNormBackwardElemtV2(mluOpHandle_t handle,
 void MLUOP_WIN_API
 mluOpSetGenCaseMode(int mode);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Creates a descriptor pointed by \p dcn_desc for a deformable convolution forward
  * or backward operation, and allocates memory for holding the information about the
@@ -13207,7 +12408,7 @@ mluOpSetGenCaseMode(int mode);
 mluOpStatus_t MLUOP_WIN_API
 mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Initializes the deformable convolution descriptor \p dcn_desc that was
  * created by ::mluOpCreateDCNDescriptor function, and sets the information about the
@@ -13306,7 +12507,7 @@ mluOpSetDCNDescriptor(mluOpDCNDescriptor_t dcn_desc,
                       int im2col_step,
                       const mluOpDataType_t compute_type);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Destroys a deformable convolution descriptor \p dcn_desc that was previously created by
  * ::mluOpCreateDCNDescriptor.
@@ -13334,7 +12535,7 @@ mluOpSetDCNDescriptor(mluOpDCNDescriptor_t dcn_desc,
 mluOpStatus_t MLUOP_WIN_API
 mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Returns in \p workspace_size the size of the MLU memory that is used as an extra
  *        workspace to optimize the deformable convolution forward operation.
@@ -13407,7 +12608,7 @@ mluOpGetDCNForwardWorkspaceSize(mluOpHandle_t handle,
                                 const mluOpTensorDescriptor_t output_desc,
                                 size_t *workspace_size);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Performs a 2D deformable convolution forward operation. Compared with the standard
  *        convolution, the deformable convolution introduces 2D offsets and masks to make
@@ -13575,7 +12776,7 @@ mluOpDCNForward(mluOpHandle_t handle,
                 const mluOpTensorDescriptor_t output_desc,
                 void *output);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Returns in \p workspace_size the size of the MLU memory that is used as an extra
  *        workspace to optimize the deformable convolution backward filter operation.
@@ -13652,7 +12853,7 @@ mluOpGetDCNBackwardWeightWorkspaceSize(mluOpHandle_t handle,
                                        const mluOpTensorDescriptor_t grad_bias_desc,
                                        size_t *workspace_size);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Performs the back-propagation of a deformable convolution operation to compute
  *        the gradient with respect to filter \p grad_filter and bias \p grad_bias
@@ -13798,7 +12999,7 @@ mluOpDCNBackwardWeight(mluOpHandle_t handle,
                        const mluOpTensorDescriptor_t grad_bias_desc,
                        void *grad_bias);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Returns in \p workspace_size the size of the MLU memory that is used as an extra
  * workspace to optimize the deformable convolution backward data operation.
@@ -13885,7 +13086,7 @@ mluOpGetDCNBakcwardDataWorkspaceSize(mluOpHandle_t handle,
                                      const mluOpTensorDescriptor_t grad_mask_desc,
                                      size_t *workspace_size);
 
-// Group: DeformConv
+// Group:DCN
 /*!
  * @brief Performs the back-propagation of a deformable convolution operation to compute
  * the gradient with respect to input \p grad_input, offset \p grad_offset, and mask
@@ -14087,17 +13288,17 @@ typedef struct mluOpFFTStruct *mluOpFFTPlan_t;
  *
  * @par API Dependency
  * - After calling this function, you can call the ::mluOpMakeFFTPlanMany function to initialize and set the
- *   information to the created descriptor.
+ * information to the created descriptor.
  * - You need to call the ::mluOpDestroyFFTPlan to destroy the descriptor.
- *   Otherwise, the memory leak may occur.
+ * Otherwise, the memory leak may occur.
  *
  * @par Note
  * - This function only supports 1D FFT currently. 2D FFT and 3D FFT
- *   will be supported in the future.
+ * will be supported in the future.
  * - When the data type of input is float or complex_float, the 1D FFT length should be equal to:
- *   length = \f$base * 2^ {m}\f$, and the base should be less than or equal to 4096.
+ * length = \f$base * 2^ {m}\f$ , and the base should be less than or equal to 4096.
  * - When the data type of input is half or complex_half, the 1D FFT length should be equal to:
- *   length = \f$2^{m}\f$.
+ * length = \f$2^{m}
  *
  * @par Example.
  * - None.
@@ -14110,6 +13311,7 @@ mluOpCreateFFTPlan(mluOpFFTPlan_t *fft_plan);
 
 // Group: FFT
 /*!
+
  * @brief Initializes the FFT descriptor pointed by \p fft_plan that is previously created
  * with the ::mluOpCreateFFTPlan function, and sets the information about the
  * tensor descriptors of input tensor and output tensor, the rank of FFT, and the FFT size on each
@@ -14149,14 +13351,22 @@ mluOpCreateFFTPlan(mluOpFFTPlan_t *fft_plan);
  * - The supported data types of \p input and \p output tensors are as follows:
  * - real-to-complex FFT:
  *     - half(input offchip)-complex_half(output offchip)-int16(input onchip)
+ *     - float(input offchip)-complex_float(output offchip)-int31(input onchip)
+ * - complex-to-real FFT:
+ *     - complex_half(input offchip)-half(output offchip)-int16(input onchip)
+ *     - complex_float(input offchip)-float(output offchip)-int31(input onchip)
+ * - complex-to-complex FFT:
+ *     - complex_half(input offchip)-complex_half(output offchip)-int16(input onchip)
+ *     - complex_float(input offchip)-complex_float(output offchip)-int31(input onchip)
+ * - On MLU300 series or above, this function also supports the combinations of
+ *   data types as follows:
+ * - real-to-complex FFT:
  *     - half(input offchip)-complex_half(output offchip)-half(input onchip)
  *     - float(input offchip)-complex_float(output offchip)-float(input onchip)
  * - complex-to-real FFT:
- *     - complex_half(input offchip)-half(output offchip)-int16(input onchip)
  *     - complex_half(input offchip)-half(output offchip)-half(input onchip)
  *     - complex_float(input offchip)-float(output offchip)-float(input onchip)
  * - complex-to-complex FFT:
- *     - complex_half(input offchip)-complex_half(output offchip)-int16(input onchip)
  *     - complex_half(input offchip)-complex_half(output offchip)-half(input onchip)
  *     - complex_float(input offchip)-complex_float(output offchip)-float(input onchip)
  *
@@ -14200,10 +13410,12 @@ mluOpMakeFFTPlanMany(mluOpHandle_t handle,
                      const int rank,
                      const int n[],
                      size_t *reservespace_size,
-                     size_t *workspace_size);
+                     size_t *workspace_size,
+                     const int direction);
 
 // Group:FFT
 /*!
+
  * @brief Bonds the \p reservespace to the \p fft_plan. The size of reserved space can be derived
  * through ::mluOpMakeFFTPlanMany.
  *
@@ -14248,6 +13460,7 @@ mluOpSetFFTReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan, void *rese
 
 // Group:FFT
 /*!
+
  * @brief Executes any FFT. In case of complex-to-real and real-to-complex
  * transforms, \p direction parameter is ignored. This function stores the Fourier coefficients
  * in the output array. If the address of input and output are the same, an in-place FFT
@@ -14280,7 +13493,7 @@ mluOpSetFFTReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan, void *rese
  *   data type, the output is computed through the FFT formula with computation rules of NaN or
  *   infinity based on IEEE 754.
  * - When \p input contains NaN or infinity and the input onchip data type of FFT is quantized
- *   data type such as int16, the output will be unpredictable.
+ *   data type such as int31 or int16, the output will be unpredictable.
  * - \p Input is recommended to be in range of [-10, 10] with uniform
  *   distribution for higher precision.
  * - \p Scale_factor is recommended to be in range of [-1, 1] to avoid exceeding
@@ -14327,6 +13540,7 @@ mluOpExecFFT(mluOpHandle_t handle,
 
 // Group:FFT
 /*!
+
  * @brief Destroys an FFT plan \p fft_plan that is created with the
  * ::mluOpCreateFFTPlan function. The FFT plan is defined in ::mluOpFFTPlan_t and
  * holds the information about the FFT operation.

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_1.prototxt
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_1.prototxt
@@ -1,0 +1,89 @@
+device: GPU
+op_name: "fft"
+input {
+  id: "input1"
+  shape {
+    dims: 1 
+    dims: 9 
+    dim_stride: 9 
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -10
+    upper_bound_double: 10
+  }
+  onchip_dtype: DTYPE_FLOAT
+}
+output {
+  id: "output1"
+  shape {
+    dims: 1 
+    dims: 9 
+    dim_stride: 9
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  value_h: "0"
+  random_data {
+    distribution: UNIFORM
+    lower_bound_double: -1
+    upper_bound_double: 1
+  }
+  thresholds {
+    evaluation_threshold: 1e-05
+    evaluation_threshold: 1e-05
+    evaluation_threshold_imag: 1e-05
+    evaluation_threshold_imag: 1e-05
+  }
+}
+evaluation_criterion: DIFF1
+evaluation_criterion: DIFF2
+supported_mlu_platform: MLU370
+handle_param {
+  round_mode: ROUND_OFF_ZERO
+}
+fft_param {
+  rank: 1
+  n: 9
+  direction: 0
+  scale_factor: 1
+}

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_2.prototxt
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_2.prototxt
@@ -1,0 +1,55 @@
+op_name: "fft"
+input {
+  id: "input1"
+  shape {
+    dims: 1 
+    dims: 9 
+    dim_stride: 9 
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  random_data {
+    seed: 23
+    distribution: UNIFORM
+    lower_bound_double: -10
+    upper_bound_double: 10
+  }
+  onchip_dtype: DTYPE_FLOAT
+}
+output {
+  id: "output1"
+  shape {
+    dims: 1 
+    dims: 9 
+    dim_stride: 9
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  thresholds {
+    evaluation_threshold: 1e-05
+    evaluation_threshold: 1e-05
+    evaluation_threshold_imag: 1e-05
+    evaluation_threshold_imag: 1e-05
+  }
+}
+evaluation_criterion: DIFF1
+evaluation_criterion: DIFF2
+supported_mlu_platform: MLU370
+handle_param {
+  round_mode: ROUND_OFF_ZERO
+}
+fft_param {
+  rank: 1
+  n: 9
+  direction: 0
+  scale_factor: 1
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 1e-05
+  error_threshold: 1e-05
+  baseline_device: CPU
+}

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_3.prototxt
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_3.prototxt
@@ -1,0 +1,55 @@
+op_name: "fft"
+input {
+  id: "input1"
+  shape {
+    dims: 1 
+    dims: 27
+    dim_stride: 27
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  random_data {
+    seed: 23
+    distribution: UNIFORM
+    lower_bound_double: -10
+    upper_bound_double: 10
+  }
+  onchip_dtype: DTYPE_FLOAT
+}
+output {
+  id: "output1"
+  shape {
+    dims: 1 
+    dims: 27
+    dim_stride: 27
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  thresholds {
+    evaluation_threshold: 1e-05
+    evaluation_threshold: 1e-05
+    evaluation_threshold_imag: 1e-05
+    evaluation_threshold_imag: 1e-05
+  }
+}
+evaluation_criterion: DIFF1
+evaluation_criterion: DIFF2
+supported_mlu_platform: MLU370
+handle_param {
+  round_mode: ROUND_OFF_ZERO
+}
+fft_param {
+  rank: 1
+  n: 27
+  direction: 0
+  scale_factor: 1
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 1e-05
+  error_threshold: 1e-05
+  baseline_device: CPU
+}

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_4.prototxt
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_4.prototxt
@@ -1,0 +1,55 @@
+op_name: "fft"
+input {
+  id: "input1"
+  shape {
+    dims: 1 
+    dims: 81
+    dim_stride: 81
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  random_data {
+    seed: 23
+    distribution: UNIFORM
+    lower_bound_double: -10
+    upper_bound_double: 10
+  }
+  onchip_dtype: DTYPE_FLOAT
+}
+output {
+  id: "output1"
+  shape {
+    dims: 1 
+    dims: 81
+    dim_stride: 81
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  thresholds {
+    evaluation_threshold: 1e-05
+    evaluation_threshold: 1e-05
+    evaluation_threshold_imag: 1e-05
+    evaluation_threshold_imag: 1e-05
+  }
+}
+evaluation_criterion: DIFF1
+evaluation_criterion: DIFF2
+supported_mlu_platform: MLU370
+handle_param {
+  round_mode: ROUND_OFF_ZERO
+}
+fft_param {
+  rank: 1
+  n: 81
+  direction: 0
+  scale_factor: 1
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 1e-05
+  error_threshold: 1e-05
+  baseline_device: CPU
+}

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_5.prototxt
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/fft/test_case/fft_5.prototxt
@@ -1,0 +1,55 @@
+op_name: "fft"
+input {
+  id: "input1"
+  shape {
+    dims: 1 
+    dims: 243
+    dim_stride: 243
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  random_data {
+    seed: 23
+    distribution: UNIFORM
+    lower_bound_double: -10
+    upper_bound_double: 10
+  }
+  onchip_dtype: DTYPE_FLOAT
+}
+output {
+  id: "output1"
+  shape {
+    dims: 1 
+    dims: 243
+    dim_stride: 243
+    dim_stride: 1
+  }
+  layout: LAYOUT_ARRAY
+  dtype: DTYPE_COMPLEX_FLOAT
+  thresholds {
+    evaluation_threshold: 1e-05
+    evaluation_threshold: 1e-05
+    evaluation_threshold_imag: 1e-05
+    evaluation_threshold_imag: 1e-05
+  }
+}
+evaluation_criterion: DIFF1
+evaluation_criterion: DIFF2
+supported_mlu_platform: MLU370
+handle_param {
+  round_mode: ROUND_OFF_ZERO
+}
+fft_param {
+  rank: 1
+  n: 243
+  direction: 0
+  scale_factor: 1
+}
+test_param: {
+  error_func: DIFF1
+  error_func: DIFF2
+  error_threshold: 1e-05
+  error_threshold: 1e-05
+  baseline_device: CPU
+}


### PR DESCRIPTION
# MLU 2D C2C FFT 方案

[TOC]

## 1 FFT 2D算法介绍

二维FFT（Fast Fourier Transform）由一维FFT推广而来，近几十年来常被运用在图像处理上。DFT能够将二维复数序列{$${x_{n_1,n_2}}$$}转化为二维复数序列{$${Y_{n_1,n_2}}$$}，计算公式为：

![clip_image006](https://github.com/Cambricon/mlu-ops/assets/115060807/299b8aa2-1782-4d59-ba72-e001fe267112)


可以将二维FFT看作是在输入的两个维度分别做一维FFT，因此其计算方式与一维FFT本质相同，这里不再对FFT计算细节进行赘述。 

## 2 MLU实现性能分析

### 2.1 简单实现

目前利用一维FFT以及转置算子实现二维FFT，如图1所示，其步骤如下，以[batch=1,n0, n1]为例：

1) 调用FFT 1D 算子，其参数为batch=n0, n = [n1]
2) 调用转置算子，数据类型为复数浮点数，将[n0, n1]转置为[n1, n0] 
3) 调用FFT 1D 算子，其参数为batch=n1, n = [n0]
4) 调用转置算子，数据类型为复数浮点数，将[n1, n0]转置为[n0, n1] 

![clip_image008](https://github.com/Cambricon/mlu-ops/assets/115060807/20ecece9-c189-4c29-9601-8b71babb2ad0)

图1 FFT2D 简单实现

### 2.2 性能测试

当前与FFT 2D重点规模相关的FFT1D的实现性能如下：

**表1 FFT1D 二的幂重点规模性能**

| [batch:32] power-of-2 |          |         |          |          |          |          |          |
| --------------------- | -------- | ------- | -------- | -------- | -------- | -------- | -------- |
| nfft                  | 1024     | 2048    | 4096     | 8192     | 16384    | 32768    | 65536    |
| mlu(us)               | 23       | 31      | 43.2     | 96.8     | 209      | 547      | 1256     |
| v100(us)              | 6.14     | 7.17    | 8.19     | 12.29    | 22.59    | 51.20    | 99.33    |
|                       | 3.745928 | 4.32357 | 5.274725 | 7.876322 | 9.251881 | 10.68359 | 12.64472 |



**表2 FF1D 非二的幂重点规模性能**

| [batch:32] |          |          |          |          |         |          |          |          |          |
| ---------- | -------- | -------- | -------- | -------- | ------- | -------- | -------- | -------- | -------- |
| nfft       | 6000     | 7000     | 8000     | 9000     | 10000   | 11000    | 12000    | 13000    | 14000    |
| mlu(us)    | 71.8     | 112      | 119      | 148      | 162     | 176      | 177.8    | 220      | 223      |
| v100(us)   | 12.29    | 13.31    | 13.31    | 15.36    | 16.38   | 21.50    | 29.70    | 34.82    | 29.70    |
|            | 5.842148 | 8.414726 | 8.940646 | 9.635417 | 9.89011 | 8.186047 | 5.986532 | 6.318208 | 7.508418 |

测试[1, 2048, 6000]、[1, 2048, 14000]等2D规模，并与v100上cufft的性能对比：1)和3)两个FFT1D算子所占时间约为cufft的10倍；2)和4)两个转置算子所占时间约为cufft的40倍。



**表3 FFT2D重点规模性能**

| FFT2D [batch:1, n0=2048] |          |          |          |          |         |          |          |          |          |
| ------------------------ | -------- | -------- | -------- | -------- | ------- | -------- | -------- | -------- | -------- |
| n1                       | 6000     | 7000     | 8000     | 9000     | 10000   | 11000    | 12000    | 13000    | 14000    |
| mlu(us)                  | 31494    | 65389.2  | 75470.8  | 80076.4  | 87351.6 | 96647.6  | 103201   | 108816   | 116488   |
| v100 (us)                | 711.68   | 917.50   | 916.48   | 1124.35  | 1202.18 | 1429.50  | 2369.02  | 2656.26  | 2862.59  |
|                          | 44.25304 | 71.26888 | 82.34855 | 71.22017 | 72.661  | 67.60937 | 43.56274 | 40.96587 | 40.69322 |

 

**表4 FFT2D重点规模性能(直接去除转置算子，运算结果错误)**

| FFT2D [batch:1, n0=2048] no transpose |          |          |         |          |          |          |          |          |          |
| ------------------------------------- | -------- | -------- | ------- | -------- | -------- | -------- | -------- | -------- | -------- |
| n1                                    | 6000     | 7000     | 8000    | 9000     | 10000    | 11000    | 12000    | 13000    | 14000    |
| mlu(us)                               | 7864.4   | 11065.2  | 12129.8 | 14411.8  | 16450.2  | 17316.2  | 17960    | 21244.8  | 22434.6  |
| v100 (us)                             | 711.68   | 917.50   | 916.48  | 1124.35  | 1202.18  | 1429.50  | 2369.02  | 2656.26  | 2862.59  |
|                                       | 11.05047 | 12.06016 | 13.2352 | 12.81789 | 13.68364 | 12.11347 | 7.581194 | 7.998012 | 7.837168 |

 

### 2.3 性能分析

FFT1D中的蝶形网络采用的是片下网络（GDRAM）-片上网络（NRAM）双层网络，通过将FFT规模分解为尽可能少的stage，每个stage中的蝶形加载至NRAM中进行处理。在NRAM中，即片上网络中，依然可以利用FFT将蝶形进一步分解，从而优化计算量。

FFT1D中的软流水优化仅优化了片上网络的性能，用片上网络的计算隐藏访存，而不同batch之间是几乎完全串行的。但对于2048和6000规模，由于整个FFT 1D的片下网络能够完全放到片上，即片下网络的stage为1，故只需加载一次片上网络并进行处理，故软流水优化无效。

对于简单版本实现来说，转置的耗时占比高达80%，这是不可接受的，因此应当进一步优化实现，直接去掉转置，由下一部分详细介绍。

## 3 MLU上的FFT 2D优化实现

### 3.1 列主序FFT 1D实现

想要去除两个转置算子，可以通过列主序FFT 1D实现，如图2所示，其FFT 2D计算步骤如下：

1) 调用FFT 1D 算子，其参数为batch=n0, n = [n1]
2) 调用列主序FFT 1D 算子，其参数为batch=n1, n = [n0]

在已实现的FFT 1D算子中，从片下网络加载大基至片上的方式是利用2D __memcpy进行gather-load操作，如图1所示。当片上网络规模未达到NRAM的容量，我们会同时加载同一个FFT中连续的多个大基，从而提升gather-load的效率。

而对于列主序版本，如果要加载连续的多个大基至片上，则需要加载不同batch的FFT中相同位置的大基，如图二所示。与行主序版本的gather-load和scatter-store相比，stride更大，性能可能明显下降，因此将采用分块与重排等方式提升数据的局部性。

![clip_image010](https://github.com/Cambricon/mlu-ops/assets/115060807/2ad24109-3dba-47cc-9362-8e65b57dbe23)


图2 FFT2D 列主序版本实现

### 3.2 软流水优化

由于对于较小的FFT 1D (n≤6000)，增加针对不同batch之间计算隐藏访存的软流水。预期能够对重点规模中2048和6000相关的FFT2D性能进行提升。

## 4 MLU层需求分析

### 4.1 算子需求分析



| 算子功能简介                                                 | FFT2D/IFFT2D                                                 |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| 需求来源                                                     | PyTorch/Tensorflow/                                          |
| 应用网络                                                     | Conformer                                                    |
| 输入数据类型                                                 | complex_half, complex_float                                  |
| 输入Shape                                                    | [batches, n0, n1]                                            |
| 输入Layout                                                   | ARRAY                                                        |
| 输出数据类型                                                 | float/complex float                                          |
| 输出Shape                                                    | complex_half, complex_float                                  |
| 输出Layout                                                   | ARRAY                                                        |
| 模式                                                         | 无                                                           |
| 是否含有 dim/axis 等类似语义的参数且该参数支持负数/其他特殊处理 | 通过stride语义来支持dim                                      |
| 是否含有 labels/index 等类似语义的参数且该参数支持负数/界外情况/其他特殊处理 | 无                                                           |
| 是否需要支持原位                                             | 是                                                           |
| 是否需要支持stride机制                                       | 是                                                           |
| 是否需要支持广播                                             | 否                                                           |
| 0元素检查是否直接返回                                        |                                                              |
| 其他特殊需求                                                 | 无                                                           |
| 本次开发优先支持的规模/模式                                  | (2048, 6000)  (2048, 7000)  ...(最后一维，每次递增1000,步进到14000)   (2048, 14000) |

### 4.2 算子功能和应用场景描述

FFT2D:实现对输入规模为[n0, n1]的二维复数序列做二维傅里叶变换。

IFFT2D: 实现对输入规模为[n0, n1]的二维复数序列做二维逆傅里叶变换。

### 4.3 算子输入输出参数要求

| 参数       | 语义      | 类型 | 支持类型                            | 物理布局          | 规模限制         |
| ---------- | --------- | ---- | ----------------------------------- | ----------------- | ---------------- |
| handle     |           | 句柄 |                                     | /                 | 无               |
| fft2d_plan | FFT描述符 | 输入 |                                     |                   | 暂时不支持大质数 |
| input      | 输入矩阵  | 输入 | complex half/complex float/ complex | [batches, n0, n1] |                  |
| output     | 输出矩阵  | 输出 | complex half/complex float/ complex | [batches, n0, n1] |                  |

## 5算子接口设计

与FFT1D接口相同

1. FFT plan描述符定义，用于描述执行过程所需的信息

```c++
typedef struct mluopFFTStruct *mluopFFTPlan_t;
```

2. 创建FFT plan的接口函数

```c++
mluopStatus_t mluopCreateFFTPlan(mluopFFTPlan_t *fft_plan);
```

3. plan初始化接口，根据输入描述符input_desc、输出描述符output_desc、变换维度rank，变换规模n[], reservespace大小reservespace_size, 以及workspace大小 workspace_size分配所需内存以及提前计算kernel中所需的常数

```c++
mluopStatus_t mluopMakeFFTPlanMany(
    	mluopHandle_t handle,
        mluopFFTPlan_t fft_plan,
        const mluopTensorDescriptor_t input_desc,
        const mluopTensorDescriptor_t output_desc,
        const int rank,
		const int n[],
        size_t *reservespace_size,
		size_t *workspace_size);
```

4. 给plan绑定reservespace指针

```c++
mluopStatus_t mluopSetFFTReserveArea(
    			mluopHandle_t handle,
				mluopFFTPlan_t fft_plan,
				void *reservespace);
```

5. 执行接口，可利用创建后的plan多次执行相应FFT

```c++
mluopStatus_t mluopExecFFT(mluopHandle_t handle,
                           const mluopFFTPlan_t fft_plan,
                           const void *input,
                           const float scale_factor,
                           void *workspace,
                           void *output,
                           int direction);
```

6. Destroy接口，负责释放plan与reservespace

```c++
mluopStatus_t mluopDestroyFFTPlan(mluopFFTPlan_t fft_plan);
```

## 6 总结

在该实现方案中，我们首先简要描述了FFT2D的算法及其与FFT1D之间的关联，其次分析了调用FFT1D行主序算子与转置算子实现的简单版本，认为主要性能损失在于转置算子的调用以及部分规模软流水优化的实现，并根据该分析提出了相应的优化方法，即通过实现列主序FFT1D算子去除转置算子，并针对部分规模1D FFT进行batch间的软流水优化。最后给出需求分析与接口设计。