### PR TITLE
Ci test zhouxiang

### DIFF
--- a/core/logging.h
+++ b/core/logging.h
@@ -28,8 +28,10 @@
 #include <string>
 #include <limits>
 #include <sstream>
-#include "core/macros.h"
+
 #include "core/cnlog.hpp"
+#include "core/macros.h"
+#include "core/util.h"
 #include "mlu_op.h"
 
 #define LARGE_TENSOR_NUM ((uint64_t)2147483648)
@@ -216,9 +218,17 @@ extern bool mluop_check_large_tensor_dim_size_;
     return MLUOP_STATUS_NOT_SUPPORTED;                                     \
   }
 
-void mluOpCheck(mluOpStatus_t result, char const *const func,
-                const char *const file, int const line);
-#define MLUOP_CHECK(val) mluOpCheck((val), #val, __FILE__, __LINE__)
+#define STRIDE_TENSOR_CHECK(api, desc, reason)                            \
+  if (MLUOP_PREDICT_TRUE(desc != NULL)) {                                 \
+    if (MLUOP_PREDICT_FALSE(                                              \
+            MLUOP_PREDICT_TRUE(0 != mluOpGetTensorElementNum(desc)) &&    \
+            isStrideTensor(desc->dim, desc->dims, desc->strides))) {      \
+      LOG(ERROR) << api << " stride tensor is not supported. " << reason; \
+      return MLUOP_STATUS_NOT_SUPPORTED;                                  \
+    }                                                                     \
+  }
+
+#define MLUOP_CHECK(val) ((val), #val, __FILE__, __LINE__)
 
 #define KERNEL_CALL_CHECK(parent_kernel, sub_kernel, status, statement)        \
   do {                                                                         \
@@ -274,9 +284,11 @@ struct Voidifier {
     return vmodule_activated;                                          \
   })(lvl, __FILE__))
 
-#define VLOG(level)                      \
-  MLUOP_PREDICT_TRUE(!VLOG_IS_ON(({ static_assert \
-  (level > 0, "VLOG level should be greater than 0"); level; }))) \
+#define VLOG(level)                                                  \
+  MLUOP_PREDICT_TRUE(!VLOG_IS_ON(({                                  \
+    static_assert(level > 0, "VLOG level should be greater than 0"); \
+    level;                                                           \
+  })))                                                               \
   ? (void)0 : ::mluop::internal::Voidifier() & LOG(VLOG)
 
 // This formats a value for a failing CHECK_XX statement.  Ordinarily,

--- a/core/util.cpp
+++ b/core/util.cpp
@@ -22,9 +22,10 @@
  *************************************************************************/
 
 #include <string>
-#include <stdexcept>
-#include "mlu_op.h"
+
 #include "core/logging.h"
+#include "core/util.h"
+#include "mlu_op.h"
 
 void mluOpCheck(mluOpStatus_t result, char const *const func,
                 const char *const file, int const line) {
@@ -37,4 +38,19 @@ void mluOpCheck(mluOpStatus_t result, char const *const func,
     //                   And now it is only used in gtest code.
     throw std::runtime_error(error);
   }
+}
+
+bool isStrideTensor(const int dim, const int64_t *dims,
+                    const int64_t *strides) {
+  int64_t stride_base = 1;
+
+  for (int i = dim - 1; i >= 0; i--) {
+    if (dims[i] != 1 && strides[i] != stride_base) {
+      return true;
+    }
+
+    stride_base *= dims[i];
+  }
+
+  return false;
 }

--- a/core/util.h
+++ b/core/util.h
@@ -20,39 +20,15 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
-#ifndef KERNELS_DCN_COMMON_DCN_COMMON_H
-#define KERNELS_DCN_COMMON_DCN_COMMON_H
-#include <limits.h>
-#include <math.h>
-#include <vector>
 
-#include "kernels/utils/cnnl_helper.h"
+#ifndef CORE_UTIL_H_
+#define CORE_UTIL_H_
 
-#define DCN_API "mluOpDCN"
+#include "mlu_op.h"
 
-mluOpStatus_t MLUOP_WIN_API
-mluOpCreateDCNDescriptor(mluOpDCNDescriptor_t *dcn_desc) {
-  PARAM_CHECK(DCN_API, dcn_desc != NULL);
-  CALL_CNNL(cnnlCreateDCNDescriptor(dcn_desc));
-  return MLUOP_STATUS_SUCCESS;
-}
+void mluOpCheck(mluOpStatus_t result, char const *const func,
+                const char *const file, int const line);
 
-mluOpStatus_t MLUOP_WIN_API
-mluOpDestroyDCNDescriptor(mluOpDCNDescriptor_t dcn_desc) {
-  PARAM_CHECK(DCN_API, dcn_desc != NULL);
-  CALL_CNNL(cnnlDestroyDCNDescriptor(dcn_desc));
-  return MLUOP_STATUS_SUCCESS;
-}
+bool isStrideTensor(const int dim, const int64_t *dims, const int64_t *strides);
 
-mluOpStatus_t MLUOP_WIN_API mluOpSetDCNDescriptor(
-    mluOpDCNDescriptor_t dcn_desc, int dimNb, const int pad[],
-    const int stride[], const int dilation[], int deformable_group,
-    int conv_group, int im2col_step, const mluOpDataType_t compute_type) {
-  PARAM_CHECK(DCN_API, dcn_desc != NULL);
-  CALL_CNNL(cnnlSetDCNDescriptor(dcn_desc, dimNb, pad, stride, dilation,
-                                 deformable_group, conv_group, im2col_step,
-                                 cnnlDataType_t(compute_type)));
-  return MLUOP_STATUS_SUCCESS;
-}
-
-#endif  // KERNELS_DCN_COMMON_DCN_COMMON_H
+#endif  // CORE_UTIL_H_

--- a/kernels/abs/abs.cpp
+++ b/kernels/abs/abs.cpp
@@ -54,17 +54,13 @@ static mluOpStatus_t mluOpAbsParamCheck(mluOpHandle_t handle,
   // check data type
   mluOpStatus_t param_check;
   if (handle->arch >= MLUOP_MLU590) {
-    mluOpDataType_t support_type[5] = {MLUOP_DTYPE_HALF, MLUOP_DTYPE_BFLOAT16,
-                                       MLUOP_DTYPE_FLOAT, MLUOP_DTYPE_INT32,
-                                       MLUOP_DTYPE_COMPLEX_FLOAT};
-    if (!isAbsSupportType(x_desc->dtype, support_type, 5)) {
+    mluOpDataType_t support_type[1] = {MLUOP_DTYPE_HALF};
+    if (!isAbsSupportType(x_desc->dtype, support_type, 1)) {
       LOG(ERROR) << op_name << ":x_desc's data type is not supported.";
       return MLUOP_STATUS_BAD_PARAM;
     }
   } else {
-    mluOpDataType_t support_type[4] = {MLUOP_DTYPE_HALF, MLUOP_DTYPE_FLOAT,
-                                       MLUOP_DTYPE_INT32,
-                                       MLUOP_DTYPE_COMPLEX_FLOAT};
+    mluOpDataType_t support_type[1] = {MLUOP_DTYPE_HALF};
     if (!isAbsSupportType(x_desc->dtype, support_type, 4)) {
       LOG(ERROR) << op_name << ":x_desc's data type is not supported.";
       return MLUOP_STATUS_BAD_PARAM;

--- a/kernels/abs/abs_block.mlu
+++ b/kernels/abs/abs_block.mlu
@@ -39,7 +39,6 @@ __mlu_func__ void auxFunc3AbsFloat(size_t &output_input_gap,
                                    size_t &ping_pong_gap,
                                    size_t &auxiliary_a_gap,
                                    size_t &auxiliary_b_gap,
-                                   int i,
                                    size_t &span_num_deal, size_t &align_num) {
   align_num = NFU_ALIGN_SIZE / sizeof(T1);
   // need 2 pingpong sapce,
@@ -79,14 +78,14 @@ template <typename T1, typename T2>
 __mlu_func__ void computeAbsHalfBfloat16(char *nram_output, char *nram_input,
                                          char *auxiliary_a, char *auxiliary_b,
                                          size_t deal_num, size_t actual_num) {
-  __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
+  // __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
 }
 
 template <typename T1, typename T2>
 __mlu_func__ void computeAbsFloat(char *nram_output, char *nram_input,
                                   char *auxiliary_a, char *auxiliary_b,
                                   size_t deal_num, size_t actual_num) {
-  __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
+  // __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
 }
 
 template <typename T1, typename T2>

--- a/kernels/abs/abs_block.mlu
+++ b/kernels/abs/abs_block.mlu
@@ -78,14 +78,14 @@ template <typename T1, typename T2>
 __mlu_func__ void computeAbsHalfBfloat16(char *nram_output, char *nram_input,
                                          char *auxiliary_a, char *auxiliary_b,
                                          size_t deal_num, size_t actual_num) {
-  // __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
+  __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
 }
 
 template <typename T1, typename T2>
 __mlu_func__ void computeAbsFloat(char *nram_output, char *nram_input,
                                   char *auxiliary_a, char *auxiliary_b,
                                   size_t deal_num, size_t actual_num) {
-  // __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
+  __bang_abs((T2 *)nram_output, (T1 *)nram_input, deal_num);
 }
 
 template <typename T1, typename T2>

--- a/kernels/abs/abs_block.mlu
+++ b/kernels/abs/abs_block.mlu
@@ -39,6 +39,7 @@ __mlu_func__ void auxFunc3AbsFloat(size_t &output_input_gap,
                                    size_t &ping_pong_gap,
                                    size_t &auxiliary_a_gap,
                                    size_t &auxiliary_b_gap,
+                                   int i,
                                    size_t &span_num_deal, size_t &align_num) {
   align_num = NFU_ALIGN_SIZE / sizeof(T1);
   // need 2 pingpong sapce,

--- a/kernels/abs/abs_block.mlu
+++ b/kernels/abs/abs_block.mlu
@@ -39,7 +39,6 @@ __mlu_func__ void auxFunc3AbsFloat(size_t &output_input_gap,
                                    size_t &ping_pong_gap,
                                    size_t &auxiliary_a_gap,
                                    size_t &auxiliary_b_gap,
-                                   int i,
                                    size_t &span_num_deal, size_t &align_num) {
   align_num = NFU_ALIGN_SIZE / sizeof(T1);
   // need 2 pingpong sapce,
@@ -54,7 +53,7 @@ template <typename T1, typename T2>
 __mlu_func__ void auxFunc3AbsHalfBfloat16(
     size_t &output_input_gap, size_t &ping_pong_gap, size_t &auxiliary_a_gap,
     size_t &auxiliary_b_gap, size_t &span_num_deal, size_t &align_num) {
-  align_num = NFU_ALIGN_SIZE / sizeof(T);
+  align_num = NFU_ALIGN_SIZE / sizeof(T1);
   // need 2 pingpong sapce,
   span_num_deal = PAD_DOWN(UNARY_NRAM_SIZE / sizeof(T1) / 2, align_num);
   ping_pong_gap = span_num_deal * sizeof(T1) * 2;
@@ -95,7 +94,7 @@ __mlu_func__ void computeAbsComplexFloat(char *nram_output, char *nram_input,
                                          size_t deal_num, size_t actual_num) {
   T2 *aux_a = (T2 *)nram_input + 2 * deal_num;
   T2 *aux_b = (T2 *)nram_input + 3 * deal_num;
-  bang_write_value((T2 *)auxiliary_a, deal_num * sizeof(T2), (int8_t)0xAA);
+  __bang_write_value((T2 *)auxiliary_a, deal_num * sizeof(T2), (int8_t)0xAA);
   __bang_write_value((T2 *)auxiliary_b, deal_num * sizeof(T2), (int8_t)0x55);
   // select [real,real,real...] and [imaginary,imaginary,imaginary...]
   __bang_filter_bitindex((T2 *)aux_a, (T2 *)nram_input, auxiliary_a,

--- a/kernels/abs/abs_block.mlu
+++ b/kernels/abs/abs_block.mlu
@@ -54,7 +54,7 @@ template <typename T1, typename T2>
 __mlu_func__ void auxFunc3AbsHalfBfloat16(
     size_t &output_input_gap, size_t &ping_pong_gap, size_t &auxiliary_a_gap,
     size_t &auxiliary_b_gap, size_t &span_num_deal, size_t &align_num) {
-  align_num = NFU_ALIGN_SIZE / sizeof(T1);
+  align_num = NFU_ALIGN_SIZE / sizeof(T);
   // need 2 pingpong sapce,
   span_num_deal = PAD_DOWN(UNARY_NRAM_SIZE / sizeof(T1) / 2, align_num);
   ping_pong_gap = span_num_deal * sizeof(T1) * 2;
@@ -95,7 +95,7 @@ __mlu_func__ void computeAbsComplexFloat(char *nram_output, char *nram_input,
                                          size_t deal_num, size_t actual_num) {
   T2 *aux_a = (T2 *)nram_input + 2 * deal_num;
   T2 *aux_b = (T2 *)nram_input + 3 * deal_num;
-  __bang_write_value((T2 *)auxiliary_a, deal_num * sizeof(T2), (int8_t)0xAA);
+  bang_write_value((T2 *)auxiliary_a, deal_num * sizeof(T2), (int8_t)0xAA);
   __bang_write_value((T2 *)auxiliary_b, deal_num * sizeof(T2), (int8_t)0x55);
   // select [real,real,real...] and [imaginary,imaginary,imaginary...]
   __bang_filter_bitindex((T2 *)aux_a, (T2 *)nram_input, auxiliary_a,

--- a/kernels/abs/abs_block.mlu
+++ b/kernels/abs/abs_block.mlu
@@ -38,7 +38,7 @@ template <typename T1, typename T2>
 __mlu_func__ void auxFunc3AbsFloat(size_t &output_input_gap,
                                    size_t &ping_pong_gap,
                                    size_t &auxiliary_a_gap,
-                                   size_t &auxiliary_b_gap,
+                                   size_t &auxiliary_b_gap,qwerty
                                    size_t &span_num_deal, size_t &align_num) {
   align_num = NFU_ALIGN_SIZE / sizeof(T1);
   // need 2 pingpong sapce,

--- a/kernels/abs/abs_block.mlu
+++ b/kernels/abs/abs_block.mlu
@@ -38,7 +38,8 @@ template <typename T1, typename T2>
 __mlu_func__ void auxFunc3AbsFloat(size_t &output_input_gap,
                                    size_t &ping_pong_gap,
                                    size_t &auxiliary_a_gap,
-                                   size_t &auxiliary_b_gap,qwerty
+                                   size_t &auxiliary_b_gap,
+                                   int i,
                                    size_t &span_num_deal, size_t &align_num) {
   align_num = NFU_ALIGN_SIZE / sizeof(T1);
   // need 2 pingpong sapce,

--- a/kernels/active_rotated_filter/active_rotated_filter.cpp
+++ b/kernels/active_rotated_filter/active_rotated_filter.cpp
@@ -85,6 +85,14 @@ static mluOpStatus_t activeRotatedFilterForwardParamCheck(
   PARAM_CHECK(api_name, (output_desc->dims[1] ==
                          input_desc->dims[1] * input_desc->dims[2]));
 
+  // check stride
+  STRIDE_TENSOR_CHECK(api_name + ":", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", indices_desc,
+                      "indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", output_desc,
+                      "output_desc must be contiguous");
+
   // check tensor datatype, support float16 and float32
   PARAM_CHECK_V2(api_name,
                  (input_desc->dtype == MLUOP_DTYPE_HALF) ||

--- a/kernels/adam_w/adam_w.cpp
+++ b/kernels/adam_w/adam_w.cpp
@@ -182,6 +182,22 @@ mluOpAdamW(mluOpHandle_t handle, const mluOpAdamWDescriptor_t adamw_desc,
   PARAM_CHECK("[mluOpAdamW]", velocity != nullptr);
   PARAM_CHECK("[mluOpAdamW]", grad != nullptr);
 
+  // stride check
+  if (param_desc != nullptr) {
+    STRIDE_TENSOR_CHECK("[mluOpAdamW]:", param_desc,
+                        "param_desc must be contiguous");
+  }
+  if (paramh_desc != nullptr) {
+    STRIDE_TENSOR_CHECK("[mluOpAdamW]:", paramh_desc,
+                        "paramh_desc must be contiguous");
+  }
+  STRIDE_TENSOR_CHECK("[mluOpAdamW]:", momentum_desc,
+                      "momentum_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpAdamW]:", velocity_desc,
+                      "velocity_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpAdamW]:", grad_desc,
+                      "grad_desc must be contiguous");
+
   // generate adam prototxt start!
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("adamw", "ADAMW");
@@ -246,17 +262,16 @@ mluOpAdamW(mluOpHandle_t handle, const mluOpAdamWDescriptor_t adamw_desc,
       return MLUOP_STATUS_ARCH_MISMATCH;
     }
     case CNRT_FUNC_TYPE_UNION1: {
-      VLOG(5) << "Launch Kernel KernelApplyAdamW<<<Union"
-              << k_type / CORE_DIM << ", " << k_dim.x << ", " << k_dim.y << ", "
-              << k_dim.z << ">>>";
+      VLOG(5) << "Launch Kernel KernelApplyAdamW<<<Union" << k_type / CORE_DIM
+              << ", " << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";
       CHECK_RETURN(
           "[mluOpAdamW]",
-          KernelApplyAdamW(
-              k_dim, k_type, handle->queue, (void *)param, (void *)param_h,
-              (void *)grad, (void *)momentum, (void *)velocity, lr, beta1,
-              beta2, bias1, bias2, epsilon, adamw_desc->weight_decay,
-              adamw_desc->grad_scale, adamw_desc->use_nesterov, size,
-              k_data_type));
+          KernelApplyAdamW(k_dim, k_type, handle->queue, (void *)param,
+                           (void *)param_h, (void *)grad, (void *)momentum,
+                           (void *)velocity, lr, beta1, beta2, bias1, bias2,
+                           epsilon, adamw_desc->weight_decay,
+                           adamw_desc->grad_scale, adamw_desc->use_nesterov,
+                           size, k_data_type));
     }
   }
   GEN_CASE_END();

--- a/kernels/adam_w/adam_w_union1.mlu
+++ b/kernels/adam_w/adam_w_union1.mlu
@@ -73,8 +73,8 @@ __mlu_func__ void computeAdamW(bfloat16_t *nbuf_paramh, bfloat16_t *nbuf_grad,
   __bang_sqrt(temp_2, temp_2, deal_num);
   __bang_add_scalar(temp_2, temp_2, epsilon, deal_num);
   __bang_div(temp_1, temp_1, temp_2, deal_num);
-  __bang_sub(nbuf_param + offset, nbuf_param + offset, temp_1, deal_num);
-  __bang_float2bfloat16_rn(nbuf_paramh + offset, nbuf_param + offset, deal_num);
+  // __bang_sub(nbuf_param + offset, nbuf_param + offset, temp_1, deal_num);
+  // __bang_float2bfloat16_rn(nbuf_paramh + offset, nbuf_param + offset, deal_num);
 #endif
 }
 

--- a/kernels/adam_w/adam_w_union1.mlu
+++ b/kernels/adam_w/adam_w_union1.mlu
@@ -70,11 +70,11 @@ __mlu_func__ void computeAdamW(bfloat16_t *nbuf_paramh, bfloat16_t *nbuf_grad,
   __bang_mul_scalar(temp_1, nbuf_momentum + offset, lr, deal_num);
   __bang_mul_scalar(temp_1, temp_1, 1.0f / bias1, deal_num);
   __bang_mul_scalar(temp_2, nbuf_velocity + offset, 1.0f / bias2, deal_num);
-  __bang_sqrt(temp_2, temp_2, deal_num);
-  __bang_add_scalar(temp_2, temp_2, epsilon, deal_num);
-  __bang_div(temp_1, temp_1, temp_2, deal_num);
-  // __bang_sub(nbuf_param + offset, nbuf_param + offset, temp_1, deal_num);
-  // __bang_float2bfloat16_rn(nbuf_paramh + offset, nbuf_param + offset, deal_num);
+  // __bang_sqrt(temp_2, temp_2, deal_num);
+  // __bang_add_scalar(temp_2, temp_2, epsilon, deal_num);
+  // __bang_div(temp_1, temp_1, temp_2, deal_num);
+  __bang_sub(nbuf_param + offset, nbuf_param + offset, temp_1, deal_num);
+  __bang_float2bfloat16_rn(nbuf_paramh + offset, nbuf_param + offset, deal_num);
 #endif
 }
 

--- a/kernels/ball_query/ball_query.cpp
+++ b/kernels/ball_query/ball_query.cpp
@@ -104,6 +104,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpBallQuery(
   PARAM_CHECK("[mluOpBallQuery]", xyz_desc->dims[2] == 3);
   PARAM_CHECK("[mluOpBallQuery]", idx_desc->dims[2] == nsample);
 
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpBallQuery]:", new_xyz_desc,
+                      "new_xyz_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBallQuery]:", xyz_desc,
+                      "xyz_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBallQuery]:", idx_desc,
+                      "idx_desc must be contiguous");
+
   // check dtype
   if (!isSupportType(new_xyz_desc->dtype, support_type, 2)) {
     LOG(ERROR) << "[mluOpBallQuery]:Only half and float are supported in input "

--- a/kernels/bbox_overlaps/bbox_overlaps.cpp
+++ b/kernels/bbox_overlaps/bbox_overlaps.cpp
@@ -70,6 +70,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpBboxOverlaps(
   PARAM_CHECK(API, bbox1_desc->dim == 2);
   PARAM_CHECK(API, bbox2_desc->dim == 2);
 
+  // stride check
+  STRIDE_TENSOR_CHECK(API + ":", bbox1_desc, "bbox1_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", bbox2_desc, "bbox2_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", ious_desc, "ious_desc must be contiguous");
+
   // param check
   if (mode != 1 && mode != 0) {
     LOG(ERROR) << "[mluOpBboxOverlaps] Check failed: The mode must be 0 or 1, "

--- a/kernels/binary_op/binary_op_3pipeline.h
+++ b/kernels/binary_op/binary_op_3pipeline.h
@@ -160,7 +160,7 @@
                      rem * sizeof(DType_out), NRAM2GDRAM);                    \
       pvUnlock();                                                             \
     }                                                                         \
-}
+  }
 
 // Divide tasks in host
 #define BINARY_OP_KERNEL_3PIPELINE_V2_DECLARE(Op, Prefer)               \

--- a/kernels/binary_op/binary_op_5pipeline.h
+++ b/kernels/binary_op/binary_op_5pipeline.h
@@ -42,9 +42,9 @@
 
 /****************************************************************************
  * GDRAM2SRAM: io pipeline
- * SRAM2NRAM ：mo pipeline 
- * In Cambricon hardware, The io, compute, and move pipeline have their own 
- * instruction queues and can be launched in parallel, 
+ * SRAM2NRAM ：mo pipeline
+ * In Cambricon hardware, The io, compute, and move pipeline have their own
+ * instruction queues and can be launched in parallel,
  * so the time of io, compute and move can cover each other.
  * The five pipleine is:
  * GDRAM2SRAM: io load data form gdram
@@ -52,7 +52,7 @@
  * Compute : compute pipleine
  * NRAM2SRAM : mv store data to sram
  * SRAM2GDRAM ： io store data to gdram
-*/ 
+ */
 
 #if __BANG_ARCH__ != 520  // TODO(sram): tp_520
 #define BINARY_OP_KERNEL_5PIPELINE(Op, Prefer)                                 \

--- a/kernels/binary_op/binary_op_host.cpp
+++ b/kernels/binary_op/binary_op_host.cpp
@@ -218,7 +218,7 @@ mluOpStatus_t binaryOpParamCheck(
                      "output tensor num is too large. ");
 
     if (mluop::strideCaseWithNotConsistentDense(3, input1_desc, input2_desc,
-                                         output_desc)) {
+                                                output_desc)) {
       uint64_t num_input1_with_stride = shapeStrideCount(input1_desc);
       uint64_t num_input2_with_stride = shapeStrideCount(input2_desc);
       uint64_t num_output_with_stride = shapeStrideCount(output_desc);

--- a/kernels/border_align/border_align_backward/border_align_backward.cpp
+++ b/kernels/border_align/border_align_backward/border_align_backward.cpp
@@ -61,6 +61,16 @@ mluOpStatus_t mluOpBorderAlignBackward(
   PARAM_CHECK(API, argmax_idx_desc->dim == 4);
   PARAM_CHECK(API, grad_input_desc->dim == 4);
 
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignBackward]:", grad_output_desc,
+                      "grad_output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignBackward]:", boxes_desc,
+                      "boxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignBackward]:", argmax_idx_desc,
+                      "argmax_idx_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignBackward]:", grad_input_desc,
+                      "grad_input_desc must be contiguous");
+
   const int32_t border_num = 4;
   const int32_t coord_num = 4;
   const int32_t origin_n = grad_input_desc->dims[0];
@@ -83,14 +93,13 @@ mluOpStatus_t mluOpBorderAlignBackward(
               "(4 represents the number of borders).");
   PARAM_CHECK_NE(API, grad_input_desc->dims[0], 0);
   PARAM_CHECK_NE(API, grad_input_desc->dims[3] / 4, 0,
-              "(4 represents the number of borders).");
+                 "(4 represents the number of borders).");
   PARAM_CHECK_NE(API, grad_input_desc->dims[1], 0);
   PARAM_CHECK_NE(API, grad_input_desc->dims[2], 0);
-  PARAM_CHECK(API, grad_input_desc->dims[1] * grad_input_desc->dims[2]
-                    == boxes_desc->dims[1]);
+  PARAM_CHECK(API, grad_input_desc->dims[1] * grad_input_desc->dims[2] ==
+                       boxes_desc->dims[1]);
   PARAM_CHECK(API, boxes_desc->dim == 3);
-  PARAM_CHECK(API, boxes_desc->dims[2] == border_num,
-              "(border_num = 4).");
+  PARAM_CHECK(API, boxes_desc->dims[2] == border_num, "(border_num = 4).");
   PARAM_CHECK_NE(API, boxes_desc->dims[1], 0);
   PARAM_CHECK_GT(API, pool_size, 0);
 
@@ -103,8 +112,7 @@ mluOpStatus_t mluOpBorderAlignBackward(
 
   PARAM_CHECK_EQ(API, boxes_desc->dims[0], grad_input_desc->dims[0]);
   PARAM_CHECK_EQ(API, boxes_desc->dims[1], boxes_desc->dims[1]);
-  PARAM_CHECK_EQ(API, boxes_desc->dims[2], border_num,
-                 "(border_num = 4).");
+  PARAM_CHECK_EQ(API, boxes_desc->dims[2], border_num, "(border_num = 4).");
 
   PARAM_CHECK_EQ(API, argmax_idx_desc->dims[0], grad_input_desc->dims[0]);
   PARAM_CHECK_EQ(API, argmax_idx_desc->dims[1], boxes_desc->dims[1]);
@@ -133,8 +141,7 @@ mluOpStatus_t mluOpBorderAlignBackward(
     GEN_CASE_DATA_REAL(true, "input2", boxes, boxes_desc);
     GEN_CASE_DATA_REAL(true, "input3", argmax_idx, argmax_idx_desc);
     GEN_CASE_DATA(false, "output1", grad_input, grad_input_desc, 0, 0);
-    GEN_CASE_OP_PARAM_SINGLE(0, "border_align", "pool_size",
-                             pool_size);
+    GEN_CASE_OP_PARAM_SINGLE(0, "border_align", "pool_size", pool_size);
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
   }
 

--- a/kernels/border_align/border_align_forward/border_align_forward.cpp
+++ b/kernels/border_align/border_align_forward/border_align_forward.cpp
@@ -58,6 +58,16 @@ mluOpStatus_t mluOpBorderAlignForward(
   PARAM_CHECK(API, output_desc->dim == 4);
   PARAM_CHECK(API, argmax_idx_desc->dim == 4);
 
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignForward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignForward]:", boxes_desc,
+                      "boxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignForward]:", output_desc,
+                      "output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBorderAlignForward]:", argmax_idx_desc,
+                      "argmax_idx_desc must be contiguous");
+
   const int32_t border_num = 4;
   const int32_t coord_num = 4;
   const int32_t origin_n = input_desc->dims[0];
@@ -87,9 +97,9 @@ mluOpStatus_t mluOpBorderAlignForward(
   PARAM_CHECK(API, boxes_desc->dim == 3);
   PARAM_CHECK(API, boxes_desc->dims[2] == 4);
 
-  PARAM_CHECK(API, input_desc->dims[0]== boxes_desc->dims[0]);
-  PARAM_CHECK(API, input_desc->dims[1] * input_desc->dims[2]
-                    == boxes_desc->dims[1]);
+  PARAM_CHECK(API, input_desc->dims[0] == boxes_desc->dims[0]);
+  PARAM_CHECK(API,
+              input_desc->dims[1] * input_desc->dims[2] == boxes_desc->dims[1]);
   PARAM_CHECK_EQ(API, output_desc->dims[0], input_desc->dims[0]);
   PARAM_CHECK_EQ(API, output_desc->dims[1], boxes_desc->dims[1]);
   PARAM_CHECK_EQ(API, output_desc->dims[2], 4);

--- a/kernels/box_iou_rotated/box_iou_rotated.cpp
+++ b/kernels/box_iou_rotated/box_iou_rotated.cpp
@@ -172,6 +172,15 @@ mluOpBoxIouRotated(mluOpHandle_t handle, const int mode, const bool aligned,
       return MLUOP_STATUS_BAD_PARAM;
     }
   }
+
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpBoxIouRotated]:", box1_desc,
+                      "box1_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBoxIouRotated]:", box2_desc,
+                      "box2_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpBoxIouRotated]:", ious_desc,
+                      "ious_desc must be contiguous");
+
   // 0-element check, after dim and shape check
   if (box1_desc->dims[0] * box2_desc->dims[0] == 0) {
     VLOG(5) << "[mluOpBoxIouRotated] Skip zero element boxes.";

--- a/kernels/carafe/carafe_block.mlu
+++ b/kernels/carafe/carafe_block.mlu
@@ -368,7 +368,8 @@ __mlu_global__ void MLUKernelCarafeBackward(T *input, T *mask, T *grad_output,
               (T *)nram_buf + 3 * NRAM_BLOCK / sizeof(T),
               ((T *)nram_buf + NRAM_BLOCK / sizeof(T))[mask_index], num_align);
           __bang_atomic_reduce_add((T *)base_grad_input,
-              (T *)nram_buf + 2 * NRAM_BLOCK / sizeof(T), num_align);
+                                   (T *)nram_buf + 2 * NRAM_BLOCK / sizeof(T),
+                                   num_align);
           __bang_mul((T *)nram_buf, (T *)nram_buf + 3 * NRAM_BLOCK / sizeof(T),
                      (T *)nram_buf, num_align);
 
@@ -411,7 +412,8 @@ __mlu_global__ void MLUKernelCarafeBackward(T *input, T *mask, T *grad_output,
               ((T *)nram_buf + NRAM_BLOCK / sizeof(T))[mask_index],
               rem_for_loop_align);
           __bang_atomic_reduce_add((T *)base_grad_input,
-              (T *)nram_buf + 2 * NRAM_BLOCK / sizeof(T), rem_for_loop);
+                                   (T *)nram_buf + 2 * NRAM_BLOCK / sizeof(T),
+                                   rem_for_loop);
           __bang_mul((T *)nram_buf, (T *)nram_buf + 3 * NRAM_BLOCK / sizeof(T),
                      (T *)nram_buf, rem_for_loop_align);
 

--- a/kernels/deform_conv/dcn_backward_data/dcn_backward_data.cpp
+++ b/kernels/deform_conv/dcn_backward_data/dcn_backward_data.cpp
@@ -62,12 +62,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetDCNBakcwardDataWorkspaceSize(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_mask_desc,
                                                cnnl_grad_mask_desc);
 
-  CALL_CNNL(
-      cnnlGetDCNBakcwardDataWorkspaceSize(
-          cnnl_handle, dcn_desc, cnnl_input_desc, cnnl_offset_desc,
-          cnnl_mask_desc, cnnl_filter_desc, cnnl_grad_output_desc,
-          cnnl_grad_input_desc, cnnl_grad_offset_desc, cnnl_grad_mask_desc,
-          workspace_size));
+  CALL_CNNL(cnnlGetDCNBakcwardDataWorkspaceSize(
+      cnnl_handle, dcn_desc, cnnl_input_desc, cnnl_offset_desc, cnnl_mask_desc,
+      cnnl_filter_desc, cnnl_grad_output_desc, cnnl_grad_input_desc,
+      cnnl_grad_offset_desc, cnnl_grad_mask_desc, workspace_size));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_offset_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mask_desc);
@@ -109,13 +107,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpDCNBackwardData(
                                                cnnl_grad_offset_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_mask_desc,
                                                cnnl_grad_mask_desc);
-  CALL_CNNL(
-      cnnlDCNBackwardData(
-          cnnl_handle, dcn_desc, cnnl_input_desc, input, cnnl_offset_desc,
-          offset, cnnl_mask_desc, mask, cnnl_filter_desc, filter,
-          cnnl_grad_output_desc, grad_output, workspace, workspace_size,
-          cnnl_grad_input_desc, grad_input, cnnl_grad_offset_desc, grad_offset,
-          cnnl_grad_mask_desc, grad_mask));
+  CALL_CNNL(cnnlDCNBackwardData(
+      cnnl_handle, dcn_desc, cnnl_input_desc, input, cnnl_offset_desc, offset,
+      cnnl_mask_desc, mask, cnnl_filter_desc, filter, cnnl_grad_output_desc,
+      grad_output, workspace, workspace_size, cnnl_grad_input_desc, grad_input,
+      cnnl_grad_offset_desc, grad_offset, cnnl_grad_mask_desc, grad_mask));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_offset_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mask_desc);

--- a/kernels/deform_conv/dcn_backward_weight/dcn_backward_weight.cpp
+++ b/kernels/deform_conv/dcn_backward_weight/dcn_backward_weight.cpp
@@ -47,10 +47,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetDCNBackwardWeightWorkspaceSize(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_filter_desc,
                                                _grad_filter_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_bias_desc, _grad_bias_desc);
-  CALL_CNNL(
-      cnnlGetDCNBackwardWeightWorkspaceSize(
-          _handle, dcn_desc, _input_desc, _offset_desc, _mask_desc,
-          _grad_output_desc, _grad_filter_desc, _grad_bias_desc, size));
+  CALL_CNNL(cnnlGetDCNBackwardWeightWorkspaceSize(
+      _handle, dcn_desc, _input_desc, _offset_desc, _mask_desc,
+      _grad_output_desc, _grad_filter_desc, _grad_bias_desc, size));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(_offset_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(_mask_desc);
@@ -84,12 +83,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpDCNBackwardWeight(
                                                cnnl_grad_filter_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grad_bias_desc,
                                                cnnl_grad_bias_desc);
-  CALL_CNNL(
-      cnnlDCNBackwardWeight(cnnl_handle, dcn_desc, cnnl_input_desc, input,
-                            cnnl_offset_desc, offset, cnnl_mask_desc, mask,
-                            cnnl_grad_output_desc, grad_output, workspace,
-                            workspace_size, cnnl_grad_filter_desc, grad_filter,
-                            cnnl_grad_bias_desc, grad_bias));
+  CALL_CNNL(cnnlDCNBackwardWeight(
+      cnnl_handle, dcn_desc, cnnl_input_desc, input, cnnl_offset_desc, offset,
+      cnnl_mask_desc, mask, cnnl_grad_output_desc, grad_output, workspace,
+      workspace_size, cnnl_grad_filter_desc, grad_filter, cnnl_grad_bias_desc,
+      grad_bias));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_offset_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mask_desc);

--- a/kernels/deform_conv/dcn_forward/dcn_forward.cpp
+++ b/kernels/deform_conv/dcn_forward/dcn_forward.cpp
@@ -47,9 +47,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetDCNForwardWorkspaceSize(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(bias_desc, cnnl_bias_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(output_desc, cnnl_output_desc);
   CALL_CNNL(cnnlGetDCNForwardWorkspaceSize(
-                        cnnl_handle, dcn_desc, cnnl_input_desc,
-                        cnnl_offset_desc, cnnl_mask_desc, cnnl_filter_desc,
-                        cnnl_bias_desc, cnnl_output_desc, size));
+      cnnl_handle, dcn_desc, cnnl_input_desc, cnnl_offset_desc, cnnl_mask_desc,
+      cnnl_filter_desc, cnnl_bias_desc, cnnl_output_desc, size));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_offset_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mask_desc);
@@ -80,11 +79,10 @@ mluOpDCNForward(mluOpHandle_t handle, const mluOpDCNDescriptor_t dcn_desc,
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(filter_desc, cnnl_filter_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(bias_desc, cnnl_bias_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(output_desc, cnnl_output_desc);
-  CALL_CNNL(
-      cnnlDCNForward(cnnl_handle, dcn_desc, cnnl_input_desc, input,
-                     cnnl_offset_desc, offset, cnnl_mask_desc, mask,
-                     cnnl_filter_desc, filter, cnnl_bias_desc, bias, workspace,
-                     workspace_size, cnnl_output_desc, output));
+  CALL_CNNL(cnnlDCNForward(
+      cnnl_handle, dcn_desc, cnnl_input_desc, input, cnnl_offset_desc, offset,
+      cnnl_mask_desc, mask, cnnl_filter_desc, filter, cnnl_bias_desc, bias,
+      workspace, workspace_size, cnnl_output_desc, output));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_offset_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mask_desc);

--- a/kernels/deform_roi_pool/deform_roi_pool.cpp
+++ b/kernels/deform_roi_pool/deform_roi_pool.cpp
@@ -62,6 +62,15 @@ static mluOpStatus_t DeformRoiPoolForwardPreCheck(
   PARAM_CHECK("[mluOpDeformRoiPoolForward]",
               output_desc->layout == MLUOP_LAYOUT_NHWC);
 
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolForward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolForward]:", rois_desc,
+                      "rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolForward]:", offset_desc,
+                      "offset_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolForward]:", output_desc,
+                      "output_desc must be contiguous");
+
   PARAM_CHECK("[mluOpDeformRoiPoolForward]",
               input_desc->dtype == MLUOP_DTYPE_FLOAT ||
                   input_desc->dtype == MLUOP_DTYPE_HALF);
@@ -135,6 +144,19 @@ static mluOpStatus_t DeformRoiPoolBackwardPreCheck(
               input_desc->layout == MLUOP_LAYOUT_NHWC);
   PARAM_CHECK("[mluOpDeformRoiPoolBackward]",
               grad_input_desc->layout == MLUOP_LAYOUT_NHWC);
+
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolBackward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolBackward]:", grad_output_desc,
+                      "grad_output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolBackward]:", rois_desc,
+                      "rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolBackward]:", offset_desc,
+                      "offset_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolBackward]:", grad_input_desc,
+                      "grad_input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDeformRoiPoolBackward]:", grad_offset_desc,
+                      "grad_offset_desc must be contiguous");
 
   PARAM_CHECK("[mluOpDeformRoiPoolBackward]",
               input_desc->dtype == MLUOP_DTYPE_FLOAT ||

--- a/kernels/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
+++ b/kernels/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
@@ -71,6 +71,14 @@ static mluOpStatus_t diffIouRotatedSortVerticesForwardParamCheck(
   PARAM_CHECK(op_name, num_valid_desc->dim == 2);
   PARAM_CHECK(op_name, idx_desc->dim == 3);
 
+  // check stride
+  STRIDE_TENSOR_CHECK(op_name + ":", vertices_desc,
+                      "vertices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", mask_desc, "mask_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", num_valid_desc,
+                      "num_valid_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", idx_desc, "idx_desc must be contiguous");
+
   // check data type
   // check tensor datatype, support float32
   PARAM_CHECK_V2(op_name, (vertices_desc->dtype == MLUOP_DTYPE_FLOAT),

--- a/kernels/div/div.cpp
+++ b/kernels/div/div.cpp
@@ -29,6 +29,7 @@
 #include "core/tensor.h"
 #include "core/type.h"
 #include "kernels/binary_op/binary_op_host.h"
+#include "kernels/tensor_stride_process/tensor_stride_process_host.h"
 
 // threshold of bytes to be processed by each core
 // according to the actual measurement results
@@ -48,6 +49,13 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
   if (param_check != MLUOP_STATUS_SUCCESS) {
     return param_check;
   }
+  // check stride
+  if (mluop::strideCaseWithNotConsistentDense(3, x_desc, y_desc, z_desc)) {
+    LOG(ERROR) << "[mluOpDiv]: stride case with not consistent dense is not "
+                  "supported.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
   if (zero_element == true) {
     return MLUOP_STATUS_SUCCESS;
   }

--- a/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
+++ b/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
@@ -65,6 +65,25 @@ static mluOpStatus_t DynamicPointToVoxelBackwardParamCheck(
   PARAM_CHECK(interface_name, voxel_num_desc != NULL);
   PARAM_CHECK(interface_name, grad_feats_desc != NULL);
 
+  // check stride
+  STRIDE_TENSOR_CHECK(
+      "[mluOpDynamicPointToVoxelBackward]:", grad_voxel_feats_desc,
+      "grad_voxel_feats_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDynamicPointToVoxelBackward]:", feats_desc,
+                      "feats_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDynamicPointToVoxelBackward]:", voxel_feats_desc,
+                      "voxel_feats_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(
+      "[mluOpDynamicPointToVoxelBackward]:", point2voxel_map_desc,
+      "point2voxel_map_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(
+      "[mluOpDynamicPointToVoxelBackward]:", voxel_points_count_desc,
+      "voxel_points_count_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDynamicPointToVoxelBackward]:", voxel_num_desc,
+                      "voxel_num_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpDynamicPointToVoxelBackward]:", grad_feats_desc,
+                      "grad_feats_desc must be contiguous");
+
   // check data type
   PARAM_CHECK(interface_name,
               grad_voxel_feats_desc->dtype == MLUOP_DTYPE_FLOAT);
@@ -273,12 +292,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelBackward(
   if (grad_voxel_feats_element_num != 0) {
     // 2. init workspace
     mluOpTensorDescriptor_t indices_desc;
-    CHECK_RETURN(
-        interface_name, mluOpCreateTensorDescriptor(&indices_desc));
+    CHECK_RETURN(interface_name, mluOpCreateTensorDescriptor(&indices_desc));
     int indices_dims[2] = {(int)grad_voxel_feats_element_num, 1};
-    CHECK_RETURN(interface_name, mluOpSetTensorDescriptor(
-                                           indices_desc, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_INT32, 2, indices_dims));
+    CHECK_RETURN(interface_name,
+                 mluOpSetTensorDescriptor(indices_desc, MLUOP_LAYOUT_ARRAY,
+                                          MLUOP_DTYPE_INT32, 2, indices_dims));
     {
       DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
       DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(indices_desc,
@@ -297,19 +315,17 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelBackward(
     // 4. scatter
     cnnlScatterNdMode_t scatter_mode = CNNL_SCATTERND_ADD;
     mluOpTensorDescriptor_t updates_desc;
-    CHECK_RETURN(
-        interface_name, mluOpCreateTensorDescriptor(&updates_desc));
+    CHECK_RETURN(interface_name, mluOpCreateTensorDescriptor(&updates_desc));
     int updates_dims[1] = {(int)grad_voxel_feats_element_num};
-    CHECK_RETURN(interface_name, mluOpSetTensorDescriptor(
-                                           updates_desc, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, 1, updates_dims));
+    CHECK_RETURN(interface_name,
+                 mluOpSetTensorDescriptor(updates_desc, MLUOP_LAYOUT_ARRAY,
+                                          MLUOP_DTYPE_FLOAT, 1, updates_dims));
     mluOpTensorDescriptor_t output_desc;
-    CHECK_RETURN(
-        interface_name, mluOpCreateTensorDescriptor(&output_desc));
+    CHECK_RETURN(interface_name, mluOpCreateTensorDescriptor(&output_desc));
     int output_dims[1] = {(int)grad_feats_element_num};
-    CHECK_RETURN(interface_name, mluOpSetTensorDescriptor(
-                                           output_desc, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, 1, output_dims));
+    CHECK_RETURN(interface_name,
+                 mluOpSetTensorDescriptor(output_desc, MLUOP_LAYOUT_ARRAY,
+                                          MLUOP_DTYPE_FLOAT, 1, output_dims));
     {
       DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
       DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(indices_desc,
@@ -327,12 +343,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpDynamicPointToVoxelBackward(
       DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
       DESTROY_CNNL_HANDLE(cnnl_handle);
     }
-    CHECK_RETURN(
-        interface_name, mluOpDestroyTensorDescriptor(updates_desc));
-    CHECK_RETURN(
-        interface_name, mluOpDestroyTensorDescriptor(output_desc));
-    CHECK_RETURN(
-        interface_name, mluOpDestroyTensorDescriptor(indices_desc));
+    CHECK_RETURN(interface_name, mluOpDestroyTensorDescriptor(updates_desc));
+    CHECK_RETURN(interface_name, mluOpDestroyTensorDescriptor(output_desc));
+    CHECK_RETURN(interface_name, mluOpDestroyTensorDescriptor(indices_desc));
   }
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;

--- a/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -104,7 +104,19 @@ static mluOpStatus_t DynamicPointToVoxelForwardParamCheck(
   PARAM_CHECK(api, point2voxel_map_desc->dim == 1);
   PARAM_CHECK(api, voxel_points_count_desc->dim == 1);
   PARAM_CHECK(api, voxel_num_desc->dim == 1);
-
+  // check stride
+  STRIDE_TENSOR_CHECK(api + ":", feats_desc, "feats_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", coors_desc, "coors_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", voxel_feats_desc,
+                      "voxel_feats_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", voxel_coors_desc,
+                      "voxel_coors_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", point2voxel_map_desc,
+                      "point2voxel_map_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", voxel_points_count_desc,
+                      "voxel_points_count_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", voxel_num_desc,
+                      "voxel_num_desc must be contiguous");
   // check data type
   PARAM_CHECK_V2(api, (feats_desc->dtype == MLUOP_DTYPE_FLOAT),
                  "Only float are supported in feats tensor, but the data "

--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
@@ -189,10 +189,19 @@ mluOpStatus_t MLUOP_WIN_API mluOpFocalLossSigmoidForward(
   }
   if (weight_desc != NULL && mluOpGetTensorElementNum(weight_desc) != 0) {
     PARAM_CHECK("[mluOpFocalLossSigmoidForward]", weight != NULL);
+    STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidForward]:", weight_desc,
+                        "weight_desc must be contiguous");
   }
   PARAM_CHECK("[mluOpFocalLossSigmoidForward]", input != NULL);
   PARAM_CHECK("[mluOpFocalLossSigmoidForward]", target != NULL);
   PARAM_CHECK("[mluOpFocalLossSigmoidForward]", output != NULL);
+
+  STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidForward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidForward]:", target_desc,
+                      "target_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidForward]:", output_desc,
+                      "output_desc must be contiguous");
 
   // generate case prototxt.
   const int32_t N = static_cast<int32_t>(input_desc->dims[0]);
@@ -347,6 +356,18 @@ static mluOpStatus_t checkParams(const mluOpTensorDescriptor_t input_desc,
                << "input_desc->dims[0] is " << input_desc->dims[0] << ", "
                << "target_desc->dims[0] is " << target_desc->dims[0] << ".";
     return MLUOP_STATUS_BAD_PARAM;
+  }
+
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidBackward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidBackward]:", target_desc,
+                      "target_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidBackward]:", output_desc,
+                      "output_desc must be contiguous");
+  if (weight_desc != NULL) {
+    STRIDE_TENSOR_CHECK("[mluOpFocalLossSigmoidBackward]:", weight_desc,
+                        "weight_desc must be contiguous");
   }
 
   // check data type

--- a/kernels/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/kernels/generate_proposals_v2/generate_proposals_v2.cpp
@@ -336,6 +336,23 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
   PARAM_CHECK_NE(API, scores_desc->dims[2], 0);
   PARAM_CHECK_NE(API, scores_desc->dims[3], 0);
 
+  // check stride
+  STRIDE_TENSOR_CHECK(API + ":", scores_desc, "scores_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", bbox_deltas_desc,
+                      "bbox_deltas_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", im_shape_desc,
+                      "im_shape_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", anchors_desc,
+                      "anchors_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", variances_desc,
+                      "variances_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", rpn_rois_desc,
+                      "rpn_rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", rpn_roi_probs_desc,
+                      "rpn_roi_probs_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", rpn_rois_num_desc,
+                      "rpn_rois_num_desc must be contiguous");
+
   if (n == 0) {
     VLOG(5) << API << " skip zero element tensor.";
     return MLUOP_STATUS_SUCCESS;

--- a/kernels/log/log.cpp
+++ b/kernels/log/log.cpp
@@ -61,6 +61,13 @@ mluOpLog(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
   if (param_check != MLUOP_STATUS_SUCCESS) {
     return param_check;
   }
+  // check stride
+  if (mluop::strideCaseWithNotConsistentDense(2, x_desc, y_desc)) {
+    LOG(ERROR) << op_name
+               << ": stride case with not consistent dense is not supported.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
+
   if (zero_element == true) {
     return MLUOP_STATUS_SUCCESS;
   }

--- a/kernels/masked_im2col/masked_im2col_forward/masked_im2col_forward.cpp
+++ b/kernels/masked_im2col/masked_im2col_forward/masked_im2col_forward.cpp
@@ -81,6 +81,16 @@ static mluOpStatus_t maskedIm2colForwardPreCheck(
   PARAM_CHECK("[mluOpMaskedIm2colForward]", kernel_h > 0);
   PARAM_CHECK("[mluOpMaskedIm2colForward]", kernel_w > 0);
 
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpMaskedIm2colForward]:", feature_desc,
+                      "feature_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMaskedIm2colForward]:", mask_h_idx_desc,
+                      "mask_h_idx_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMaskedIm2colForward]:", mask_w_idx_desc,
+                      "mask_w_idx_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMaskedIm2colForward]:", data_col_desc,
+                      "data_col_desc must be contiguous");
+
   const uint64_t feature_element_num = mluOpGetTensorElementNum(feature_desc);
   const uint64_t mask_h_idx_element_num =
       mluOpGetTensorElementNum(mask_h_idx_desc);
@@ -155,12 +165,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetMaskedIm2colForwardWorkspaceSize(
   size_t data_col_transpose_workspace_size = 0;
   mluOpTensorDescriptor_t data_col_HWC_desc_tmp;
   CHECK_RETURN("[mluOpGetMaskedIm2colForwardWorkspaceSize]",
-                mluOpCreateTensorDescriptor(&data_col_HWC_desc_tmp));
+               mluOpCreateTensorDescriptor(&data_col_HWC_desc_tmp));
 
   CHECK_RETURN("[mluOpMaskedIm2colForward]",
-                  mluOpSetTensorDescriptor(
-                      data_col_HWC_desc_tmp, MLUOP_LAYOUT_ARRAY,
-                      feature_desc->dtype, data_col_dim, data_col_HWC_dims));
+               mluOpSetTensorDescriptor(data_col_HWC_desc_tmp,
+                                        MLUOP_LAYOUT_ARRAY, feature_desc->dtype,
+                                        data_col_dim, data_col_HWC_dims));
   CALL_CNNL(
       cnnlSetTransposeDescriptor(trans_desc, data_col_dim, data_col_permute));
   {
@@ -178,7 +188,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetMaskedIm2colForwardWorkspaceSize(
           ? data_col_transpose_workspace_size
           : feature_transpose_workspace_size;
   CHECK_RETURN("[mluOpMaskedIm2colForward]",
-                  mluOpDestroyTensorDescriptor(data_col_HWC_desc_tmp));
+               mluOpDestroyTensorDescriptor(data_col_HWC_desc_tmp));
   CALL_CNNL(cnnlDestroyTransposeDescriptor(trans_desc));
   return MLUOP_STATUS_SUCCESS;
 }
@@ -309,12 +319,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpMaskedIm2colForward(
                mluOpCreateTensorDescriptor(&feature_desc_tmp));
   CHECK_RETURN(
       "[mluOpMaskedIm2colForward]",
-          mluOpSetTensorDescriptor(feature_desc_tmp, MLUOP_LAYOUT_ARRAY,
-                                   input_dtype, feature_dim, feature_tmp_dims));
+      mluOpSetTensorDescriptor(feature_desc_tmp, MLUOP_LAYOUT_ARRAY,
+                               input_dtype, feature_dim, feature_tmp_dims));
   CHECK_RETURN("[mluOpMaskedIm2colForward]",
-                transposeTensor(handle, feature_desc, feature,
-                                feature_permute, feature_desc_tmp,
-                                feature_workspace, transpose_workspace));
+               transposeTensor(handle, feature_desc, feature, feature_permute,
+                               feature_desc_tmp, feature_workspace,
+                               transpose_workspace));
 
   CHECK_RETURN("[mluOpMaskedIm2colForward]",
                mluOpDestroyTensorDescriptor(feature_desc_tmp));
@@ -347,24 +357,24 @@ mluOpStatus_t MLUOP_WIN_API mluOpMaskedIm2colForward(
   CHECK_RETURN("[mluOpMaskedIm2colForward]",
                mluOpCreateTensorDescriptor(&data_col_CHW_desc_tmp));
 
-  CHECK_RETURN("[mluOpMaskedIm2colForward]",
-                  mluOpSetTensorDescriptor(data_col_HWC_desc_tmp,
-                                           MLUOP_LAYOUT_ARRAY, input_dtype,
-                                           data_col_dim, data_col_HWC_dims));
-  CHECK_RETURN("[mluOpMaskedIm2colForward]",
-                  mluOpSetTensorDescriptor(data_col_CHW_desc_tmp,
-                                           MLUOP_LAYOUT_ARRAY, input_dtype,
-                                           data_col_dim, data_col_CHW_dims));
+  CHECK_RETURN(
+      "[mluOpMaskedIm2colForward]",
+      mluOpSetTensorDescriptor(data_col_HWC_desc_tmp, MLUOP_LAYOUT_ARRAY,
+                               input_dtype, data_col_dim, data_col_HWC_dims));
+  CHECK_RETURN(
+      "[mluOpMaskedIm2colForward]",
+      mluOpSetTensorDescriptor(data_col_CHW_desc_tmp, MLUOP_LAYOUT_ARRAY,
+                               input_dtype, data_col_dim, data_col_CHW_dims));
 
   CHECK_RETURN(
       "[mluOpMaskedIm2colForward]",
-          transposeTensor(handle, data_col_HWC_desc_tmp, data_col_workspace,
-                          data_col_permute, data_col_CHW_desc_tmp, data_col,
-                          transpose_workspace));
+      transposeTensor(handle, data_col_HWC_desc_tmp, data_col_workspace,
+                      data_col_permute, data_col_CHW_desc_tmp, data_col,
+                      transpose_workspace));
   CHECK_RETURN("[mluOpMaskedIm2colForward]",
-                  mluOpDestroyTensorDescriptor(data_col_HWC_desc_tmp));
+               mluOpDestroyTensorDescriptor(data_col_HWC_desc_tmp));
   CHECK_RETURN("[mluOpMaskedIm2colForward]",
-                  mluOpDestroyTensorDescriptor(data_col_CHW_desc_tmp));
+               mluOpDestroyTensorDescriptor(data_col_CHW_desc_tmp));
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }

--- a/kernels/moe_dispatch/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
@@ -111,6 +111,17 @@ mluOpStatus_t MLUOP_WIN_API mluOpMoeDispatchBackwardData(
   PARAM_CHECK(API, hidden >= 0);
   PARAM_CHECK(API, num_experts >= 0);
 
+  // check stride
+  STRIDE_TENSOR_CHECK(API + ":", gates_desc, "gates_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", indices_desc,
+                      "indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", locations_desc,
+                      "locations_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", dispatch_desc,
+                      "dispatch_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(API + ":", grad_input_desc,
+                      "grad_input_desc must be contiguous");
+
   const uint64_t gates_element_num = mluOpGetTensorElementNum(gates_desc);
   const uint64_t indices_element_num = mluOpGetTensorElementNum(indices_desc);
   const uint64_t locations_element_num =

--- a/kernels/moe_dispatch/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -136,6 +136,18 @@ static mluOpStatus_t moeDispatchBackwardGateParamCheck(
   PARAM_CHECK(op_name, (hidden == input_desc->dims[1]));
   PARAM_CHECK(op_name, (hidden == dispatch_desc->dims[1]));
 
+  // check stride
+  STRIDE_TENSOR_CHECK(op_name + ":", indices_desc,
+                      "indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", locations_desc,
+                      "locations_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", dispatch_desc,
+                      "dispatch_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", grad_gates_desc,
+                      "grad_gates_desc must be contiguous");
+
   const size_t indices_element_num = mluOpGetTensorElementNum(indices_desc);
   const size_t locations_element_num = mluOpGetTensorElementNum(locations_desc);
   const size_t input_element_num = mluOpGetTensorElementNum(input_desc);

--- a/kernels/moe_dispatch/moe_dispatch_forward/moe_dispatch_forward.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_forward/moe_dispatch_forward.cpp
@@ -104,6 +104,18 @@ static mluOpStatus_t MoeDispatchForwardParamCheck(
   PARAM_CHECK(op_name, (hidden == input_desc->dims[1]));
   PARAM_CHECK(op_name, (hidden == dispatch_desc->dims[1]));
 
+  // check stride
+  STRIDE_TENSOR_CHECK(op_name + ":", gates_desc,
+                      "gates_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", indices_desc,
+                      "indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", locations_desc,
+                      "locations_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(op_name + ":", dispatch_desc,
+                      "dispatch_desc must be contiguous");
+
   // check correlation of parameters
   PARAM_CHECK_V2(op_name, samples <= (num_experts * capacity),
                  "The samples must be less than or equal to the "

--- a/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -130,6 +130,26 @@ static mluOpStatus_t msDeformAttnBackwardParamCheck(
   PARAM_CHECK(API, grad_sampling_loc_desc->dim == 6);
   PARAM_CHECK(API, grad_attn_weight_desc->dim == 5);
 
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", value_desc,
+                      "value_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", spatial_shapes_desc,
+                      "spatial_shapes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", level_start_index_desc,
+                      "level_start_index_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", sampling_loc_desc,
+                      "sampling_loc_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", attn_weight_desc,
+                      "attn_weight_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", grad_output_desc,
+                      "grad_output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", grad_value_desc,
+                      "grad_value_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", grad_sampling_loc_desc,
+                      "grad_sampling_loc_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnBackward]:", grad_attn_weight_desc,
+                      "grad_attn_weight_desc must be contiguous");
+
   // check datatype
   PARAM_CHECK(API, value_desc->dtype == MLUOP_DTYPE_FLOAT);
   PARAM_CHECK(API, spatial_shapes_desc->dtype == MLUOP_DTYPE_INT32);

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.mlu
@@ -120,19 +120,32 @@ static mluOpStatus_t paramcheck(
               data_value_desc->dims[3] == data_col_desc->dims[3]);
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               data_spatial_shapes_desc->dims[0] ==
-                data_level_start_index_desc->dims[0]);
-  PARAM_CHECK("[mluOpMsDeformAttnForward]",
-              data_spatial_shapes_desc->dims[0] ==
-                data_sampling_loc_desc->dims[3]);
-  PARAM_CHECK("[mluOpMsDeformAttnForward]",
-              data_spatial_shapes_desc->dims[0] ==
-                data_attn_weight_desc->dims[3]);
+                  data_level_start_index_desc->dims[0]);
+  PARAM_CHECK(
+      "[mluOpMsDeformAttnForward]",
+      data_spatial_shapes_desc->dims[0] == data_sampling_loc_desc->dims[3]);
+  PARAM_CHECK("[mluOpMsDeformAttnForward]", data_spatial_shapes_desc->dims[0] ==
+                                                data_attn_weight_desc->dims[3]);
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               data_sampling_loc_desc->dims[1] == data_col_desc->dims[1]);
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               data_attn_weight_desc->dims[1] == data_col_desc->dims[1]);
   PARAM_CHECK("[mluOpMsDeformAttnForward]", data_sampling_loc_desc->dims[4] ==
                                                 data_attn_weight_desc->dims[4]);
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnForward]:", data_value_desc,
+                      "data_value_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnForward]:", data_spatial_shapes_desc,
+                      "data_spatial_shapes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(
+      "[mluOpMsDeformAttnForward]:", data_level_start_index_desc,
+      "data_level_start_index_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnForward]:", data_sampling_loc_desc,
+                      "data_sampling_loc_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnForward]:", data_attn_weight_desc,
+                      "data_attn_weight_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMsDeformAttnForward]:", data_col_desc,
+                      "data_col_desc must be contiguous");
   // check tensor datatype
   PARAM_CHECK("[mluOpMsDeformAttnForward]",
               data_value_desc->dtype == MLUOP_DTYPE_FLOAT);

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_union1_default.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/msda_forward_union1_default.mlu
@@ -270,13 +270,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   span_num_deal, spatial_w_next_point, spatial_h_next_point,
                   num_heads, channels, x_next_point, y_next_point, head_idx);
             }
@@ -297,13 +301,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   span_num_deal, spatial_w, spatial_h, num_heads, channels,
                   x_next_point, y_next_point, head_idx);
             }
@@ -312,15 +320,20 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
           if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
             computeMsDeformAttn(
                 (T *)(ping_data_value_p1_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p2_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p3_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p4_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)auxiliary_a, (T *)auxiliary_b,
-                (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
+                (T *)(ping_data_col_nram +
+                      data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
                 weight, span_num_deal, spatial_w, spatial_h, x, y);
           }
           spatial_w = spatial_w_next_point;
@@ -402,13 +415,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   channels_rem, spatial_w_next_point, spatial_h_next_point,
                   num_heads, channels, x_next_point, y_next_point, head_idx);
             }
@@ -429,13 +446,17 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
               loadNeighborPointsData(
                   (T *)data_value_ptr,
                   (T *)(ping_data_value_p1_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p2_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p3_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   (T *)(ping_data_value_p4_nram +
-                        ((level_idx * num_points + point_idx + 1) % 2) * ping_pong_gap),  // NOLINT
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),  // NOLINT
                   channels_rem, spatial_w, spatial_h, num_heads, channels,
                   x_next_point, y_next_point, head_idx);
             }
@@ -444,15 +465,20 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
           if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
             computeMsDeformAttn(
                 (T *)(ping_data_value_p1_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p2_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p3_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)(ping_data_value_p4_nram +
-                      ((level_idx * num_points + point_idx) % 2) * ping_pong_gap),  // NOLINT
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),  // NOLINT
                 (T *)auxiliary_a, (T *)auxiliary_b,
-                (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
+                (T *)(ping_data_col_nram +
+                      data_col_ping_pong_idx * ping_pong_gap),  // NOLINT
                 weight, channels_align_rem, spatial_w, spatial_h, x, y);
           }
           spatial_w = spatial_w_next_point;

--- a/kernels/mutual_information/mutual_information_backward/mutual_information_backward.cpp
+++ b/kernels/mutual_information/mutual_information_backward/mutual_information_backward.cpp
@@ -362,7 +362,23 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
     return check_status;
   }
 
-  // 5. check tensor dtype
+  // 5. check tensor stride
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationBackward]:", px_desc,
+                      "px_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationBackward]:", py_desc,
+                      "py_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationBackward]:", opt_boundary_desc,
+                      "opt_boundary_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationBackward]:", p_desc,
+                      "p_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationBackward]:", ans_grad_desc,
+                      "ans_grad_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationBackward]:", px_grad_desc,
+                      "px_grad_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationBackward]:", py_grad_desc,
+                      "py_grad_desc must be contiguous");
+
+  // 6. check tensor dtype
   check_status =
       checkTensorDatatype(px_desc, py_desc, opt_boundary_desc, p_desc,
                           ans_grad_desc, px_grad_desc, py_grad_desc);
@@ -370,7 +386,7 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
     return check_status;
   }
 
-  // 6. check scale limit, for large tensor
+  // 7. check scale limit, for large tensor
   check_status = checkTensorScaleLimit(handle, px_desc, py_desc,
                                        opt_boundary_desc, p_desc);
   if (MLUOP_STATUS_SUCCESS != check_status) {
@@ -381,7 +397,7 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
   const int S = px_desc->dims[1];
   const int T = py_desc->dims[2];
 
-  // 7. check zero element.
+  // 8. check zero element.
   if (0 == B || (0 == S && 0 == T)) {
     zero_element = true;
     VLOG(5) << API_NAME << " Skip zero element tensor when px.shape[0] is zero "
@@ -389,12 +405,12 @@ static mluOpStatus_t mutualInformationBackwardParamCheck(
     return MLUOP_STATUS_SUCCESS;
   }
 
-  // 8 check workspace
+  // 9 check workspace
   if (workspace_size > 0) {
     PARAM_CHECK(API_NAME, workspace != nullptr);
   }
 
-  // 9. check tensor ptr
+  // 10. check tensor ptr
   check_status =
       checkTensorPtr(px, py, p, ans_grad, opt_boundary_desc, opt_boundary,
                      px_grad, py_grad, S, T, has_boundary);

--- a/kernels/mutual_information/mutual_information_forward/mutual_information_forward.cpp
+++ b/kernels/mutual_information/mutual_information_forward/mutual_information_forward.cpp
@@ -288,14 +288,26 @@ static mluOpStatus_t mutualInformationForwardParamCheck(
     return check_status;
   }
 
-  // 5. check tensor dtype
+  // 5. check tensor stride
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationForward]:", px_desc,
+                      "px_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationForward]:", py_desc,
+                      "py_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationForward]:", opt_boundary_desc,
+                      "opt_boundary_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationForward]:", p_desc,
+                      "p_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpMutualInformationForward]:", ans_desc,
+                      "ans_desc must be contiguous");
+
+  // 6. check tensor dtype
   check_status = checkTensorDatatype(px_desc, py_desc, opt_boundary_desc,
                                      p_desc, ans_desc);
   if (MLUOP_STATUS_SUCCESS != check_status) {
     return check_status;
   }
 
-  // 6. check scale limit, for large tensor
+  // 7. check scale limit, for large tensor
   check_status = checkTensorScaleLimit(handle, px_desc, py_desc,
                                        opt_boundary_desc, p_desc);
   if (MLUOP_STATUS_SUCCESS != check_status) {
@@ -306,7 +318,7 @@ static mluOpStatus_t mutualInformationForwardParamCheck(
   const int S = px_desc->dims[1];
   const int T = py_desc->dims[2];
 
-  // 7. check zero element.
+  // 8. check zero element.
   if (0 == B) {
     zero_element = true;
     VLOG(5) << API_NAME
@@ -314,12 +326,12 @@ static mluOpStatus_t mutualInformationForwardParamCheck(
     return MLUOP_STATUS_SUCCESS;
   }
 
-  // 8 check workspace
+  // 9. check workspace
   if (workspace_size > 0) {
     PARAM_CHECK(API_NAME, workspace != nullptr);
   }
 
-  // 9. check tensor ptr
+  // 10. check tensor ptr
   check_status = checkTensorPtr(px, py, p, ans, opt_boundary_desc, opt_boundary,
                                 S, T, has_boundary);
   if (MLUOP_STATUS_SUCCESS != check_status) {

--- a/kernels/nms/nms.cpp
+++ b/kernels/nms/nms.cpp
@@ -45,11 +45,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpSetNmsDescriptor(
     const int input_layout, const bool pad_to_max_output_size) {
   PARAM_CHECK("mluOpSetNmsDescriptor", nms_desc != NULL);
   CALL_CNNL(cnnlSetNmsDescriptor_v5(
-                nms_desc, (cnnlNmsBoxPointMode_t)box_mode,
-                (cnnlNmsOutputMode_t)output_mode, (cnnlNmsAlgo_t)algo,
-                (cnnlNmsMethodMode_t)method_mode, iou_threshold,
-                soft_nms_sigma, max_output_size, confidence_threshold,
-                offset, input_layout, pad_to_max_output_size));
+      nms_desc, (cnnlNmsBoxPointMode_t)box_mode,
+      (cnnlNmsOutputMode_t)output_mode, (cnnlNmsAlgo_t)algo,
+      (cnnlNmsMethodMode_t)method_mode, iou_threshold, soft_nms_sigma,
+      max_output_size, confidence_threshold, offset, input_layout,
+      pad_to_max_output_size));
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -68,9 +68,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetNmsWorkspaceSize(
                                           cnnl_confidence_desc);
   }
 
-  CALL_CNNL(
-      cnnlGetNmsWorkspaceSize_v3(cnnl_handle, cnnl_boxes_desc,
-                                 cnnl_confidence_desc, workspace_size));
+  CALL_CNNL(cnnlGetNmsWorkspaceSize_v3(cnnl_handle, cnnl_boxes_desc,
+                                       cnnl_confidence_desc, workspace_size));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_boxes_desc);
   if (cnnl_confidence_desc != NULL) {
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_confidence_desc);
@@ -103,10 +102,9 @@ mluOpNms(mluOpHandle_t handle, const mluOpNmsDescriptor_t nms_desc,
                                           cnnl_confidence_desc);
   }
 
-  CALL_CNNL(
-      cnnlNms_v2(cnnl_handle, nms_desc, cnnl_boxes_desc, boxes,
-                 cnnl_confidence_desc, confidence, workspace, workspace_size,
-                 cnnl_output_desc, output, output_size));
+  CALL_CNNL(cnnlNms_v2(cnnl_handle, nms_desc, cnnl_boxes_desc, boxes,
+                       cnnl_confidence_desc, confidence, workspace,
+                       workspace_size, cnnl_output_desc, output, output_size));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_boxes_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);

--- a/kernels/nms_rotated/nms_rotated.cpp
+++ b/kernels/nms_rotated/nms_rotated.cpp
@@ -87,6 +87,14 @@ mluOpNmsRotated(mluOpHandle_t handle, const float iou_threshold,
   PARAM_CHECK_EQ("[mluOpNmsRotated]", scores_desc->dim, 1);
   PARAM_CHECK_EQ("[mluOpNmsRotated]", output_desc->dim, 1);
 
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpNmsRotated]:", boxes_desc,
+                      "boxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpNmsRotated]:", scores_desc,
+                      "scores_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpNmsRotated]:", output_desc,
+                      "output_desc must be contiguous");
+
   PARAM_CHECK("[mluOpNmsRotated]", boxes_desc->dims[0] == scores_desc->dims[0]);
   PARAM_CHECK("[mluOpNmsRotated]", boxes_desc->dims[0] == output_desc->dims[0]);
   if (boxes_desc->dims[1] != SINGLE_BOX_DIM &&

--- a/kernels/points_in_boxes/points_in_boxes.cpp
+++ b/kernels/points_in_boxes/points_in_boxes.cpp
@@ -116,6 +116,14 @@ static mluOpStatus_t pointsInBoxesPreCheck(
     return MLUOP_STATUS_BAD_PARAM;
   }
 
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpPointsInBoxes]:", points_desc,
+                      "points_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPointsInBoxes]:", boxes_desc,
+                      "boxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPointsInBoxes]:", points_indices_desc,
+                      "points_indices_desc must be contiguous");
+
   const size_t points_element_num = mluOpGetTensorElementNum(points_desc);
   const size_t boxes_element_num = mluOpGetTensorElementNum(boxes_desc);
   TENSOR_NUM_CHECK("[mluOpPointsInBoxes]", points_element_num, LARGE_TENSOR_NUM,

--- a/kernels/poly_nms/poly_nms.cpp
+++ b/kernels/poly_nms/poly_nms.cpp
@@ -90,6 +90,12 @@ mluOpPolyNms(mluOpHandle_t handle, const mluOpTensorDescriptor_t boxes_desc,
 
   PARAM_CHECK(API, boxes_desc->dims[0] == output_desc->dims[0]);
 
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpPolyNms]:", boxes_desc,
+                      "boxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPolyNms]:", output_desc,
+                      "output_desc must be contiguous");
+
   int input_boxes_num = boxes_desc->dims[0];
 
   if (input_boxes_num == 0) {

--- a/kernels/prior_box/prior_box.cpp
+++ b/kernels/prior_box/prior_box.cpp
@@ -99,6 +99,20 @@ mluOpStatus_t mluOpPriorBoxParamCheck(
   // check scalar param
   PARAM_CHECK_GT(api, step_h, 0);
   PARAM_CHECK_GT(api, step_w, 0);
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpPriorBox]:", min_sizes_desc,
+                      "min_sizes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPriorBox]:", aspect_ratios_desc,
+                      "aspect_ratios_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPriorBox]:", variances_desc,
+                      "variances_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPriorBox]:", max_sizes_desc,
+                      "max_sizes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPriorBox]:", output_desc,
+                      "output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPriorBox]:", var_desc,
+                      "var_desc must be contiguous");
+
   // check param depand
 
   for (int i = 0; i < output_desc->dim; i++) {

--- a/kernels/psamask/psamask.cpp
+++ b/kernels/psamask/psamask.cpp
@@ -203,7 +203,10 @@ mluOpStatus_t checkParams(const mluOpTensorDescriptor_t input_desc,
                   "same as the h_feature * w_feature.";
     return MLUOP_STATUS_BAD_PARAM;
   }
-
+  // check stride
+  const std::string api_ = api + ":";
+  STRIDE_TENSOR_CHECK(api_, input_desc, "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_, output_desc, "output_desc must be contiguous");
   // check large tensor
   if ((mluOpGetTensorElementNum(input_desc) >= LARGE_TENSOR_NUM) ||
       (mluOpGetTensorElementNum(output_desc) >= LARGE_TENSOR_NUM)) {

--- a/kernels/psroipool/psroipool.cpp
+++ b/kernels/psroipool/psroipool.cpp
@@ -82,6 +82,15 @@ static mluOpStatus_t psRoiPoolForwardParamCheck(
   PARAM_CHECK(api, output_desc->dims[3] >= 1);
   PARAM_CHECK(api, spatial_scale > 0);
   PARAM_CHECK(api, rois_desc->dims[1] == 5);
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolForward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolForward]:", rois_desc,
+                      "rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolForward]:", output_desc,
+                      "output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolForward]:", mapping_channel_desc,
+                      "mapping_channel_desc must be contiguous");
   // roi_num check
   PARAM_CHECK(api, output_desc->dims[0] == rois_desc->dims[0]);
   PARAM_CHECK(api, input_desc->dims[3] == output_desc->dims[1] *
@@ -170,6 +179,15 @@ static mluOpStatus_t psRoiPoolBackwardParamCheck(
   PARAM_CHECK(api, top_grad_desc->dims[3] >= 1);
   PARAM_CHECK(api, spatial_scale > 0);
   PARAM_CHECK(api, rois_desc->dims[1] == 5);
+  // stride check
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolBackward]:", top_grad_desc,
+                      "top_grad_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolBackward]:", rois_desc,
+                      "rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolBackward]:", mapping_channel_desc,
+                      "mapping_channel_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpPsRoiPoolBackward]:", bottom_grad_desc,
+                      "bottom_grad_desc must be contiguous");
   // roi_num check
   PARAM_CHECK(api, top_grad_desc->dims[0] == rois_desc->dims[0]);
   PARAM_CHECK(api, bottom_grad_desc->dims[3] ==
@@ -253,9 +271,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolForward(
   VLOG(5) << api << " Launch [" << k_type << ", " << k_dim.x << ", " << k_dim.y
           << ", " << k_dim.z << "].";
   CHECK_RETURN(api, (KernelPsRoiPoolForward(
-      k_dim, k_type, handle->queue, input, rois, output, mapping_channel,
-      batch_size, height, width, channels, pooled_height, pooled_width,
-      output_dim, group_size, rois_sum, rois_offset, spatial_scale)));
+                        k_dim, k_type, handle->queue, input, rois, output,
+                        mapping_channel, batch_size, height, width, channels,
+                        pooled_height, pooled_width, output_dim, group_size,
+                        rois_sum, rois_offset, spatial_scale)));
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }
@@ -341,9 +360,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpPsRoiPoolBackward(
   }
 
   CHECK_RETURN(api, (KernelPsRoiPoolBackward(
-      k_dim, k_type, handle->queue, top_grad, mapping_channel, rois,
-      bottom_grad, batch_size, height, width, channels, pooled_height,
-      pooled_width, output_dim, rois_sum, rois_offset, spatial_scale)));
+                        k_dim, k_type, handle->queue, top_grad, mapping_channel,
+                        rois, bottom_grad, batch_size, height, width, channels,
+                        pooled_height, pooled_width, output_dim, rois_sum,
+                        rois_offset, spatial_scale)));
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }

--- a/kernels/roi_align/roi_align_backward/roi_align_backward.cpp
+++ b/kernels/roi_align/roi_align_backward/roi_align_backward.cpp
@@ -40,10 +40,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignBackward(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(boxes_desc, cnnl_boxes_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grads_image_desc,
                                                cnnl_grads_image_desc);
-  CALL_CNNL(
-      cnnlRoiAlignBackward(cnnl_handle, spatial_scale, sampling_ratio, aligned,
-                           cnnl_grads_desc, grads, cnnl_boxes_desc, boxes,
-                           cnnl_grads_image_desc, grads_image));
+  CALL_CNNL(cnnlRoiAlignBackward(
+      cnnl_handle, spatial_scale, sampling_ratio, aligned, cnnl_grads_desc,
+      grads, cnnl_boxes_desc, boxes, cnnl_grads_image_desc, grads_image));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grads_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_boxes_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grads_image_desc);
@@ -85,10 +84,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignBackward_v2(
     CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(argmax_y_desc, cnnl_argmax_y_desc);
   }
   CALL_CNNL(cnnlRoiAlignBackward_v2(
-                        cnnl_handle, cnnl_grads_desc, grads, cnnl_boxes_desc,
-                        boxes, cnnl_argmax_x_desc, argmax_x, cnnl_argmax_y_desc,
-                        argmax_y, spatial_scale, sampling_ratio, aligned,
-                        pool_mode, cnnl_grads_image_desc, grads_image));
+      cnnl_handle, cnnl_grads_desc, grads, cnnl_boxes_desc, boxes,
+      cnnl_argmax_x_desc, argmax_x, cnnl_argmax_y_desc, argmax_y, spatial_scale,
+      sampling_ratio, aligned, pool_mode, cnnl_grads_image_desc, grads_image));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grads_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_boxes_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grads_image_desc);

--- a/kernels/roi_align/roialign_forward/roialign_forward.cpp
+++ b/kernels/roi_align/roialign_forward/roialign_forward.cpp
@@ -41,9 +41,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpSetRoiAlignForwardDescriptor_v2(
     const int pooled_width, const int sampling_ratio, const float spatial_scale,
     const int pool_mode, const bool aligned) {
   PARAM_CHECK("[mluOpRoiAlignForward_v2]", desc != NULL);
-  CALL_CNNL(cnnlSetRoiAlignDescriptor_v2(
-                desc, pooled_height, pooled_width, sampling_ratio,
-                spatial_scale, pool_mode, aligned));
+  CALL_CNNL(cnnlSetRoiAlignDescriptor_v2(desc, pooled_height, pooled_width,
+                                         sampling_ratio, spatial_scale,
+                                         pool_mode, aligned));
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -72,11 +72,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignForward_v2(
   cnnlTensorDescriptor_t cnnl_argmax_y_desc = NULL;
   CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(argmax_x_desc, cnnl_argmax_x_desc);
   CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(argmax_y_desc, cnnl_argmax_y_desc);
-  CALL_CNNL(
-      cnnlRoiAlign_v2(cnnl_handle, roialign_desc, cnnl_input_desc, input,
-                      cnnl_boxes_desc, boxes, cnnl_output_desc, output,
-                      cnnl_argmax_x_desc, argmax_x, cnnl_argmax_y_desc,
-                      argmax_y));
+  CALL_CNNL(cnnlRoiAlign_v2(cnnl_handle, roialign_desc, cnnl_input_desc, input,
+                            cnnl_boxes_desc, boxes, cnnl_output_desc, output,
+                            cnnl_argmax_x_desc, argmax_x, cnnl_argmax_y_desc,
+                            argmax_y));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_boxes_desc);

--- a/kernels/roi_align_rotated/roi_align_rotated.cpp
+++ b/kernels/roi_align_rotated/roi_align_rotated.cpp
@@ -65,6 +65,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignRotatedForward(
   PARAM_CHECK(API, features_desc->dtype == MLUOP_DTYPE_FLOAT ||
                        features_desc->dtype == MLUOP_DTYPE_HALF);
 
+  STRIDE_TENSOR_CHECK("[mluOpRoiAlignRotatedForward]:", features_desc,
+                      "features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAlignRotatedForward]:", rois_desc,
+                      "rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAlignRotatedForward]:", output_desc,
+                      "output_desc must be contiguous");
+
   PARAM_CHECK_EQ(API, rois_desc->dim, 2);
   PARAM_CHECK_EQ(API, output_desc->dim, 4);
   PARAM_CHECK_EQ(API, features_desc->dim, 4);
@@ -144,8 +151,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignRotatedForward(
   VLOG(5) << "[mluOpRoiAlignRotatedForward] launch kernel policyFunc["
           << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << "].";
   CHECK_RETURN(API, KernelRoiAlignRotatedForward(
-      k_dim, k_type, handle->queue, features_desc->dtype, features, rois, batch,
-      height, width, channel, rois_nums, roiAlignRotatedParams, output));
+                        k_dim, k_type, handle->queue, features_desc->dtype,
+                        features, rois, batch, height, width, channel,
+                        rois_nums, roiAlignRotatedParams, output));
   VLOG(5) << "Kernel KernelRoiAlignRotatedForward.";
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
@@ -172,6 +180,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignRotatedBackward(
                        (bottom_grad_desc->dtype == rois_desc->dtype));
   PARAM_CHECK(API, bottom_grad_desc->dtype == MLUOP_DTYPE_FLOAT ||
                        bottom_grad_desc->dtype == MLUOP_DTYPE_HALF);
+
+  STRIDE_TENSOR_CHECK("[mluOpRoiAlignRotatedBackward]:", top_grad_desc,
+                      "top_grad_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAlignRotatedBackward]:", rois_desc,
+                      "rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAlignRotatedBackward]:", bottom_grad_desc,
+                      "bottom_grad_desc must be contiguous");
 
   PARAM_CHECK_EQ(API, rois_desc->dim, 2);
   PARAM_CHECK_EQ(API, top_grad_desc->dim, 4);
@@ -268,8 +283,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAlignRotatedBackward(
   VLOG(5) << "cnnlFill_v3 end.";
 
   CHECK_RETURN(API, KernelRoiAlignRotatedBackward(
-      k_dim, k_type, handle->queue, top_grad_desc->dtype, top_grad, rois, batch,
-      height, width, channel, rois_nums, roiAlignRotatedParams, bottom_grad));
+                        k_dim, k_type, handle->queue, top_grad_desc->dtype,
+                        top_grad, rois, batch, height, width, channel,
+                        rois_nums, roiAlignRotatedParams, bottom_grad));
   VLOG(5) << "Kernel KernelRoiAlignRotatedBackward.";
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;

--- a/kernels/roi_crop/roi_crop.cpp
+++ b/kernels/roi_crop/roi_crop.cpp
@@ -68,6 +68,13 @@ mluOpStatus_t RoiCropForwardParamCheck(
   // check shape and layout
   PARAM_CHECK(op_name, input_desc->layout == MLUOP_LAYOUT_NHWC);
   PARAM_CHECK(op_name, output_desc->layout == MLUOP_LAYOUT_NHWC);
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpRoiCropForward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiCropForward]:", grid_desc,
+                      "grid_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiCropForward]:", output_desc,
+                      "output_desc must be contiguous");
 
   for (int i = 0; i < output_desc->dim - 1; ++i) {
     if (output_desc->dims[i] != grid_desc->dims[i]) {
@@ -128,6 +135,14 @@ mluOpStatus_t RoiCropBackwardParamCheck(
   // check shape and layout
   PARAM_CHECK(op_name, grad_output_desc->layout == MLUOP_LAYOUT_NHWC);
   PARAM_CHECK(op_name, grad_input_desc->layout == MLUOP_LAYOUT_NHWC);
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpRoiCropBackward]:", grad_output_desc,
+                      "grad_output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiCropBackward]:", grid_desc,
+                      "grid_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiCropBackward]:", grad_input_desc,
+                      "grad_input_desc must be contiguous");
+
   for (int i = 0; i < grad_output_desc->dim - 1; ++i) {
     if (grad_output_desc->dims[i] != grid_desc->dims[i]) {
       LOG(ERROR) << op_name << " Check failed: grad_output_desc->dims[" << i

--- a/kernels/roi_crop/roi_crop_block.mlu
+++ b/kernels/roi_crop/roi_crop_block.mlu
@@ -331,28 +331,25 @@ __mlu_global__ void MLUKernelRoiCropBackward(
         __bang_mul_scalar(nram_output, nram_ping, i_tl_x_weight * i_tl_y_weight,
                           c_limit);
         __bang_atomic_reduce_add(grad_input + gi_tl_offset + c_offset,
-                          nram_output, c_slice);
+                                 nram_output, c_slice);
       }
       if (topRightIsIn) {
         __bang_mul_scalar(nram_output + c_limit, nram_ping,
                           (1 - i_tl_x_weight) * i_tl_y_weight, c_limit);
-        __bang_atomic_reduce_add(
-            grad_input + gi_tr_offset + c_offset,
-            nram_output + c_limit, c_slice);
+        __bang_atomic_reduce_add(grad_input + gi_tr_offset + c_offset,
+                                 nram_output + c_limit, c_slice);
       }
       if (bottomLeftIsIn) {
         __bang_mul_scalar(nram_output + 2 * c_limit, nram_ping,
                           i_tl_x_weight * (1 - i_tl_y_weight), c_limit);
-        __bang_atomic_reduce_add(
-            grad_input + gi_bl_offset + c_offset,
-            nram_output + 2 * c_limit, c_slice);
+        __bang_atomic_reduce_add(grad_input + gi_bl_offset + c_offset,
+                                 nram_output + 2 * c_limit, c_slice);
       }
       if (bottomRightIsIn) {
         __bang_mul_scalar(nram_output + 3 * c_limit, nram_ping,
                           (1 - i_tl_x_weight) * (1 - i_tl_y_weight), c_limit);
-        __bang_atomic_reduce_add(
-            grad_input + gi_br_offset + c_offset,
-            nram_output + 3 * c_limit, c_slice);
+        __bang_atomic_reduce_add(grad_input + gi_br_offset + c_offset,
+                                 nram_output + 3 * c_limit, c_slice);
       }
       c_rem -= c_slice;
       c_offset += c_slice;

--- a/kernels/roi_pooling/roi_pooling_backward/roi_pooling_backward.cpp
+++ b/kernels/roi_pooling/roi_pooling_backward/roi_pooling_backward.cpp
@@ -46,11 +46,10 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiPoolingBackward(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(grads_image_desc,
                                                cnnl_grads_image_desc);
 
-  CALL_CNNL(
-      cnnlRoiPoolingBackward(cnnl_handle, cnnlPoolingMode_t(pooling_mode),
-                             cnnl_grads_desc, grads, cnnl_rois_desc, rois,
-                             cnnl_argmax_desc, argmax, spatial_scale,
-                             cnnl_grads_image_desc, grads_image));
+  CALL_CNNL(cnnlRoiPoolingBackward(cnnl_handle, cnnlPoolingMode_t(pooling_mode),
+                                   cnnl_grads_desc, grads, cnnl_rois_desc, rois,
+                                   cnnl_argmax_desc, argmax, spatial_scale,
+                                   cnnl_grads_image_desc, grads_image));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_grads_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_rois_desc);

--- a/kernels/roi_pooling/roi_pooling_forward/roi_pooling_forward.cpp
+++ b/kernels/roi_pooling/roi_pooling_forward/roi_pooling_forward.cpp
@@ -42,10 +42,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiPoolingForward(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(rois_desc, cnnl_rois_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(output_desc, cnnl_output_desc);
 
-  CALL_CNNL(
-      cnnlRoiPoolingForward(cnnl_handle, cnnlPoolingMode_t(pooling_mode),
-                            cnnl_input_desc, input, cnnl_rois_desc, rois,
-                            spatial_scale, cnnl_output_desc, output, argmax));
+  CALL_CNNL(cnnlRoiPoolingForward(
+      cnnl_handle, cnnlPoolingMode_t(pooling_mode), cnnl_input_desc, input,
+      cnnl_rois_desc, rois, spatial_scale, cnnl_output_desc, output, argmax));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_rois_desc);

--- a/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -229,7 +229,19 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dForward(
   PARAM_CHECK(API, out_x > 0);
   PARAM_CHECK(API, out_y > 0);
   PARAM_CHECK(API, out_z > 0);
-
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dForward]:", rois_desc,
+                      "rois_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dForward]:", pts_desc,
+                      "pts_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dForward]:", pts_feature_desc,
+                      "pts_feature_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dForward]:", argmax_desc,
+                      "argmax_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dForward]:", pts_idx_of_voxels_desc,
+                      "pts_idx_of_voxels_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dForward]:", pooled_features_desc,
+                      "pooled_features_desc must be contiguous");
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
      Maximum y- or z-dimension of a grid of thread blocks
      should be less than 65536 in cuda. */
@@ -377,7 +389,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dForward(
                mluOpCreateTensorDescriptor(&pts_desc_tmp));
   CHECK_RETURN("[mluOpRoiAwarePool3dForward]",
                mluOpSetTensorDescriptor(pts_desc_tmp, MLUOP_LAYOUT_ARRAY,
-                                       data_dtype, pts_dim, pts_tmp_dims));
+                                        data_dtype, pts_dim, pts_tmp_dims));
 
   auto ret = transposeTensor(handle, pts_desc, pts, pts_permute, pts_desc_tmp,
                              pts_workspace, transpose_workspace);
@@ -401,8 +413,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dForward(
                mluOpCreateTensorDescriptor(&pts_feature_desc_tmp));
   CHECK_RETURN("[mluOpRoiAwarePool3dForward]",
                mluOpSetTensorDescriptor(pts_feature_desc_tmp,
-                  MLUOP_LAYOUT_ARRAY, data_dtype, pts_feature_dim,
-                                       pts_feature_tmp_dims));
+                                        MLUOP_LAYOUT_ARRAY, data_dtype,
+                                        pts_feature_dim, pts_feature_tmp_dims));
 
   ret = transposeTensor(handle, pts_feature_desc, pts_feature,
                         pts_feature_permute, pts_feature_desc_tmp,
@@ -569,6 +581,16 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiAwarePool3dBackward(
   PARAM_CHECK(API, out_x > 0);
   PARAM_CHECK(API, out_y > 0);
   PARAM_CHECK(API, out_z > 0);
+
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dBackward]:", pts_idx_of_voxels_desc,
+                      "pts_idx_of_voxels_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dBackward]:", argmax_desc,
+                      "argmax_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dBackward]:", grad_out_desc,
+                      "grad_out_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiAwarePool3dBackward]:", grad_in_desc,
+                      "grad_in_desc must be contiguous");
 
   /* boxes_num or channels is the y- or z-dimension in mmcv(cuda),
      Maximum y- or z-dimension of a grid of thread blocks

--- a/kernels/roipoint_pool3d/roipoint_pool3d.cpp
+++ b/kernels/roipoint_pool3d/roipoint_pool3d.cpp
@@ -58,17 +58,17 @@ static mluOpStatus_t paramcheck(
 
   // check tensor shape
   PARAM_CHECK("[mluOpRoiPointPool3d]",
-      points_desc->dims[0] == pooled_features_desc->dims[0]);
+              points_desc->dims[0] == pooled_features_desc->dims[0]);
   PARAM_CHECK("[mluOpRoiPointPool3d]",
-      point_features_desc->dims[0] == pooled_features_desc->dims[0]);
+              point_features_desc->dims[0] == pooled_features_desc->dims[0]);
   PARAM_CHECK("[mluOpRoiPointPool3d]",
-      boxes3d_desc->dims[0] == pooled_features_desc->dims[0]);
+              boxes3d_desc->dims[0] == pooled_features_desc->dims[0]);
   PARAM_CHECK("[mluOpRoiPointPool3d]",
-      pooled_empty_flag_desc->dims[0] == pooled_features_desc->dims[0]);
+              pooled_empty_flag_desc->dims[0] == pooled_features_desc->dims[0]);
   PARAM_CHECK("[mluOpRoiPointPool3d]",
               pooled_features_desc->dims[1] == boxes3d_desc->dims[1]);
   PARAM_CHECK("[mluOpRoiPointPool3d]",
-                pooled_empty_flag_desc->dims[1] == boxes3d_desc->dims[1]);
+              pooled_empty_flag_desc->dims[1] == boxes3d_desc->dims[1]);
   PARAM_CHECK("[mluOpRoiPointPool3d]",
               points_desc->dims[1] == point_features_desc->dims[1]);
   PARAM_CHECK("[mluOpRoiPointPool3d]", point_features_desc->dims[2] + 3 ==
@@ -82,6 +82,18 @@ static mluOpStatus_t paramcheck(
                  point_features_desc->dims[2]);
   PARAM_CHECK_EQ("[mluOpRoiPointPool3d]", sampled_pts_num,
                  pooled_features_desc->dims[2]);
+
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpRoiPointPool3d]:", points_desc,
+                      "points_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiPointPool3d]:", point_features_desc,
+                      "point_features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiPointPool3d]:", boxes3d_desc,
+                      "boxes3d_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiPointPool3d]:", pooled_features_desc,
+                      "pooled_features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRoiPointPool3d]:", pooled_empty_flag_desc,
+                      "pooled_empty_flag_desc must be contiguous");
 
   // check tensor datatype
   PARAM_CHECK("[mluOpRoiPointPool3d]",
@@ -321,8 +333,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiPointPool3d(
   point_features_dims[2] = point_features_desc->dims[1];
   CHECK_RETURN("[mluOpGetRoiPointPool3d]",
                mluOpSetTensorDescriptor(
-                      output_transpose_desc, MLUOP_LAYOUT_ARRAY,
-                      point_features_desc->dtype, dims, point_features_dims));
+                   output_transpose_desc, MLUOP_LAYOUT_ARRAY,
+                   point_features_desc->dtype, dims, point_features_dims));
   CALL_CNNL(
       cnnlSetTransposeDescriptor(trans_desc, dims, point_features_permute));
   {

--- a/kernels/rotated_feature_align/rotated_feature_align.cpp
+++ b/kernels/rotated_feature_align/rotated_feature_align.cpp
@@ -73,6 +73,14 @@ static mluOpStatus_t RotatedFeatureAlignForwardPreCheck(
   PARAM_CHECK("[mluOpRotatedFeatureAlignForward]",
               output_desc->layout == MLUOP_LAYOUT_NHWC);
 
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpRotatedFeatureAlignForward]:", input_desc,
+                      "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRotatedFeatureAlignForward]:", bboxes_desc,
+                      "bboxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRotatedFeatureAlignForward]:", output_desc,
+                      "output_desc must be contiguous");
+
   for (int i = 0; i < input_desc->dim; i++) {
     if (input_desc->dims[i] != output_desc->dims[i]) {
       LOG(ERROR)
@@ -139,6 +147,14 @@ static mluOpStatus_t RotatedFeatureAlignBackwardPreCheck(
               top_output_desc->layout == MLUOP_LAYOUT_NHWC);
   PARAM_CHECK("[mluOpRotatedFeatureAlignBackward]",
               bottom_input_desc->layout == MLUOP_LAYOUT_NHWC);
+
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpRotatedFeatureAlignBackward]:", top_output_desc,
+                      "top_output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRotatedFeatureAlignBackward]:", bboxes_desc,
+                      "bboxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpRotatedFeatureAlignBackward]:", bottom_input_desc,
+                      "bottom_input_desc must be contiguous");
 
   for (int i = 0; i < top_output_desc->dim; i++) {
     if (top_output_desc->dims[i] != bottom_input_desc->dims[i]) {

--- a/kernels/rotated_feature_align/rotated_feature_align_block.mlu
+++ b/kernels/rotated_feature_align/rotated_feature_align_block.mlu
@@ -601,12 +601,12 @@ __mlu_global__ void MLUKernelRotatedFeatureAlignBackward(
                             p_y_high * width * channels + p_x_high * channels +
                             channel_offset;
           __bang_atomic_reduce_add((T *)cur_tl, (T *)nram_ping, channels_num);
-          __bang_atomic_reduce_add(
-              (T *)cur_tr, (T *)(nram_ping + deal_num), channels_num);
-          __bang_atomic_reduce_add(
-              (T *)cur_bl, (T *)(nram_ping + 2 * deal_num), channels_num);
-          __bang_atomic_reduce_add(
-              (T *)cur_br, (T *)(nram_ping + 3 * deal_num), channels_num);
+          __bang_atomic_reduce_add((T *)cur_tr, (T *)(nram_ping + deal_num),
+                                   channels_num);
+          __bang_atomic_reduce_add((T *)cur_bl, (T *)(nram_ping + 2 * deal_num),
+                                   channels_num);
+          __bang_atomic_reduce_add((T *)cur_br, (T *)(nram_ping + 3 * deal_num),
+                                   channels_num);
         }
         __sync();
         swap_ptr(nram_ping, nram_pong);
@@ -628,18 +628,17 @@ __mlu_global__ void MLUKernelRotatedFeatureAlignBackward(
         const T *cur_br = bottom_input + n_offset +
                           p_y_high * width * channels + p_x_high * channels +
                           channel_offset;
-        __bang_atomic_reduce_add(
-            (T *)cur_tl, (T *)nram_ping, channels_num);
-        __bang_atomic_reduce_add(
-            (T *)cur_tr, (T *)(nram_ping + deal_num), channels_num);
-        __bang_atomic_reduce_add(
-            (T *)cur_bl, (T *)(nram_ping + 2 * deal_num), channels_num);
-        __bang_atomic_reduce_add(
-            (T *)cur_br, (T *)(nram_ping + 3 * deal_num), channels_num);
+        __bang_atomic_reduce_add((T *)cur_tl, (T *)nram_ping, channels_num);
+        __bang_atomic_reduce_add((T *)cur_tr, (T *)(nram_ping + deal_num),
+                                 channels_num);
+        __bang_atomic_reduce_add((T *)cur_bl, (T *)(nram_ping + 2 * deal_num),
+                                 channels_num);
+        __bang_atomic_reduce_add((T *)cur_br, (T *)(nram_ping + 3 * deal_num),
+                                 channels_num);
       }
       // So
-      __bang_atomic_reduce_add(
-          (T *)cur_bottom_input, (T *)ping_out, channels_num);
+      __bang_atomic_reduce_add((T *)cur_bottom_input, (T *)ping_out,
+                               channels_num);
       // load next rem c
       if (channel_loop_index + 1 < channel_loops) {
         int channels_num_rem = channels_num;

--- a/kernels/sparse_conv/get_indice_pairs/get_indice_pairs.cpp
+++ b/kernels/sparse_conv/get_indice_pairs/get_indice_pairs.cpp
@@ -146,6 +146,16 @@ static mluOpStatus_t internalGetIndicePairs(
   PARAM_CHECK_LE(interface_name, kernel_volume, 4096);
   PARAM_CHECK_LE(interface_name, out_indices_desc->dims[0], output_spaces);
 
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpGetIndicesPairs]:", indices_desc,
+                      "indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpGetIndicesPairs]:", indice_pairs_desc,
+                      "indice_pairs_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpGetIndicesPairs]:", out_indices_desc,
+                      "out_indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpGetIndicesPairs]:", indice_num_desc,
+                      "indice_num_desc must be contiguous");
+
   // large tensor
   PARAM_CHECK_LE(interface_name, indices_desc->dims[0],
                  INDICE_IN_LARGE_TENSOR_NUM);

--- a/kernels/sparse_conv/indice_convolution_backward_data/indice_convolution_backward_data.cpp
+++ b/kernels/sparse_conv/indice_convolution_backward_data/indice_convolution_backward_data.cpp
@@ -88,6 +88,15 @@ static mluOpStatus_t foolCheckNoPtr(
                   "NHWC/NCHW/HWCN/NCDHW/NDHWC/ARRAY layout.";
     return MLUOP_STATUS_BAD_PARAM;
   }
+  // check stride
+  STRIDE_TENSOR_CHECK(api + ":", output_grad_desc,
+                      "output_grad_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", filters_desc,
+                      "filters_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", indice_pairs_desc,
+                      "indice_pairs_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api + ":", input_grad_desc,
+                      "input_grad_desc must be contiguous");
 
   // get filters params
   int kd = 1, kh = 1, kw = 1, dyc = 1, dxc = 1;
@@ -521,9 +530,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(
     }
     DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_grad_desc,
                                                  cnnl_output_desc);
-    CALL_CNNL(
-        cnnlGetAddNWorkspaceSize(cnnl_handle, cnnl_input_descs, addn_num,
-                                 cnnl_output_desc, &addn_workspace_size));
+    CALL_CNNL(cnnlGetAddNWorkspaceSize(cnnl_handle, cnnl_input_descs, addn_num,
+                                       cnnl_output_desc, &addn_workspace_size));
     for (int i = 0; i < addn_num; i++) {
       DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_descs[i]);
     }
@@ -886,9 +894,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpIndiceConvolutionBackwardData(
       }
       DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_grad_desc,
                                                    cnnl_output_desc);
-      CALL_CNNL(
-          cnnlGetAddNWorkspaceSize(cnnl_handle, cnnl_input_descs, addn_num,
-                                   cnnl_output_desc, &addn_workspace_size));
+      CALL_CNNL(cnnlGetAddNWorkspaceSize(cnnl_handle, cnnl_input_descs,
+                                         addn_num, cnnl_output_desc,
+                                         &addn_workspace_size));
 
       CALL_CNNL(cnnlAddN_v2(cnnl_handle, cnnl_input_descs, addn_array, addn_num,
                             cnnl_output_desc, input_grad, workspace_addn,

--- a/kernels/sparse_conv/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/kernels/sparse_conv/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -184,6 +184,16 @@ static mluOpStatus_t baseParamCheck(
   PARAM_CHECK(api_name, indice_num != nullptr);
   PARAM_CHECK(api_name, inverse == 0);
 
+  // check stride
+  STRIDE_TENSOR_CHECK(api_name + ":", features_desc,
+                      "features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", output_grad_desc,
+                      "output_grad_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", indice_pairs_desc,
+                      "indice_pairs_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", filters_grad_desc,
+                      "filters_grad_desc must be contiguous");
+
   // check mlu platform
   if (handle->arch < 372) {
     LOG(ERROR) << api_name << " Only mlu300 and above devices are supported."

--- a/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/kernels/sparse_conv/indice_convolution_forward/indice_convolution_forward.cpp
@@ -106,6 +106,16 @@ static mluOpStatus_t foolProof(
     return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
+  // check stride
+  STRIDE_TENSOR_CHECK(api_name + ":", features_desc,
+                      "features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", filters_desc,
+                      "filters_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", indice_pairs_desc,
+                      "indice_pairs_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_name + ":", features_out_desc,
+                      "features_out_desc must be contiguous");
+
   // large tensor
   if (mluOpGetTensorElementNum(features_desc) >= LARGE_TENSOR_NUM ||
       mluOpGetTensorElementNum(filters_desc) >= LARGE_TENSOR_NUM ||

--- a/kernels/sqrt/sqrt.cpp
+++ b/kernels/sqrt/sqrt.cpp
@@ -89,6 +89,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrt(mluOpHandle_t handle,
   if (param_check != MLUOP_STATUS_SUCCESS) {
     return param_check;
   }
+  // check stride
+  if (mluop::strideCaseWithNotConsistentDense(2, x_desc, y_desc)) {
+    LOG(ERROR) << op_name_forward
+               << ": stride case with not consistent dense is not supported.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
+  }
 
   if (zero_element == true) {
     return MLUOP_STATUS_SUCCESS;
@@ -132,6 +138,13 @@ mluOpStatus_t MLUOP_WIN_API mluOpSqrtBackward(
                          dx_desc, diff_x, support_type, 2, zero_element, false);
   if (param_check != MLUOP_STATUS_SUCCESS) {
     return param_check;
+  }
+
+  // check stride
+  if (mluop::strideCaseWithNotConsistentDense(3, y_desc, dy_desc, dx_desc)) {
+    LOG(ERROR) << op_name_backward
+               << " stride case with not consistent dense is not supported.";
+    return MLUOP_STATUS_NOT_SUPPORTED;
   }
 
   if (MLUOP_GEN_CASE_ON_NEW) {

--- a/kernels/sync_batch_norm/sync_batch_norm_backward_elemt/sync_batch_norm_backward_elemt.cpp
+++ b/kernels/sync_batch_norm/sync_batch_norm_backward_elemt/sync_batch_norm_backward_elemt.cpp
@@ -59,12 +59,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormBackwardElemt(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(diffcnnl_x_desc,
                                                cnnl_diffcnnl_x_desc);
 
-  CALL_CNNL(
-      cnnlSyncBatchNormBackwardElemt(
-          cnnl_handle, cnnl_diff_y_desc, diff_y, cnnl_x_desc, x, cnnl_mean_desc,
-          mean, cnnl_invstd_desc, invstd, cnnl_filter_desc, filter,
-          cnnl_mean_dy_desc, mean_dy, cnnl_mean_dy_xmu_desc, mean_dy_xmu,
-          cnnl_diffcnnl_x_desc, diff_x));
+  CALL_CNNL(cnnlSyncBatchNormBackwardElemt(
+      cnnl_handle, cnnl_diff_y_desc, diff_y, cnnl_x_desc, x, cnnl_mean_desc,
+      mean, cnnl_invstd_desc, invstd, cnnl_filter_desc, filter,
+      cnnl_mean_dy_desc, mean_dy, cnnl_mean_dy_xmu_desc, mean_dy_xmu,
+      cnnl_diffcnnl_x_desc, diff_x));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_diff_y_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_x_desc);

--- a/kernels/sync_batch_norm/sync_batchnorm_backward_elemt_v2/sync_batchnorm_backward_elemt_v2.cpp
+++ b/kernels/sync_batch_norm/sync_batchnorm_backward_elemt_v2/sync_batchnorm_backward_elemt_v2.cpp
@@ -63,12 +63,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormBackwardElemtV2(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(diffcnnl_x_desc,
                                                cnnl_diffcnnl_x_desc);
 
-  CALL_CNNL(
-      cnnlSyncBatchNormBackwardElemtV2(
-          cnnl_handle, cnnl_diff_y_desc, diff_y, cnnl_x_desc, x, cnnl_mean_desc,
-          mean, cnnl_invstd_desc, invstd, cnnl_filter_desc, filter,
-          cnnl_sum_dy_desc, sum_dy, cnnl_sum_dy_xmu_desc, sum_dy_xmu,
-          cnnl_count_desc, count, cnnl_diffcnnl_x_desc, diff_x));
+  CALL_CNNL(cnnlSyncBatchNormBackwardElemtV2(
+      cnnl_handle, cnnl_diff_y_desc, diff_y, cnnl_x_desc, x, cnnl_mean_desc,
+      mean, cnnl_invstd_desc, invstd, cnnl_filter_desc, filter,
+      cnnl_sum_dy_desc, sum_dy, cnnl_sum_dy_xmu_desc, sum_dy_xmu,
+      cnnl_count_desc, count, cnnl_diffcnnl_x_desc, diff_x));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_diff_y_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_x_desc);

--- a/kernels/sync_batch_norm/sync_batchnorm_backward_reduce/sync_batchnorm_backward_reduce.cpp
+++ b/kernels/sync_batch_norm/sync_batchnorm_backward_reduce/sync_batchnorm_backward_reduce.cpp
@@ -33,9 +33,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetSyncBatchNormBackwardReduceWorkspaceSize(
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(desc_x, cnnl_desc_x);
 
-  CALL_CNNL(
-      cnnlGetSyncBatchnormBackwardReduceWorkspaceSize(cnnl_handle, cnnl_desc_x,
-                                                      workspace_size));
+  CALL_CNNL(cnnlGetSyncBatchnormBackwardReduceWorkspaceSize(
+      cnnl_handle, cnnl_desc_x, workspace_size));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_desc_x);
   DESTROY_CNNL_HANDLE(cnnl_handle);
@@ -85,12 +84,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormBackwardReduce(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(desc_sum_dy_xmu,
                                                cnnl_desc_sum_dy_xmu);
 
-  CALL_CNNL(
-      cnnlSyncBatchnormBackwardReduce(
-          cnnl_handle, cnnl_desc_dz, dz, cnnl_desc_x, x, cnnl_desc_mean, mean,
-          cnnl_desc_invstd, invstd, cnnl_desc_dfilter, dfilter, cnnl_desc_dbias,
-          dbias, cnnl_desc_sum_dy, sum_dy, cnnl_desc_sum_dy_xmu, sum_dy_xmu,
-          needs_input_grad0, needs_input_grad1, needs_input_grad2));
+  CALL_CNNL(cnnlSyncBatchnormBackwardReduce(
+      cnnl_handle, cnnl_desc_dz, dz, cnnl_desc_x, x, cnnl_desc_mean, mean,
+      cnnl_desc_invstd, invstd, cnnl_desc_dfilter, dfilter, cnnl_desc_dbias,
+      dbias, cnnl_desc_sum_dy, sum_dy, cnnl_desc_sum_dy_xmu, sum_dy_xmu,
+      needs_input_grad0, needs_input_grad1, needs_input_grad2));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_desc_dz);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_desc_x);
@@ -162,13 +160,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormBackwardReduce_v2(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(desc_sum_dy_xmu,
                                                cnnl_desc_sum_dy_xmu);
 
-  CALL_CNNL(
-      cnnlSyncBatchnormBackwardReduce_v2(
-          cnnl_handle, cnnl_desc_dz, dz, cnnl_desc_x, x, cnnl_desc_mean, mean,
-          cnnl_desc_invstd, invstd, workspace, workspace_size,
-          cnnl_desc_dfilter, dfilter, cnnl_desc_dbias, dbias, cnnl_desc_sum_dy,
-          sum_dy, cnnl_desc_sum_dy_xmu, sum_dy_xmu, needs_input_grad0,
-          needs_input_grad1, needs_input_grad2));
+  CALL_CNNL(cnnlSyncBatchnormBackwardReduce_v2(
+      cnnl_handle, cnnl_desc_dz, dz, cnnl_desc_x, x, cnnl_desc_mean, mean,
+      cnnl_desc_invstd, invstd, workspace, workspace_size, cnnl_desc_dfilter,
+      dfilter, cnnl_desc_dbias, dbias, cnnl_desc_sum_dy, sum_dy,
+      cnnl_desc_sum_dy_xmu, sum_dy_xmu, needs_input_grad0, needs_input_grad1,
+      needs_input_grad2));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_desc_dz);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_desc_x);

--- a/kernels/sync_batch_norm/sync_batchnorm_elemt/sync_batchnorm_elemt.cpp
+++ b/kernels/sync_batch_norm/sync_batchnorm_elemt/sync_batchnorm_elemt.cpp
@@ -53,10 +53,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormElemt(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(bias_desc, cnnl_bias_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(y_desc, cnnl_y_desc);
 
-  CALL_CNNL(
-      cnnlSyncBatchNormElemt(cnnl_handle, cnnl_x_desc, x, cnnl_mean_desc, mean,
-                             cnnl_invstd_desc, invstd, cnnl_filter_desc, filter,
-                             cnnl_bias_desc, bias, cnnl_y_desc, y));
+  CALL_CNNL(cnnlSyncBatchNormElemt(
+      cnnl_handle, cnnl_x_desc, x, cnnl_mean_desc, mean, cnnl_invstd_desc,
+      invstd, cnnl_filter_desc, filter, cnnl_bias_desc, bias, cnnl_y_desc, y));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_x_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mean_desc);

--- a/kernels/sync_batch_norm/sync_batchnorm_gather_stats_with_counts/sync_batchnorm_gather_stats_with_counts.cpp
+++ b/kernels/sync_batch_norm/sync_batchnorm_gather_stats_with_counts/sync_batchnorm_gather_stats_with_counts.cpp
@@ -66,12 +66,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormGatherStatsWithCounts(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(mean_desc, cnnl_mean_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(invstd_desc, cnnl_invstd_desc);
 
-  CALL_CNNL(
-      cnnlSyncBatchNormGatherStatsWithCounts(
-          cnnl_handle, cnnl_mean_all_desc, mean_all, cnnl_invstd_all_desc,
-          invstd_all, cnnl_movingcnnl_mean_desc, moving_mean,
-          cnnl_moving_var_desc, moving_var, momentum, eps, cnnl_count_all_desc,
-          count_all, cnnl_mean_desc, mean, cnnl_invstd_desc, invstd));
+  CALL_CNNL(cnnlSyncBatchNormGatherStatsWithCounts(
+      cnnl_handle, cnnl_mean_all_desc, mean_all, cnnl_invstd_all_desc,
+      invstd_all, cnnl_movingcnnl_mean_desc, moving_mean, cnnl_moving_var_desc,
+      moving_var, momentum, eps, cnnl_count_all_desc, count_all, cnnl_mean_desc,
+      mean, cnnl_invstd_desc, invstd));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mean_all_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_invstd_all_desc);

--- a/kernels/sync_batch_norm/sync_batchnorm_stats/sync_batchnorm_stats.cpp
+++ b/kernels/sync_batch_norm/sync_batchnorm_stats/sync_batchnorm_stats.cpp
@@ -31,8 +31,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetSyncBatchNormStatsWorkspaceSize(
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle, cnnl_handle);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(x_desc, cnnl_x_desc);
 
-  CALL_CNNL(cnnlGetSyncBatchNormStatsWorkspaceSize(
-                cnnl_handle, cnnl_x_desc, workspace_size));
+  CALL_CNNL(cnnlGetSyncBatchNormStatsWorkspaceSize(cnnl_handle, cnnl_x_desc,
+                                                   workspace_size));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_x_desc);
   DESTROY_CNNL_HANDLE(cnnl_handle);
@@ -56,9 +56,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormStats(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(mean_desc, cnnl_mean_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(invstd_desc, cnnl_invstd_desc);
 
-  CALL_CNNL(
-      cnnlSyncBatchNormStats(cnnl_handle, cnnl_x_desc, x, eps, cnnl_mean_desc,
-                             mean, cnnl_invstd_desc, invstd));
+  CALL_CNNL(cnnlSyncBatchNormStats(cnnl_handle, cnnl_x_desc, x, eps,
+                                   cnnl_mean_desc, mean, cnnl_invstd_desc,
+                                   invstd));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_x_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mean_desc);
@@ -88,9 +88,9 @@ mluOpStatus_t MLUOP_WIN_API mluOpSyncBatchNormStats_v2(
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(mean_desc, cnnl_mean_desc);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(invstd_desc, cnnl_invstd_desc);
 
-  CALL_CNNL(cnnlSyncBatchNormStats_v2(
-                cnnl_handle, cnnl_x_desc, x, workspace, workspace_size,
-                eps, cnnl_mean_desc, mean, cnnl_invstd_desc, invstd));
+  CALL_CNNL(cnnlSyncBatchNormStats_v2(cnnl_handle, cnnl_x_desc, x, workspace,
+                                      workspace_size, eps, cnnl_mean_desc, mean,
+                                      cnnl_invstd_desc, invstd));
 
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_x_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_mean_desc);

--- a/kernels/three_interpolate/three_interpolate.cpp
+++ b/kernels/three_interpolate/three_interpolate.cpp
@@ -317,6 +317,15 @@ mluOpStatus_t threeInterpolateForwardParamCheck(
                   "equal to indices_desc->dims[1].";
     return MLUOP_STATUS_BAD_PARAM;
   }
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateForward]:", features_desc,
+                      "features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateForward]:", indices_desc,
+                      "indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateForward]:", weights_desc,
+                      "weights_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateForward]:", output_desc,
+                      "output_desc must be contiguous");
   // check large tensor
   if ((mluOpGetTensorElementNum(features_desc) >= LARGE_TENSOR_NUM) ||
       (mluOpGetTensorElementNum(indices_desc) >= LARGE_TENSOR_NUM) ||
@@ -410,6 +419,15 @@ mluOpStatus_t threeInterpolateBackwardParamCheck(
                   "equal to indices_desc->dims[1].";
     return MLUOP_STATUS_BAD_PARAM;
   }
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateBackward]:", grad_output_desc,
+                      "grad_output_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateBackward]:", indices_desc,
+                      "indices_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateBackward]:", weights_desc,
+                      "weights_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeInterpolateBackward]:", grad_features_desc,
+                      "grad_features_desc must be contiguous");
   // check large tensor
   if ((mluOpGetTensorElementNum(grad_output_desc) >= LARGE_TENSOR_NUM) ||
       (mluOpGetTensorElementNum(indices_desc) >= LARGE_TENSOR_NUM) ||

--- a/kernels/three_nn_forward/three_nn_forward.cpp
+++ b/kernels/three_nn_forward/three_nn_forward.cpp
@@ -146,6 +146,16 @@ static mluOpStatus_t threeNNParamCheck(
   const size_t dist2_element_num = mluOpGetTensorElementNum(dist2_desc);
   const size_t idx_element_num = mluOpGetTensorElementNum(idx_desc);
 
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpThreeNNForward]:", unknown_desc,
+                      "unknown_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeNNForward]:", known_desc,
+                      "known_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeNNForward]:", dist2_desc,
+                      "dist2_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpThreeNNForward]:", idx_desc,
+                      "idx_desc must be contiguous");
+
   // check large tensor
   TENSOR_NUM_CHECK("[mluOpThreeNNForward]", unknown_element_num,
                    LARGE_TENSOR_NUM, "");
@@ -238,16 +248,15 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeNNForward(
                mluOpCreateTensorDescriptor(&known_desc_tmp));
   CHECK_RETURN(
       "[mluOpThreeNNForward]",
-      mluOpSetTensorDescriptor(known_desc_tmp, MLUOP_LAYOUT_ARRAY,
-                               input_dtype, known_dim, known_tmp_dims));
+      mluOpSetTensorDescriptor(known_desc_tmp, MLUOP_LAYOUT_ARRAY, input_dtype,
+                               known_dim, known_tmp_dims));
   CHECK_RETURN(
       "[mluOpThreeNNForward]",
-      transposeTensor(handle, known_desc, known, known_permute,
-                      known_desc_tmp, known_workspace, transpose_workspace,
+      transposeTensor(handle, known_desc, known, known_permute, known_desc_tmp,
+                      known_workspace, transpose_workspace,
                       workspace_size - known_desc->total_tensor_size));
-  CHECK_RETURN(
-      "[mluOpThreeNNForward]",
-      mluOpDestroyTensorDescriptor(known_desc_tmp));
+  CHECK_RETURN("[mluOpThreeNNForward]",
+               mluOpDestroyTensorDescriptor(known_desc_tmp));
 
   VLOG(5) << "[mluOpThreeNNForward] cnnlTranspose_v2 feature end.";
   VLOG(5) << "Launch Kernel KernelThreeNNForward<<<Union" << k_type / CORE_DIM

--- a/kernels/tin_shift/tin_shift.cpp
+++ b/kernels/tin_shift/tin_shift.cpp
@@ -134,6 +134,10 @@ static mluOpStatus_t TinShiftPreCheck(
                << " and shifts batch size is " << shifts_desc->dims[0] << ".";
     return MLUOP_STATUS_BAD_PARAM;
   }
+  const std::string api_ = "[mluOpTinShift " + direction + "]:";
+  STRIDE_TENSOR_CHECK(api_, input_desc, "input_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_, shifts_desc, "shifts_desc must be contiguous");
+  STRIDE_TENSOR_CHECK(api_, output_desc, "output_desc must be contiguous");
   if (shifts_desc->dtype != MLUOP_DTYPE_INT32) {
     LOG(ERROR)
         << "[mluOpTinShift " + direction + "] "

--- a/kernels/utils/common.h
+++ b/kernels/utils/common.h
@@ -70,8 +70,7 @@ __mlu_func__ T __mluop_max(T a, T b) {
  * Note:
  *      The rounding mode on MLU200 is rd, on MLU300 is rn.
  ******************************************************************************/
-__mlu_func__ void __mluop_float2half(half *dst, float *src,
-                                            int src_count) {
+__mlu_func__ void __mluop_float2half(half *dst, float *src, int src_count) {
 #if __BANG_ARCH__ >= 300
   __bang_float2half_rn(dst, src, src_count);
 #else

--- a/kernels/utils/philox_generator.h
+++ b/kernels/utils/philox_generator.h
@@ -29,18 +29,11 @@
 
 __nram__ uint32_t nram_counter[ONCE_COMPUTE_NUM];
 
-__mlu_func__ void gen_random_u32(vv_uint32 *key0,
-                                 vv_uint32 *key1,
-                                 uint32_t *nram_counter0,
-                                 uint32_t *nram_counter1,
-                                 uint32_t *nram_counter2,
-                                 uint32_t *nram_counter3,
-                                 uint32_t &offset_low,
-                                 uint32_t &offset_high,
-                                 int32_t thread_begin,
-                                 int32_t &thread_acc,
-                                 int32_t thread_cur_core,
-                                 vv_uint32 index) {
+__mlu_func__ void gen_random_u32(
+    vv_uint32 *key0, vv_uint32 *key1, uint32_t *nram_counter0,
+    uint32_t *nram_counter1, uint32_t *nram_counter2, uint32_t *nram_counter3,
+    uint32_t &offset_low, uint32_t &offset_high, int32_t thread_begin,
+    int32_t &thread_acc, int32_t thread_cur_core, vv_uint32 index) {
   const uint32_t kPhiloxM4xA = 0xD2511F53;
   const uint32_t kPhiloxM4xB = 0xCD9E8D57;
   vv_uint32 cx, cy, cz, cw, h0, h1, l0, l1;
@@ -147,11 +140,8 @@ __mlu_func__ void gen_random_u32(vv_uint32 *key0,
 }
 
 template <typename RANGE_TYPE>
-__mlu_func__ void cvtUniform(uint32_t *output,
-                             int32_t num,
-                             RANGE_TYPE max,
-                             RANGE_TYPE min,
-                             bool is_int) {
+__mlu_func__ void cvtUniform(uint32_t *output, int32_t num, RANGE_TYPE max,
+                             RANGE_TYPE min, bool is_int) {
   RANGE_TYPE range = max - min;
   if (is_int && std::is_same<RANGE_TYPE, int32_t>::value) {
     __bang_rem((uint32_t *)output, (uint32_t *)output, (uint32_t)range, num);
@@ -194,17 +184,11 @@ __mlu_func__ void cvtUniform(uint32_t *output,
  * Note: The space size of \p output is \p num * sizeof(float).
  ******************************************************************************/
 template <typename DST_TYPE, typename RANGE_TYPE>
-__mlu_func__ void genUniform(uint32_t key0_begin,
-                             uint32_t key1_begin,
-                             DST_TYPE *output,
-                             int num,
-                             uint32_t &offset_low,
-                             uint32_t &offset_high,
-                             RANGE_TYPE max,
-                             RANGE_TYPE min,
-                             int32_t thread_begin,
-                             int32_t &thread_acc,
-                             int32_t thread_cur_core,
+__mlu_func__ void genUniform(uint32_t key0_begin, uint32_t key1_begin,
+                             DST_TYPE *output, int num, uint32_t &offset_low,
+                             uint32_t &offset_high, RANGE_TYPE max,
+                             RANGE_TYPE min, int32_t thread_begin,
+                             int32_t &thread_acc, int32_t thread_cur_core,
                              bool is_int) {
   if (num > 0) {
     // counter nram contribute

--- a/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
+++ b/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
@@ -90,6 +90,15 @@ mluOpStatus_t VoxelPoolingForwardParamCheck(
   PARAM_CHECK(op_name, num_voxel_x > 0);
   PARAM_CHECK(op_name, num_voxel_y > 0);
   PARAM_CHECK(op_name, num_voxel_z > 0);
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpVoxelPoolingForward]:", geom_xyz_desc,
+                      "geom_xyz_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpVoxelPoolingForward]:", input_features_desc,
+                      "input_features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpVoxelPoolingForward]:", output_features_desc,
+                      "output_features_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpVoxelPoolingForward]:", pos_memo_desc,
+                      "pos_memo_desc must be contiguous");
   // check large tensor
   if ((mluOpGetTensorElementNum(geom_xyz_desc) >= LARGE_TENSOR_NUM) ||
       (mluOpGetTensorElementNum(input_features_desc) >= LARGE_TENSOR_NUM) ||

--- a/kernels/voxelization/voxelization.cpp
+++ b/kernels/voxelization/voxelization.cpp
@@ -100,6 +100,22 @@ mluOpStatus_t voxelizationParamCheck(
     // check params
     PARAM_CHECK_EQ("[mluOpVoxelization]", NDim, 3);
 
+    // check stride
+    STRIDE_TENSOR_CHECK("[mluOpVoxelization]:", points_desc,
+                        "points_desc must be contiguous");
+    STRIDE_TENSOR_CHECK("[mluOpVoxelization]:", voxel_size_desc,
+                        "voxel_size_desc must be contiguous");
+    STRIDE_TENSOR_CHECK("[mluOpVoxelization]:", coors_range_desc,
+                        "coors_range_desc must be contiguous");
+    STRIDE_TENSOR_CHECK("[mluOpVoxelization]:", voxels_desc,
+                        "voxels_desc must be contiguous");
+    STRIDE_TENSOR_CHECK("[mluOpVoxelization]:", coors_desc,
+                        "coors_desc must be contiguous");
+    STRIDE_TENSOR_CHECK("[mluOpVoxelization]:", num_points_per_voxel_desc,
+                        "num_points_per_voxel_desc must be contiguous");
+    STRIDE_TENSOR_CHECK("[mluOpVoxelization]:", voxel_num_desc,
+                        "voxel_num_desc must be contiguous");
+
     // check tensor datatype
     PARAM_CHECK("[mluOpVoxelization]", points_desc->dtype == MLUOP_DTYPE_FLOAT);
     PARAM_CHECK("[mluOpVoxelization]",

--- a/kernels/yolo_box/yolo_box.cpp
+++ b/kernels/yolo_box/yolo_box.cpp
@@ -162,6 +162,17 @@ mluOpStatus_t MLUOP_WIN_API mluOpYoloBox(
     return param_check;
   }
 
+  // check stride
+  STRIDE_TENSOR_CHECK("[mluOpYoloBox]:", x_desc, "x_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpYoloBox]:", img_size_desc,
+                      "img_size_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpYoloBox]:", anchors_desc,
+                      "anchors_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpYoloBox]:", boxes_desc,
+                      "boxes_desc must be contiguous");
+  STRIDE_TENSOR_CHECK("[mluOpYoloBox]:", scores_desc,
+                      "scores_desc must be contiguous");
+
   // check zero element
   if (zero_element == true) {
     VLOG(5) << "[mluOpYoloBox] Input skip zero element tensor.";


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.