### PR TITLE
[Fix](mluOpGenerateProposalsV2): support nan/inf except score tensor.

### DIFF
--- a/kernels/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/kernels/generate_proposals_v2/generate_proposals_v2.cpp
@@ -54,7 +54,7 @@ static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
     *k_type = CNRT_FUNC_TYPE_BLOCK;
   } else {
     *k_type = CNRT_FUNC_TYPE_UNION1;
-    k_dim->x = handle->core_num_per_cluster;
+    k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   }
   return;
 }
@@ -226,8 +226,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGetGenerateProposalsV2WorkspaceSize_v2(
     // handle->core_num_per_cluster * data_size: workspace be used to store per
     // core proposals_num.
     *size = topk_workspace_size_align + 2 * nhwa_size_align +
-            10 * hwa * data_size +
-            handle->core_num_per_cluster * handle->cluster_num * data_size;
+            10 * hwa * data_size + handle->core_num_per_cluster * 3 * data_size;
   } else {
     // 4 * hwa: workspace be used store proposals_box/scores
     // 8 * hwa: workspace be used store decode boxes/scores

--- a/kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
+++ b/kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
@@ -251,7 +251,8 @@ __mlu_func__ void scoreUpdate(
 #endif
     // 2. select the box
     __bang_mul_scalar(inter_x2, inter_x2, nms_thresh, actual_num_align);
-    __bang_le(inter_y1, inter_x1, inter_x2, actual_num_align);
+    __bang_gt(inter_y1, inter_x1, inter_x2, actual_num_align);
+    __bang_not(inter_y1, inter_y1, actual_num_align);
     __bang_gt(inter_y2, inter_x1, inter_x2, actual_num_align);
     __bang_mul(inter_y1, scores, inter_y1, actual_num_align);
     __bang_mul_scalar(inter_y2, inter_y2, FLOAT_MIN_GPV2, actual_num_align);
@@ -373,6 +374,7 @@ __mlu_func__ void nonMaximumSuppress(
       findClusterMaxBox((T *)sram_buffer, max_box, inter_x1, input_scores_ptr);
       calMaxArea(max_box, pixel_offset, &max_area);
       global_max_index = ((int *)(max_box + 5))[0];
+      input_scores_ptr[global_max_index] = FLOAT_MIN_GPV2;
     }
     /******by now, we get: max_score|max_index|max_box|max_area******/
     storeResult(max_box, nram_save, output_boxes_ptr, output_scores_ptr, nms_id,

--- a/kernels/generate_proposals_v2/generate_proposals_v2_union1_500.mlu
+++ b/kernels/generate_proposals_v2/generate_proposals_v2_union1_500.mlu
@@ -54,8 +54,7 @@ __mlu_func__ void filterBoxes(T *proposals_score_nram, T *proposals_box_nram,
     // w = w + offset, h = h + offset
     __bang_add_scalar(wh, wh, offset, deal_num * 2);
   }
-  // cx = box[0] + 0.5 * w, cy = box[1] + 0.5 * h
-  __bang_fusion(FUSION_FMA, cx, wh, (T)0.5, xymin, 2 * deal_num, 2 * deal_num);
+
   float real_min_size = min_size > 1.0 ? min_size : 1.0;
   // mask_tmp1 = w >= min_size ? 1 : 0;
   __bang_ge_scalar(mask_tmp1, wh, real_min_size, deal_num * 2);
@@ -63,6 +62,9 @@ __mlu_func__ void filterBoxes(T *proposals_score_nram, T *proposals_box_nram,
   __bang_and(mask_tmp2, mask_tmp1, mask_tmp2, deal_num);
 
   if (pixel_offset) {
+    // cx = box[0] + 0.5 * w, cy = box[1] + 0.5 * h
+    __bang_fusion(FUSION_FMA, cx, wh, (T)0.5, xymin, 2 * deal_num,
+                  2 * deal_num);
     T im_h = im_shape[0];
     T im_w = im_shape[1];
     // mask_tmp1 = cx <= im_w ? 1 : 0;  mask_tmp2 = cy <= im_h ? 1 : 0;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.cpp
@@ -120,14 +120,14 @@ void GenerateProposalsV2Executor::compute() {
   auto rpn_rois_batch_size_ptr = parser_->getMetaTensor("output4").dev_ptr;
 
   VLOG(4) << "[mluOpGenerateProposalsV2] call "
-             "mluOpGetGenerateProposalsV2WorkspaceSize()";
+             "mluOpGetGenerateProposalsV2WorkspaceSize_v2()";
   size_t workspace_size = 0;
   MLUOP_CHECK(mluOpGetGenerateProposalsV2WorkspaceSize_v2(
       handle_, tensor_scores, pre_nms_top_n, &workspace_size));
   interface_timer_.start();
 
   VLOG(4) << "[mluOpGenerateProposalsV2] call "
-             "mluOpGetGenerateProposalsV2WorkspaceSize()";
+             "mluOpGetGenerateProposalsV2WorkspaceSize_v2()";
 
   MLUOP_CHECK(mluOpGenerateProposalsV2(
       handle_, pre_nms_top_n, post_nms_top_n, nms_thresh, min_size, eta,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

support vars/box_deltas/im_shape/anchors tensor nan/inf except score tensor.

## 2. Modification

modified:   kernels/generate_proposals_v2/generate_proposals_v2.cpp
modified:   kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
modified:   kernels/generate_proposals_v2/generate_proposals_v2_union1_500.mlu
modified:   test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.cpp
