### PR TITLE
Ms deform 290

### DIFF
--- a/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.h
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.h
@@ -30,6 +30,23 @@
 #define MS_DEFORM_ATTN_FORWARD_HEADVECTOR 1
 
 template <typename T>
+__mlu_func__ void __mluop_floor(T *dst_ram, T* src_ram, int size) {
+// #if (__BANG_ARCH__ >= 322)
+//   __bang_floor(dst_ram, src_ram, size);  // This bang interface is for nan/inf
+//                                   // temp.
+// #else
+  if(sizeof(T) == sizeof(float)) {
+    int16 *mid = (int16 *)(dst_ram + size / 2);
+    __bang_float2int16_dn(mid, (float *)src_ram, size, 0);
+    __bang_int162float((float *)dst_ram, (int16_t*)mid, size, 0);
+  } else {
+    __bang_half2int16_dn((int16_t *)dst_ram, (half *)src_ram, size, 0);
+    __bang_int162half((half *)dst_ram, (int16_t*)dst_ram, size, 0);
+  }
+// #endif
+}
+
+template <typename T>
 __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
     const char *data_value_gdram, const char *data_spatial_shapes_gdram,
     const char *data_level_start_index_gdram,

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -36,9 +36,12 @@ __mlu_func__ void broadcastSpatialHW(
   float* spatial_w_bd_nram,       // (num_levels, num_points)
   int32_t* spatial_shapes_nram,   // (num_levels, 2)
   int32_t* spatial_offset_nram,   // (num_levels)
-  const int32_t num_levels, const int32_t num_points) {
+  const int32_t num_levels, const int32_t num_points, const int32_t pad_num_points_levels) {
+  __bang_write_value(spatial_h_bd_nram, pad_num_points_levels, 0);
+  __bang_write_value(spatial_w_bd_nram, pad_num_points_levels, 0);
+  __bang_write_value(spatial_offset_bd_nram, pad_num_points_levels, 0);
   __bang_int322float((float*)spatial_shapes_nram, spatial_shapes_nram,
-                    num_levels * 2, 0);
+                    num_levels * 2, 0); // 这个指令还需要换成 mluop_int322float
   for(int i = 0; i < num_levels; i++) {
     __memcpy(spatial_h_bd_nram + i * num_points,
             spatial_shapes_nram + i * 2, sizeof(float),
@@ -50,7 +53,7 @@ __mlu_func__ void broadcastSpatialHW(
             NRAM2NRAM, sizeof(float), 0, num_points - 1);
   }
   __bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
-                    num_levels, 0);
+                    num_levels, 0); // 这个指令还需要换成 mluop_int322float
   for(int i = 0; i < num_levels; i++) {
     __memcpy(spatial_offset_bd_nram + i * num_points,
             spatial_offset_nram + i, sizeof(float),
@@ -66,74 +69,90 @@ __mlu_func__ void getConditionCoordWeight(
     T* spatial_offset_bd_nram, T* spatial_w_bd_nram, T* spatial_h_bd_nram,
     T* buf_nram, const int32_t deal_n, const int32_t num_levels, const int32_t num_points,
     const int32_t num_heads, const int32_t channels) {
-  int32_t total_points = deal_n * num_levels * num_points;
-  int32_t block_points = num_levels * num_points;
+  int32_t pad_num_points_levels =
+    PAD_UP(num_points * num_levels, NFU_ALIGN_SIZE / sizeof(T));
+  // int32_t total_points = deal_n * num_levels * num_points;
+  int32_t pad_total_points = deal_n * pad_num_points_levels;
+  // int32_t block_points = num_levels * num_points;
+  int32_t pad_block_points = pad_num_points_levels;
   T* buf_x_nram = buf_nram;
-  T* buf_y_nram = buf_nram + total_points;
-  T* buf_cond_nram = buf_nram + 2 * total_points;
-  T* buf_x_floor = buf_nram + 2 * total_points;
-  T* buf_x_ceil = buf_nram + 3 * total_points;
-  T* buf_y_floor = buf_nram + 4 * total_points;
-  T* buf_y_ceil = buf_nram + 5 * total_points;
+  T* buf_y_nram = buf_nram + pad_total_points;
+  T* buf_cond_nram = buf_nram + 2 * pad_total_points;
+  T* buf_x_floor = buf_nram + 2 * pad_total_points;
+  T* buf_x_ceil = buf_nram + 3 * pad_total_points;
+  T* buf_y_floor = buf_nram + 4 * pad_total_points;
+  T* buf_y_ceil = buf_nram + 5 * pad_total_points;
   //================================================================================================
-  int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
+  int32_t total_coord_pad = PAD_UP(pad_total_points * 2, BIT_COLLECT_PAD);
   __bang_collect_bitindex(buf_x_nram, loc_nram, mask_x_nram, total_coord_pad);
   __bang_collect_bitindex(buf_y_nram, loc_nram, mask_y_nram, total_coord_pad);
   // x = loc_x * spatial_w - 0.5; y = loc_y * spatial_h - 0.5;
-  __bang_fusion(FUSION_FMS, buf_x_nram, buf_x_nram, spatial_w_bd_nram, (T)0.5,
-                total_points, block_points);
-  __bang_fusion(FUSION_FMS, buf_y_nram, buf_y_nram, spatial_h_bd_nram, (T)0.5,
-                total_points, block_points);
+  // FUSION_FMS < dst >=< src0 > × < src1 > − < src2 >
+  // __bang_fusion(FUSION_FMS, buf_x_nram, buf_x_nram, spatial_w_bd_nram, (T)0.5,
+  //               total_points, block_points);
+  __bang_cycle_mul(buf_x_nram, buf_x_nram, spatial_w_bd_nram, pad_total_points, pad_block_points);
+  __bang_sub_scalar(buf_x_nram, buf_x_nram, (T)0.5, pad_total_points);
+
+  // __bang_fusion(FUSION_FMS, buf_y_nram, buf_y_nram, spatial_h_bd_nram, (T)0.5,
+  //               total_points, block_points);
+  __bang_cycle_mul(buf_y_nram, buf_y_nram, spatial_h_bd_nram, pad_total_points, pad_block_points);
+  __bang_sub_scalar(buf_y_nram, buf_y_nram, (T)0.5, pad_total_points);
   //================================================================================================
   // get point condition. use buf0, buf1, buf2
   // (x > -1 && y > -1 && y < spatial_h && x < spatial_w)
-  __bang_gt_scalar(cond_point_valid_nram, buf_x_nram, (T)-1.0, total_points);
-  __bang_gt_scalar(buf_cond_nram, buf_y_nram, (T)-1.0, total_points);
+  // __bang_gt_scalar(cond_point_valid_nram, buf_x_nram, (T)-1.0, total_points);
+  __bang_write_value(cond_point_valid_nram, pad_total_points, (T)-1.0);
+  __bang_gt(cond_point_valid_nram, buf_x_nram, cond_point_valid_nram, pad_total_points);
+
+  // __bang_gt_scalar(buf_cond_nram, buf_y_nram, (T)-1.0, total_points);
+  __bang_write_value(buf_cond_nram, pad_total_points, (T)-1.0);
+  __bang_gt(buf_cond_nram, buf_y_nram, buf_cond_nram, pad_total_points);
+
   __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
-             total_points);
-  __bang_cycle_lt(buf_cond_nram, buf_x_nram, spatial_w_bd_nram, total_points,
-                  block_points);
+             pad_total_points);
+  __bang_cycle_lt(buf_cond_nram, buf_x_nram, spatial_w_bd_nram, pad_total_points,
+                  pad_block_points);
   __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
-             total_points);
-  __bang_cycle_lt(buf_cond_nram, buf_y_nram, spatial_h_bd_nram, total_points,
-                  block_points);
+             pad_total_points);
+  __bang_cycle_lt(buf_cond_nram, buf_y_nram, spatial_h_bd_nram, pad_total_points,
+                  pad_block_points);
   __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
-             total_points);
+             pad_total_points);
   //================================================================================================
-  __bang_floor(buf_x_floor, buf_x_nram, total_points);
-  __bang_add_scalar(buf_x_ceil, buf_x_floor, 1.0, total_points);
-  __bang_floor(buf_y_floor, buf_y_nram, total_points);
-  __bang_add_scalar(buf_y_ceil, buf_y_floor, 1.0, total_points);
+  __mluop_floor(buf_x_floor, buf_x_nram, pad_total_points);
+  __bang_add_scalar(buf_x_ceil, buf_x_floor, 1.0, pad_total_points);
+  __mluop_floor(buf_y_floor, buf_y_nram, pad_total_points);
+  __bang_add_scalar(buf_y_ceil, buf_y_floor, 1.0, pad_total_points);
   T* cond_point_polation_nram_tl = cond_point_polation_nram;
-  T* cond_point_polation_nram_bl = cond_point_polation_nram + total_points;
-  T* cond_point_polation_nram_tr = cond_point_polation_nram + 2 * total_points;
-  T* cond_point_polation_nram_br = cond_point_polation_nram + 3 * total_points;
+  T* cond_point_polation_nram_bl = cond_point_polation_nram + pad_total_points;
+  T* cond_point_polation_nram_tr = cond_point_polation_nram + 2 * pad_total_points;
+  T* cond_point_polation_nram_br = cond_point_polation_nram + 3 * pad_total_points;
   T* cond_point_polation_nram_cond1 = weight_polation_nram;
-  T* cond_point_polation_nram_cond2 = weight_polation_nram + total_points;
-  T* cond_point_polation_nram_cond3 = weight_polation_nram + 2 * total_points;
-  T* cond_point_polation_nram_cond4 = weight_polation_nram + 3 * total_points;
+  T* cond_point_polation_nram_cond2 = weight_polation_nram + pad_total_points;
+  T* cond_point_polation_nram_cond3 = weight_polation_nram + 2 * pad_total_points;
+  T* cond_point_polation_nram_cond4 = weight_polation_nram + 3 * pad_total_points;
   __bang_ge_scalar(cond_point_polation_nram_cond1, buf_x_floor, (T)0,
-                   total_points);
+                   pad_total_points);
   __bang_cycle_lt(cond_point_polation_nram_cond2, buf_x_ceil, spatial_w_bd_nram,
-                  total_points, block_points);
+                  pad_total_points, pad_block_points);
   __bang_ge_scalar(cond_point_polation_nram_cond3, buf_y_floor, (T)0,
-                   total_points);
+                   pad_total_points);
   __bang_cycle_lt(cond_point_polation_nram_cond4, buf_y_ceil, spatial_h_bd_nram,
-                  total_points, block_points);
+                  pad_total_points, pad_block_points);
   __bang_and(cond_point_polation_nram_tl, cond_point_polation_nram_cond1,
-             cond_point_polation_nram_cond4, total_points);
+             cond_point_polation_nram_cond4, pad_total_points);
   __bang_and(cond_point_polation_nram_bl, cond_point_polation_nram_cond1,
-             cond_point_polation_nram_cond3, total_points);
+             cond_point_polation_nram_cond3, pad_total_points);
   __bang_and(cond_point_polation_nram_tr, cond_point_polation_nram_cond2,
-             cond_point_polation_nram_cond4, total_points);
+             cond_point_polation_nram_cond4, pad_total_points);
   __bang_and(cond_point_polation_nram_br, cond_point_polation_nram_cond2,
-             cond_point_polation_nram_cond3, total_points);
+             cond_point_polation_nram_cond3, pad_total_points);
   //================================================================================================
   // get polation weight.
   T* buf_dx = (T*)data_offset_nram;
-  T* buf_dy = buf_dx + total_points;
-  T* buf_dx_1 = buf_dy + total_points;
-  T* buf_dy_1 = buf_dx_1 + total_points;
+  T* buf_dy = buf_dx + pad_total_points;
+  T* buf_dx_1 = buf_dy + pad_total_points;
+  T* buf_dy_1 = buf_dx_1 + pad_total_points;
   // -dx = x_floor-x
   // -dy = y_floor-y
   // w1 = (1-dx)*dy     = (dx-1)*(-dy)
@@ -141,68 +160,90 @@ __mlu_func__ void getConditionCoordWeight(
   // w3 = dx*dy         = (-dx)*(-dy)
   // w4 = dx*(1-dy)     = (-dx)*(dy-1)
   T* weight_polation_nram_1 = weight_polation_nram;
-  T* weight_polation_nram_2 = weight_polation_nram + 1 * total_points;
-  T* weight_polation_nram_3 = weight_polation_nram + 2 * total_points;
-  T* weight_polation_nram_4 = weight_polation_nram + 3 * total_points;
+  T* weight_polation_nram_2 = weight_polation_nram + 1 * pad_total_points;
+  T* weight_polation_nram_3 = weight_polation_nram + 2 * pad_total_points;
+  T* weight_polation_nram_4 = weight_polation_nram + 3 * pad_total_points;
   // T* weight_polation_nram_buf = buf_nram + 4 * total_points;
-  __bang_sub(buf_dx, buf_x_floor, buf_x_nram, total_points);
-  __bang_sub(buf_dy, buf_y_floor, buf_y_nram, total_points);
-  __bang_fusion(FUSION_FSS, buf_dx_1, buf_x_nram, buf_x_floor, (T)1.0,
-                total_points, total_points);
-  __bang_fusion(FUSION_FSS, buf_dy_1, buf_y_nram, buf_y_floor, (T)1.0,
-                total_points, total_points);
-  __bang_mul(weight_polation_nram_1, buf_dx_1, buf_dy, total_points);
-  __bang_mul(weight_polation_nram_2, buf_dx_1, buf_dy_1, total_points);
-  __bang_mul(weight_polation_nram_3, buf_dx, buf_dy, total_points);
-  __bang_mul(weight_polation_nram_4, buf_dx, buf_dy_1, total_points);
+  __bang_sub(buf_dx, buf_x_floor, buf_x_nram, pad_total_points);
+  __bang_sub(buf_dy, buf_y_floor, buf_y_nram, pad_total_points);
+  // FUSION_FSS < dst >=< src0 > − < src1 > − < src2 >
+  // __bang_fusion(FUSION_FSS, buf_dx_1, buf_x_nram, buf_x_floor, (T)1.0,
+  //               total_points, total_points);
+  __bang_sub(buf_dx_1, buf_x_nram, buf_x_floor, pad_total_points);
+  __bang_sub_scalar(buf_dx_1, buf_dx_1, (T)1.0, pad_total_points);
+
+  // __bang_fusion(FUSION_FSS, buf_dy_1, buf_y_nram, buf_y_floor, (T)1.0,
+  //               total_points, total_points);
+  __bang_sub(buf_dy_1, buf_y_nram, buf_y_floor, pad_total_points);
+  __bang_sub_scalar(buf_dy_1, buf_dy_1, (T)1.0, pad_total_points);
+
+  __bang_mul(weight_polation_nram_1, buf_dx_1, buf_dy, pad_total_points);
+  __bang_mul(weight_polation_nram_2, buf_dx_1, buf_dy_1, pad_total_points);
+  __bang_mul(weight_polation_nram_3, buf_dx, buf_dy, pad_total_points);
+  __bang_mul(weight_polation_nram_4, buf_dx, buf_dy_1, pad_total_points);
   //================================================================================================
   // correct the x,y in [0, w-1] and [0, h-1]
   T* spatial_w1_bd_nram = buf_nram;
-  T* spatial_h1_bd_nram = buf_nram + block_points;
-  __bang_sub_scalar(spatial_w1_bd_nram, spatial_w_bd_nram, (T)1, block_points);
-  __bang_sub_scalar(spatial_h1_bd_nram, spatial_h_bd_nram, (T)1, block_points);
-  __bang_maxeq_scalar(buf_x_floor, buf_x_floor, (T)0, total_points);
-  __bang_maxeq_scalar(buf_x_ceil, buf_x_ceil, (T)0, total_points);
+  T* spatial_h1_bd_nram = buf_nram + pad_block_points;
+  __bang_sub_scalar(spatial_w1_bd_nram, spatial_w_bd_nram, (T)1, pad_block_points);
+  __bang_sub_scalar(spatial_h1_bd_nram, spatial_h_bd_nram, (T)1, pad_block_points);
+  T* maxtemp = (T*)data_offset_nram;
+  __bang_write_value(maxtemp, pad_total_points, (T)0);
+  // __bang_maxeq_scalar(buf_x_floor, buf_x_floor, (T)0, total_points);
+  __bang_maxequal(buf_x_floor, buf_x_floor, maxtemp, pad_total_points);
+  // __bang_maxeq_scalar(buf_x_ceil, buf_x_ceil, (T)0, total_points);
+  __bang_maxequal(buf_x_ceil, buf_x_ceil, maxtemp, pad_total_points);
+
   __bang_cycle_minequal(buf_x_floor, buf_x_floor, spatial_w1_bd_nram,
-                        total_points, block_points);
+                        pad_total_points, pad_block_points);
   __bang_cycle_minequal(buf_x_ceil, buf_x_ceil, spatial_w1_bd_nram,
-                        total_points, block_points);
-  __bang_maxeq_scalar(buf_y_floor, buf_y_floor, (T)0, total_points);
-  __bang_maxeq_scalar(buf_y_ceil, buf_y_ceil, (T)0, total_points);
+                        pad_total_points, pad_block_points);
+  // __bang_maxeq_scalar(buf_y_floor, buf_y_floor, (T)0, total_points);
+  __bang_maxequal(buf_y_floor, buf_y_floor, maxtemp, pad_total_points);
+  // __bang_maxeq_scalar(buf_y_ceil, buf_y_ceil, (T)0, total_points);
+  __bang_maxequal(buf_y_ceil, buf_y_ceil, maxtemp, pad_total_points);
   __bang_cycle_minequal(buf_y_floor, buf_y_floor, spatial_h1_bd_nram,
-                        total_points, block_points);
+                        pad_total_points, pad_block_points);
   __bang_cycle_minequal(buf_y_ceil, buf_y_ceil, spatial_h1_bd_nram,
-                        total_points, block_points);
+                        pad_total_points, pad_block_points);
   //================================================================================================
   // offset = y*w + x
   T* buf_hw_offset = buf_nram;
   T* data_offset_nram_tl = (T*)data_offset_nram;
-  T* data_offset_nram_bl = data_offset_nram_tl + total_points;
-  T* data_offset_nram_tr = data_offset_nram_bl + total_points;
-  T* data_offset_nram_br = data_offset_nram_tr + total_points;
+  T* data_offset_nram_bl = data_offset_nram_tl + pad_total_points;
+  T* data_offset_nram_tr = data_offset_nram_bl + pad_total_points;
+  T* data_offset_nram_br = data_offset_nram_tr + pad_total_points;
   // y_ceil*w + offset + x_floor
-  __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_ceil, spatial_w_bd_nram,
-                spatial_offset_bd_nram, total_points, block_points);
-  __bang_add(data_offset_nram_tl, buf_hw_offset, buf_x_floor, total_points);
+  // FUSION_FMA < dst >=< src0 > × < src1 > + < src2 >
+  // __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_ceil, spatial_w_bd_nram,
+  //               spatial_offset_bd_nram, total_points, block_points);
+  __bang_cycle_mul(buf_hw_offset, buf_y_ceil, spatial_w_bd_nram, pad_total_points, pad_block_points);
+  __bang_cycle_add(buf_hw_offset, buf_hw_offset, spatial_offset_bd_nram, pad_total_points,
+                   pad_block_points);
+
+  __bang_add(data_offset_nram_tl, buf_hw_offset, buf_x_floor, pad_total_points);
   // y_ceil*w + offset + x_ceil
-  __bang_add(data_offset_nram_tr, buf_hw_offset, buf_x_ceil, total_points);
+  __bang_add(data_offset_nram_tr, buf_hw_offset, buf_x_ceil, pad_total_points);
   // y_floor*w + offset + x_foor
-  __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_floor, spatial_w_bd_nram,
-                spatial_offset_bd_nram, total_points, block_points);
-  __bang_add(data_offset_nram_bl, buf_hw_offset, buf_x_floor, total_points);
+  // __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_floor, spatial_w_bd_nram,
+  //               spatial_offset_bd_nram, total_points, block_points);
+  __bang_cycle_mul(buf_hw_offset, buf_y_floor, spatial_w_bd_nram, pad_total_points, pad_block_points);
+  __bang_cycle_add(buf_hw_offset, buf_hw_offset, spatial_offset_bd_nram, pad_total_points,
+                   pad_block_points);
+  __bang_add(data_offset_nram_bl, buf_hw_offset, buf_x_floor, pad_total_points);
   // y_floor*w + offset + x_ceil
-  __bang_add(data_offset_nram_br, buf_hw_offset, buf_x_ceil, total_points);
+  __bang_add(data_offset_nram_br, buf_hw_offset, buf_x_ceil, pad_total_points);
   __bang_cycle_and(cond_point_polation_nram, cond_point_polation_nram,
-                   cond_point_valid_nram, 4 * total_points, total_points);
+                   cond_point_valid_nram, 4 * pad_total_points, pad_total_points);
   __bang_cycle_mul(weight_polation_nram, weight_polation_nram,
-                   weight_attn_nram, 4 * total_points, total_points);
-  __bang_mul(weight_polation_nram, weight_polation_nram, cond_point_polation_nram, total_points * 4);
+                   weight_attn_nram, 4 * pad_total_points, pad_total_points);
+  __bang_mul(weight_polation_nram, weight_polation_nram, cond_point_polation_nram, pad_total_points * 4);
   __bang_sub((float*)data_offset_nram_bl,
              (float*)data_offset_nram_bl,
-             (float*)data_offset_nram_tl, total_points);
+             (float*)data_offset_nram_tl, pad_total_points);
   __bang_sub((float*)data_offset_nram_tr,
              (float*)data_offset_nram_tr,
-             (float*)data_offset_nram_tl, total_points);
+             (float*)data_offset_nram_tl, pad_total_points);
 }
 
 /*
@@ -227,18 +268,16 @@ __mlu_func__ void reduceLevelByConv(
     int32_t* cond_selected_base, T* weight_selected_base, T* weight_attn_nram,
     T* weight_compute, int32_t* cond_compute, const int32_t valid_num, const int32_t channels,
     const int32_t sample_stride_3) {
-    int32_t ci = 4 * valid_num;
-    int32_t co = channels;
+    // int32_t ci = 4 * valid_num;
+    // int32_t co = channels;
+    int32_t pad_channels = PAD_UP(channels, NFU_ALIGN_SIZE/sizeof(T));
     __memcpy(weight_compute, weight_selected_base, valid_num * sizeof(T),
                    NRAM2NRAM, valid_num * sizeof(T),
                    sample_stride_3 * sizeof(T), 3);
-    __bang_transpose(input_trans, input_nram, ci, co);
-    __sync_move();
-    __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
-    __bang_sumpool(input_pooled, input_trans, valid_num, channels, 4, 1, 4, 1,
-                  1);
-    __bang_sumpool(output_nram, input_pooled, 1, channels, valid_num, 1,
-                  valid_num, 1, 1);
+    for(int k = 0; k < 4 *valid_num; k++) {
+      __bang_mul_scalar(input_nram + pad_channels * k, input_nram + pad_channels * k, weight_compute[k], pad_channels);
+    }
+    __bang_sumpool(output_nram, input_nram, pad_channels, 4, valid_num, 4, valid_num, 1, 1);
 }
 
 __mlu_func__ void loadNram2Gpr(int32_t& v1, int32_t& v2, int32_t& v3,
@@ -278,24 +317,28 @@ __mlu_func__ void loadDataValueXram2NramAsync(
   int32_t next = 0;
   int32_t loop_num = num_levels_points / 2;
   int32_t remain = num_levels_points % 2;
-  int32_t data_value_stride = num_levels_points * channel_size;
+  // int32_t data_value_stride = num_levels_points * channel_size;
+  int32_t pad_num_points_levels = PAD_UP(num_levels_points, NFU_ALIGN_SIZE/sizeof(T));
+  int32_t pad_channels = PAD_UP(channel_size, NFU_ALIGN_SIZE/sizeof(T));
+  int pad_data_value_stride = pad_num_points_levels * pad_channels; 
+
   for (int32_t j = 0; j < loop_num * 2; j += 2) {
-    value_offset = j * channel_size;
+    value_offset = j * pad_channels;
     next = j + 2;
     for(int i = 0; i < 2; i++)
     {
-      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + data_value_stride * i,
+      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + pad_data_value_stride * i,
                      (int8_t*)value_src + offset_1_a + i * stride_2_1_a,
-                      channel_size, GDRAM2NRAM, 2 * data_value_stride, stride_3_1_a, 1);
+                      channel_size, GDRAM2NRAM, 2 * pad_data_value_stride, stride_3_1_a, 1);
     }
 
     loadNram2Gpr(offset_1_a, stride_2_1_a, stride_3_1_a, offset_1 + next,
                  stride_2_1 + next, stride_3_1 + next, num_heads, channel_size);
     for(int i = 0; i < 2; i++)
     {
-      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size + data_value_stride * i,
+      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + pad_channels + pad_data_value_stride * i,
                      (int8_t*)value_src + offset_1_b + i * stride_2_1_b,
-                      channel_size, GDRAM2NRAM, 2 * data_value_stride, stride_3_1_b, 1);
+                      channel_size, GDRAM2NRAM, 2 * pad_data_value_stride, stride_3_1_b, 1);
     }
 
     loadNram2Gpr(offset_1_b, stride_2_1_b, stride_3_1_b, offset_1 + next + 1,
@@ -306,9 +349,9 @@ __mlu_func__ void loadDataValueXram2NramAsync(
     value_offset = loop_num * 2 * channel_size;
     for(int i = 0; i < 2; i++)
     {
-      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + data_value_stride * i,
+      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + pad_data_value_stride * i,
                      (int8_t*)value_src + offset_1_a + i * stride_2_1_a,
-                      channel_size, GDRAM2NRAM, 2 * data_value_stride, stride_3_1_a, 1);
+                      channel_size, GDRAM2NRAM, 2 * pad_data_value_stride, stride_3_1_a, 1);
     }
   }
 }
@@ -322,12 +365,16 @@ __mlu_func__ void loadNeighborPolationAttn(
     const int32_t num_levels, const int32_t num_points, const int32_t num_keys,
     const int32_t channels, const int32_t num_heads) {
   int32_t channel_size = channels * sizeof(T);
-  int32_t sample_stride_3 = deal_n * num_levels * num_points;
   int32_t value_stride_3 = num_levels * num_points * channels;
+  int32_t pad_num_points_levels = PAD_UP(num_levels*num_points, NFU_ALIGN_SIZE/sizeof(T));
+  int32_t sample_stride_3 = deal_n * num_levels * num_points;
+  int32_t pad_sample_stride_3 = deal_n * pad_num_points_levels;
+  int32_t pad_channels = PAD_UP(channels, NFU_ALIGN_SIZE/sizeof(T));
+  int32_t pad_value_stride_3 = pad_num_points_levels * pad_channels;
   int32_t value_stride_3_size = value_stride_3 * sizeof(T);
   T* buf_value_nram = buf_nram;  // (4, num_levels, num_points, channels)
   T* buf_value_nram_trans =
-      buf_nram + 4 * value_stride_3;  // (4, num_levels, num_points, channels)
+      buf_nram + 4 * pad_value_stride_3;  // (4, num_levels, num_points, channels)
   T* buf_value_nram_pool =
       buf_nram + 8 * value_stride_3;  // (1, num_levels, num_points, channels)
   T* weight_compute_nram = compute_buf_nram;      // (4, num_levels, num_points)
@@ -336,8 +383,8 @@ __mlu_func__ void loadNeighborPolationAttn(
   __sync_compute();
 
   int32_t* offset = data_offset_nram;
-  int32_t* stride_2_1 = offset + sample_stride_3;
-  int32_t* stride_3_1 = stride_2_1 + sample_stride_3;
+  int32_t* stride_2_1 = offset + pad_sample_stride_3;
+  int32_t* stride_3_1 = stride_2_1 + pad_sample_stride_3;
   T* output_nram = value_output_nram;
   int32_t step_offset = 0;
   for (int32_t i = 0; i < deal_n; i++) {
@@ -352,11 +399,11 @@ __mlu_func__ void loadNeighborPolationAttn(
         weight_polation_nram + step_offset, weight_attn_nram + step_offset,
         weight_compute_nram, cond_compute_nram, valid_num,
         channels, sample_stride_3);
-    step_offset += valid_num;
+    step_offset += pad_num_points_levels;
     offset = data_offset_nram + step_offset;
-    stride_2_1 = offset + sample_stride_3;
-    stride_3_1 = stride_2_1 + sample_stride_3;
-    output_nram += channels;
+    stride_2_1 = offset + pad_sample_stride_3;
+    stride_3_1 = stride_2_1 + pad_sample_stride_3;
+    output_nram += pad_channels;
   }
 }
 
@@ -382,7 +429,7 @@ __mlu_func__ void prepareLoop(
   __sync_io_move_compute();
   broadcastSpatialHW(spatial_offset_bd_nram, spatial_h_bd_nram,
                      spatial_w_bd_nram, spatial_hw_nram, spatial_offset_nram,
-                     num_levels, num_points);
+                     num_levels, num_points, pad_num_points_levels);
 }
 
 /*
@@ -409,64 +456,66 @@ __mlu_func__ void prepareLoop(
 */
 template <typename T>
 __mlu_func__ void memPolicyCommon(
-    T*& buf_compute_nram, T*& ones_nram, T*& value_output_nram,
-    int32_t*& data_offset_nram, T*& weight_polation_nram,
-    T*& cond_point_polation_nram, T*& cond_point_valid_nram, T*& loc_nram,
-    T*& weight_attn_nram, T*& buf_nram, T*& buf_nram_end, int8_t*& mask_x_nram,
-    int8_t*& mask_y_nram, T*& spatial_offset_bd_nram, T*& spatial_w_bd_nram,
-    T*& spatial_h_bd_nram, int32_t*& spatial_offset_nram,
-    int32_t*& spatial_hw_nram, int32_t& max_deal_n,
-    int32_t& mask_size, const int32_t batch_size, const int32_t num_keys,
-    const int32_t num_heads, const int32_t channels, const int32_t num_levels,
-    const int32_t num_queries, const int32_t num_points) {
-  int32_t num_points_levels = num_levels * num_points;
-  int32_t pad_num_points_levels =
-      PAD_UP(num_points_levels, NFU_ALIGN_SIZE / sizeof(T));
-  int32_t pad_num_points_levels_8 =
-      PAD_UP(8 * num_points_levels, NFU_ALIGN_SIZE / sizeof(T));
-  int32_t spatial_info_size =
-      PAD_UP(3 * num_levels * sizeof(int32_t), NFU_ALIGN_SIZE);
-  int32_t fix_space_size =
-      spatial_info_size + 2 * BIT_COLLECT_PAD * sizeof(T) +
-      (4 * pad_num_points_levels + pad_num_points_levels_8) * sizeof(T);
-  int32_t left_space_size = NRAM_AVALIABLE_SIZE - fix_space_size;
-  int32_t common_buffer_size_each = 6 * num_points_levels * sizeof(T);
-  int32_t inter_result_size_each =
-      17 * num_points_levels * sizeof(T) + channels * sizeof(T);
+  T*& buf_compute_nram, T*& ones_nram, T*& value_output_nram,
+  int32_t*& data_offset_nram, T*& weight_polation_nram,
+  T*& cond_point_polation_nram, T*& cond_point_valid_nram, T*& loc_nram,
+  T*& weight_attn_nram, T*& buf_nram, T*& buf_nram_end, int8_t*& mask_x_nram,
+  int8_t*& mask_y_nram, T*& spatial_offset_bd_nram, T*& spatial_w_bd_nram,
+  T*& spatial_h_bd_nram, int32_t*& spatial_offset_nram,
+  int32_t*& spatial_hw_nram, int32_t& max_deal_n,
+  int32_t& mask_size, const int32_t batch_size, const int32_t num_keys,
+  const int32_t num_heads, const int32_t channels, const int32_t num_levels,
+  const int32_t num_queries, const int32_t num_points) {
+int32_t pad_channels = PAD_UP(channels, NFU_ALIGN_SIZE/sizeof(T));
+int32_t num_points_levels = num_levels * num_points;
+int32_t pad_num_points_levels =
+    PAD_UP(num_points_levels, NFU_ALIGN_SIZE / sizeof(T));
+int32_t pad_num_points_levels_8 = 8 * pad_num_points_levels;
+    // PAD_UP(8 * num_points_levels, NFU_ALIGN_SIZE / sizeof(T));
+int32_t spatial_info_size =
+    PAD_UP(3 * num_levels * sizeof(int32_t), NFU_ALIGN_SIZE);
+int32_t fix_space_size =
+    spatial_info_size + 2 * BIT_COLLECT_PAD * sizeof(T) +
+    (4 * pad_num_points_levels + pad_num_points_levels_8) * sizeof(T);
+int32_t left_space_size = NRAM_AVALIABLE_SIZE - fix_space_size;
+int32_t common_buffer_size_each = 6 * pad_num_points_levels * sizeof(T);
+int32_t inter_result_size_each =
+    17 * pad_num_points_levels * sizeof(T) + pad_channels * sizeof(T);
 
-  max_deal_n =
-      left_space_size / (common_buffer_size_each + inter_result_size_each);
-  int32_t compute_buffer_size =
-      (9 * num_points_levels * channels + max_deal_n) * sizeof(T);
-  int32_t common_buffer_size = max_deal_n * common_buffer_size_each;
-  // make sure buf_nram is large enough for compute
-  if (compute_buffer_size > common_buffer_size) {
-    int32_t tmp_deal_n =
-        (left_space_size - compute_buffer_size) / inter_result_size_each;
-    max_deal_n = __mluop_min(max_deal_n, tmp_deal_n);
-  }
+max_deal_n =
+    left_space_size / (common_buffer_size_each + inter_result_size_each);
+int32_t compute_buffer_size =
+    (9 * pad_num_points_levels * pad_channels + max_deal_n) * sizeof(T);
+int32_t common_buffer_size = max_deal_n * common_buffer_size_each;
+// make sure buf_nram is large enough for compute
+if (compute_buffer_size > common_buffer_size) {
+  int32_t tmp_deal_n =
+      (left_space_size - compute_buffer_size) / inter_result_size_each;
+  max_deal_n = __mluop_min(max_deal_n, tmp_deal_n);
+}
 
-  int32_t total_points = max_deal_n * num_points_levels;
-  int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
-  mask_size = total_coord_pad / BIT_COLLECT_PAD;
-  ones_nram = (T*)nram_buffer;
-  buf_compute_nram = ones_nram + pad_num_points_levels;
-  spatial_offset_nram = (int32_t*)(buf_compute_nram + pad_num_points_levels_8);
-  spatial_hw_nram = spatial_offset_nram + num_levels;
-  spatial_offset_bd_nram = (T*)(spatial_hw_nram + num_levels * 2);
-  spatial_w_bd_nram = spatial_offset_bd_nram + num_points_levels;
-  spatial_h_bd_nram = spatial_w_bd_nram + num_points_levels;
-  mask_x_nram = (int8_t*)(spatial_h_bd_nram + num_points_levels);
-  mask_y_nram = mask_x_nram + mask_size;
-  value_output_nram = (T*)(mask_y_nram + mask_size);
-  data_offset_nram = (int32_t*)(value_output_nram + max_deal_n * channels);
-  weight_polation_nram = (T*)(data_offset_nram + 4 * total_points);
-  cond_point_polation_nram = weight_polation_nram + 4 * total_points;
-  cond_point_valid_nram = cond_point_polation_nram + 4 * total_points;
-  loc_nram = cond_point_valid_nram + total_points;
-  weight_attn_nram = loc_nram + total_coord_pad;
-  buf_nram = weight_attn_nram + total_points;
-  buf_nram_end = buf_nram + 6 * max_deal_n * num_points_levels;
+// int32_t total_points = max_deal_n * num_points_levels;
+int32_t pad_total_points = max_deal_n * pad_num_points_levels;
+int32_t total_coord_pad = PAD_UP(pad_total_points * 2, BIT_COLLECT_PAD);
+mask_size = total_coord_pad / BIT_COLLECT_PAD;
+ones_nram = (T*)nram_buffer;
+buf_compute_nram = ones_nram + pad_num_points_levels;
+spatial_offset_nram = (int32_t*)(buf_compute_nram + pad_num_points_levels_8);
+spatial_hw_nram = spatial_offset_nram + num_levels;
+spatial_offset_bd_nram = (T*)(spatial_hw_nram + num_levels * 2);
+spatial_w_bd_nram = spatial_offset_bd_nram + pad_num_points_levels;
+spatial_h_bd_nram = spatial_w_bd_nram + pad_num_points_levels;
+mask_x_nram = (int8_t*)(spatial_h_bd_nram + pad_num_points_levels);
+mask_y_nram = mask_x_nram + mask_size;
+value_output_nram = (T*)(mask_y_nram + mask_size);
+data_offset_nram = (int32_t*)(value_output_nram + max_deal_n * pad_channels);
+weight_polation_nram = (T*)(data_offset_nram + 4 * pad_total_points);
+cond_point_polation_nram = weight_polation_nram + 4 * pad_total_points;
+cond_point_valid_nram = cond_point_polation_nram + 4 * pad_total_points;
+loc_nram = cond_point_valid_nram + pad_total_points;
+weight_attn_nram = loc_nram + total_coord_pad;
+buf_nram = weight_attn_nram + pad_total_points;
+buf_nram_end = buf_nram + 6 * max_deal_n * pad_num_points_levels;
 }
 
 template <typename T>
@@ -504,6 +553,11 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
   T* ones_nram = nullptr;                  // (1, num_levels, num_points)
   int32_t max_deal_n = 0;
   int32_t mask_size = 0;
+  int32_t num_points_levels = num_levels * num_points;
+  int32_t pad_num_points_levels =
+      PAD_UP(num_points_levels, NFU_ALIGN_SIZE / sizeof(T));
+  int32_t pad_channels = PAD_UP(channels, NFU_ALIGN_SIZE/sizeof(T));
+
   memPolicyCommon(buf_compute_nram, ones_nram, value_output_nram,
                   data_offset_nram, weight_polation_nram,
                   cond_point_polation_nram, cond_point_valid_nram, loc_nram,
@@ -565,11 +619,11 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
       if (first_deal_query > 0) {
         __memcpy(loc_nram, (T*)data_sampling_loc_gdram + loc_offset,
                  input_stride_2 * 2 * sizeof(T), GDRAM2NRAM,
-                 input_stride_2 * 2 * sizeof(T), input_stride_3 * 2 * sizeof(T),
+                 pad_num_points_levels * 2 * sizeof(T), input_stride_3 * 2 * sizeof(T),
                  first_deal_query - 1);
         __memcpy(
             weight_attn_nram, (T*)data_attn_weight_gdram + attn_weight_offset,
-            input_stride_2 * sizeof(T), GDRAM2NRAM, input_stride_2 * sizeof(T),
+            input_stride_2 * sizeof(T), GDRAM2NRAM, pad_num_points_levels * sizeof(T),
             input_stride_3 * sizeof(T), first_deal_query - 1);
         getConditionCoordWeight<T>(
             data_offset_nram, weight_polation_nram, cond_point_polation_nram,
@@ -603,11 +657,11 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
         int32_t loc_offset = attn_weight_offset * 2;
         __memcpy_async(loc_nram, (T*)data_sampling_loc_gdram + loc_offset,
                        input_stride_2 * 2 * sizeof(T), GDRAM2NRAM,
-                       input_stride_2 * 2 * sizeof(T),
+                       pad_num_points_levels * 2 * sizeof(T),
                        input_stride_3 * 2 * sizeof(T), load_n - 1);
         __memcpy_async(
             weight_attn_nram, (T*)data_attn_weight_gdram + attn_weight_offset,
-            input_stride_2 * sizeof(T), GDRAM2NRAM, input_stride_2 * sizeof(T),
+            input_stride_2 * sizeof(T), GDRAM2NRAM, pad_num_points_levels * sizeof(T),
             input_stride_3 * sizeof(T), load_n - 1);
         __sync_io_move_compute();
       }
@@ -616,7 +670,7 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
           ((size_t)core_begin_query + i * core_step_query) * output_stride_2;
       __memcpy_async((T*)data_col_gdram + output_base_offset + output_offset,
                      value_output_nram, channels * sizeof(T), NRAM2GDRAM,
-                     output_stride_2 * sizeof(T), channels * sizeof(T),
+                     output_stride_2 * sizeof(T), pad_channels * sizeof(T),
                      deal_n - 1);
 
       // compute cond/weight/offset

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -24,29 +24,11 @@
 
 #pragma bang walign(64)
 
-#define MAX_MEMCPY_SEGNUM (65536)
 #define NRAM_REMAIN_SIZE (48 * 1024)
-#define SRAM_REMAIN_SIZE (32 * 1024)
 #define NRAM_AVALIABLE_SIZE (__MLU_NRAM_SIZE__ * 1024 - NRAM_REMAIN_SIZE)
-#define WRAM_AVALIABLE_SIZE (__MLU_WRAM_SIZE__ * 1024)
-#define SRAM_AVALIABLE_SIZE (__MLU_SRAM_SIZE__ * 1024 - SRAM_REMAIN_SIZE)
-#define SRAM_FOR_VALUE_SIZE (SRAM_AVALIABLE_SIZE - 128)
 
-#ifndef LT_NUM
-#define LT_NUM 64
-#endif
-
-#ifndef WRAM_LT_STRIDE
-#define WRAM_LT_STRIDE (__MLU_WRAM_SIZE__ * 1024 / LT_NUM)
-#endif
-
-#ifndef WRAM_ALIGN_SIZE
-#define WRAM_ALIGN_SIZE (64)
-#endif
 
 __nram__ char nram_buffer[NRAM_AVALIABLE_SIZE];
-__mlu_shared__ char sram_buffer[SRAM_AVALIABLE_SIZE];
-__wram__ char wram_buffer[WRAM_AVALIABLE_SIZE];
 
 __mlu_func__ void broadcastSpatialHW(
   float* spatial_offset_bd_nram,  // (num_levels, num_points)
@@ -55,83 +37,34 @@ __mlu_func__ void broadcastSpatialHW(
   int32_t* spatial_shapes_nram,   // (num_levels, 2)
   int32_t* spatial_offset_nram,   // (num_levels)
   const int32_t num_levels, const int32_t num_points) {
-__bang_int322float((float*)spatial_shapes_nram, spatial_shapes_nram,
-                   num_levels * 2, 0);
-// __memcpy(spatial_h_bd_nram, spatial_shapes_nram, sizeof(float), NRAM2NRAM,
-//          sizeof(float), num_points - 1, num_points * sizeof(float),
-//          num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
-//          num_levels - 1);
-for(int i = 0; i < num_levels; i++) {
-  __memcpy(spatial_h_bd_nram + i * num_points,
-           spatial_shapes_nram + i * 2, sizeof(float),
-           NRAM2NRAM, sizeof(float), 0, num_points - 1);
-}
-// __memcpy(spatial_w_bd_nram, (float*)spatial_shapes_nram + 1, sizeof(float),
-//          NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
-//          num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
-//          num_levels - 1);
-for(int i = 0; i < num_levels; i++) {
-  __memcpy(spatial_w_bd_nram + i * num_points,
-           spatial_shapes_nram + 1 + i * 2, sizeof(float),
-           NRAM2NRAM, sizeof(float), 0, num_points - 1);
-}
-__bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
-                   num_levels, 0);
-// __memcpy(spatial_offset_bd_nram, spatial_offset_nram, sizeof(float),
-//          NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
-//          num_levels - 1, 0, num_points - 1, sizeof(float), num_levels - 1);
-for(int i = 0; i < num_levels; i++) {
-  __memcpy(spatial_offset_bd_nram + i * num_points,
-           spatial_offset_nram + i, sizeof(float),
-           NRAM2NRAM, sizeof(float), 0, num_points - 1);
-}
-}
-
-template <typename T>
-__mlu_func__ void tileWeight2WramAsync(T* dst,
-                                       T* src,  // (co, ci)
-                                       int32_t co, int32_t ci, int32_t pad_co,
-                                       int32_t pad_ci) {
-  int32_t co_num = co / LT_NUM;
-  int32_t co_remain = co % LT_NUM;
-  if (co_num > 0) {
-    __memcpy_async(dst, src, ci * sizeof(T), NRAM2WRAM, WRAM_LT_STRIDE,
-                   LT_NUM - 1, pad_ci * sizeof(T), co_num - 1, ci * sizeof(T),
-                   LT_NUM - 1, LT_NUM * ci * sizeof(T), co_num - 1);
+  __bang_int322float((float*)spatial_shapes_nram, spatial_shapes_nram,
+                    num_levels * 2, 0);
+  for(int i = 0; i < num_levels; i++) {
+    __memcpy(spatial_h_bd_nram + i * num_points,
+            spatial_shapes_nram + i * 2, sizeof(float),
+            NRAM2NRAM, sizeof(float), 0, num_points - 1);
   }
-  if (co_remain > 0) {
-    __memcpy_async(dst + co_num * pad_ci, src + co_num * LT_NUM * ci,
-                   ci * sizeof(T), NRAM2WRAM, WRAM_LT_STRIDE, ci * sizeof(T),
-                   co_remain - 1);
+  for(int i = 0; i < num_levels; i++) {
+    __memcpy(spatial_w_bd_nram + i * num_points,
+            spatial_shapes_nram + 1 + i * 2, sizeof(float),
+            NRAM2NRAM, sizeof(float), 0, num_points - 1);
+  }
+  __bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
+                    num_levels, 0);
+  for(int i = 0; i < num_levels; i++) {
+    __memcpy(spatial_offset_bd_nram + i * num_points,
+            spatial_offset_nram + i, sizeof(float),
+            NRAM2NRAM, sizeof(float), 0, num_points - 1);
   }
 }
 
 template <typename T>
-__mlu_func__ void tileWeight2WramSync(T* dst,
-                                      T* src,  // (co, ci)
-                                      int32_t co, int32_t ci, int32_t pad_co,
-                                      int32_t pad_ci) {
-  int32_t co_num = co / LT_NUM;
-  int32_t co_remain = co % LT_NUM;
-  if (co_num > 0) {
-    __memcpy(dst, src, ci * sizeof(T), NRAM2WRAM, WRAM_LT_STRIDE, LT_NUM - 1,
-             pad_ci * sizeof(T), co_num - 1, ci * sizeof(T), LT_NUM - 1,
-             LT_NUM * ci * sizeof(T), co_num - 1);
-  }
-  if (co_remain > 0) {
-    __memcpy(dst + co_num * pad_ci, src + co_num * LT_NUM * ci, ci * sizeof(T),
-             NRAM2WRAM, WRAM_LT_STRIDE, ci * sizeof(T), co_remain - 1);
-  }
-}
-
-template <typename T, bool SRAM_STAY>
 __mlu_func__ void getConditionCoordWeight(
     int32_t* data_offset_nram, T* weight_polation_nram,
     T* cond_point_polation_nram, T* cond_point_valid_nram, T* loc_nram,
     T* weight_attn_nram, int8_t* mask_x_nram, int8_t* mask_y_nram,
     T* spatial_offset_bd_nram, T* spatial_w_bd_nram, T* spatial_h_bd_nram,
-    T* buf_nram, bool& w_contain_inf, const bool value_contain_infnan,
-    const int32_t deal_n, const int32_t num_levels, const int32_t num_points,
+    T* buf_nram, const int32_t deal_n, const int32_t num_levels, const int32_t num_points,
     const int32_t num_heads, const int32_t channels) {
   int32_t total_points = deal_n * num_levels * num_points;
   int32_t block_points = num_levels * num_points;
@@ -142,18 +75,6 @@ __mlu_func__ void getConditionCoordWeight(
   T* buf_x_ceil = buf_nram + 3 * total_points;
   T* buf_y_floor = buf_nram + 4 * total_points;
   T* buf_y_ceil = buf_nram + 5 * total_points;
-  //================================================================================================
-  // if weight_attn_nram contain inf
-  // int32_t inf_p = 0x7f7fffff;
-  // int32_t inf_n = 0xff7fffff;
-  // T inf_p_f = *((T*)&inf_p);
-  // T inf_n_f = *((T*)&inf_n);
-  // __bang_lt_scalar(buf_nram, weight_attn_nram, inf_n_f, total_points);
-  // __bang_gt_scalar(buf_nram + total_points, weight_attn_nram, inf_p_f,
-  //                  total_points);
-  // __bang_sumpool(buf_nram + 2 * total_points, buf_nram, 1, 2 * total_points, 1,
-  //                2 * total_points, 1, 1, 1);
-  // w_contain_inf = buf_nram[2 * total_points] > 0;
   //================================================================================================
   int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
   __bang_collect_bitindex(buf_x_nram, loc_nram, mask_x_nram, total_coord_pad);
@@ -271,83 +192,17 @@ __mlu_func__ void getConditionCoordWeight(
   __bang_add(data_offset_nram_bl, buf_hw_offset, buf_x_floor, total_points);
   // y_floor*w + offset + x_ceil
   __bang_add(data_offset_nram_br, buf_hw_offset, buf_x_ceil, total_points);
-  //================================================================================================
-  // merge and select conditions and weight
-  // T* weight_polation_nram_tmp = (T*)buf_nram;
   __bang_cycle_and(cond_point_polation_nram, cond_point_polation_nram,
                    cond_point_valid_nram, 4 * total_points, total_points);
-  // if (!w_contain_inf) {
   __bang_cycle_mul(weight_polation_nram, weight_polation_nram,
                    weight_attn_nram, 4 * total_points, total_points);
-  // }
-  // __bang_mul_scalar(buf_nram, weight_attn_nram, (T)1, total_points);
-  // __bang_mul((float*)weight_attn_nram, (float*)weight_attn_nram,
-  //                cond_point_valid_nram, total_points);
-  // __bang_collect((float*)weight_attn_nram, (float*)buf_nram,
-  //                cond_point_valid_nram, total_points);
-  // __bang_float2int32((int32_t*)cond_point_polation_nram,
-  //                    cond_point_polation_nram, total_points * 4, 0);
-  // __bang_mul_scalar((int32_t*)cond_point_polation_nram,
-  //                   (int32_t*)cond_point_polation_nram, (int32_t)0xffffffff,
-  //                   total_points * 4);
   __bang_mul(weight_polation_nram, weight_polation_nram, cond_point_polation_nram, total_points * 4);
-  // __bang_band((char*)weight_polation_nram_tmp, (char*)weight_polation_nram,
-  //             (char*)cond_point_polation_nram,
-  //             total_points * 4 * sizeof(float));
-  // __bang_collect((float*)weight_polation_nram, (float*)weight_polation_nram_tmp,
-  //                cond_point_valid_nram, total_points);
-  // __bang_collect((float*)weight_polation_nram + total_points,
-  //                (float*)weight_polation_nram_tmp + total_points,
-  //                cond_point_valid_nram, total_points);
-  // __bang_collect((float*)weight_polation_nram + 2 * total_points,
-  //                (float*)weight_polation_nram_tmp + 2 * total_points,
-  //                cond_point_valid_nram, total_points);
-  // __bang_collect((float*)weight_polation_nram + 3 * total_points,
-  //                (float*)weight_polation_nram_tmp + 3 * total_points,
-  //                cond_point_valid_nram, total_points);
-  //================================================================================================
-  // select cond_point_polation_nram if value_contain_infnan
-  // if (value_contain_infnan) {
-  //   int32_t* cond_point_polation_nram_tmp = (int32_t*)buf_nram;
-  //   __bang_mul_scalar((int32_t*)cond_point_polation_nram_tmp,
-  //                     (int32_t*)cond_point_polation_nram, (int32_t)1,
-  //                     total_points * 4);
-  //   __bang_collect((float*)cond_point_polation_nram,
-  //                  (float*)cond_point_polation_nram_tmp, cond_point_valid_nram,
-  //                  total_points);
-  //   __bang_collect((float*)cond_point_polation_nram + total_points,
-  //                  (float*)cond_point_polation_nram_tmp + total_points,
-  //                  cond_point_valid_nram, total_points);
-  //   __bang_collect((float*)cond_point_polation_nram + 2 * total_points,
-  //                  (float*)cond_point_polation_nram_tmp + 2 * total_points,
-  //                  cond_point_valid_nram, total_points);
-  //   __bang_collect((float*)cond_point_polation_nram + 3 * total_points,
-  //                  (float*)cond_point_polation_nram_tmp + 3 * total_points,
-  //                  cond_point_valid_nram, total_points);
-  // }
-  //================================================================================================
-  // compute and select offset and stride
-  // int32_t* data_offset_nram_tl_tmp = (int32_t*)buf_nram;
-  // int32_t* data_offset_nram_bl_tmp = data_offset_nram_tl_tmp + total_points;
-  // int32_t* data_offset_nram_tr_tmp = data_offset_nram_bl_tmp + total_points;
-  // __bang_float2int32(data_offset_nram_tl_tmp, data_offset_nram_tl,
-  //                    total_points * 4, 0);
-  // int32_t stride =
-  //     SRAM_STAY ? channels * sizeof(T) : num_heads * channels * sizeof(T);
-  // __bang_mul_scalar((int32_t*)data_offset_nram_tl, data_offset_nram_tl_tmp, stride,
-  //                   total_points * 4);
   __bang_sub((float*)data_offset_nram_bl,
              (float*)data_offset_nram_bl,
              (float*)data_offset_nram_tl, total_points);
   __bang_sub((float*)data_offset_nram_tr,
              (float*)data_offset_nram_tr,
              (float*)data_offset_nram_tl, total_points);
-  // __bang_collect((float*)data_offset_nram_tl, (float*)data_offset_nram_tl_tmp,
-  //                cond_point_valid_nram, total_points);
-  // __bang_collect((float*)data_offset_nram_bl, (float*)data_offset_nram_bl_tmp,
-  //                cond_point_valid_nram, total_points);
-  // __bang_collect((float*)data_offset_nram_tr, (float*)data_offset_nram_tr_tmp,
-  //                cond_point_valid_nram, total_points);
 }
 
 /*
@@ -365,94 +220,25 @@ __mlu_func__ void getConditionCoordWeight(
 
   valid_num <= num_levels * num_points
   sample_stride_3 = deal_n * num_levels * num_points
-
-  Note:
-  If w_contain_inf is true, cannot merge attn_w and polation_w, so use sumpool
-  twice. If w_contain_inf is false, merge attn_w and polation_w and use matmul
-  instead. If value_contain_infnan is true, fill data_value of invalid
-  neighbors with 0.
 */
 template <typename T>
 __mlu_func__ void reduceLevelByConv(
     T* output_nram, T* input_nram, T* input_trans, T* input_pooled,
     int32_t* cond_selected_base, T* weight_selected_base, T* weight_attn_nram,
-    T* weight_compute, int32_t* cond_compute, T* input_wram,
-    const int32_t valid_num, const int32_t channels,
-    const int32_t sample_stride_3, const bool w_contain_inf,
-    const bool value_contain_infnan) {
+    T* weight_compute, int32_t* cond_compute, const int32_t valid_num, const int32_t channels,
+    const int32_t sample_stride_3) {
+    int32_t ci = 4 * valid_num;
+    int32_t co = channels;
     __memcpy(weight_compute, weight_selected_base, valid_num * sizeof(T),
                    NRAM2NRAM, valid_num * sizeof(T),
                    sample_stride_3 * sizeof(T), 3);
-    for(int k = 0; k < 4 *valid_num; k++) {
-      __bang_mul_scalar(input_nram + channels * k, input_nram + channels * k, weight_compute[k], channels);
-    }
-    __bang_sumpool(output_nram, input_nram, channels, 4 * valid_num, 1, 4 * valid_num, 1, 1, 1);
-}
-
-
-// template <typename T>
-// __mlu_func__ void reduceLevelByConv(
-//     T* output_nram, T* input_nram, T* input_trans, T* input_pooled,
-//     int32_t* cond_selected_base, T* weight_selected_base, T* weight_attn_nram,
-//     T* weight_compute, int32_t* cond_compute, T* input_wram,
-//     const int32_t valid_num, const int32_t channels,
-//     const int32_t sample_stride_3, const bool w_contain_inf,
-//     const bool value_contain_infnan) {
-//   // if (valid_num > 0) {
-//     // __bang_printf("valid_num: %d\n", valid_num);
-//     int32_t ci = 4 * valid_num;
-//     // int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
-//     int32_t co = channels;
-//     // int32_t pad_co = PAD_UP(co, LT_NUM);
-//     // if (value_contain_infnan) {
-//     //   __memcpy_async(cond_compute, cond_selected_base,
-//     //                  valid_num * sizeof(int32_t), NRAM2NRAM,
-//     //                  valid_num * sizeof(T), sample_stride_3 * sizeof(T), 3);
-//     // }
-//     __memcpy(weight_compute, weight_selected_base, valid_num * sizeof(T),
-//                    NRAM2NRAM, valid_num * sizeof(T),
-//                    sample_stride_3 * sizeof(T), 3);
-//     __bang_transpose(input_trans, input_nram, ci, co);
-//     __sync_move();
-//     // for(int k = 0; k < 4 *valid_num; k++) {
-//     //   __bang_mul_scalar(input_nram + channels * k, input_nram + channels * k, weight_compute[k], channels);
-//     // }
-//     // if (value_contain_infnan) {
-//     //   __bang_cycle_band((char*)input_trans, (char*)input_trans,
-//     //                     (char*)cond_compute, co * ci * sizeof(T),
-//     //                     ci * sizeof(T));
-//     // }
-
-//     // if (w_contain_inf) {
-//     // __bang_mul(input_nram, input_nram, input_trans, 4 * valid_num * channels);
-//     __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
-//       // __bang_sumpool(input_pooled, input_trans, valid_num, channels,4, 1, 4, 1,
-//       //                1);
-//     __bang_transpose(input_nram, input_trans, co, ci);
-//     __bang_sumpool(output_nram, input_nram, channels, 4 * valid_num, 1, 4 * valid_num, 1, 1, 1);
-//       // __bang_cycle_mul(input_pooled, input_pooled, weight_attn_nram,
-//       //                  channels * valid_num, valid_num);
-//       // __bang_sumpool(output_nram, input_pooled, 1, channels, valid_num, 1,
-//       //                valid_num, 1, 1);
-//     // } else {
-//       // tileWeight2WramSync(input_wram, input_trans, co, ci, pad_co, pad_ci);
-//       // __bang_conv(output_nram, weight_compute, input_wram, ci, 1, 1, 1, 1, 1, 1,
-//       //             co);
-//     // }
-//   // } else {
-//   //   __bang_write_value(output_nram, channels, (T)0);
-//   // }
-// }
-
-template <typename T>
-__mlu_func__ int32_t getReduceLevelByConvWramSize(const int32_t num_levels,
-                                                  const int32_t num_points,
-                                                  const int32_t channels) {
-  int32_t ci = 4 * num_levels * num_points;
-  int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
-  int32_t co = channels;
-  int32_t pad_co = PAD_UP(co, LT_NUM);
-  return pad_co * pad_ci * sizeof(T);
+    __bang_transpose(input_trans, input_nram, ci, co);
+    __sync_move();
+    __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
+    __bang_sumpool(input_pooled, input_trans, valid_num, channels, 4, 1, 4, 1,
+                  1);
+    __bang_sumpool(output_nram, input_pooled, 1, channels, valid_num, 1,
+                  valid_num, 1, 1);
 }
 
 __mlu_func__ void loadNram2Gpr(int32_t& v1, int32_t& v2, int32_t& v3,
@@ -477,7 +263,7 @@ __mlu_func__ void loadNram2Gpr(int32_t& v1, int32_t& v2, int32_t& v3,
 
   Trickly fold the loop as 2.
 */
-template <typename T, mluMemcpyDirection_t DIR>
+template <typename T>
 __mlu_func__ void loadDataValueXram2NramAsync(
     T* buf_value_nram_1, int32_t* offset_1, int32_t* stride_2_1,
     int32_t* stride_3_1, T* value_src, const int32_t num_levels_points,
@@ -496,29 +282,20 @@ __mlu_func__ void loadDataValueXram2NramAsync(
   for (int32_t j = 0; j < loop_num * 2; j += 2) {
     value_offset = j * channel_size;
     next = j + 2;
-    // __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
-    //                (int8_t*)value_src + offset_1_a, channel_size, DIR,
-    //                2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
-    //                1, stride_2_1_a, 1);
     for(int i = 0; i < 2; i++)
     {
       __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + data_value_stride * i,
                      (int8_t*)value_src + offset_1_a + i * stride_2_1_a,
-                      channel_size, DIR, 2 * data_value_stride, stride_3_1_a, 1);
+                      channel_size, GDRAM2NRAM, 2 * data_value_stride, stride_3_1_a, 1);
     }
 
     loadNram2Gpr(offset_1_a, stride_2_1_a, stride_3_1_a, offset_1 + next,
                  stride_2_1 + next, stride_3_1 + next, num_heads, channel_size);
-
-    // __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size,
-    //                (int8_t*)value_src + offset_1_b, channel_size, DIR,
-    //                2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_b,
-    //                1, stride_2_1_b, 1);
     for(int i = 0; i < 2; i++)
     {
       __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size + data_value_stride * i,
                      (int8_t*)value_src + offset_1_b + i * stride_2_1_b,
-                      channel_size, DIR, 2 * data_value_stride, stride_3_1_b, 1);
+                      channel_size, GDRAM2NRAM, 2 * data_value_stride, stride_3_1_b, 1);
     }
 
     loadNram2Gpr(offset_1_b, stride_2_1_b, stride_3_1_b, offset_1 + next + 1,
@@ -527,28 +304,23 @@ __mlu_func__ void loadDataValueXram2NramAsync(
 
   if (remain > 0) {
     value_offset = loop_num * 2 * channel_size;
-    // __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
-    //                (int8_t*)value_src + offset_1_a, channel_size, DIR,
-    //                2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
-    //                1, stride_2_1_a, 1);
     for(int i = 0; i < 2; i++)
     {
       __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + data_value_stride * i,
                      (int8_t*)value_src + offset_1_a + i * stride_2_1_a,
-                      channel_size, DIR, 2 * data_value_stride, stride_3_1_a, 1);
+                      channel_size, GDRAM2NRAM, 2 * data_value_stride, stride_3_1_a, 1);
     }
   }
 }
 
-template <typename T, bool SRAM_STAY, int32_t REDUCE_TYPE = 0>
+template <typename T>
 __mlu_func__ void loadNeighborPolationAttn(
-    T* value_output_nram, T* value_sram, T* value_gdram,
+    T* value_output_nram, T* value_gdram,
     int32_t* data_offset_nram, T* weight_polation_nram,
     T* cond_point_polation_nram, T* cond_point_valid_nram, T* weight_attn_nram,
     T* buf_nram, T* compute_buf_nram, T* nram_ones, const int32_t deal_n,
     const int32_t num_levels, const int32_t num_points, const int32_t num_keys,
-    const int32_t channels, const bool w_contain_inf,
-    const bool value_contain_infnan, const int32_t num_heads) {
+    const int32_t channels, const int32_t num_heads) {
   int32_t channel_size = channels * sizeof(T);
   int32_t sample_stride_3 = deal_n * num_levels * num_points;
   int32_t value_stride_3 = num_levels * num_points * channels;
@@ -558,14 +330,9 @@ __mlu_func__ void loadNeighborPolationAttn(
       buf_nram + 4 * value_stride_3;  // (4, num_levels, num_points, channels)
   T* buf_value_nram_pool =
       buf_nram + 8 * value_stride_3;  // (1, num_levels, num_points, channels)
-  // int32_t* sample_valid_count =
-  //     (int32_t*)(buf_nram + 9 * value_stride_3);  // (deal_n)
   T* weight_compute_nram = compute_buf_nram;      // (4, num_levels, num_points)
   int32_t* cond_compute_nram =
       (int32_t*)(weight_compute_nram + 4 * num_levels * num_points);
-
-  // countValidSamples(sample_valid_count, cond_point_valid_nram, nram_ones,
-  //                   (T*)wram_buffer, num_levels, num_points, deal_n);
   __sync_compute();
 
   int32_t* offset = data_offset_nram;
@@ -573,19 +340,18 @@ __mlu_func__ void loadNeighborPolationAttn(
   int32_t* stride_3_1 = stride_2_1 + sample_stride_3;
   T* output_nram = value_output_nram;
   int32_t step_offset = 0;
-  T* value_src = SRAM_STAY ? value_sram : value_gdram;
   for (int32_t i = 0; i < deal_n; i++) {
-    int32_t valid_num = num_levels * num_points; //sample_valid_count[i];
-    loadDataValueXram2NramAsync<T, GDRAM2NRAM>(
-        buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
+    int32_t valid_num = num_levels * num_points;
+    loadDataValueXram2NramAsync<T>(
+        buf_value_nram, offset, stride_2_1, stride_3_1, value_gdram, valid_num,
         channel_size, value_stride_3_size, num_heads);
     __sync_io();
     reduceLevelByConv(
         output_nram, buf_value_nram, buf_value_nram_trans, buf_value_nram_pool,
         (int32_t*)cond_point_polation_nram + step_offset,
         weight_polation_nram + step_offset, weight_attn_nram + step_offset,
-        weight_compute_nram, cond_compute_nram, (T*)wram_buffer, valid_num,
-        channels, sample_stride_3, w_contain_inf, value_contain_infnan);
+        weight_compute_nram, cond_compute_nram, valid_num,
+        channels, sample_stride_3);
     step_offset += valid_num;
     offset = data_offset_nram + step_offset;
     stride_2_1 = offset + sample_stride_3;
@@ -598,7 +364,7 @@ template <typename T>
 __mlu_func__ void prepareLoop(
     T* ones_nram, int32_t* spatial_offset_nram, int32_t* spatial_hw_nram,
     int8_t* mask_x_nram, int8_t* mask_y_nram, T* spatial_offset_bd_nram,
-    T* spatial_h_bd_nram, T* spatial_w_bd_nram, T* value_sram,
+    T* spatial_h_bd_nram, T* spatial_w_bd_nram,
     const char* data_level_start_index_gdram,
     const char* data_spatial_shapes_gdram, const int32_t num_keys,
     const int32_t num_levels, const int32_t num_points,
@@ -617,28 +383,6 @@ __mlu_func__ void prepareLoop(
   broadcastSpatialHW(spatial_offset_bd_nram, spatial_h_bd_nram,
                      spatial_w_bd_nram, spatial_hw_nram, spatial_offset_nram,
                      num_levels, num_points);
-}
-
-template <typename T>
-__mlu_func__ void loadDataValueGdram2Sram(T* value_sram, T* data_value_gdram,
-                                          const int32_t batch_idx,
-                                          const int32_t head_idx,
-                                          const int32_t num_keys,
-                                          const int32_t num_heads,
-                                          const int32_t channels) {
-  int32_t loop_num = (num_keys + MAX_MEMCPY_SEGNUM - 1) / MAX_MEMCPY_SEGNUM;
-  int32_t num_heads_channels = num_heads * channels;
-  for (int32_t i = 0; i < loop_num; i++) {
-    int32_t load_num =
-        __mluop_min(MAX_MEMCPY_SEGNUM, num_keys - i * MAX_MEMCPY_SEGNUM);
-    size_t src_offset = ((size_t)batch_idx * num_keys + i * MAX_MEMCPY_SEGNUM) *
-                            num_heads_channels +
-                        head_idx * channels;
-    int32_t dst_offset = i * MAX_MEMCPY_SEGNUM * channels;
-    __memcpy(value_sram + dst_offset, (T*)data_value_gdram + src_offset,
-             channels * sizeof(T), GDRAM2SRAM, channels * sizeof(T),
-             num_heads_channels * sizeof(T), load_num - 1);
-  }
 }
 
 /*
@@ -671,15 +415,15 @@ __mlu_func__ void memPolicyCommon(
     T*& weight_attn_nram, T*& buf_nram, T*& buf_nram_end, int8_t*& mask_x_nram,
     int8_t*& mask_y_nram, T*& spatial_offset_bd_nram, T*& spatial_w_bd_nram,
     T*& spatial_h_bd_nram, int32_t*& spatial_offset_nram,
-    int32_t*& spatial_hw_nram, T*& value_sram, int32_t& max_deal_n,
+    int32_t*& spatial_hw_nram, int32_t& max_deal_n,
     int32_t& mask_size, const int32_t batch_size, const int32_t num_keys,
     const int32_t num_heads, const int32_t channels, const int32_t num_levels,
     const int32_t num_queries, const int32_t num_points) {
   int32_t num_points_levels = num_levels * num_points;
   int32_t pad_num_points_levels =
-      PAD_UP(num_points_levels, WRAM_ALIGN_SIZE / sizeof(T));
+      PAD_UP(num_points_levels, NFU_ALIGN_SIZE / sizeof(T));
   int32_t pad_num_points_levels_8 =
-      PAD_UP(8 * num_points_levels, WRAM_ALIGN_SIZE / sizeof(T));
+      PAD_UP(8 * num_points_levels, NFU_ALIGN_SIZE / sizeof(T));
   int32_t spatial_info_size =
       PAD_UP(3 * num_levels * sizeof(int32_t), NFU_ALIGN_SIZE);
   int32_t fix_space_size =
@@ -702,14 +446,6 @@ __mlu_func__ void memPolicyCommon(
     max_deal_n = __mluop_min(max_deal_n, tmp_deal_n);
   }
 
-  int32_t reduce_need_wram_size =
-      getReduceLevelByConvWramSize<T>(num_levels, num_points, channels);
-  int32_t count_valid_max =
-      PAD_DOWN(WRAM_AVALIABLE_SIZE / sizeof(T) / pad_num_points_levels, LT_NUM);
-  int32_t wram_deal_n =
-      (int)(reduce_need_wram_size <= WRAM_AVALIABLE_SIZE) * count_valid_max;
-  max_deal_n = __mluop_min(max_deal_n, wram_deal_n);
-
   int32_t total_points = max_deal_n * num_points_levels;
   int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
   mask_size = total_coord_pad / BIT_COLLECT_PAD;
@@ -731,10 +467,9 @@ __mlu_func__ void memPolicyCommon(
   weight_attn_nram = loc_nram + total_coord_pad;
   buf_nram = weight_attn_nram + total_points;
   buf_nram_end = buf_nram + 6 * max_deal_n * num_points_levels;
-  value_sram = (T*)sram_buffer;
 }
 
-template <typename T, int32_t POLICY>
+template <typename T>
 __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
     const char* data_value_gdram, const char* data_spatial_shapes_gdram,
     const char* data_level_start_index_gdram,
@@ -748,7 +483,6 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
   int32_t output_stride_3 = num_queries * num_heads * channels;
   int32_t output_stride_2 = num_heads * channels;
   int32_t data_value_stride_3 = num_keys * num_heads * channels;
-  constexpr bool sram_stay = (POLICY == 0);
 
   T* value_output_nram = nullptr;         // (deal_n, channels)
   int32_t* data_offset_nram = nullptr;    // (4, deal_n, num_levels, num_points)
@@ -768,7 +502,6 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
   int32_t* spatial_hw_nram = nullptr;      // (num_levels, 2)
   T* buf_compute_nram = nullptr;           // (8, num_levels, num_points)
   T* ones_nram = nullptr;                  // (1, num_levels, num_points)
-  T* value_sram = nullptr;                 // (num_keys, channels)
   int32_t max_deal_n = 0;
   int32_t mask_size = 0;
   memPolicyCommon(buf_compute_nram, ones_nram, value_output_nram,
@@ -777,7 +510,7 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
                   weight_attn_nram, buf_nram, buf_nram_end, mask_x_nram,
                   mask_y_nram, spatial_offset_bd_nram, spatial_w_bd_nram,
                   spatial_h_bd_nram, spatial_offset_nram, spatial_hw_nram,
-                  value_sram, max_deal_n, mask_size, batch_size, num_keys,
+                  max_deal_n, mask_size, batch_size, num_keys,
                   num_heads, channels, num_levels, num_queries, num_points);
   if (max_deal_n <= 0) {
     return;
@@ -808,7 +541,7 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
 
   prepareLoop(ones_nram, spatial_offset_nram, spatial_hw_nram, mask_x_nram,
               mask_y_nram, spatial_offset_bd_nram, spatial_h_bd_nram,
-              spatial_w_bd_nram, value_sram, data_level_start_index_gdram,
+              spatial_w_bd_nram, data_level_start_index_gdram,
               data_spatial_shapes_gdram, num_keys, num_levels, num_points,
               max_deal_n, mask_size, channels);
 
@@ -816,28 +549,15 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
        bh_idx < cluster_end_batch_head; bh_idx++) {
     int32_t b = bh_idx / num_heads;
     int32_t head_idx = bh_idx % num_heads;
-    bool w_contain_inf = false;
-    bool value_contain_infnan = true;
 
     size_t output_base_offset =
         (size_t)b * output_stride_3 + head_idx * channels;
     int32_t attn_weight_base_offset =
         b * input_stride_4 + head_idx * input_stride_2;
 
-    if (sram_stay && __is_mpu()) {
-      loadDataValueGdram2Sram(value_sram, (T*)data_value_gdram, b, head_idx,
-                              num_keys, num_heads, channels);
-    }
     __sync_cluster();
 
     if (__is_ipu()) {
-      // if (sram_stay) {
-      //   int32_t buf_size =
-      //       (int)((char*)buf_nram_end - (char*)value_output_nram);
-      //   isValueContainInfNan(value_sram, value_sram + num_keys * channels,
-      //                        value_output_nram, value_contain_infnan, buf_size,
-      //                        num_keys * channels);
-      // }
       // compute weight, offset and condition
       int32_t attn_weight_offset =
           attn_weight_base_offset + core_begin_query * input_stride_3;
@@ -851,11 +571,11 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
             weight_attn_nram, (T*)data_attn_weight_gdram + attn_weight_offset,
             input_stride_2 * sizeof(T), GDRAM2NRAM, input_stride_2 * sizeof(T),
             input_stride_3 * sizeof(T), first_deal_query - 1);
-        getConditionCoordWeight<T, sram_stay>(
+        getConditionCoordWeight<T>(
             data_offset_nram, weight_polation_nram, cond_point_polation_nram,
             cond_point_valid_nram, loc_nram, weight_attn_nram, mask_x_nram,
             mask_y_nram, spatial_offset_bd_nram, spatial_w_bd_nram,
-            spatial_h_bd_nram, buf_nram, w_contain_inf, value_contain_infnan,
+            spatial_h_bd_nram, buf_nram,
             first_deal_query, num_levels, num_points, num_heads, channels);
       }
     }
@@ -866,13 +586,13 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
       int32_t load_n =
           i < core_loop_num - 2 ? core_step_query : core_remain_query;
       // load value and polation
-      loadNeighborPolationAttn<T, sram_stay>(
-          value_output_nram, value_sram,
+      loadNeighborPolationAttn<T>(
+          value_output_nram,
           (T*)data_value_gdram + b * data_value_stride_3 + head_idx * channels,
           data_offset_nram, weight_polation_nram, cond_point_polation_nram,
           cond_point_valid_nram, weight_attn_nram, buf_nram, buf_compute_nram,
           ones_nram, deal_n, num_levels, num_points, num_keys, channels,
-          w_contain_inf, value_contain_infnan, num_heads);
+          num_heads);
       __sync_io_move_compute();
       // load next weight and loc
       if (i < core_loop_num - 1) {
@@ -901,11 +621,11 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
 
       // compute cond/weight/offset
       if (i < core_loop_num - 1) {
-        getConditionCoordWeight<T, sram_stay>(
+        getConditionCoordWeight<T>(
             data_offset_nram, weight_polation_nram, cond_point_polation_nram,
             cond_point_valid_nram, loc_nram, weight_attn_nram, mask_x_nram,
             mask_y_nram, spatial_offset_bd_nram, spatial_w_bd_nram,
-            spatial_h_bd_nram, buf_nram, w_contain_inf, value_contain_infnan,
+            spatial_h_bd_nram, buf_nram,
             load_n, num_levels, num_points, num_heads, channels);
       }
       __sync_io_move_compute();
@@ -922,7 +642,7 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardFast(
     const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
     const int32_t channels, const int32_t num_levels, const int32_t num_queries,
     const int32_t num_points, char* data_col_gdram) {
-    MLUKernelMsDeformAttnForwardFastImpl<float, 1>(
+    MLUKernelMsDeformAttnForwardFastImpl<float>(
         data_value_gdram, data_spatial_shapes_gdram,
         data_level_start_index_gdram, data_sampling_loc_gdram,
         data_attn_weight_gdram, batch_size, num_keys, num_heads, channels,

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -48,6 +48,45 @@ __nram__ char nram_buffer[NRAM_AVALIABLE_SIZE];
 __mlu_shared__ char sram_buffer[SRAM_AVALIABLE_SIZE];
 __wram__ char wram_buffer[WRAM_AVALIABLE_SIZE];
 
+__mlu_func__ void broadcastSpatialHW(
+  float* spatial_offset_bd_nram,  // (num_levels, num_points)
+  float* spatial_h_bd_nram,       // (num_levels, num_points)
+  float* spatial_w_bd_nram,       // (num_levels, num_points)
+  int32_t* spatial_shapes_nram,   // (num_levels, 2)
+  int32_t* spatial_offset_nram,   // (num_levels)
+  const int32_t num_levels, const int32_t num_points) {
+__bang_int322float((float*)spatial_shapes_nram, spatial_shapes_nram,
+                   num_levels * 2, 0);
+// __memcpy(spatial_h_bd_nram, spatial_shapes_nram, sizeof(float), NRAM2NRAM,
+//          sizeof(float), num_points - 1, num_points * sizeof(float),
+//          num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
+//          num_levels - 1);
+for(int i = 0; i < num_levels; i++) {
+  __memcpy(spatial_h_bd_nram + i * num_points,
+           spatial_shapes_nram + i * 2, sizeof(float),
+           NRAM2NRAM, sizeof(float), 0, num_points - 1);
+}
+// __memcpy(spatial_w_bd_nram, (float*)spatial_shapes_nram + 1, sizeof(float),
+//          NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+//          num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
+//          num_levels - 1);
+for(int i = 0; i < num_levels; i++) {
+  __memcpy(spatial_w_bd_nram + i * num_points,
+           spatial_shapes_nram + 1 + i * 2, sizeof(float),
+           NRAM2NRAM, sizeof(float), 0, num_points - 1);
+}
+__bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
+                   num_levels, 0);
+// __memcpy(spatial_offset_bd_nram, spatial_offset_nram, sizeof(float),
+//          NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+//          num_levels - 1, 0, num_points - 1, sizeof(float), num_levels - 1);
+for(int i = 0; i < num_levels; i++) {
+  __memcpy(spatial_offset_bd_nram + i * num_points,
+           spatial_offset_nram + i, sizeof(float),
+           NRAM2NRAM, sizeof(float), 0, num_points - 1);
+}
+}
+
 template <typename T>
 __mlu_func__ void tileWeight2WramAsync(T* dst,
                                        T* src,  // (co, ci)
@@ -85,53 +124,6 @@ __mlu_func__ void tileWeight2WramSync(T* dst,
   }
 }
 
-template <typename T>
-__mlu_func__ void isValueContainInfNan(T* input_sram, T* output_sram,
-                                       T* nram_buf, bool& value_contain_infnan,
-                                       int32_t nram_buf_size,
-                                       int32_t data_num) {
-  int32_t core_avg_num = (data_num + coreDim - 1) / coreDim;
-  int32_t core_begin_num = core_avg_num * coreId;
-  int32_t core_act_num = __mluop_min(data_num - core_begin_num, core_avg_num);
-  int32_t core_step_num =
-      PAD_DOWN(nram_buf_size - NFU_ALIGN_SIZE, NFU_ALIGN_SIZE) / sizeof(T);
-  int32_t c = NFU_ALIGN_SIZE / sizeof(T);
-  int32_t loop_num = (core_act_num + core_step_num - 1) / core_step_num;
-  int32_t remain_num = (int)(loop_num > 0) * (core_act_num % core_step_num);
-  T* input_sram_base = input_sram + core_begin_num;
-  T* nram_out = nram_buf;
-  T* nram_input = nram_buf + NFU_ALIGN_SIZE / sizeof(T);
-  T sum = 0;
-
-  if (remain_num > 0) {
-    int32_t n = (remain_num + c - 1) / c;
-    __bang_write_value(nram_input + (n - 1) * c, c, (T)0);
-  }
-
-  for (int32_t i = 0; i < loop_num; i++) {
-    int32_t deal_num =
-        __mluop_min(core_step_num, core_act_num - i * core_step_num);
-    int32_t n = (deal_num + c - 1) / c;
-    __memcpy(nram_input, input_sram_base + i * core_step_num,
-             deal_num * sizeof(T), SRAM2NRAM);
-    __bang_sumpool(nram_out, nram_input, c, n, 1, n, 1, 1, 1);
-    __bang_sumpool(nram_input, nram_out, 1, c, 1, c, 1, 1, 1);
-    T tmp = nram_input[0];
-    if (isnan(tmp) || isinf(tmp)) {
-      sum = 1;
-      break;
-    } else {
-      sum = 0;
-    }
-  }
-
-  output_sram[coreId] = sum;
-  __sync_all_ipu_within_cluster();
-  __memcpy(nram_input, output_sram, coreDim * sizeof(T), SRAM2NRAM);
-  value_contain_infnan =
-      (nram_input[0] + nram_input[1] + nram_input[2] + nram_input[3]) > 0;
-}
-
 template <typename T, bool SRAM_STAY>
 __mlu_func__ void getConditionCoordWeight(
     int32_t* data_offset_nram, T* weight_polation_nram,
@@ -152,16 +144,16 @@ __mlu_func__ void getConditionCoordWeight(
   T* buf_y_ceil = buf_nram + 5 * total_points;
   //================================================================================================
   // if weight_attn_nram contain inf
-  int32_t inf_p = 0x7f7fffff;
-  int32_t inf_n = 0xff7fffff;
-  T inf_p_f = *((T*)&inf_p);
-  T inf_n_f = *((T*)&inf_n);
-  __bang_lt_scalar(buf_nram, weight_attn_nram, inf_n_f, total_points);
-  __bang_gt_scalar(buf_nram + total_points, weight_attn_nram, inf_p_f,
-                   total_points);
-  __bang_sumpool(buf_nram + 2 * total_points, buf_nram, 1, 2 * total_points, 1,
-                 2 * total_points, 1, 1, 1);
-  w_contain_inf = buf_nram[2 * total_points] > 0;
+  // int32_t inf_p = 0x7f7fffff;
+  // int32_t inf_n = 0xff7fffff;
+  // T inf_p_f = *((T*)&inf_p);
+  // T inf_n_f = *((T*)&inf_n);
+  // __bang_lt_scalar(buf_nram, weight_attn_nram, inf_n_f, total_points);
+  // __bang_gt_scalar(buf_nram + total_points, weight_attn_nram, inf_p_f,
+  //                  total_points);
+  // __bang_sumpool(buf_nram + 2 * total_points, buf_nram, 1, 2 * total_points, 1,
+  //                2 * total_points, 1, 1, 1);
+  // w_contain_inf = buf_nram[2 * total_points] > 0;
   //================================================================================================
   int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
   __bang_collect_bitindex(buf_x_nram, loc_nram, mask_x_nram, total_coord_pad);
@@ -335,21 +327,21 @@ __mlu_func__ void getConditionCoordWeight(
   // }
   //================================================================================================
   // compute and select offset and stride
-  int32_t* data_offset_nram_tl_tmp = (int32_t*)buf_nram;
+  // int32_t* data_offset_nram_tl_tmp = (int32_t*)buf_nram;
   // int32_t* data_offset_nram_bl_tmp = data_offset_nram_tl_tmp + total_points;
   // int32_t* data_offset_nram_tr_tmp = data_offset_nram_bl_tmp + total_points;
-  __bang_float2int32(data_offset_nram_tl_tmp, data_offset_nram_tl,
-                     total_points * 4, 0);
-  int32_t stride =
-      SRAM_STAY ? channels * sizeof(T) : num_heads * channels * sizeof(T);
-  __bang_mul_scalar((int32_t*)data_offset_nram_tl, data_offset_nram_tl_tmp, stride,
-                    total_points * 4);
-  __bang_sub((int32_t*)data_offset_nram_bl,
-             (int32_t*)data_offset_nram_bl,
-             (int32_t*)data_offset_nram_tl, total_points);
-  __bang_sub((int32_t*)data_offset_nram_tr,
-             (int32_t*)data_offset_nram_tr,
-             (int32_t*)data_offset_nram_tl, total_points);
+  // __bang_float2int32(data_offset_nram_tl_tmp, data_offset_nram_tl,
+  //                    total_points * 4, 0);
+  // int32_t stride =
+  //     SRAM_STAY ? channels * sizeof(T) : num_heads * channels * sizeof(T);
+  // __bang_mul_scalar((int32_t*)data_offset_nram_tl, data_offset_nram_tl_tmp, stride,
+  //                   total_points * 4);
+  __bang_sub((float*)data_offset_nram_bl,
+             (float*)data_offset_nram_bl,
+             (float*)data_offset_nram_tl, total_points);
+  __bang_sub((float*)data_offset_nram_tr,
+             (float*)data_offset_nram_tr,
+             (float*)data_offset_nram_tl, total_points);
   // __bang_collect((float*)data_offset_nram_tl, (float*)data_offset_nram_tl_tmp,
   //                cond_point_valid_nram, total_points);
   // __bang_collect((float*)data_offset_nram_bl, (float*)data_offset_nram_bl_tmp,
@@ -388,46 +380,69 @@ __mlu_func__ void reduceLevelByConv(
     const int32_t valid_num, const int32_t channels,
     const int32_t sample_stride_3, const bool w_contain_inf,
     const bool value_contain_infnan) {
-  if (valid_num > 0) {
-    // __bang_printf("valid_num: %d\n", valid_num);
-    int32_t ci = 4 * valid_num;
-    int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
-    int32_t co = channels;
-    int32_t pad_co = PAD_UP(co, LT_NUM);
-    // if (value_contain_infnan) {
-    //   __memcpy_async(cond_compute, cond_selected_base,
-    //                  valid_num * sizeof(int32_t), NRAM2NRAM,
-    //                  valid_num * sizeof(T), sample_stride_3 * sizeof(T), 3);
-    // }
-    __memcpy_async(weight_compute, weight_selected_base, valid_num * sizeof(T),
+    __memcpy(weight_compute, weight_selected_base, valid_num * sizeof(T),
                    NRAM2NRAM, valid_num * sizeof(T),
                    sample_stride_3 * sizeof(T), 3);
-    __bang_transpose(input_trans, input_nram, ci, co);
-    __sync_move();
-
-    // if (value_contain_infnan) {
-    //   __bang_cycle_band((char*)input_trans, (char*)input_trans,
-    //                     (char*)cond_compute, co * ci * sizeof(T),
-    //                     ci * sizeof(T));
-    // }
-
-    if (w_contain_inf) {
-      __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
-      __bang_sumpool(input_pooled, input_trans, valid_num, channels, 4, 1, 4, 1,
-                     1);
-      __bang_cycle_mul(input_pooled, input_pooled, weight_attn_nram,
-                       channels * valid_num, valid_num);
-      __bang_sumpool(output_nram, input_pooled, 1, channels, valid_num, 1,
-                     valid_num, 1, 1);
-    } else {
-      tileWeight2WramSync(input_wram, input_trans, co, ci, pad_co, pad_ci);
-      __bang_conv(output_nram, weight_compute, input_wram, ci, 1, 1, 1, 1, 1, 1,
-                  co);
+    for(int k = 0; k < 4 *valid_num; k++) {
+      __bang_mul_scalar(input_nram + channels * k, input_nram + channels * k, weight_compute[k], channels);
     }
-  } else {
-    __bang_write_value(output_nram, channels, (T)0);
-  }
+    __bang_sumpool(output_nram, input_nram, channels, 4 * valid_num, 1, 4 * valid_num, 1, 1, 1);
 }
+
+
+// template <typename T>
+// __mlu_func__ void reduceLevelByConv(
+//     T* output_nram, T* input_nram, T* input_trans, T* input_pooled,
+//     int32_t* cond_selected_base, T* weight_selected_base, T* weight_attn_nram,
+//     T* weight_compute, int32_t* cond_compute, T* input_wram,
+//     const int32_t valid_num, const int32_t channels,
+//     const int32_t sample_stride_3, const bool w_contain_inf,
+//     const bool value_contain_infnan) {
+//   // if (valid_num > 0) {
+//     // __bang_printf("valid_num: %d\n", valid_num);
+//     int32_t ci = 4 * valid_num;
+//     // int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
+//     int32_t co = channels;
+//     // int32_t pad_co = PAD_UP(co, LT_NUM);
+//     // if (value_contain_infnan) {
+//     //   __memcpy_async(cond_compute, cond_selected_base,
+//     //                  valid_num * sizeof(int32_t), NRAM2NRAM,
+//     //                  valid_num * sizeof(T), sample_stride_3 * sizeof(T), 3);
+//     // }
+//     __memcpy(weight_compute, weight_selected_base, valid_num * sizeof(T),
+//                    NRAM2NRAM, valid_num * sizeof(T),
+//                    sample_stride_3 * sizeof(T), 3);
+//     __bang_transpose(input_trans, input_nram, ci, co);
+//     __sync_move();
+//     // for(int k = 0; k < 4 *valid_num; k++) {
+//     //   __bang_mul_scalar(input_nram + channels * k, input_nram + channels * k, weight_compute[k], channels);
+//     // }
+//     // if (value_contain_infnan) {
+//     //   __bang_cycle_band((char*)input_trans, (char*)input_trans,
+//     //                     (char*)cond_compute, co * ci * sizeof(T),
+//     //                     ci * sizeof(T));
+//     // }
+
+//     // if (w_contain_inf) {
+//     // __bang_mul(input_nram, input_nram, input_trans, 4 * valid_num * channels);
+//     __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
+//       // __bang_sumpool(input_pooled, input_trans, valid_num, channels,4, 1, 4, 1,
+//       //                1);
+//     __bang_transpose(input_nram, input_trans, co, ci);
+//     __bang_sumpool(output_nram, input_nram, channels, 4 * valid_num, 1, 4 * valid_num, 1, 1, 1);
+//       // __bang_cycle_mul(input_pooled, input_pooled, weight_attn_nram,
+//       //                  channels * valid_num, valid_num);
+//       // __bang_sumpool(output_nram, input_pooled, 1, channels, valid_num, 1,
+//       //                valid_num, 1, 1);
+//     // } else {
+//       // tileWeight2WramSync(input_wram, input_trans, co, ci, pad_co, pad_ci);
+//       // __bang_conv(output_nram, weight_compute, input_wram, ci, 1, 1, 1, 1, 1, 1,
+//       //             co);
+//     // }
+//   // } else {
+//   //   __bang_write_value(output_nram, channels, (T)0);
+//   // }
+// }
 
 template <typename T>
 __mlu_func__ int32_t getReduceLevelByConvWramSize(const int32_t num_levels,
@@ -441,10 +456,11 @@ __mlu_func__ int32_t getReduceLevelByConvWramSize(const int32_t num_levels,
 }
 
 __mlu_func__ void loadNram2Gpr(int32_t& v1, int32_t& v2, int32_t& v3,
-                               int32_t* p1, int32_t* p2, int32_t* p3) {
-  v1 = __load_nram(p1);
-  v2 = __load_nram(p2);
-  v3 = __load_nram(p3);
+                               int32_t* p1, int32_t* p2, int32_t* p3, int32_t num_heads, int32_t channels_size) {
+  int32_t stride = num_heads * channels_size;
+  v1 = ((int32_t)__load_nram((float *)p1)) * stride;
+  v2 = ((int32_t)__load_nram((float *)p2)) * stride;
+  v3 = ((int32_t)__load_nram((float *)p3)) * stride;
 }
 
 /*
@@ -465,13 +481,13 @@ template <typename T, mluMemcpyDirection_t DIR>
 __mlu_func__ void loadDataValueXram2NramAsync(
     T* buf_value_nram_1, int32_t* offset_1, int32_t* stride_2_1,
     int32_t* stride_3_1, T* value_src, const int32_t num_levels_points,
-    const int32_t channel_size, const int32_t value_stride_3_size) {
+    const int32_t channel_size, const int32_t value_stride_3_size, const int32_t num_heads) {
   int32_t offset_1_a, stride_2_1_a, stride_3_1_a;
   int32_t offset_1_b, stride_2_1_b, stride_3_1_b;
   loadNram2Gpr(offset_1_a, stride_2_1_a, stride_3_1_a, offset_1, stride_2_1,
-               stride_3_1);
+               stride_3_1, num_heads, channel_size);
   loadNram2Gpr(offset_1_b, stride_2_1_b, stride_3_1_b, offset_1 + 1,
-               stride_2_1 + 1, stride_3_1 + 1);
+               stride_2_1 + 1, stride_3_1 + 1, num_heads, channel_size);
   int32_t value_offset = 0;
   int32_t next = 0;
   int32_t loop_num = num_levels_points / 2;
@@ -480,52 +496,48 @@ __mlu_func__ void loadDataValueXram2NramAsync(
   for (int32_t j = 0; j < loop_num * 2; j += 2) {
     value_offset = j * channel_size;
     next = j + 2;
-    __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
-                   (int8_t*)value_src + offset_1_a, channel_size, DIR,
-                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
-                   1, stride_2_1_a, 1);
+    // __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
+    //                (int8_t*)value_src + offset_1_a, channel_size, DIR,
+    //                2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
+    //                1, stride_2_1_a, 1);
+    for(int i = 0; i < 2; i++)
+    {
+      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + data_value_stride * i,
+                     (int8_t*)value_src + offset_1_a + i * stride_2_1_a,
+                      channel_size, DIR, 2 * data_value_stride, stride_3_1_a, 1);
+    }
 
     loadNram2Gpr(offset_1_a, stride_2_1_a, stride_3_1_a, offset_1 + next,
-                 stride_2_1 + next, stride_3_1 + next);
+                 stride_2_1 + next, stride_3_1 + next, num_heads, channel_size);
 
-    __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size,
-                   (int8_t*)value_src + offset_1_b, channel_size, DIR,
-                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_b,
-                   1, stride_2_1_b, 1);
+    // __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size,
+    //                (int8_t*)value_src + offset_1_b, channel_size, DIR,
+    //                2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_b,
+    //                1, stride_2_1_b, 1);
+    for(int i = 0; i < 2; i++)
+    {
+      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size + data_value_stride * i,
+                     (int8_t*)value_src + offset_1_b + i * stride_2_1_b,
+                      channel_size, DIR, 2 * data_value_stride, stride_3_1_b, 1);
+    }
 
     loadNram2Gpr(offset_1_b, stride_2_1_b, stride_3_1_b, offset_1 + next + 1,
-                 stride_2_1 + next + 1, stride_3_1 + next + 1);
+                 stride_2_1 + next + 1, stride_3_1 + next + 1, num_heads, channel_size);
   }
 
   if (remain > 0) {
     value_offset = loop_num * 2 * channel_size;
-    __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
-                   (int8_t*)value_src + offset_1_a, channel_size, DIR,
-                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
-                   1, stride_2_1_a, 1);
+    // __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
+    //                (int8_t*)value_src + offset_1_a, channel_size, DIR,
+    //                2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
+    //                1, stride_2_1_a, 1);
+    for(int i = 0; i < 2; i++)
+    {
+      __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + data_value_stride * i,
+                     (int8_t*)value_src + offset_1_a + i * stride_2_1_a,
+                      channel_size, DIR, 2 * data_value_stride, stride_3_1_a, 1);
+    }
   }
-}
-
-/*
-  use matmul to count valid samples.
-  sample_valid_count:     (deal_n)
-  cond_point_valid_nram:  (deal_n, num_levels, num_points)
-  nram_ones:              (num_levels, num_points)
-*/
-template <typename T>
-__mlu_func__ void countValidSamples(int32_t* sample_valid_count,
-                                    T* cond_point_valid_nram, T* nram_ones,
-                                    T* wram_buffer, int32_t num_levels,
-                                    int32_t num_points, int32_t deal_n) {
-  int32_t ci = num_levels * num_points;
-  int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
-  int32_t co = deal_n;
-  int32_t pad_co = PAD_UP(co, LT_NUM);
-  tileWeight2WramSync(wram_buffer, cond_point_valid_nram, co, ci, pad_co,
-                      pad_ci);
-  __bang_conv((T*)sample_valid_count, nram_ones, wram_buffer, ci, 1, 1, 1, 1, 1,
-              1, co);
-  __bang_float2int32(sample_valid_count, (T*)sample_valid_count, deal_n, 0);
 }
 
 template <typename T, bool SRAM_STAY, int32_t REDUCE_TYPE = 0>
@@ -536,7 +548,7 @@ __mlu_func__ void loadNeighborPolationAttn(
     T* buf_nram, T* compute_buf_nram, T* nram_ones, const int32_t deal_n,
     const int32_t num_levels, const int32_t num_points, const int32_t num_keys,
     const int32_t channels, const bool w_contain_inf,
-    const bool value_contain_infnan) {
+    const bool value_contain_infnan, const int32_t num_heads) {
   int32_t channel_size = channels * sizeof(T);
   int32_t sample_stride_3 = deal_n * num_levels * num_points;
   int32_t value_stride_3 = num_levels * num_points * channels;
@@ -546,14 +558,14 @@ __mlu_func__ void loadNeighborPolationAttn(
       buf_nram + 4 * value_stride_3;  // (4, num_levels, num_points, channels)
   T* buf_value_nram_pool =
       buf_nram + 8 * value_stride_3;  // (1, num_levels, num_points, channels)
-  int32_t* sample_valid_count =
-      (int32_t*)(buf_nram + 9 * value_stride_3);  // (deal_n)
+  // int32_t* sample_valid_count =
+  //     (int32_t*)(buf_nram + 9 * value_stride_3);  // (deal_n)
   T* weight_compute_nram = compute_buf_nram;      // (4, num_levels, num_points)
   int32_t* cond_compute_nram =
       (int32_t*)(weight_compute_nram + 4 * num_levels * num_points);
 
-  countValidSamples(sample_valid_count, cond_point_valid_nram, nram_ones,
-                    (T*)wram_buffer, num_levels, num_points, deal_n);
+  // countValidSamples(sample_valid_count, cond_point_valid_nram, nram_ones,
+  //                   (T*)wram_buffer, num_levels, num_points, deal_n);
   __sync_compute();
 
   int32_t* offset = data_offset_nram;
@@ -566,7 +578,7 @@ __mlu_func__ void loadNeighborPolationAttn(
     int32_t valid_num = num_levels * num_points; //sample_valid_count[i];
     loadDataValueXram2NramAsync<T, GDRAM2NRAM>(
         buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
-        channel_size, value_stride_3_size);
+        channel_size, value_stride_3_size, num_heads);
     __sync_io();
     reduceLevelByConv(
         output_nram, buf_value_nram, buf_value_nram_trans, buf_value_nram_pool,
@@ -819,13 +831,13 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
     __sync_cluster();
 
     if (__is_ipu()) {
-      if (sram_stay) {
-        int32_t buf_size =
-            (int)((char*)buf_nram_end - (char*)value_output_nram);
-        isValueContainInfNan(value_sram, value_sram + num_keys * channels,
-                             value_output_nram, value_contain_infnan, buf_size,
-                             num_keys * channels);
-      }
+      // if (sram_stay) {
+      //   int32_t buf_size =
+      //       (int)((char*)buf_nram_end - (char*)value_output_nram);
+      //   isValueContainInfNan(value_sram, value_sram + num_keys * channels,
+      //                        value_output_nram, value_contain_infnan, buf_size,
+      //                        num_keys * channels);
+      // }
       // compute weight, offset and condition
       int32_t attn_weight_offset =
           attn_weight_base_offset + core_begin_query * input_stride_3;
@@ -860,7 +872,7 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
           data_offset_nram, weight_polation_nram, cond_point_polation_nram,
           cond_point_valid_nram, weight_attn_nram, buf_nram, buf_compute_nram,
           ones_nram, deal_n, num_levels, num_points, num_keys, channels,
-          w_contain_inf, value_contain_infnan);
+          w_contain_inf, value_contain_infnan, num_heads);
       __sync_io_move_compute();
       // load next weight and loc
       if (i < core_loop_num - 1) {

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -281,36 +281,38 @@ __mlu_func__ void getConditionCoordWeight(
   __bang_add(data_offset_nram_br, buf_hw_offset, buf_x_ceil, total_points);
   //================================================================================================
   // merge and select conditions and weight
-  T* weight_polation_nram_tmp = (T*)buf_nram;
+  // T* weight_polation_nram_tmp = (T*)buf_nram;
   __bang_cycle_and(cond_point_polation_nram, cond_point_polation_nram,
                    cond_point_valid_nram, 4 * total_points, total_points);
-  if (!w_contain_inf) {
-    __bang_cycle_mul(weight_polation_nram, weight_polation_nram,
-                     weight_attn_nram, 4 * total_points, total_points);
-  }
-  __bang_mul_scalar(buf_nram, weight_attn_nram, (T)1, total_points);
-  __bang_collect((float*)weight_attn_nram, (float*)buf_nram,
-                 cond_point_valid_nram, total_points);
+  // if (!w_contain_inf) {
+  __bang_cycle_mul(weight_polation_nram, weight_polation_nram,
+                   weight_attn_nram, 4 * total_points, total_points);
+  // }
+  // __bang_mul_scalar(buf_nram, weight_attn_nram, (T)1, total_points);
+  // __bang_mul((float*)weight_attn_nram, (float*)weight_attn_nram,
+  //                cond_point_valid_nram, total_points);
+  // __bang_collect((float*)weight_attn_nram, (float*)buf_nram,
+  //                cond_point_valid_nram, total_points);
   // __bang_float2int32((int32_t*)cond_point_polation_nram,
   //                    cond_point_polation_nram, total_points * 4, 0);
   // __bang_mul_scalar((int32_t*)cond_point_polation_nram,
   //                   (int32_t*)cond_point_polation_nram, (int32_t)0xffffffff,
   //                   total_points * 4);
-  __bang_mul(weight_polation_nram_tmp, weight_polation_nram, cond_point_polation_nram, total_points * 4);
+  __bang_mul(weight_polation_nram, weight_polation_nram, cond_point_polation_nram, total_points * 4);
   // __bang_band((char*)weight_polation_nram_tmp, (char*)weight_polation_nram,
   //             (char*)cond_point_polation_nram,
   //             total_points * 4 * sizeof(float));
-  __bang_collect((float*)weight_polation_nram, (float*)weight_polation_nram_tmp,
-                 cond_point_valid_nram, total_points);
-  __bang_collect((float*)weight_polation_nram + total_points,
-                 (float*)weight_polation_nram_tmp + total_points,
-                 cond_point_valid_nram, total_points);
-  __bang_collect((float*)weight_polation_nram + 2 * total_points,
-                 (float*)weight_polation_nram_tmp + 2 * total_points,
-                 cond_point_valid_nram, total_points);
-  __bang_collect((float*)weight_polation_nram + 3 * total_points,
-                 (float*)weight_polation_nram_tmp + 3 * total_points,
-                 cond_point_valid_nram, total_points);
+  // __bang_collect((float*)weight_polation_nram, (float*)weight_polation_nram_tmp,
+  //                cond_point_valid_nram, total_points);
+  // __bang_collect((float*)weight_polation_nram + total_points,
+  //                (float*)weight_polation_nram_tmp + total_points,
+  //                cond_point_valid_nram, total_points);
+  // __bang_collect((float*)weight_polation_nram + 2 * total_points,
+  //                (float*)weight_polation_nram_tmp + 2 * total_points,
+  //                cond_point_valid_nram, total_points);
+  // __bang_collect((float*)weight_polation_nram + 3 * total_points,
+  //                (float*)weight_polation_nram_tmp + 3 * total_points,
+  //                cond_point_valid_nram, total_points);
   //================================================================================================
   // select cond_point_polation_nram if value_contain_infnan
   // if (value_contain_infnan) {
@@ -334,26 +336,26 @@ __mlu_func__ void getConditionCoordWeight(
   //================================================================================================
   // compute and select offset and stride
   int32_t* data_offset_nram_tl_tmp = (int32_t*)buf_nram;
-  int32_t* data_offset_nram_bl_tmp = data_offset_nram_tl_tmp + total_points;
-  int32_t* data_offset_nram_tr_tmp = data_offset_nram_bl_tmp + total_points;
+  // int32_t* data_offset_nram_bl_tmp = data_offset_nram_tl_tmp + total_points;
+  // int32_t* data_offset_nram_tr_tmp = data_offset_nram_bl_tmp + total_points;
   __bang_float2int32(data_offset_nram_tl_tmp, data_offset_nram_tl,
                      total_points * 4, 0);
   int32_t stride =
       SRAM_STAY ? channels * sizeof(T) : num_heads * channels * sizeof(T);
-  __bang_mul_scalar(data_offset_nram_tl_tmp, data_offset_nram_tl_tmp, stride,
+  __bang_mul_scalar((int32_t*)data_offset_nram_tl, data_offset_nram_tl_tmp, stride,
                     total_points * 4);
-  __bang_sub((int32_t*)data_offset_nram_bl_tmp,
-             (int32_t*)data_offset_nram_bl_tmp,
-             (int32_t*)data_offset_nram_tl_tmp, total_points);
-  __bang_sub((int32_t*)data_offset_nram_tr_tmp,
-             (int32_t*)data_offset_nram_tr_tmp,
-             (int32_t*)data_offset_nram_tl_tmp, total_points);
-  __bang_collect((float*)data_offset_nram_tl, (float*)data_offset_nram_tl_tmp,
-                 cond_point_valid_nram, total_points);
-  __bang_collect((float*)data_offset_nram_bl, (float*)data_offset_nram_bl_tmp,
-                 cond_point_valid_nram, total_points);
-  __bang_collect((float*)data_offset_nram_tr, (float*)data_offset_nram_tr_tmp,
-                 cond_point_valid_nram, total_points);
+  __bang_sub((int32_t*)data_offset_nram_bl,
+             (int32_t*)data_offset_nram_bl,
+             (int32_t*)data_offset_nram_tl, total_points);
+  __bang_sub((int32_t*)data_offset_nram_tr,
+             (int32_t*)data_offset_nram_tr,
+             (int32_t*)data_offset_nram_tl, total_points);
+  // __bang_collect((float*)data_offset_nram_tl, (float*)data_offset_nram_tl_tmp,
+  //                cond_point_valid_nram, total_points);
+  // __bang_collect((float*)data_offset_nram_bl, (float*)data_offset_nram_bl_tmp,
+  //                cond_point_valid_nram, total_points);
+  // __bang_collect((float*)data_offset_nram_tr, (float*)data_offset_nram_tr_tmp,
+  //                cond_point_valid_nram, total_points);
 }
 
 /*
@@ -387,6 +389,7 @@ __mlu_func__ void reduceLevelByConv(
     const int32_t sample_stride_3, const bool w_contain_inf,
     const bool value_contain_infnan) {
   if (valid_num > 0) {
+    // __bang_printf("valid_num: %d\n", valid_num);
     int32_t ci = 4 * valid_num;
     int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
     int32_t co = channels;
@@ -560,7 +563,7 @@ __mlu_func__ void loadNeighborPolationAttn(
   int32_t step_offset = 0;
   T* value_src = SRAM_STAY ? value_sram : value_gdram;
   for (int32_t i = 0; i < deal_n; i++) {
-    int32_t valid_num = sample_valid_count[i];
+    int32_t valid_num = num_levels * num_points; //sample_valid_count[i];
     loadDataValueXram2NramAsync<T, GDRAM2NRAM>(
         buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
         channel_size, value_stride_3_size);

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_fast_union1.mlu
@@ -24,8 +24,6 @@
 
 #pragma bang walign(64)
 
-#if (__BANG_ARCH__ >= 372)
-
 #define MAX_MEMCPY_SEGNUM (65536)
 #define NRAM_REMAIN_SIZE (48 * 1024)
 #define SRAM_REMAIN_SIZE (32 * 1024)
@@ -293,14 +291,15 @@ __mlu_func__ void getConditionCoordWeight(
   __bang_mul_scalar(buf_nram, weight_attn_nram, (T)1, total_points);
   __bang_collect((float*)weight_attn_nram, (float*)buf_nram,
                  cond_point_valid_nram, total_points);
-  __bang_float2int32((int32_t*)cond_point_polation_nram,
-                     cond_point_polation_nram, total_points * 4, 0);
-  __bang_mul_scalar((int32_t*)cond_point_polation_nram,
-                    (int32_t*)cond_point_polation_nram, (int32_t)0xffffffff,
-                    total_points * 4);
-  __bang_band((char*)weight_polation_nram_tmp, (char*)weight_polation_nram,
-              (char*)cond_point_polation_nram,
-              total_points * 4 * sizeof(float));
+  // __bang_float2int32((int32_t*)cond_point_polation_nram,
+  //                    cond_point_polation_nram, total_points * 4, 0);
+  // __bang_mul_scalar((int32_t*)cond_point_polation_nram,
+  //                   (int32_t*)cond_point_polation_nram, (int32_t)0xffffffff,
+  //                   total_points * 4);
+  __bang_mul(weight_polation_nram_tmp, weight_polation_nram, cond_point_polation_nram, total_points * 4);
+  // __bang_band((char*)weight_polation_nram_tmp, (char*)weight_polation_nram,
+  //             (char*)cond_point_polation_nram,
+  //             total_points * 4 * sizeof(float));
   __bang_collect((float*)weight_polation_nram, (float*)weight_polation_nram_tmp,
                  cond_point_valid_nram, total_points);
   __bang_collect((float*)weight_polation_nram + total_points,
@@ -314,24 +313,24 @@ __mlu_func__ void getConditionCoordWeight(
                  cond_point_valid_nram, total_points);
   //================================================================================================
   // select cond_point_polation_nram if value_contain_infnan
-  if (value_contain_infnan) {
-    int32_t* cond_point_polation_nram_tmp = (int32_t*)buf_nram;
-    __bang_mul_scalar((int32_t*)cond_point_polation_nram_tmp,
-                      (int32_t*)cond_point_polation_nram, (int32_t)1,
-                      total_points * 4);
-    __bang_collect((float*)cond_point_polation_nram,
-                   (float*)cond_point_polation_nram_tmp, cond_point_valid_nram,
-                   total_points);
-    __bang_collect((float*)cond_point_polation_nram + total_points,
-                   (float*)cond_point_polation_nram_tmp + total_points,
-                   cond_point_valid_nram, total_points);
-    __bang_collect((float*)cond_point_polation_nram + 2 * total_points,
-                   (float*)cond_point_polation_nram_tmp + 2 * total_points,
-                   cond_point_valid_nram, total_points);
-    __bang_collect((float*)cond_point_polation_nram + 3 * total_points,
-                   (float*)cond_point_polation_nram_tmp + 3 * total_points,
-                   cond_point_valid_nram, total_points);
-  }
+  // if (value_contain_infnan) {
+  //   int32_t* cond_point_polation_nram_tmp = (int32_t*)buf_nram;
+  //   __bang_mul_scalar((int32_t*)cond_point_polation_nram_tmp,
+  //                     (int32_t*)cond_point_polation_nram, (int32_t)1,
+  //                     total_points * 4);
+  //   __bang_collect((float*)cond_point_polation_nram,
+  //                  (float*)cond_point_polation_nram_tmp, cond_point_valid_nram,
+  //                  total_points);
+  //   __bang_collect((float*)cond_point_polation_nram + total_points,
+  //                  (float*)cond_point_polation_nram_tmp + total_points,
+  //                  cond_point_valid_nram, total_points);
+  //   __bang_collect((float*)cond_point_polation_nram + 2 * total_points,
+  //                  (float*)cond_point_polation_nram_tmp + 2 * total_points,
+  //                  cond_point_valid_nram, total_points);
+  //   __bang_collect((float*)cond_point_polation_nram + 3 * total_points,
+  //                  (float*)cond_point_polation_nram_tmp + 3 * total_points,
+  //                  cond_point_valid_nram, total_points);
+  // }
   //================================================================================================
   // compute and select offset and stride
   int32_t* data_offset_nram_tl_tmp = (int32_t*)buf_nram;
@@ -392,22 +391,22 @@ __mlu_func__ void reduceLevelByConv(
     int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
     int32_t co = channels;
     int32_t pad_co = PAD_UP(co, LT_NUM);
-    if (value_contain_infnan) {
-      __memcpy_async(cond_compute, cond_selected_base,
-                     valid_num * sizeof(int32_t), NRAM2NRAM,
-                     valid_num * sizeof(T), sample_stride_3 * sizeof(T), 3);
-    }
+    // if (value_contain_infnan) {
+    //   __memcpy_async(cond_compute, cond_selected_base,
+    //                  valid_num * sizeof(int32_t), NRAM2NRAM,
+    //                  valid_num * sizeof(T), sample_stride_3 * sizeof(T), 3);
+    // }
     __memcpy_async(weight_compute, weight_selected_base, valid_num * sizeof(T),
                    NRAM2NRAM, valid_num * sizeof(T),
                    sample_stride_3 * sizeof(T), 3);
     __bang_transpose(input_trans, input_nram, ci, co);
     __sync_move();
 
-    if (value_contain_infnan) {
-      __bang_cycle_band((char*)input_trans, (char*)input_trans,
-                        (char*)cond_compute, co * ci * sizeof(T),
-                        ci * sizeof(T));
-    }
+    // if (value_contain_infnan) {
+    //   __bang_cycle_band((char*)input_trans, (char*)input_trans,
+    //                     (char*)cond_compute, co * ci * sizeof(T),
+    //                     ci * sizeof(T));
+    // }
 
     if (w_contain_inf) {
       __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
@@ -422,7 +421,6 @@ __mlu_func__ void reduceLevelByConv(
       __bang_conv(output_nram, weight_compute, input_wram, ci, 1, 1, 1, 1, 1, 1,
                   co);
     }
-
   } else {
     __bang_write_value(output_nram, channels, (T)0);
   }
@@ -563,17 +561,10 @@ __mlu_func__ void loadNeighborPolationAttn(
   T* value_src = SRAM_STAY ? value_sram : value_gdram;
   for (int32_t i = 0; i < deal_n; i++) {
     int32_t valid_num = sample_valid_count[i];
-    if (SRAM_STAY) {
-      loadDataValueXram2NramAsync<T, SRAM2NRAM>(
-          buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
-          channel_size, value_stride_3_size);
-      __sync_move();
-    } else {
-      loadDataValueXram2NramAsync<T, GDRAM2NRAM>(
-          buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
-          channel_size, value_stride_3_size);
-      __sync_io();
-    }
+    loadDataValueXram2NramAsync<T, GDRAM2NRAM>(
+        buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
+        channel_size, value_stride_3_size);
+    __sync_io();
     reduceLevelByConv(
         output_nram, buf_value_nram, buf_value_nram_trans, buf_value_nram_pool,
         (int32_t*)cond_point_polation_nram + step_offset,
@@ -907,336 +898,6 @@ __mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
     __sync_cluster();
   }
 }
-#endif
-
-#if (__BANG_ARCH__ == 592)
-
-/*
-  The shape of each tensor on nram:
-  spatial_offset_nram:       (num_levels)
-  spatial_hw_nram:           (num_levels, 2)
-  spatial_offset_bd_nram:    (num_levels, num_points)
-  spatial_w_bd_nram:         (num_levels, num_points)
-  spatial_h_bd_nram:         (num_levels, num_points)
-  mask_x_nram:               (deal_n, num_levels, num_points, 2) / 8
-  mask_y_nram:               (deal_n, num_levels, num_points, 2) / 8
-  data_offset_nram:          (4, deal_n, num_levels, num_points)
-  weight_polation_nram:      (4, deal_n, num_levels, num_points)
-  cond_point_polation_nram:  (4, deal_n, num_levels, num_points)
-  cond_point_valid_nram:     (deal_n, num_levels, num_points)
-  loc_nram:                  (deal_n, num_levels, num_points, 2)
-  buf_nram:                  (6, deal_n, num_levels, num_points)
-
-  The shape of each tensor on sram:
-  data_offset_nram:          (4, deal_n, num_levels, num_points)
-  weight_polation_nram:      (4, deal_n, num_levels, num_points)
-  cond_point_polation_nram:  (4, deal_n, num_levels, num_points) / 8
-  cond_point_valid_nram:     (deal_n, num_levels, num_points)
-*/
-template <typename T>
-__mlu_func__ void memPolicy590(
-    T*& zeros_nram, int32_t*& data_offset_nram, T*& weight_polation_nram,
-    T*& cond_point_polation_nram, T*& cond_point_valid_nram, T*& loc_nram,
-    T*& buf_nram, T*& buf_nram_end, int8_t*& mask_x_nram, int8_t*& mask_y_nram,
-    T*& spatial_offset_bd_nram, T*& spatial_w_bd_nram, T*& spatial_h_bd_nram,
-    int32_t*& spatial_offset_nram, int32_t*& spatial_hw_nram, T*& value_ping,
-    T*& value_pong, T*& compute_buffer, T*& weight_polation_nram_stg2,
-    T*& weight_attn_nram_stg2, int32_t*& offset_nram_stg2, T*& output_nram,
-    T*& cond_nram_stg2, int32_t*& data_offset_sram, T*& weight_polation_sram,
-    T*& weight_attn_sram, T*& cond_point_polation_sram, char* nram_buffer,
-    char* sram_buffer, int32_t& max_cached_n, int32_t& stage_1_max_deal_n,
-    int32_t& stage_2_max_deal_n, int32_t& mask_size,
-    const int32_t nram_avaliable_size, const int32_t sram_avaliable_size,
-    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
-    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
-    const int32_t num_points) {
-  int32_t num_points_levels = num_levels * num_points;
-  int32_t spatial_info_size =
-      PAD_UP(3 * num_levels * sizeof(int32_t), WRAM_ALIGN_SIZE);
-  int32_t spatial_info_bd_size =
-      PAD_UP(3 * num_points_levels * sizeof(T), WRAM_ALIGN_SIZE);
-  int32_t zeros_size = PAD_UP(channels * sizeof(T), WRAM_ALIGN_SIZE);
-  int32_t fix_space_size = spatial_info_size + 2 * BIT_COLLECT_PAD * sizeof(T) +
-                           spatial_info_bd_size + zeros_size;
-  int32_t left_space_size = nram_avaliable_size - fix_space_size;
-  stage_1_max_deal_n = left_space_size / (20 * num_points_levels * sizeof(T));
-  int32_t total_points = stage_1_max_deal_n * num_points_levels;
-  int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
-  mask_size = PAD_UP(total_coord_pad / BIT_COLLECT_PAD, WRAM_ALIGN_SIZE);
-  stage_2_max_deal_n =
-      (left_space_size - 2 * mask_size) /
-      ((12 * num_points_levels * channels + 17 * num_points_levels) *
-       sizeof(T));
-  // fix nram space
-  zeros_nram = (T*)(nram_buffer);
-  spatial_offset_nram = (int32_t*)(zeros_nram + zeros_size / sizeof(T));
-  spatial_hw_nram = spatial_offset_nram + num_levels;
-  spatial_offset_bd_nram =
-      (T*)((int8_t*)spatial_offset_nram + spatial_info_size);
-  spatial_w_bd_nram = spatial_offset_bd_nram + num_points_levels;
-  spatial_h_bd_nram = spatial_w_bd_nram + num_points_levels;
-  mask_x_nram = (int8_t*)spatial_offset_bd_nram + spatial_info_bd_size;
-  mask_y_nram = mask_x_nram + mask_size;
-  // stage1 nram space
-  // 4 + 4 + 4 + 1 + 6
-  data_offset_nram = (int32_t*)(mask_y_nram + mask_size);
-  weight_polation_nram = (T*)(data_offset_nram + 4 * total_points);
-  cond_point_polation_nram = weight_polation_nram + 4 * total_points;
-  cond_point_valid_nram = cond_point_polation_nram + 4 * total_points;
-  buf_nram = cond_point_valid_nram + total_points;
-  loc_nram = buf_nram + 4 * total_points;
-  buf_nram_end = buf_nram + 6 * total_points + total_coord_pad;
-  // stage2 nram space
-  int32_t total_points_stg2 = stage_2_max_deal_n * num_points_levels;
-  cond_nram_stg2 = (T*)(mask_y_nram + mask_size);
-  value_ping = cond_nram_stg2 + 4 * total_points_stg2 + BIT_COLLECT_PAD;
-  value_pong = value_ping + 4 * total_points_stg2 * channels;
-  compute_buffer = value_pong + 4 * total_points_stg2 * channels;
-  weight_polation_nram_stg2 = compute_buffer + 4 * total_points_stg2 * channels;
-  weight_attn_nram_stg2 = weight_polation_nram_stg2 + 4 * total_points_stg2;
-  offset_nram_stg2 = (int32_t*)(weight_attn_nram_stg2 + total_points_stg2);
-  // sram space: 4 + 4 + 1 + 4
-  int32_t polation_info_size = 13 * num_points_levels * sizeof(T);
-  int32_t avg_sram_size = sram_avaliable_size / coreDim;
-  max_cached_n = avg_sram_size / polation_info_size;
-  int max_cached_points = max_cached_n * num_points_levels;
-  T* sram_buf_base = (T*)(sram_buffer + avg_sram_size * coreId);
-  data_offset_sram = (int32_t*)sram_buf_base;
-  weight_polation_sram = (T*)(data_offset_sram + 4 * max_cached_points);
-  weight_attn_sram = (T*)(weight_polation_sram + 4 * max_cached_points);
-  cond_point_polation_sram = (T*)(weight_attn_sram + max_cached_points);
-}
-
-template <typename T>
-__mlu_func__ void forwardStageTwoLoop(
-    T* value_ping_nram, T* value_pong_nram, T* compute_buffer_nram,
-    T* zeros_nram, T* weight_polation_nram_stg2, T* weight_attn_nram_stg2,
-    int32_t* offset_nram_stg2, T* output_nram, T* cond_nram_stg2,
-    int32_t* data_offset_sram, T* weight_polation_sram, T* weight_attn_sram,
-    T* cond_point_polation_sram, T* data_value_gdram, T* weight_attn_gdram,
-    T* output_gdram, const int32_t total_deal_n, const int32_t max_deal_n,
-    const int32_t input_stride_2, const int32_t input_stride_3,
-    const int32_t output_stride_2, const int32_t num_heads,
-    const int32_t channels, const int32_t num_levels,
-    const int32_t num_points) {
-  int32_t loop_num = (total_deal_n + max_deal_n - 1) / max_deal_n;
-  int32_t num_levels_points = num_levels * num_points;
-  int32_t sram_src_stride = total_deal_n * num_levels_points * sizeof(T);
-  T* value_nram[2] = {value_ping_nram, value_pong_nram};
-  int32_t* offset_zero_nram_stg2 =
-      offset_nram_stg2 + 4 * max_deal_n * num_levels_points;
-  for (int32_t i = 0; i < loop_num + 1; i++) {
-    int32_t compute_idx = i - 1;
-    int32_t compute_offset = compute_idx * max_deal_n;
-    int32_t load_n = std::min(total_deal_n - i * max_deal_n, max_deal_n);
-    int32_t compute_n =
-        std::min(total_deal_n - compute_idx * max_deal_n, max_deal_n);
-    int32_t load_point_num = 4 * load_n * num_levels_points;
-    int32_t nq_nlp_4 = compute_n * num_levels_points * 4;
-    int32_t nq_nlp = compute_n * num_levels_points;
-
-    int32_t total_point_pad_8 = PAD_UP(load_point_num, BIT_COLLECT_PAD);
-    int32_t gather_mask_size = total_point_pad_8 / BIT_COLLECT_PAD;
-    T* v_compute = value_nram[compute_idx % 2];
-    T* v_load = value_nram[i % 2];
-    int8_t* cond_nram_stg2_reverse = (int8_t*)cond_nram_stg2 + gather_mask_size;
-
-    if (i > 0) {
-      int32_t copy_size_1 = compute_n * num_levels_points * sizeof(T);
-      int32_t sram_src_offset = compute_idx * max_deal_n * num_levels_points;
-      __memcpy_async(weight_polation_nram_stg2,
-                     weight_polation_sram + sram_src_offset, copy_size_1,
-                     SRAM2NRAM, copy_size_1, sram_src_stride, 3);
-      __memcpy_async(weight_attn_nram_stg2, weight_attn_sram + sram_src_offset,
-                     copy_size_1, SRAM2NRAM);
-    }
-
-    if (i < loop_num) {
-      int32_t copy_size_1 = load_n * num_levels_points * sizeof(T);
-      int32_t copy_size_2 = load_n * num_levels_points * sizeof(int32_t);
-      int32_t sram_src_offset = i * max_deal_n * num_levels_points;
-      __memcpy_async(offset_nram_stg2, data_offset_sram + sram_src_offset,
-                     copy_size_2, SRAM2NRAM, copy_size_2, sram_src_stride, 3);
-      __memcpy_async(cond_nram_stg2, cond_point_polation_sram + sram_src_offset,
-                     copy_size_1, SRAM2NRAM, copy_size_1, sram_src_stride, 3);
-      __bang_write_value(compute_buffer_nram, load_point_num, (T)0);
-      __bang_write_value(offset_zero_nram_stg2, load_point_num, (int32_t)0);
-      __sync_move();
-      __bang_gt_bitindex(cond_nram_stg2, cond_nram_stg2, compute_buffer_nram,
-                         total_point_pad_8);
-      __bang_bnot((char*)cond_nram_stg2_reverse, (char*)cond_nram_stg2,
-                  gather_mask_size);
-    }
-
-    __sync_io_move_compute();
-
-    if (i < loop_num) {
-      gatherAsync(v_load, zeros_nram, (unsigned int*)offset_zero_nram_stg2,
-                  cond_nram_stg2_reverse, channels * sizeof(T), NRAM2NRAM,
-                  channels * sizeof(T), load_point_num);
-      gatherAsync(v_load, data_value_gdram, (unsigned int*)offset_nram_stg2,
-                  cond_nram_stg2, channels * sizeof(T), GDRAM2NRAM,
-                  channels * sizeof(T), load_point_num);
-    }
-
-    if (i > 0) {
-      __bang_transpose(compute_buffer_nram, v_compute, nq_nlp_4, channels);
-      __bang_cycle_mul(compute_buffer_nram, compute_buffer_nram,
-                       weight_polation_nram_stg2, channels * nq_nlp_4,
-                       nq_nlp_4);
-      __bang_sumpool(v_compute, compute_buffer_nram, nq_nlp, channels, 4, 1, 4,
-                     1, 1);
-      __bang_cycle_mul(v_compute, v_compute, weight_attn_nram_stg2,
-                       channels * nq_nlp, nq_nlp);
-      __bang_transpose(compute_buffer_nram, v_compute, channels, nq_nlp);
-      __bang_sumpool(v_compute, compute_buffer_nram, channels, compute_n,
-                     num_levels_points, 1, num_levels_points, 1, 1);
-      __memcpy(output_gdram + compute_offset * output_stride_2, v_compute,
-               channels * sizeof(T), NRAM2GDRAM, output_stride_2 * sizeof(T),
-               channels * sizeof(T), compute_n - 1);
-    }
-    __sync_io_move_compute();
-  }
-}
-
-// only for 590
-template <typename T>
-__mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
-    const char* data_value_gdram, const char* data_spatial_shapes_gdram,
-    const char* data_level_start_index_gdram,
-    const char* data_sampling_loc_gdram, const char* data_attn_weight_gdram,
-    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
-    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
-    const int32_t num_points, char* data_col_gdram) {
-  int32_t input_stride_4 = num_queries * num_heads * num_levels * num_points;
-  int32_t input_stride_3 = num_heads * num_levels * num_points;
-  int32_t input_stride_2 = num_levels * num_points;
-  int32_t output_stride_3 = num_queries * num_heads * channels;
-  int32_t output_stride_2 = num_heads * channels;
-  int32_t data_value_stride_3 = num_keys * num_heads * channels;
-
-  T* zeros_nram = nullptr;                // (channels)
-  int32_t* data_offset_nram = nullptr;    // (4, deal_n, num_levels, num_points)
-  T* weight_polation_nram = nullptr;      // (4, deal_n, num_levels, num_points)
-  T* cond_point_polation_nram = nullptr;  // (4, deal_n, num_levels, num_points)
-  T* cond_point_valid_nram = nullptr;     // (deal_n, num_levels, num_points)
-  T* loc_nram = nullptr;                  // (deal_n, num_levels, num_points, 2)
-  T* buf_nram = nullptr;                  // (6, deal_n, num_levels, num_points)
-  T* buf_nram_end = nullptr;
-  int8_t* mask_x_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
-  int8_t* mask_y_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
-  T* spatial_offset_bd_nram = nullptr;     // (num_levels, num_points)
-  T* spatial_w_bd_nram = nullptr;          // (num_levels, num_points)
-  T* spatial_h_bd_nram = nullptr;          // (num_levels, num_points)
-  int32_t* spatial_offset_nram = nullptr;  // (num_levels)
-  int32_t* spatial_hw_nram = nullptr;      // (num_levels, 2)
-  T* value_ping_nram = nullptr;  // (deal_n, num_levels, num_points, channels)
-  T* value_pong_nram = nullptr;  // (deal_n, num_levels, num_points, channels)
-  T* compute_buffer_nram =
-      nullptr;  // (deal_n, num_levels, num_points, channels)
-  T* weight_polation_nram_stg2 =
-      nullptr;                          // (4, deal_n, num_levels, num_points)
-  T* weight_attn_nram_stg2 = nullptr;   // (1, deal_n, num_levels, num_points)
-  int32_t* offset_nram_stg2 = nullptr;  // (4, deal_n, num_levels, num_points)
-  T* output_nram = nullptr;             // (deal_n, channels)
-  T* cond_nram_stg2 = nullptr;          // (4, deal_n, num_levels, num_points)
-  T* value_sram = nullptr;              // (num_keys, channels)
-  int32_t* data_offset_sram = nullptr;
-  T* weight_polation_sram = nullptr;
-  T* wegith_attn_sram = nullptr;
-  T* cond_point_polation_sram = nullptr;
-  int32_t stage_1_max_deal_n = 0;
-  int32_t stage_2_max_deal_n = 0;
-  int32_t max_cached_n = 0;
-  int32_t mask_size = 0;
-  memPolicy590(
-      zeros_nram, data_offset_nram, weight_polation_nram,
-      cond_point_polation_nram, cond_point_valid_nram, loc_nram, buf_nram,
-      buf_nram_end, mask_x_nram, mask_y_nram, spatial_offset_bd_nram,
-      spatial_w_bd_nram, spatial_h_bd_nram, spatial_offset_nram,
-      spatial_hw_nram, value_ping_nram, value_pong_nram, compute_buffer_nram,
-      weight_polation_nram_stg2, weight_attn_nram_stg2, offset_nram_stg2,
-      output_nram, cond_nram_stg2, data_offset_sram, weight_polation_sram,
-      wegith_attn_sram, cond_point_polation_sram, nram_buffer, sram_buffer,
-      max_cached_n, stage_1_max_deal_n, stage_2_max_deal_n, mask_size,
-      NRAM_AVALIABLE_SIZE, SRAM_AVALIABLE_SIZE, batch_size, num_keys, num_heads,
-      channels, num_levels, num_queries, num_points);
-  if (stage_1_max_deal_n <= 0 || stage_2_max_deal_n <= 0) {
-    return;
-  }
-
-  int32_t cluster_begin_batch_head = 0;
-  int32_t cluster_act_batch_head = 0;
-  int32_t cluster_end_batch_head = 0;
-  int32_t core_begin_query = 0;
-  int32_t core_act_query = 0;
-  int32_t core_loop_num = 0;
-  int32_t core_step_query = 0;
-  splitTaskV2(cluster_begin_batch_head, cluster_act_batch_head,
-              cluster_end_batch_head, core_begin_query, core_act_query,
-              core_loop_num, core_step_query, max_cached_n, batch_size,
-              num_keys, num_heads, channels, num_levels, num_queries,
-              num_points);
-
-  prepareLoopV2((int32_t*)nullptr, zeros_nram, spatial_offset_nram,
-                spatial_hw_nram, mask_x_nram, mask_y_nram,
-                spatial_offset_bd_nram, spatial_h_bd_nram, spatial_w_bd_nram,
-                value_sram, data_level_start_index_gdram,
-                data_spatial_shapes_gdram, num_keys, num_levels, num_points,
-                stage_1_max_deal_n, mask_size, channels);
-
-  for (int32_t bh_idx = cluster_begin_batch_head;
-       bh_idx < cluster_end_batch_head; bh_idx++) {
-    int32_t b = bh_idx / num_heads;
-    int32_t head_idx = bh_idx % num_heads;
-    size_t output_base_offset =
-        (size_t)b * output_stride_3 + head_idx * channels;
-    size_t attn_weight_base_offset =
-        (size_t)b * input_stride_4 + head_idx * input_stride_2;
-    size_t data_value_base_offset =
-        (size_t)b * data_value_stride_3 + head_idx * channels;
-
-    for (int32_t i = 0; __is_ipu() && i < core_loop_num; i++) {
-      int32_t deal_n =
-          std::min(core_act_query - core_step_query * i, core_step_query);
-      int32_t core_query_offset = i * core_step_query;
-      size_t attn_weight_offset =
-          attn_weight_base_offset +
-          (core_begin_query + core_query_offset) * input_stride_3;
-      size_t loc_offset = attn_weight_offset * 2;
-      size_t output_offset =
-          output_base_offset +
-          (core_begin_query + i * core_step_query) * output_stride_2;
-
-      // compute offset/cond/wp
-      stageOneLoop((T*)data_sampling_loc_gdram + loc_offset,
-                   (T*)data_attn_weight_gdram + attn_weight_offset,
-                   data_offset_nram, nullptr, weight_polation_nram,
-                   cond_point_polation_nram, cond_point_valid_nram, loc_nram,
-                   buf_nram, buf_nram_end, mask_x_nram, mask_y_nram,
-                   spatial_offset_bd_nram, spatial_w_bd_nram, spatial_h_bd_nram,
-                   spatial_offset_nram, spatial_hw_nram, data_offset_sram,
-                   nullptr, weight_polation_sram, wegith_attn_sram,
-                   cond_point_polation_sram, false, false, deal_n,
-                   stage_1_max_deal_n, num_heads, channels, num_levels,
-                   num_points, input_stride_2, input_stride_3);
-
-      // compute and store output
-      forwardStageTwoLoop(
-          value_ping_nram, value_pong_nram, compute_buffer_nram, zeros_nram,
-          weight_polation_nram_stg2, weight_attn_nram_stg2, offset_nram_stg2,
-          output_nram, cond_nram_stg2, data_offset_sram, weight_polation_sram,
-          wegith_attn_sram, cond_point_polation_sram,
-          (T*)data_value_gdram + data_value_base_offset,
-          (T*)data_attn_weight_gdram + attn_weight_offset,
-          (T*)data_col_gdram + output_offset, deal_n, stage_2_max_deal_n,
-          input_stride_2, input_stride_3, output_stride_2, num_heads, channels,
-          num_levels, num_points);
-    }
-  }
-}
-
-#endif
 
 template <typename T>
 __mlu_global__ void MLUKernelMsDeformAttnForwardFast(
@@ -1246,29 +907,11 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardFast(
     const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
     const int32_t channels, const int32_t num_levels, const int32_t num_queries,
     const int32_t num_points, char* data_col_gdram) {
-#if (__BANG_ARCH__ == 372)
-  size_t single_value_size = num_keys * channels * sizeof(T);
-  if (single_value_size <= SRAM_FOR_VALUE_SIZE) {
-    MLUKernelMsDeformAttnForwardFastImpl<float, 0>(
-        data_value_gdram, data_spatial_shapes_gdram,
-        data_level_start_index_gdram, data_sampling_loc_gdram,
-        data_attn_weight_gdram, batch_size, num_keys, num_heads, channels,
-        num_levels, num_queries, num_points, data_col_gdram);
-  } else {
     MLUKernelMsDeformAttnForwardFastImpl<float, 1>(
         data_value_gdram, data_spatial_shapes_gdram,
         data_level_start_index_gdram, data_sampling_loc_gdram,
         data_attn_weight_gdram, batch_size, num_keys, num_heads, channels,
         num_levels, num_queries, num_points, data_col_gdram);
-  }
-#endif
-
-#if (__BANG_ARCH__ == 592)
-  MLUKernelMsDeformAttnForwardFastImpl<float>(
-      data_value_gdram, data_spatial_shapes_gdram, data_level_start_index_gdram,
-      data_sampling_loc_gdram, data_attn_weight_gdram, batch_size, num_keys,
-      num_heads, channels, num_levels, num_queries, num_points, data_col_gdram);
-#endif
 }
 
 template __mlu_global__ void MLUKernelMsDeformAttnForwardFast<float>(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.