### PR TITLE
[Feature](mlu-ops): change getSizeOfDataType to mluOpGetSizeOfDataType.

### DIFF
--- a/test/mlu_op_gtest/pb_gtest/src/parser.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/parser.cpp
@@ -268,8 +268,10 @@ void Parser::parse(const std::string &file) {
     mt->total_count = getTensorStrideCount(pt, mt->value_type);
     // shape_count come from value_f/value_i/value_h/value_ui/value_ul and
     // shape. not include stride
+    size_t dtype_size;
+    MLUOP_CHECK(mluOpGetSizeOfDataType(mt->dtype, &dtype_size));
     mt->shape_count = getTensorShapeCount(pt);
-    mt->sizeof_dtype = mluop::getSizeOfDataType(mt->dtype);
+    mt->sizeof_dtype = dtype_size;
     mt->size_in_bytes = mt->total_count * mt->sizeof_dtype;
     if (mt->total_count != mt->shape_count) {
       VLOG(4) << "WARNING: Parser: the " << mt->name

--- a/test/mlu_op_gtest/pb_gtest/src/stride.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/stride.cpp
@@ -137,7 +137,8 @@ void *Stride::strideOutputByDtype() { return pimpl_->strideOutputByDtype(); }
 
 void *Stride::StrideImpl::strideOutputByDtype() {
   if (have_stride_) {
-    size_t dtype_size = mluop::getSizeOfDataType(ts_->dtype);
+    size_t dtype_size;
+    MLUOP_CHECK(mluOpGetSizeOfDataType(ts_->dtype, &dtype_size));
     void *tensor_out = cpu_runtime_->allocate(ts_->total_count * dtype_size);
     if (init_by_input_) {
       memcpy(tensor_out, tensor_copy_, ts_->total_count * dtype_size);

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -206,12 +206,15 @@ int64_t IndiceConvolutionBackwardFilterExecutor::getTheoryIoSize() {
   int64_t in_active_num = input_indice_desc_->dims[0];
   int64_t kernel_volume = indice_pair_desc_->dims[0];
   int64_t theory_ios = 0;
-  auto input_indice_dwidth =
-      mluop::getSizeOfDataType(input_indice_desc_->dtype);
-  auto diffy_indice_dwidth =
-      mluop::getSizeOfDataType(diffy_indice_desc_->dtype);
-  auto indice_pair_dwidth = mluop::getSizeOfDataType(indice_pair_desc_->dtype);
-  auto diffw_dwidth = mluop::getSizeOfDataType(diffw_desc_->dtype);
+  size_t input_indice_dwidth, diffy_indice_dwidth, indice_pair_dwidth,
+      diffw_dwidth;
+  MLUOP_CHECK(
+      mluOpGetSizeOfDataType(input_indice_desc_->dtype, &input_indice_dwidth));
+  MLUOP_CHECK(
+      mluOpGetSizeOfDataType(diffy_indice_desc_->dtype, &diffy_indice_dwidth));
+  MLUOP_CHECK(
+      mluOpGetSizeOfDataType(indice_pair_desc_->dtype, &indice_pair_dwidth));
+  MLUOP_CHECK(mluOpGetSizeOfDataType(diffw_desc_->dtype, &diffw_dwidth));
 
   auto gather_nd_ios = [&](const int64_t kernel_index, const int64_t gather_num,
                            const int64_t channel,

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/indice_convolution_forward/indice_convolution_forward.cpp
@@ -209,10 +209,14 @@ int64_t IndiceConvolutionForwardExecutor::getTheoryIoSize() {
   int64_t num_active_out = features_out_desc_->dims[0];
   int64_t num_filters = indice_pairs_desc_->dims[0];
   int64_t theory_ios = 0;
-  auto features_dwidth = mluop::getSizeOfDataType(features_desc_->dtype);
-  auto filters_dwidth = mluop::getSizeOfDataType(filters_desc_->dtype);
-  auto indice_pairs_dwith = mluop::getSizeOfDataType(indice_pairs_desc_->dtype);
-  auto features_out_dwith = mluop::getSizeOfDataType(features_out_desc_->dtype);
+  size_t features_dwidth, filters_dwidth, indice_pairs_dwith,
+      features_out_dwith;
+  MLUOP_CHECK(mluOpGetSizeOfDataType(features_desc_->dtype, &features_dwidth));
+  MLUOP_CHECK(mluOpGetSizeOfDataType(filters_desc_->dtype, &filters_dwidth));
+  MLUOP_CHECK(
+      mluOpGetSizeOfDataType(indice_pairs_desc_->dtype, &indice_pairs_dwith));
+  MLUOP_CHECK(
+      mluOpGetSizeOfDataType(features_out_desc_->dtype, &features_out_dwith));
 
   auto gather_scatter_ios = [&](const int64_t index, const int64_t num,
                                 const int64_t channel,

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
@@ -138,11 +138,15 @@ int64_t MoeDispatchBackwardDataExecutor::getTheoryOps() {
 }
 
 int64_t MoeDispatchBackwardDataExecutor::getTheoryIoSize() {
-  auto gates_dwidth = mluop::getSizeOfDataType(desc_gates_->dtype);
-  auto indices_dwidth = mluop::getSizeOfDataType(desc_indices_->dtype);
-  auto locations_dwidth = mluop::getSizeOfDataType(desc_locations_->dtype);
-  auto dispatch_dwidth = mluop::getSizeOfDataType(desc_dispatch_->dtype);
-  auto grad_input_dwidth = mluop::getSizeOfDataType(desc_grad_input_->dtype);
+  size_t gates_dwidth, indices_dwidth, locations_dwidth, dispatch_dwidth,
+      grad_input_dwidth;
+  MLUOP_CHECK(mluOpGetSizeOfDataType(desc_gates_->dtype, &gates_dwidth));
+  MLUOP_CHECK(mluOpGetSizeOfDataType(desc_indices_->dtype, &indices_dwidth));
+  MLUOP_CHECK(
+      mluOpGetSizeOfDataType(desc_locations_->dtype, &locations_dwidth));
+  MLUOP_CHECK(mluOpGetSizeOfDataType(desc_dispatch_->dtype, &dispatch_dwidth));
+  MLUOP_CHECK(
+      mluOpGetSizeOfDataType(desc_grad_input_->dtype, &grad_input_dwidth));
 
   int64_t gates_theory_ios = samples_mask_num_ * gates_dwidth;
   int64_t indices_theory_ios = samples_mask_num_ * indices_dwidth;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.