### PR TITLE
[Fix](mluOpExecFFT): fix bug

### DIFF
--- a/kernels/fft/c2c_fft/c2c_fft_host.cpp
+++ b/kernels/fft/c2c_fft/c2c_fft_host.cpp
@@ -157,7 +157,8 @@ mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       fft_plan->workspace_size += transed_input_size;
       // input trans workspace: batch * n * 2 --> 2 * batch * n
       const int in_trans_dim_num = 2;
-      int in_trans_input_dims[in_trans_dim_num] = {padded_input_num, COMPLEX};
+      int64_t in_trans_input_dims[in_trans_dim_num] = {padded_input_num,
+                                                       COMPLEX};
       int in_trans_permute[in_trans_dim_num] = {1, 0};
       size_t in_trans_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(
@@ -205,8 +206,8 @@ mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
 
       // output trans workspace: 2 * batch * n --> batch * n * 2
       const int out_trans_dim_num = 2;
-      int out_trans_input_dims[out_trans_dim_num] = {COMPLEX,
-                                                     per_matmul_output_num};
+      int64_t out_trans_input_dims[out_trans_dim_num] = {COMPLEX,
+                                                         per_matmul_output_num};
       int out_trans_permute[out_trans_dim_num] = {1, 0};
       size_t out_trans_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(
@@ -332,8 +333,8 @@ mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       // input trans workspace
       // 1st transpose: batch * n * 2 --> 2 * batch * n
       const int in_trans_1st_dim_num = 2;
-      int in_trans_1st_input_dims[in_trans_1st_dim_num] = {padded_input_num,
-                                                           COMPLEX};
+      int64_t in_trans_1st_input_dims[in_trans_1st_dim_num] = {padded_input_num,
+                                                               COMPLEX};
       int in_trans_1st_permute[in_trans_1st_dim_num] = {1, 0};
       size_t in_trans_1st_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(
@@ -344,8 +345,8 @@ mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
                    in_trans_1st_workspace_size);
       // 2nd transpose: 2 * batch * L * 2^m --> 2 * batch * 2^m * L
       const int in_trans_2nd_dim_num = 3;
-      int in_trans_2nd_input_dims[in_trans_2nd_dim_num] = {COMPLEX * batch, L,
-                                                           m};
+      int64_t in_trans_2nd_input_dims[in_trans_2nd_dim_num] = {COMPLEX * batch,
+                                                               L, m};
       int in_trans_2nd_permute[in_trans_2nd_dim_num] = {0, 2, 1};
       size_t in_trans_2nd_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(
@@ -375,12 +376,28 @@ mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       fft_plan->workspace_size += matmul_times * per_matmul_output_size;
       // matmul workspace
       size_t matmul_workspace_size = 0;
-      status = fftGetQuantizeMatMulWorkspaceSize(
-          handle, matmul_workspace_size, batch * m, L, L, false, true,
-          in_e_dtype, in_e_dtype, in_r_dtype, api);
-      fft_plan->matmul_addrs.internal_workspace_size =
-          std::max(fft_plan->matmul_addrs.internal_workspace_size,
-                   matmul_workspace_size);
+      if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
+        status = fftGetQuantizeMatMulWorkspaceSize(
+            handle, matmul_workspace_size, batch * m, L, L, false, true,
+            in_e_dtype, in_e_dtype, in_r_dtype, api);
+        fft_plan->matmul_addrs.internal_workspace_size =
+            std::max(fft_plan->matmul_addrs.internal_workspace_size,
+                     matmul_workspace_size);
+      } else {
+        status = fftGetBatchMatMulBcastWorkspaceSize(
+            handle, 2 * L, L, m * 2, batch,
+            fft_plan->matmul_addrs.dft_im_matrix_addr,
+            fft_plan->matmul_addrs.dft_pos_addr,
+            fft_plan->matmul_addrs.dft_scale_addr,
+            fft_plan->matmul_addrs.input_pad_addr,
+            fft_plan->matmul_addrs.input_pos_addr,
+            fft_plan->matmul_addrs.input_scale_addr,
+            fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, false, 1.0,
+            0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+            fft_plan->matmul_addrs.internal_workspace_addr,
+            fft_plan->matmul_addrs.internal_workspace_size, api);
+      }
+
       // optensor workspace
       size_t optensor_workspace_size = 0;
       status =
@@ -1396,8 +1413,8 @@ static mluOpStatus_t transposeFFT1dPaddedInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpTranspose for input CNFFT_FUNC_MATMUL";
     int padded_input_num = batch * n;
     const int trans_dim_num = 2;
-    int trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
-    int trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
+    int64_t trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
+    int64_t trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
     int trans_permute[trans_dim_num] = {1, 0};
 
     status =
@@ -1415,8 +1432,8 @@ static mluOpStatus_t transposeFFT1dPaddedInput(mluOpHandle_t handle,
     // 1st transpose: batch * n * 2 --> 2 * batch * n
     int padded_input_num = batch * n;
     const int trans_dim_num = 2;
-    int trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
-    int trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
+    int64_t trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
+    int64_t trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
     int trans_permute[trans_dim_num] = {1, 0};
 
     status =
@@ -1428,8 +1445,8 @@ static mluOpStatus_t transposeFFT1dPaddedInput(mluOpHandle_t handle,
 
     // 2nd transpose: 2 * batch * L * 2^m --> 2 * batch * 2^m * L
     const int trans_2nd_dim_num = 3;
-    int trans_2nd_input_dims[trans_2nd_dim_num] = {COMPLEX * batch, L, m};
-    int trans_2nd_output_dims[trans_2nd_dim_num] = {COMPLEX * batch, m, L};
+    int64_t trans_2nd_input_dims[trans_2nd_dim_num] = {COMPLEX * batch, L, m};
+    int64_t trans_2nd_output_dims[trans_2nd_dim_num] = {COMPLEX * batch, m, L};
     int trans_2nd_permute[trans_2nd_dim_num] = {0, 2, 1};
 
     status = fftTranspose(handle, trans_2nd_dim_num, trans_2nd_input_dims,
@@ -1739,8 +1756,8 @@ static mluOpStatus_t transposeFFT1dOutput(mluOpHandle_t handle,
 
     int output_num = batch * n;
     const int trans_dim_num = 2;
-    int trans_input_dims[trans_dim_num] = {COMPLEX, output_num};
-    int trans_output_dims[trans_dim_num] = {output_num, COMPLEX};
+    int64_t trans_input_dims[trans_dim_num] = {COMPLEX, output_num};
+    int64_t trans_output_dims[trans_dim_num] = {output_num, COMPLEX};
     int trans_permute[trans_dim_num] = {1, 0};
 
     status = fftTranspose(

--- a/kernels/fft/common/fft_basic_ops.h
+++ b/kernels/fft/common/fft_basic_ops.h
@@ -65,6 +65,14 @@ mluOpStatus_t fftQuantMatMul(mluOpHandle_t handle, int m, int k, int n,
                              mluOpDataType_t data_type, void *workspace,
                              size_t workspace_size, const std::string api);
 
+mluOpStatus_t fftGetBatchMatMulBcastWorkspaceSize(
+    mluOpHandle_t handle, int m, int k, int n, int batch, void *a_ptr,
+    void *a_pos, void *a_scale, void *b_ptr, void *b_pos, void *b_scale,
+    void *c_ptr, bool is_trans_a, bool is_trans_b, float alpha, float beta,
+    mluOpDataType_t a_compute_type, mluOpDataType_t b_compute_type,
+    mluOpDataType_t data_type, void *workspace, size_t workspace_size,
+    const std::string api);
+
 mluOpStatus_t fftBatchMatMulBcast(mluOpHandle_t handle, int m, int k, int n,
                                   int batch, void *a_ptr, void *a_pos,
                                   void *a_scale, void *b_ptr, void *b_pos,
@@ -77,15 +85,15 @@ mluOpStatus_t fftBatchMatMulBcast(mluOpHandle_t handle, int m, int k, int n,
 
 mluOpStatus_t fftGetTransposeWorkspaceSize(mluOpHandle_t handle,
                                            size_t &workspace_size, int dim_num,
-                                           int ori_dims[], int permute[],
+                                           int64_t ori_dims[], int permute[],
                                            mluOpDataType_t data_type,
                                            const std::string api);
 
-mluOpStatus_t fftTranspose(mluOpHandle_t handle, int dim_num, int ori_dims[],
-                           int transed_dims[], int permute[], void *ori_ptr,
-                           void *transed_ptr, mluOpDataType_t data_type,
-                           void *workspace, size_t workspace_size,
-                           const std::string api);
+mluOpStatus_t fftTranspose(mluOpHandle_t handle, int dim_num,
+                           int64_t ori_dims[], int64_t transed_dims[],
+                           int permute[], void *ori_ptr, void *transed_ptr,
+                           mluOpDataType_t data_type, void *workspace,
+                           size_t workspace_size, const std::string api);
 
 mluOpStatus_t fftGetOptensorWorkspaceSize(mluOpHandle_t handle,
                                           size_t &workspace_size, int elem_num,

--- a/kernels/fft/irfft/irfft_host.cpp
+++ b/kernels/fft/irfft/irfft_host.cpp
@@ -155,7 +155,7 @@ mluOpStatus_t makeIRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       // input trans workspace: batch * (n / 2 + 1) * 2 --> 2 * batch * (n / 2 +
       // 1)
       const int trans_dim_num = 2;
-      int trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
+      int64_t trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
       int trans_permute[trans_dim_num] = {1, 0};
       size_t trans_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(handle, trans_workspace_size,
@@ -332,7 +332,8 @@ mluOpStatus_t makeIRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       // transpose workspace: batch * (n / 2 + 1) * 2 --> 2 * batch * (n / 2 +
       // 1) concat workspace: concat do not need workspace now
       const int trans_1st_dim_num = 2;
-      int trans_1st_input_dims[trans_1st_dim_num] = {padded_input_num, COMPLEX};
+      int64_t trans_1st_input_dims[trans_1st_dim_num] = {padded_input_num,
+                                                         COMPLEX};
       int trans_1st_permute[trans_1st_dim_num] = {1, 0};
       size_t trans_1st_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(
@@ -348,7 +349,7 @@ mluOpStatus_t makeIRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       fft_plan->workspace_size += transed_input_size;
       // input trans workspace:  2 * batch * L * 2^m --> 2 * batch * 2^m * L
       const int trans_2nd_dim_num = 3;
-      int trans_2nd_input_dims[trans_2nd_dim_num] = {COMPLEX * batch, L, m};
+      int64_t trans_2nd_input_dims[trans_2nd_dim_num] = {COMPLEX * batch, L, m};
       int trans_2nd_permute[trans_2nd_dim_num] = {0, 2, 1};
       size_t trans_2nd_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(
@@ -379,12 +380,27 @@ mluOpStatus_t makeIRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       fft_plan->workspace_size += matmul_output_size;
       // matmul workspace
       size_t matmul_workspace_size = 0;
-      status = fftGetQuantizeMatMulWorkspaceSize(
-          handle, matmul_workspace_size, batch * m, L, L, false, true,
-          in_e_dtype, in_e_dtype, in_r_dtype, api);
-      fft_plan->matmul_addrs.internal_workspace_size =
-          std::max(fft_plan->matmul_addrs.internal_workspace_size,
-                   matmul_workspace_size);
+      if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
+        status = fftGetQuantizeMatMulWorkspaceSize(
+            handle, matmul_workspace_size, batch * m, L, L, false, true,
+            in_e_dtype, in_e_dtype, in_r_dtype, api);
+        fft_plan->matmul_addrs.internal_workspace_size =
+            std::max(fft_plan->matmul_addrs.internal_workspace_size,
+                     matmul_workspace_size);
+      } else {
+        status = fftGetBatchMatMulBcastWorkspaceSize(
+            handle, 2 * L, L, m, batch * 2,
+            fft_plan->matmul_addrs.dft_re_matrix_addr,
+            fft_plan->matmul_addrs.dft_pos_addr,
+            fft_plan->matmul_addrs.dft_scale_addr,
+            fft_plan->matmul_addrs.input_merged_addr,
+            fft_plan->matmul_addrs.input_pos_addr,
+            fft_plan->matmul_addrs.input_scale_addr,
+            fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, false, 1.0,
+            0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+            fft_plan->matmul_addrs.internal_workspace_addr,
+            fft_plan->matmul_addrs.internal_workspace_size, api);
+      }
       // optensor workspace
       size_t optensor_workspace_size = 0;
       status =
@@ -989,8 +1005,8 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpTranspose for input";
     int padded_input_num = batch * FFT_HALF(n);
     const int trans_dim_num = 2;
-    int trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
-    int trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
+    int64_t trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
+    int64_t trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
     int trans_permute[trans_dim_num] = {1, 0};
 
     status =
@@ -1022,9 +1038,9 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
 
     int dim1_begin = (n % 2) ? -1 : -2;
     int dim1_end = -FFT_HALF(n);
-    int begin[ss_dim_num] = {0, dim1_begin};
-    int end[ss_dim_num] = {COMPLEX * batch, dim1_end};
-    int stride[ss_dim_num] = {1, -1};
+    int64_t begin[ss_dim_num] = {0, dim1_begin};
+    int64_t end[ss_dim_num] = {COMPLEX * batch, dim1_end};
+    int64_t stride[ss_dim_num] = {1, -1};
 
     void *ss_input_addr = fft_plan->matmul_addrs.input_transed_addr;
     void *ss_output_addr = fft_plan->matmul_addrs.input_reversed_addr;
@@ -1037,9 +1053,9 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
                                                  cnnl_ss_input_desc);
     DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(ss_output_desc,
                                                  cnnl_ss_output_desc);
-    CALL_CNNL(cnnlStridedSlice(cnnl_handle, cnnl_ss_input_desc, ss_input_addr,
-                               begin, end, stride, cnnl_ss_output_desc,
-                               ss_output_addr));
+    CALL_CNNL(cnnlStridedSlice_v2(cnnl_handle, cnnl_ss_input_desc,
+                                  ss_input_addr, begin, end, stride,
+                                  cnnl_ss_output_desc, ss_output_addr));
 
     // reversed input imag part mul -1
     int reversed_input_num = batch * (n - FFT_HALF(n));
@@ -1139,8 +1155,8 @@ static mluOpStatus_t transposeIRFFT1dPaddedInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpTranspose for input MATMUL";
     int padded_input_num = batch * FFT_HALF(n);
     const int trans_dim_num = 2;
-    int trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
-    int trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
+    int64_t trans_input_dims[trans_dim_num] = {padded_input_num, COMPLEX};
+    int64_t trans_output_dims[trans_dim_num] = {COMPLEX, padded_input_num};
     int trans_permute[trans_dim_num] = {1, 0};
 
     status =
@@ -1157,8 +1173,8 @@ static mluOpStatus_t transposeIRFFT1dPaddedInput(mluOpHandle_t handle,
 
     // 2nd transpose: 2 * batch * L * 2^m --> 2 * batch * 2^m * L
     const int trans_dim_num = 3;
-    int trans_input_dims[trans_dim_num] = {COMPLEX * batch, L, m};
-    int trans_output_dims[trans_dim_num] = {COMPLEX * batch, m, L};
+    int64_t trans_input_dims[trans_dim_num] = {COMPLEX * batch, L, m};
+    int64_t trans_output_dims[trans_dim_num] = {COMPLEX * batch, m, L};
     int trans_permute[trans_dim_num] = {0, 2, 1};
 
     status =

--- a/kernels/fft/rfft/rfft_host.cpp
+++ b/kernels/fft/rfft/rfft_host.cpp
@@ -254,7 +254,7 @@ mluOpStatus_t makeRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       fft_plan->workspace_size += transed_input_size;
       // input trans workspace: batch * L * 2^m --> batch * 2^m * L
       const int trans_dim_num = 3;
-      int trans_input_dims[trans_dim_num] = {batch, L, m};
+      int64_t trans_input_dims[trans_dim_num] = {batch, L, m};
       int trans_permute[trans_dim_num] = {0, 2, 1};
       size_t trans_workspace_size = 0;
       status = fftGetTransposeWorkspaceSize(handle, trans_workspace_size,
@@ -283,12 +283,29 @@ mluOpStatus_t makeRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
       fft_plan->workspace_size += matmul_output_size;
       // matmul workspace
       size_t matmul_workspace_size = 0;
-      status = fftGetQuantizeMatMulWorkspaceSize(
-          handle, matmul_workspace_size, batch * m, L, L, false, true,
-          in_e_dtype, in_e_dtype, in_r_dtype, api);
-      fft_plan->matmul_addrs.internal_workspace_size =
-          std::max(fft_plan->matmul_addrs.internal_workspace_size,
-                   matmul_workspace_size);
+      if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
+        status = fftGetQuantizeMatMulWorkspaceSize(
+            handle, matmul_workspace_size, batch * m, L, L, false, true,
+            in_e_dtype, in_e_dtype, in_r_dtype, api);
+        fft_plan->matmul_addrs.internal_workspace_size =
+            std::max(fft_plan->matmul_addrs.internal_workspace_size,
+                     matmul_workspace_size);
+      } else {
+        status = fftGetBatchMatMulBcastWorkspaceSize(
+            handle,
+            L <= fft_plan->L_sub ? (2 * L)
+                                 : (2 * (PAD_UP(L / 2, fft_plan->L_sub) + 1)),
+            L, m, batch, fft_plan->matmul_addrs.dft_re_matrix_addr,
+            fft_plan->matmul_addrs.dft_pos_addr,
+            fft_plan->matmul_addrs.dft_scale_addr,
+            fft_plan->matmul_addrs.input_pad_addr,
+            fft_plan->matmul_addrs.input_pos_addr,
+            fft_plan->matmul_addrs.input_scale_addr,
+            fft_plan->matmul_addrs.matmul_re_mul_re_addr, false, false, 1.0,
+            0.0, in_e_dtype, in_e_dtype, in_r_dtype,
+            fft_plan->matmul_addrs.internal_workspace_addr,
+            fft_plan->matmul_addrs.internal_workspace_size, api);
+      }
 
       // output merge workspace
       size_t merge_workspace_size = matmul_output_size;
@@ -863,8 +880,8 @@ static mluOpStatus_t transposeRFFT1dPaddedInput(mluOpHandle_t handle,
     int m = (1 << fft_plan->m);
 
     const int trans_dim_num = 3;
-    int trans_input_dims[trans_dim_num] = {batch, L, m};
-    int trans_output_dims[trans_dim_num] = {batch, m, L};
+    int64_t trans_input_dims[trans_dim_num] = {batch, L, m};
+    int64_t trans_output_dims[trans_dim_num] = {batch, m, L};
     int trans_permute[trans_dim_num] = {0, 2, 1};
 
     status =

--- a/kernels/utils/cnnl_helper.h
+++ b/kernels/utils/cnnl_helper.h
@@ -60,6 +60,9 @@ void mluOpCnnlCheck(mluOpStatus_t result, char const *const func,
 cnnlStatus_t mluOpConvertDescriptor(mluOpTensorDescriptor_t desc,
                                     cnnlTensorDescriptor_t _desc);
 
+cnnlStatus_t mluOpConvertDescriptor_v2(mluOpTensorDescriptor_t desc,
+                                       cnnlTensorDescriptor_t _desc);
+
 cnnlStatus_t mluOpConvertHandle(mluOpHandle_t handle, cnnlHandle_t _handle);
 
 // Pointer type force convert
@@ -77,6 +80,27 @@ DTYPE mluOpPointerForceConvert(STYPE ptr);
         return MLUOP_STATUS_INTERNAL_ERROR;                                  \
       }                                                                      \
       ret = mluOpConvertDescriptor(desc, _desc);                             \
+      if (ret != CNNL_STATUS_SUCCESS) {                                      \
+        LOG(ERROR)                                                           \
+            << "CNNL_HELPER: Internal convert tensor descriptor failed.";    \
+        return MLUOP_STATUS_INTERNAL_ERROR;                                  \
+      }                                                                      \
+    } else {                                                                 \
+      _desc = NULL;                                                          \
+    }                                                                        \
+  }
+
+// TensorDescriptor
+#define DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR_v2(desc, _desc)         \
+  cnnlTensorDescriptor_t _desc;                                              \
+  {                                                                          \
+    if (desc != NULL) {                                                      \
+      cnnlStatus_t ret = cnnlCreateTensorDescriptor(&_desc);                 \
+      if (ret != CNNL_STATUS_SUCCESS) {                                      \
+        LOG(ERROR) << "CNNL_HELPER: CNNL creates tensor descriptor failed."; \
+        return MLUOP_STATUS_INTERNAL_ERROR;                                  \
+      }                                                                      \
+      ret = mluOpConvertDescriptor_v2(desc, _desc);                          \
       if (ret != CNNL_STATUS_SUCCESS) {                                      \
         LOG(ERROR)                                                           \
             << "CNNL_HELPER: Internal convert tensor descriptor failed.";    \

--- a/test/mlu_op_gtest/api_gtest/include/api_test_tools.h
+++ b/test/mlu_op_gtest/api_gtest/include/api_test_tools.h
@@ -59,7 +59,39 @@ class MLUOpTensorParam {
   mluOpDataType_t dtype_;
   int dim_nb_;
   std::vector<int> dim_size_;
+  std::vector<int64_t> dim_size_int64_;
   std::vector<int> dim_stride_;
+  std::vector<int64_t> dim_stride_int64_;
+  mluOpDataType_t onchip_dtype_;
+};
+
+class MLUOpTensorParamInt64 {
+ public:
+  MLUOpTensorParamInt64(mluOpTensorLayout_t layout, mluOpDataType_t dtype,
+                        int64_t dim_nb, std::vector<int64_t> dim_size,
+                        std::vector<int64_t> dim_stride = {},
+                        mluOpDataType_t onchip_dtype = MLUOP_DTYPE_INVALID) {
+    layout_ = layout;
+    dtype_ = dtype;
+    dim_nb_ = dim_nb;
+    dim_size_ = dim_size;
+    dim_stride_ = dim_stride;
+    onchip_dtype_ = onchip_dtype;
+  }
+
+  mluOpTensorLayout_t get_layout() { return layout_; }
+  mluOpDataType_t get_dtype() { return dtype_; }
+  int64_t get_dim_nb() { return dim_nb_; }
+  std::vector<int64_t> get_dim_size() { return dim_size_; }
+  std::vector<int64_t> get_dim_stride() { return dim_stride_; }
+  mluOpDataType_t get_onchip_dtype() { return onchip_dtype_; }
+
+ private:
+  mluOpTensorLayout_t layout_;
+  mluOpDataType_t dtype_;
+  int64_t dim_nb_;
+  std::vector<int64_t> dim_size_;
+  std::vector<int64_t> dim_stride_;
   mluOpDataType_t onchip_dtype_;
 };
 }  // namespace mluopapitest

--- a/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_ExecFFT.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_ExecFFT.cpp
@@ -68,20 +68,21 @@ class fft_ExecFFT : public testing::Test {
     const int batch = 2000;
     const int n[rank] = {400};
     const int ndim = rank + 1;
-    const int input_dim_size[ndim] = {batch, n[0] / 2 + 1};
-    const int input_dim_stride[ndim] = {n[0] / 2 + 1, 1};
+    const int64_t input_dim_size[ndim] = {batch, n[0] / 2 + 1};
+    const int64_t input_dim_stride[ndim] = {n[0] / 2 + 1, 1};
 
-    const int output_dim_size[ndim] = {batch, n[0] / 2 + 1};
-    const int output_dim_stride[ndim] = {n[0] / 2 + 1, 1};
+    const int64_t output_dim_size[ndim] = {batch, n[0] / 2 + 1};
+    const int64_t output_dim_stride[ndim] = {n[0] / 2 + 1, 1};
 
     mluOpCreateTensorDescriptor(&input_desc_);
     mluOpCreateTensorDescriptor(&output_desc_);
-    mluOpSetTensorDescriptorEx(input_desc_, MLUOP_LAYOUT_ARRAY, input_data_type,
-                               ndim, input_dim_size, input_dim_stride);
+    mluOpSetTensorDescriptorEx_v2(input_desc_, MLUOP_LAYOUT_ARRAY,
+                                  input_data_type, ndim, input_dim_size,
+                                  input_dim_stride);
     mluOpSetTensorDescriptorOnchipDataType(input_desc_, execution_dtype);
-    mluOpSetTensorDescriptorEx(output_desc_, MLUOP_LAYOUT_ARRAY,
-                               output_data_type, ndim, output_dim_size,
-                               output_dim_stride);
+    mluOpSetTensorDescriptorEx_v2(output_desc_, MLUOP_LAYOUT_ARRAY,
+                                  output_data_type, ndim, output_dim_size,
+                                  output_dim_stride);
     size_t reservespaceSizeInBytes_ = 64;
     size_t workspaceSizeInBytes_ = 64;
     size_t *reservespace_size = &reservespaceSizeInBytes_;

--- a/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_MakeFFTPlanMany.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_MakeFFTPlanMany.cpp
@@ -46,9 +46,9 @@ class fft_MakeFFTPlanMany : public testing::Test {
 
     if (input_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_desc_));
-      std::vector<int> input_dims{1, 400};
-      const int input_dim_stride[2] = {400, 1};
-      MLUOP_CHECK(mluOpSetTensorDescriptorEx(
+      std::vector<int64_t> input_dims{1, 400};
+      const int64_t input_dim_stride[2] = {400, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptorEx_v2(
           input_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, input_dims.size(),
           input_dims.data(), input_dim_stride));
       MLUOP_CHECK(mluOpSetTensorDescriptorOnchipDataType(input_desc_,
@@ -57,9 +57,9 @@ class fft_MakeFFTPlanMany : public testing::Test {
 
     if (output_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
-      std::vector<int> output_dims{1, 201};
-      const int output_dim_stride[2] = {201, 1};
-      MLUOP_CHECK(mluOpSetTensorDescriptorEx(
+      std::vector<int64_t> output_dims{1, 201};
+      const int64_t output_dim_stride[2] = {201, 1};
+      MLUOP_CHECK(mluOpSetTensorDescriptorEx_v2(
           output_desc_, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_COMPLEX_FLOAT,
           output_dims.size(), output_dims.data(), output_dim_stride));
     }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_general.cpp
@@ -32,8 +32,8 @@
 #include "api_test_tools.h"
 
 namespace mluopapitest {
-typedef std::tuple<MLUOpTensorParam, MLUOpTensorParam, int, int, mluOpDevType_t,
-                   mluOpStatus_t>
+typedef std::tuple<MLUOpTensorParamInt64, MLUOpTensorParamInt64, int64_t,
+                   int64_t, mluOpDevType_t, mluOpStatus_t>
     FFTParams;
 
 class fft_general : public testing::TestWithParam<FFTParams> {
@@ -44,9 +44,9 @@ class fft_general : public testing::TestWithParam<FFTParams> {
     MLUOP_CHECK(mluOpCreate(&handle_));
     MLUOP_CHECK(mluOpCreateFFTPlan(&fft_plan_));
 
-    MLUOpTensorParam input_params = std::get<0>(GetParam());
+    MLUOpTensorParamInt64 input_params = std::get<0>(GetParam());
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_desc_));
-    MLUOP_CHECK(mluOpSetTensorDescriptorEx(
+    MLUOP_CHECK(mluOpSetTensorDescriptorEx_v2(
         input_desc_, input_params.get_layout(), input_params.get_dtype(),
         input_params.get_dim_nb(), input_params.get_dim_size().data(),
         input_params.get_dim_stride().data()));
@@ -54,10 +54,10 @@ class fft_general : public testing::TestWithParam<FFTParams> {
     MLUOP_CHECK(mluOpSetTensorDescriptorOnchipDataType(
         input_desc_, input_params.get_onchip_dtype()));
 
-    MLUOpTensorParam output_params = std::get<1>(GetParam());
+    MLUOpTensorParamInt64 output_params = std::get<1>(GetParam());
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
 
-    MLUOP_CHECK(mluOpSetTensorDescriptorEx(
+    MLUOP_CHECK(mluOpSetTensorDescriptorEx_v2(
         output_desc_, output_params.get_layout(), output_params.get_dtype(),
         output_params.get_dim_nb(), output_params.get_dim_size().data(),
         output_params.get_dim_stride().data()));
@@ -138,13 +138,14 @@ TEST_P(fft_general, negative) { EXPECT_TRUE(compute()); }
 
 INSTANTIATE_TEST_CASE_P(
     zero_element, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({0, 1}), std::vector<int>({1, 1}),
-                         MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                         std::vector<int64_t>({0, 1}),
+                         std::vector<int64_t>({1, 1}), MLUOP_DTYPE_FLOAT}),
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1, 1}), std::vector<int>({1, 1})}),
+                         std::vector<int64_t>({1, 1}),
+                         std::vector<int64_t>({1, 1})}),
                      testing::Values(1), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_SUCCESS)));
@@ -152,13 +153,14 @@ INSTANTIATE_TEST_CASE_P(
 INSTANTIATE_TEST_CASE_P(
     negative_2_n,  // half,complex_half，fft length can be broken down into 2^m
     fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_HALF, 2,
-                         std::vector<int>({1, 7}), std::vector<int>({1, 1}),
-                         MLUOP_DTYPE_HALF}),
-                     testing::Values(MLUOpTensorParam{
+                         std::vector<int64_t>({1, 7}),
+                         std::vector<int64_t>({1, 1}), MLUOP_DTYPE_HALF}),
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_HALF, 2,
-                         std::vector<int>({1, 7}), std::vector<int>({1, 1})}),
+                         std::vector<int64_t>({1, 7}),
+                         std::vector<int64_t>({1, 1})}),
                      testing::Values(1), testing::Values(7),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
@@ -167,105 +169,107 @@ INSTANTIATE_TEST_CASE_P(
     negative_2_m_l,  // float/complex_float，n>4096, fft length can be broken
                      // down into 2^m*l
     fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 2,
-                         std::vector<int>({1, 4097}), std::vector<int>({1, 1}),
-                         MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                         std::vector<int64_t>({1, 4097}),
+                         std::vector<int64_t>({1, 1}), MLUOP_DTYPE_FLOAT}),
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 2,
-                         std::vector<int>({1, 4097}),
-                         std::vector<int>({1, 1})}),
+                         std::vector<int64_t>({1, 4097}),
+                         std::vector<int64_t>({1, 1})}),
                      testing::Values(1), testing::Values(4097),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
     negative_rank_1, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1})}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1})}),
                      testing::Values(4), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     negative_N_le_0, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1})}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1})}),
                      testing::Values(1), testing::Values(0, -1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     negative_batch, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 2,
-                         std::vector<int>({1, 1}), std::vector<int>({1, 1}),
-                         MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                         std::vector<int64_t>({1, 1}),
+                         std::vector<int64_t>({1, 1}), MLUOP_DTYPE_FLOAT}),
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 2,
-                         std::vector<int>({2, 1}), std::vector<int>({1, 1})}),
+                         std::vector<int64_t>({2, 1}),
+                         std::vector<int64_t>({1, 1})}),
                      testing::Values(1), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     negative_input_stride, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({-1}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({-1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1})}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1})}),
                      testing::Values(1), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     negative_output_stride, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({-1})}),
+                         std::vector<int64_t>({1}),
+                         std::vector<int64_t>({-1})}),
                      testing::Values(1), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     negative_unsupported_dtype_combination, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_HALF, 1,
-                         std::vector<int>({1}), std::vector<int>({1}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1})}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1})}),
                      testing::Values(1), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
 
 INSTANTIATE_TEST_CASE_P(
     negative_onchip_dtype, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_HALF}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1})}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1})}),
                      testing::Values(1), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
@@ -273,13 +277,13 @@ INSTANTIATE_TEST_CASE_P(
 // r2c,output!=n/2+1
 INSTANTIATE_TEST_CASE_P(
     negative_r2c_length, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_FLOAT, 1,
-                         std::vector<int>({4}), std::vector<int>({1}),
+                         std::vector<int64_t>({4}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1})}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1})}),
                      testing::Values(1), testing::Values(4),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
@@ -287,13 +291,13 @@ INSTANTIATE_TEST_CASE_P(
 // c2c,output != n
 INSTANTIATE_TEST_CASE_P(
     negative_c2c_length, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({1}), std::vector<int>({1}),
+                         std::vector<int64_t>({1}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({0}), std::vector<int>({1})}),
+                         std::vector<int64_t>({0}), std::vector<int64_t>({1})}),
                      testing::Values(1), testing::Values(1),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));
@@ -301,13 +305,13 @@ INSTANTIATE_TEST_CASE_P(
 // c2r,output!=n
 INSTANTIATE_TEST_CASE_P(
     negative_c2r_length, fft_general,
-    testing::Combine(testing::Values(MLUOpTensorParam{
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 1,
-                         std::vector<int>({4}), std::vector<int>({1}),
+                         std::vector<int64_t>({4}), std::vector<int64_t>({1}),
                          MLUOP_DTYPE_FLOAT}),
-                     testing::Values(MLUOpTensorParam{
+                     testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_FLOAT, 1,
-                         std::vector<int>({3}), std::vector<int>({1})}),
+                         std::vector<int64_t>({3}), std::vector<int64_t>({1})}),
                      testing::Values(1), testing::Values(4),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_BAD_PARAM)));


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.