### PR TITLE
[Fix](mluOpDeformRoiPoolBackward): fix cpuCompute

### DIFF
--- a/test/mlu_op_gtest/pb_gtest/src/zoo/deform_roi_pool_backward/deform_roi_pool_backward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/deform_roi_pool_backward/deform_roi_pool_backward.cpp
@@ -259,7 +259,7 @@ void DeformRoiPoolBackwardExecutor::cpuCompute() {
                   cpu_fp32_output_[1][n * pooled_width * pooled_height * 2 +
                                       pooled_width * pooled_height +
                                       ph * pooled_width + pw] += ogy;
-                  theory_ops_ += 24;  // cur block
+                  theory_ops_ += 28;  // cur block
                 }
               }
             }

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/deform_roi_pool_backward/deform_roi_pool_backward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/deform_roi_pool_backward/deform_roi_pool_backward.cpp
@@ -249,11 +249,11 @@ void DeformRoiPoolBackwardExecutor::cpuCompute() {
                   float input_11 = offset_input[y_high * width * channels +
                                                 x_high * channels + c];
                   float ogx = gamma * roi_width * grad_output_this_bin *
-                              ((input_11 - input_01) * (y - y_low) +
-                               (input_10 - input_00) * (y_high - y));
+                          (input_11 * (y - y_low) + input_10 * (y_high - y) +
+                           input_01 * (y_low - y) + input_00 * (y - y_high));
                   float ogy = gamma * roi_height * grad_output_this_bin *
-                              ((input_11 - input_10) * (x - x_low) +
-                               (input_01 - input_00) * (x_high - x));
+                          (input_11 * (x - x_low) + input_01 * (x_high - x) +
+                           input_10 * (x_low - x) + input_00 * (x - x_high));
                   cpu_fp32_output_[1][n * pooled_width * pooled_height * 2 +
                                       ph * pooled_width + pw] += ogx;
                   cpu_fp32_output_[1][n * pooled_width * pooled_height * 2 +


### PR DESCRIPTION
…- c * b not equal to (a-c)*b

Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

a * b - c * b 在特殊情况下不等于 (a - c) *b

## 2. Modification

不做简化，恢复原来代码

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details



