### PR TITLE
[Feature](mlu-ops): removing error throwing in mluops library.

### DIFF
--- a/core/util.cpp
+++ b/core/util.cpp
@@ -32,6 +32,9 @@ void mluOpCheck(mluOpStatus_t result, char const *const func,
     std::string error = "\"" + std::string(mluOpGetErrorString(result)) +
                         " in " + std::string(func) + "\"";
     LOG(ERROR) << error;
+    // TODO(liuduanhui): Remove error throwing in c library in future.
+    //                   MLUOP_CHECK should not be used in host side code.
+    //                   And now it is only used in gtest code.
     throw std::runtime_error(error);
   }
 }

--- a/kernels/utils/cnnl_helper.cpp
+++ b/kernels/utils/cnnl_helper.cpp
@@ -30,7 +30,6 @@ void mluOpCnnlCheck(mluOpStatus_t result, char const *const func,
         " in " + std::string(func) + " at " + std::string(file) +
         " line: " + std::to_string(line) + "\"";
     LOG(ERROR) << error;
-    throw std::runtime_error(error);
   }
 }
 

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -68,8 +68,8 @@ for i in ${filenames} ; do
   check_dir=$(echo $i | grep -E "^core\/|^kernels\/")
   #not_in_tools=$(echo $i | sed -r "s/^tools.*//")
   if [[ -n "${include_mlu}" ]] && [[ -n "${check_dir}" ]]; then
-    printf_log=$(sed -n -e '/\<printf\>/=' -e ' \
-      /\<__bang_printf\>/=' -e '/\<std::cout\>/=' -e '/assert(/=' $i)
+    printf_log=$(sed -n -e '/\<printf\>/=' -e \
+      '/\<__bang_printf\>/=' -e '/\<std::cout\>/=' -e '/assert(/=' $i)
     for line in ${printf_log};
     do
       echo $i +${line}


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

removing error throwing in mluops compiled library.

## 2. Modification

kernels/utils/cnnl_helper.cpp

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `CALL_CNNL return an error when parameter is nullptr.
```bash
2024-5-29 11:16:13] [CNNL] [Error]:[cnnlCreateTransposeDescriptor] Check failed: desc != NULL. 
[2024-5-29 11:16:13] [MLUOP] [Error]:CNNL_HELPER: Internal cnnl api call error accured.
[2024-5-29 11:16:13] [MLUOP] [Error]:"CNNL_STATUS_BAD_PARAM in cnnlCreateTransposeDescriptor(nullptr) at /projs/platform/liuduanhui/mluops-dev/mlu-ops/kernels/three_nn_forward/three_nn_forward.cpp line: 53"
[2024-5-29 11:16:13] [MLUOP] [Error]:"MLUOP_STATUS_BAD_PARAM in mluOpGetThreeNNForwardWorkspaceSize(handle_, known_desc, &workspace_size_)"
```



### 3.4 Summary Analysis

ci passed normally.