### PR TITLE
[Feature](mluops): Normalize assert

### DIFF
--- a/kernels/device_check.h
+++ b/kernels/device_check.h
@@ -1,0 +1,35 @@
+/*************************************************************************
+ * Copyright (C) [2024] by Cambricon, Inc.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#ifndef KERNELS_DEVICE_CHECK_H_
+#define KERNELS_DEVICE_CHECK_H_
+
+#ifdef NDEBUG
+#ifdef __BANG__
+#include "bang.h"
+__mlu_device__ __mlu_builtin__ __attribute__((noinline)) void __assert_fail(
+    const char *__message, const char *__file, unsigned int __line,
+    const char *__function);
+#endif
+#endif
+
+// The variable names on the device side are usually different from the input
+// parameters in the API function, so the logging information needs to be
+// written as needed. The detailed information of the "__assert_fail"
+// instruction can be found in
+// "llvm-project/-/blob/master/docs_bang/design_docs/assert/BANGAssert.md"
+#define MLU_KERNEL_ASSERT(cond, message)                                  \
+  if (!(cond)) {                                                          \
+    __assert_fail(message, __FILE__, static_cast<unsigned int>(__LINE__), \
+                  __func__);                                              \
+  }
+
+#endif  // KERNELS_DEVICE_CHECK_H_

--- a/kernels/kernel.h
+++ b/kernels/kernel.h
@@ -143,10 +143,4 @@
 #define NEG_MAX_INT2FLOAT_EXACT (-powf(2, 23))
 #endif
 
-#define MLU_KERNEL_ASSERT(cond, message)                                  \
-  if (!(cond)) {                                                          \
-    __assert_fail(message, __FILE__, static_cast<unsigned int>(__LINE__), \
-                  __func__);                                              \
-  }
-
 #endif  // KERNELS_KERNEL_H_

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/adam_w/adam_w.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/adam_w/adam_w.cpp
@@ -91,8 +91,8 @@ void AdamWExecutor::setMiscellaneousParam() {
 }
 
 void AdamWExecutor::cpuCompute() {
-  assert(parser_->getInputNum() == 5);
-  assert(parser_->getOutputNum() == 4);
+  GTEST_CHECK(parser_->getInputNum() == 5);
+  GTEST_CHECK(parser_->getOutputNum() == 4);
   float lr = parser_->getProtoNode()->adamw_param().lr();
   float beta1 = parser_->getProtoNode()->adamw_param().beta1();
   float beta2 = parser_->getProtoNode()->adamw_param().beta2();
@@ -110,10 +110,10 @@ void AdamWExecutor::cpuCompute() {
   auto count4 = parser_->getInputDataCount(3);
   auto count5 = parser_->getInputDataCount(4);
 
-  assert(count1 == count2);
-  assert(count1 == count3);
-  assert(count1 == count4);
-  assert(count1 == count5);
+  GTEST_CHECK(count1 == count2);
+  GTEST_CHECK(count1 == count3);
+  GTEST_CHECK(count1 == count4);
+  GTEST_CHECK(count1 == count5);
 
   auto cpu_tensor_param = cpu_fp32_input_[0];
   auto cpu_tensor_paramh = cpu_fp32_input_[1];

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/box_iou_rotated/box_iou_rotated.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/box_iou_rotated/box_iou_rotated.cpp
@@ -325,7 +325,7 @@ template <typename T>
 int BoxIouRotatedExecutor::convexHullGraham(const Point<T> (&p)[24],
                                             const int &num_in,
                                             Point<T> (&q)[24]) {
-  assert(num_in >= 2);
+  GTEST_CHECK(num_in >= 2);
   // Step1:
   // Find point with minimum y
   // if more than 1 points have the same minimum y,

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/carafe_forward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/carafe_forward/carafe_forward.cpp
@@ -65,8 +65,8 @@ void CarafeForwardExecutor::compute() {
 }
 
 void CarafeForwardExecutor::cpuCompute() {
-  assert(parser_->getInputNum() == 2);
-  assert(parser_->getOutputNum() == 1);
+  GTEST_CHECK(parser_->getInputNum() == 2);
+  GTEST_CHECK(parser_->getOutputNum() == 1);
 
   auto carafe_desc_node = parser_->getProtoNode()->carafe_param();
 
@@ -74,9 +74,9 @@ void CarafeForwardExecutor::cpuCompute() {
   int group_size = carafe_desc_node.group_size();
   int scale_factor = carafe_desc_node.scale_factor();
 
-  assert(kernel_size >= 1 && (kernel_size - 1) % 2 == 0);
-  assert(scale_factor >= 1);
-  assert(group_size >= 1);
+  GTEST_CHECK(kernel_size >= 1 && (kernel_size - 1) % 2 == 0);
+  GTEST_CHECK(scale_factor >= 1);
+  GTEST_CHECK(group_size >= 1);
 
   int half_kernel_size = (kernel_size - 1) / 2;
 
@@ -99,15 +99,15 @@ void CarafeForwardExecutor::cpuCompute() {
   int output_dimW = mluOpGetTensordimW(output_desc);
   int output_dimC = mluOpGetTensordimC(output_desc);
 
-  assert(input_dimN == mask_dimN);
-  assert(input_dimN == output_dimN);
-  assert(input_dimC == output_dimC);
-  assert(mask_dimC == kernel_size * kernel_size * group_size);
-  assert(mask_dimH == scale_factor * input_dimH);
-  assert(mask_dimW == scale_factor * input_dimW);
-  assert(mask_dimH == output_dimH);
-  assert(mask_dimW == output_dimW);
-  assert(input_dimC % group_size == 0);
+  GTEST_CHECK(input_dimN == mask_dimN);
+  GTEST_CHECK(input_dimN == output_dimN);
+  GTEST_CHECK(input_dimC == output_dimC);
+  GTEST_CHECK(mask_dimC == kernel_size * kernel_size * group_size);
+  GTEST_CHECK(mask_dimH == scale_factor * input_dimH);
+  GTEST_CHECK(mask_dimW == scale_factor * input_dimW);
+  GTEST_CHECK(mask_dimH == output_dimH);
+  GTEST_CHECK(mask_dimW == output_dimW);
+  GTEST_CHECK(input_dimC % group_size == 0);
 
   int channels_per_group = input_dimC / group_size;
 

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_weight/dcn_backward_weight.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_weight/dcn_backward_weight.cpp
@@ -346,6 +346,7 @@ void DcnBackwardWeightExecutor::transpose(float *input, float *output,
   if (dim_desc > 8 || dim_desc <= 0) {
     LOG(ERROR) << "dim_desc is " << dim_desc
                << ", it shoule less than 8 and greater than 0";
+    return;
   }
   { std::vector<int>().swap(permute_desc); }
   for (int i = 0; i < dim_num; i++) {

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_weight/dcn_backward_weight.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_backward_weight/dcn_backward_weight.cpp
@@ -378,7 +378,7 @@ static void BatchMatMul(const int &g, const int &m, const int &k, const int &n,
                         bool is_transa, bool is_transb) {
   const int batch_size = g;
 
-  assert(batch_size >= 1);
+  GTEST_CHECK(batch_size >= 1);
 #if USE_OPENBLAS
   const CBLAS_ORDER Order = CblasRowMajor;
   const CBLAS_TRANSPOSE TransA = is_transa ? CblasTrans : CblasNoTrans;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_forward/dcn_forward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_forward/dcn_forward.cpp
@@ -382,7 +382,7 @@ static void BatchMatMul(const int &g, const int &m, const int &k, const int &n,
                         const bool is_transa, const bool is_transb) {
   const int batch_size = g;
 
-  assert(batch_size >= 1);
+  GTEST_CHECK(batch_size >= 1);
 #if USE_OPENBLAS
   const CBLAS_ORDER Order = CblasRowMajor;
   const CBLAS_TRANSPOSE TransA = is_transa ? CblasTrans : CblasNoTrans;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_forward/dcn_forward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/dcn_forward/dcn_forward.cpp
@@ -351,6 +351,7 @@ void DcnForwardExecutor::transpose(float *input, float *output,
   if (dim_desc > 8 || dim_desc <= 0) {
     LOG(ERROR) << "dim_desc is " << dim_desc
                << ", it shoule less than 8 and greater than 0";
+    return;
   }
   { std::vector<int>().swap(permute_desc); }
   for (int i = 0; i < dim_num; i++) {

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/div/div.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/div/div.cpp
@@ -116,7 +116,7 @@ void DivExecutor::expand_compute_cpu(std::vector<int> shape_a,
   }
 
   bool can_broadcast = canBroadCast(shape_a, shape_b);
-  assert(can_broadcast == 1);
+  GTEST_CHECK(can_broadcast);
 
   uint64_t sizeA = 1;
   uint64_t sizeB = 1;

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.cpp
@@ -91,7 +91,7 @@ void FocalLossSigmoidBackwardExecutor::setMiscellaneousParam() {
 }
 
 void FocalLossSigmoidBackwardExecutor::cpuCompute() {
-  assert(parser_->getOutputNum() == 1);
+  GTEST_CHECK(parser_->getOutputNum() == 1);
   auto alpha =
       parser_->getProtoNode()->focal_loss_sigmoid_backward_param().alpha();
   auto gamma =

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_backward_data/indice_convolution_backward_data.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_backward_data/indice_convolution_backward_data.cpp
@@ -252,11 +252,11 @@ void IndiceConvolutionBackwardDataExecutor::cpuTransposeFilter(
 }
 
 void IndiceConvolutionBackwardDataExecutor::cpuCompute() {
-  assert(parser_->getInputNum() == 3);
-  assert(parser_->getOutputNum() == 1);
+  GTEST_CHECK(parser_->getInputNum() == 3);
+  GTEST_CHECK(parser_->getOutputNum() == 1);
   VLOG(4) << "compute cpu IndiceConvolutionBackwardData";
   auto count = parser_->getOutputDataCount(0);
-  assert(count != 0);
+  GTEST_CHECK(count != 0);
   getFilterDims();
   setSpconvdataParams();
   int K = kd * kh * kw;
@@ -300,7 +300,7 @@ void IndiceConvolutionBackwardDataExecutor::cpuCompute() {
   for (int kk = 0; kk < K; ++kk) {
     int filter_offset = kk * dxc * dyc;
     int index_num = (int)(indice_num_[kk]);
-    assert(L >= index_num);
+    GTEST_CHECK(L >= index_num);
     for (int l = 0; l < index_num; ++l) {  // index_pair data loop
       int input_idx = indice_pairs[kk * 2 * L + l];
       int output_idx = indice_pairs[kk * 2 * L + L + l];

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/log/log.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/log/log.cpp
@@ -56,8 +56,8 @@ void LogExecutor::setMiscellaneousParam() {
 }
 
 void LogExecutor::cpuCompute() {
-  assert(parser_->getInputNum() == 1);
-  assert(parser_->getOutputNum() == 1);
+  GTEST_CHECK(parser_->getInputNum() == 1);
+  GTEST_CHECK(parser_->getOutputNum() == 1);
   auto count = parser_->getInputDataCount(0);
 
   mluOpLogBase_t base =
@@ -76,7 +76,7 @@ void LogExecutor::cpuCompute() {
       cpu_fp32_output_[0][i] = log10(cpu_fp32_input_[0][i]);
     }
   } else {
-    assert(0);
+    GTEST_CHECK(0);
   }
 }
 

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/nms/nms.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/nms/nms.cpp
@@ -411,7 +411,7 @@ void NmsExecutor::nms_detection_cpu(
 }
 
 void NmsExecutor::cpuCompute() {
-  assert(parser_->getInputNum() == 2);
+  GTEST_CHECK(parser_->getInputNum() == 2);
   // assert(parser_->getOutputNum() == 1);
 
   int max_output_boxes =

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/nms_rotated/nms_rotated.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/nms_rotated/nms_rotated.cpp
@@ -359,7 +359,7 @@ template <typename T>
 int NmsRotatedExecutor::convexHullGraham(const Point<T> (&p)[24],
                                          const int &num_in,
                                          Point<T> (&q)[24]) {
-  assert(num_in >= 2);
+  GTEST_CHECK(num_in >= 2);
   // Step1:
   // Find point with minimum y
   // if more than 1 points have the same minimum y,

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/sqrt/sqrt.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/sqrt/sqrt.cpp
@@ -48,8 +48,8 @@ void SqrtExecutor::compute() {
 }
 
 void SqrtExecutor::cpuCompute() {
-  assert(parser_->getInputNum() == 1);
-  assert(parser_->getOutputNum() == 1);
+  GTEST_CHECK(parser_->getInputNum() == 1);
+  GTEST_CHECK(parser_->getOutputNum() == 1);
 
   auto count1 = parser_->getInputDataCount(0);
   auto count2 = parser_->getOutputDataCount(0);

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/sqrt_backward/sqrt_backward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/sqrt_backward/sqrt_backward.cpp
@@ -46,12 +46,12 @@ void SqrtBackwardExecutor::compute() {
 }
 
 void SqrtBackwardExecutor::cpuCompute() {
-  assert(parser_->getInputNum() == 2);
-  assert(parser_->getOutputNum() == 1);
+  GTEST_CHECK(parser_->getInputNum() == 2);
+  GTEST_CHECK(parser_->getOutputNum() == 1);
 
   auto count1 = parser_->getInputDataCount(0);
   auto count2 = parser_->getInputDataCount(1);
-  assert(count1 == count2);
+  GTEST_CHECK(count1 == count2);
 
   for (size_t i = 0; i < count1; ++i) {
     cpu_fp32_output_[0][i] =

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -69,7 +69,7 @@ for i in ${filenames} ; do
   #not_in_tools=$(echo $i | sed -r "s/^tools.*//")
   if [[ -n "${include_mlu}" ]] && [[ -n "${check_dir}" ]]; then
     printf_log=$(sed -n -e '/\<printf\>/=' -e \
-      '/\<__bang_printf\>/=' -e '/\<std::cout\>/=' -e '/assert(/=' $i)
+      '/\<__bang_printf\>/=' -e '/\<std::cout\>/=' -e '/\bassert(/=' $i)
     for line in ${printf_log};
     do
       echo $i +${line}


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

assert 只在 debug 模式下使能，gtest端将assert用GTEST_CHECK替代，host端不应该使用assert而是做paramcheck，device端检查真值使用MLU_KERNEL_ASSERT

## 2. Modification

MLU_KERNEL_ASSERT 宏更新
gtest端 assert 替换
pre-commit 检查更新，不会再防住 static_assert 等