### PR TITLE
[Feature](mlu-ops): optimization for descritpor

### DIFF
--- a/core/type.cpp
+++ b/core/type.cpp
@@ -84,36 +84,4 @@ std::string MLUOP_WIN_API MLUOP_ATTRIBUTE_FLATTEN getNameOfTensorLayout(mluOpTen
   return mluOpGetNameOfTensorLayout(layout);
 }
 
-size_t getSizeOfDataType(mluOpDataType_t dtype) {
-  switch (dtype) {
-    default: {
-      return 0;
-    }
-    case MLUOP_DTYPE_BOOL:
-    case MLUOP_DTYPE_INT8:
-    case MLUOP_DTYPE_UINT8: {
-      return 1;
-    }
-    case MLUOP_DTYPE_INT16:
-    case MLUOP_DTYPE_UINT16:
-    case MLUOP_DTYPE_HALF:
-    case MLUOP_DTYPE_BFLOAT16: {
-      return 2;
-    }
-    case MLUOP_DTYPE_INT31:
-    case MLUOP_DTYPE_INT32:
-    case MLUOP_DTYPE_UINT32:
-    case MLUOP_DTYPE_FLOAT:
-    case MLUOP_DTYPE_COMPLEX_HALF: {
-      return 4;
-    }
-    case MLUOP_DTYPE_UINT64:
-    case MLUOP_DTYPE_INT64:
-    case MLUOP_DTYPE_DOUBLE:
-    case MLUOP_DTYPE_COMPLEX_FLOAT: {
-      return 8;
-    }
-  }
-}
-
 }  // namespace mluop

--- a/core/type.h
+++ b/core/type.h
@@ -52,9 +52,38 @@ static mluOpStatus_t getLowAndHighValueFrom64Bits(T value, uint32_t* high,
   return MLUOP_STATUS_SUCCESS;
 }
 
-// TODO(None) use const char * instead of std::string (need mluop_extra
-// fix first) hide visibility
-size_t MLUOP_WIN_API getSizeOfDataType(mluOpDataType_t dtype);
+static inline size_t MLUOP_WIN_API getSizeOfDataType(mluOpDataType_t dtype) {
+  switch (dtype) {
+    default: {
+      return 0;
+    }
+    case MLUOP_DTYPE_BOOL:
+    case MLUOP_DTYPE_INT8:
+    case MLUOP_DTYPE_UINT8: {
+      return 1;
+    }
+    case MLUOP_DTYPE_INT16:
+    case MLUOP_DTYPE_UINT16:
+    case MLUOP_DTYPE_HALF:
+    case MLUOP_DTYPE_BFLOAT16: {
+      return 2;
+    }
+    case MLUOP_DTYPE_INT31:
+    case MLUOP_DTYPE_INT32:
+    case MLUOP_DTYPE_UINT32:
+    case MLUOP_DTYPE_FLOAT:
+    case MLUOP_DTYPE_COMPLEX_HALF: {
+      return 4;
+    }
+    case MLUOP_DTYPE_UINT64:
+    case MLUOP_DTYPE_INT64:
+    case MLUOP_DTYPE_DOUBLE:
+    case MLUOP_DTYPE_COMPLEX_FLOAT: {
+      return 8;
+    }
+  }
+}
+
 std::string MLUOP_WIN_API getNameOfDataType(mluOpDataType_t dtype);  // NOLINT
 std::string MLUOP_WIN_API getNameOfTensorLayout(mluOpTensorLayout_t layout);  // NOLINT
 

--- a/kernels/ball_query/ball_query.cpp
+++ b/kernels/ball_query/ball_query.cpp
@@ -51,11 +51,7 @@ void policyFuncBallQuery(const mluOpHandle_t &handle,
   size_t core_in_cluster = handle->core_num_per_cluster;
   VLOG(5) << "In current device, core_in_cluster:" << core_in_cluster;
 
-  size_t total_data_num;
-  if (desc->tensorElementsNumber(total_data_num) != MLUOP_STATUS_SUCCESS) {
-    LOG(ERROR) << "[mluOpBallQuery], In policyFuncBallQuery function, fail to "
-                  "get elem_count";
-  }
+  size_t total_data_num = desc->total_element_num;
 
   // On a core, a lot of new_xyz data element can be stored; but only one data
   // element can be processed at a time. So a cluster can only process four data

--- a/kernels/sparse_conv/get_indice_pairs/normal_get_indice_pairs.cpp
+++ b/kernels/sparse_conv/get_indice_pairs/normal_get_indice_pairs.cpp
@@ -40,7 +40,7 @@ static mluOpStatus_t getIndiceMaskAll(
     const int input_active_site, size_t *size) {
   size_t total_size = 0;
   total_size =
-      kernel_volume * input_active_site * sizeof(indice_pairs_desc->dtype);
+      kernel_volume * input_active_site * mluop::getSizeOfDataType(indice_pairs_desc->dtype);
   size[0] = total_size;
   return MLUOP_STATUS_SUCCESS;
 }
@@ -50,7 +50,7 @@ static mluOpStatus_t getIndiceIndexIn(
     const int input_active_site, size_t *size) {
   size_t total_size = 0;
   total_size =
-      kernel_volume * input_active_site * sizeof(indice_pairs_desc->dtype);
+      kernel_volume * input_active_site * mluop::getSizeOfDataType(indice_pairs_desc->dtype);
   size[0] = total_size;
   return MLUOP_STATUS_SUCCESS;
 }
@@ -60,7 +60,7 @@ static mluOpStatus_t getIndiceIndexOut(
     const int input_active_site, size_t *size) {
   size_t total_size = 0;
   total_size =
-      kernel_volume * input_active_site * sizeof(indice_pairs_desc->dtype);
+      kernel_volume * input_active_site * mluop::getSizeOfDataType(indice_pairs_desc->dtype);
   size[0] = total_size;
   return MLUOP_STATUS_SUCCESS;
 }
@@ -70,7 +70,7 @@ static mluOpStatus_t getIndiceOutExpand(
     const int input_active_site, size_t *size) {
   size_t total_size = 0;
   total_size =
-      kernel_volume * input_active_site * sizeof(indice_pairs_desc->dtype);
+      kernel_volume * input_active_site * mluop::getSizeOfDataType(indice_pairs_desc->dtype);
   size[0] = total_size;
   return MLUOP_STATUS_SUCCESS;
 }
@@ -79,7 +79,7 @@ static mluOpStatus_t getIndiceInExpand(
     const mluOpTensorDescriptor_t indice_pairs_desc,
     const int input_active_site, size_t *size) {
   size_t total_size = 0;
-  total_size = input_active_site * sizeof(indice_pairs_desc->dtype);
+  total_size = input_active_site * mluop::getSizeOfDataType(indice_pairs_desc->dtype);
   size[0] = total_size;
   return MLUOP_STATUS_SUCCESS;
 }
@@ -89,7 +89,7 @@ static mluOpStatus_t getIndiceUnique(
     const int input_active_site, size_t *size) {
   size_t total_size = 0;
   total_size = (kernel_volume * input_active_site + 1) *
-               sizeof(indice_pairs_desc->dtype);
+               mluop::getSizeOfDataType(indice_pairs_desc->dtype);
   size[0] = total_size;
   return MLUOP_STATUS_SUCCESS;
 }
@@ -97,7 +97,7 @@ static mluOpStatus_t getIndiceUnique(
 static mluOpStatus_t getGridOut(const mluOpTensorDescriptor_t indice_pairs_desc,
                                 int output_size, size_t *size) {
   size_t total_size = 0;
-  total_size = output_size * sizeof(indice_pairs_desc->dtype);
+  total_size = output_size * mluop::getSizeOfDataType(indice_pairs_desc->dtype);
   size[0] = total_size;
   return MLUOP_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Provide 10%+ performance boost
logging.h增加静态分支预测,优化deque和desc的逻辑

## 2. Modification

modified: core/logging.h
modified: core/tensor.cpp
modified: core/tensor.h
modified: core/type.cpp
modified: core/type.h
modified: kernels/ball_query/ball_query.cpp
modified: kernels/sparse_conv/get_indice_pairs/normal_get_indice_pairs.cpp

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370
```bash
Note: Google Test filter = *ball_query*
[==========] Running 2 test cases from 1 test suite.
[----------] Global test environment set-up.
[2024-6-4 15:42:55] [MLUOP] [Warning]:mluOpInternalGetCommitId not found, use fallback method
[2024-6-4 15:42:55] [MLUOP] [Warning]:mluOpInternalGetBranchInfo not found, use fallback method
[date                   ]: 2024_06_04_15_42_55
[mluop_version           ]: 1.2.0
[mlu_platform           ]: MLU370-X4[mtp_372.42]
[job_limit              ]: 
[cluster_limit          ]: 
[commit_id              ]: commit b9489c048f8515ec4ca8c4a012b17aa77498d6a9
[mluop_branch            ]:   nl18421
[driver_version         ]: 5.10.33
[cnrt_version           ]: 6.11.0
[ip                     ]: 172.18.0.1
[repeat_count           ]: 1
[----------] 2 tests from ball_query/TestSuite
[ RUN      ] ball_query/TestSuite.mluOp/0
[MLU Hardware Time      ]: 80 (us)
[MLU Interface Time     ]: 6856.14 (us)
[MLU IO Efficiency      ]: 0.0476667
[MLU Compute Efficiency ]: 0.128
[MLU Workspace Size     ]: -1 (Bytes)
[MLU Kernel Name(s)     ]: {}
[MLU TheoryOps          ]: 1.04858e+07 (Ops)
[MLU TheoryIOs          ]: 1.17146e+06 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF1: 0.000000e+00
DIFF2: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/ball_query/test_case/case_0.prototxt
[       OK ] ball_query/TestSuite.mluOp/0 (98 ms)
[ RUN      ] ball_query/TestSuite.mluOp/1
[MLU Hardware Time      ]: 12 (us)
[MLU Interface Time     ]: 8.751 (us)
[MLU IO Efficiency      ]: 0.000434028
[MLU Compute Efficiency ]: 0.000416667
[MLU Workspace Size     ]: -1 (Bytes)
[MLU Kernel Name(s)     ]: {}
[MLU TheoryOps          ]: 10240 (Ops)
[MLU TheoryIOs          ]: 1600 (Bytes)
[MLU ComputeForce       ]: 2.048e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output]
DIFF1: 0.000000e+00
DIFF2: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/ball_query/test_case/case_1.prototxt
[       OK ] ball_query/TestSuite.mluOp/1 (18 ms)
[----------] 2 tests from ball_query/TestSuite (116 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 2 cases of 1 op(s).
ALL PASSED.
[==========] 2 test cases from 1 test suite ran. (23651 ms total)
[  PASSED  ] 2 test cases.
```

```bash
Note: Google Test filter = *get_indice_pairs*
[==========] Running 1 test case from 1 test suite.
[----------] Global test environment set-up.
[2024-6-4 16:8:31] [MLUOP] [Warning]:mluOpInternalGetCommitId not found, use fallback method
[2024-6-4 16:8:31] [MLUOP] [Warning]:mluOpInternalGetBranchInfo not found, use fallback method
[date                   ]: 2024_06_04_16_08_31
[mluop_version           ]: 1.2.0
[mlu_platform           ]: MLU370-X4[mtp_372.42]
[job_limit              ]: 
[cluster_limit          ]: 
[commit_id              ]: commit b9489c048f8515ec4ca8c4a012b17aa77498d6a9
[mluop_branch            ]:   nl18421
[driver_version         ]: 5.10.33
[cnrt_version           ]: 6.11.0
[ip                     ]: 172.18.0.1
[repeat_count           ]: 1
[----------] 1 test from get_indice_pairs/TestSuite
[ RUN      ] get_indice_pairs/TestSuite.mluOp/0
[MLU Hardware Time      ]: 6060 (us)
[MLU Interface Time     ]: 57758.9 (us)
[MLU IO Efficiency      ]: 0.0149645
[MLU Compute Efficiency ]: 0.00111015
[MLU Workspace Size     ]: 5.50499e+07 (Bytes)
[MLU Kernel Name(s)     ]: {}
[MLU TheoryOps          ]: 6.88899e+06 (Ops)
[MLU TheoryIOs          ]: 2.78584e+07 (Bytes)
[MLU ComputeForce       ]: 1.024e+12 (op/s)
[MLU IoBandWidth        ]: 307.2 (GB/s)
[GPU Hardware Time      ]: -1 (us)
[GPU IO Efficiency      ]: -1
[GPU Compute Efficiency ]: -1
[GPU Workspace Size     ]: -1 (Bytes)
[Diffs]:
[output1]
DIFF3: 0.000000e+00
[output2]
DIFF3: 0.000000e+00
[output3]
DIFF3: 0.000000e+00
[^      OK ] ../../test/mlu_op_gtest/pb_gtest/src/zoo/get_indice_pairs/test_cases/case_1.prototxt
[       OK ] get_indice_pairs/TestSuite.mluOp/0 (604 ms)
[----------] 1 test from get_indice_pairs/TestSuite (604 ms total)

[----------] Global test environment tear-down
[ SUMMARY  ] Total 1 cases of 1 op(s).
ALL PASSED.
[==========] 1 test case from 1 test suite ran. (4670 ms total)
[  PASSED  ] 1 test case.
```
### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.