### PR TITLE
[Feature](mlu-ops): Update to toolkit4+

### DIFF
--- a/docs/design_docs/roiaware_pool3d_forward/roiaware_pool3d_forward.md
+++ b/docs/design_docs/roiaware_pool3d_forward/roiaware_pool3d_forward.md
@@ -274,21 +274,21 @@ __global__ roiaware_pool3d_forward_kernel(){
 __device__ check_point_in_roi(float *X, float *Y, float *Z,
       float *local_X, float *local_Y, float *local_Z,
       float cx, float cy, float cz, float x_size, float y_size, float z_size, float rz, int num) {
-  __bang_sub_const(local_Z, Z, cz, num);  //  local_Z
+  __bang_sub_scalar(local_Z, Z, cz, num);  //  local_Z
   __bang_active_abs(tmp, local_Z, num);
   __bang_write_value(tmp1, num, 0.5 * dz);
   __bang_le(flag, tmp, tmp1, num);     // Z in_flag
   float cosa = std::cos(-rz);
   float sina = std::sin(-rz);
-  __bang_sub_const(tmp, X, cx, num);
-  __bang_sub_const(tmp1, Y, cy, num);
-  __bang_mul_const(tmp2, tmp, cosa, num);
-  __bang_mul_const(tmp3, tmp1, sina, num);
-  __bang_sub_const(local_X, tmp2, tmp3, num);  //  local_X
+  __bang_sub_scalar(tmp, X, cx, num);
+  __bang_sub_scalar(tmp1, Y, cy, num);
+  __bang_mul_scalar(tmp2, tmp, cosa, num);
+  __bang_mul_scalar(tmp3, tmp1, sina, num);
+  __bang_sub_scalar(local_X, tmp2, tmp3, num);  //  local_X
 
-  __bang_mul_const(tmp, tmp, sina, num);
-  __bang_mul_const(tmp1, tmp1, cosa, num);
-  __bang_add_const(local_Y, tmp, tmp1, num);  //  local_Y
+  __bang_mul_scalar(tmp, tmp, sina, num);
+  __bang_mul_scalar(tmp1, tmp1, cosa, num);
+  __bang_add_scalar(local_Y, tmp, tmp1, num);  //  local_Y
 
   __bang_active_abs(tmp2, tmp2, num);
   __bang_write_value(tmp1, num, 0.5 * dx);

--- a/kernels/binary_op/binary_op_3pipeline.h
+++ b/kernels/binary_op/binary_op_3pipeline.h
@@ -99,11 +99,9 @@
       __asm__ volatile("sync;");                                              \
     }                                                                         \
     for (int32_t i = 0; i < repeat - 2; ++i) {                                \
-      pvLock();                                                               \
       __memcpy_async(output_start + i * span_store_size,                      \
                      ping_output + (i % 2) * ping_pong_gap, span_store_size,  \
                      NRAM2GDRAM);                                             \
-      pvUnlock();                                                             \
       __memcpy_async(ping_input1 + (i % 2) * ping_pong_gap,                   \
                      input1_start + (i + 2) * span_load_input1_size,          \
                      span_load_input1_size, GDRAM2NRAM);                      \
@@ -118,11 +116,9 @@
       __asm__ volatile("sync;");                                              \
     }                                                                         \
     if (repeat > 1) {                                                         \
-      pvLock();                                                               \
       __memcpy_async(output_start + (repeat - 2) * span_store_size,           \
                      ping_output + ((repeat - 2) % 2) * ping_pong_gap,        \
                      span_store_size, NRAM2GDRAM);                            \
-      pvUnlock();                                                             \
     }                                                                         \
     if (rem > 0) {                                                            \
       __memcpy_async(ping_input1 + (repeat % 2) * ping_pong_gap,              \
@@ -141,11 +137,9 @@
     }                                                                         \
     __asm__ volatile("sync;");                                                \
     if (repeat > 0) {                                                         \
-      pvLock();                                                               \
       __memcpy_async(output_start + (repeat - 1) * span_store_size,           \
                      ping_output + ((repeat - 1) % 2) * ping_pong_gap,        \
                      span_store_size, NRAM2GDRAM);                            \
-      pvUnlock();                                                             \
     }                                                                         \
     if (rem > 0) {                                                            \
       compute##Op##Prefer<DType_in1, DType_in2, DType_out>(                   \
@@ -154,11 +148,9 @@
           ping_input2 + (repeat % 2) * ping_pong_gap, auxiliary_a,            \
           auxiliary_b, auxiliary_c, align_rem, rem, args...);                 \
       __asm__ volatile("sync;");                                              \
-      pvLock();                                                               \
       __memcpy_async(output_start + repeat * span_store_size,                 \
                      ping_output + (repeat % 2) * ping_pong_gap,              \
                      rem * sizeof(DType_out), NRAM2GDRAM);                    \
-      pvUnlock();                                                             \
     }                                                                         \
   }
 

--- a/kernels/border_align/border_align_backward/border_align_backward_union1.mlu
+++ b/kernels/border_align/border_align_backward/border_align_backward_union1.mlu
@@ -177,15 +177,17 @@ __mlu_func__ void computeImpl(T *nram_grad_output, const T *grad_output,
                 deal_num_align);  // NOLINT
       if (__mluop_is_float<T>()) {
         __nram__ int32_t table[COMPUTE_COUNT_ALIGN] = {0, (int32_t)0xffffffff};
-        __bang_lut_s32((int32_t *)nram_argmax_idx, (int32_t *)nram_argmax_idx,
-                       table, deal_num_align, COMPUTE_COUNT_ALIGN);  // NOLINT
+        __bang_lut((int32_t *)nram_argmax_idx, (uint32_t *)nram_argmax_idx,
+                   table, (uint32_t)deal_num_align,
+                   COMPUTE_COUNT_ALIGN);  // NOLINT
       } else {
         __nram__ int16_t table[COMPUTE_COUNT_ALIGN] = {0, (int16_t)0xffff};
         __bang_int322int16((int16_t *)nram_argmax_idx,
                            (int32_t *)nram_argmax_idx, deal_num_align, 0,
                            0);  // NOLINT
-        __bang_lut_s16((int16_t *)nram_argmax_idx, (int16_t *)nram_argmax_idx,
-                       table, deal_num_align, COMPUTE_COUNT_ALIGN);  // NOLINT
+        __bang_lut((int16_t *)nram_argmax_idx, (uint16_t *)nram_argmax_idx,
+                   table, (uint32_t)deal_num_align,
+                   COMPUTE_COUNT_ALIGN);  // NOLINT
       }
 
       // load grad_output, and calculate grad_input

--- a/kernels/box_iou_rotated/box_iou_rotated_aligned.h
+++ b/kernels/box_iou_rotated/box_iou_rotated_aligned.h
@@ -267,14 +267,14 @@ __mlu_func__ void MLUUnion1BoxIouRotatedAligned(const T *box1, const T *box2,
       __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
       __bang_float2int32((int32_t *)temp9_ram, (float *)temp9_ram,
                          actual_compute_box_num, 0);
-      __bang_lut_s32((int32_t *)temp9_ram, (int32_t *)temp9_ram,
-                     (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      __bang_lut((int32_t *)temp9_ram, (uint32_t *)temp9_ram, (int32_t *)table,
+                 actual_compute_box_num, TABLE_LENGTH);
     } else {
       __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
       __bang_half2int16_rd((int16_t *)temp9_ram, (half *)temp9_ram,
                            actual_compute_box_num, 0);
-      __bang_lut_s16((int16_t *)temp9_ram, (int16_t *)temp9_ram,
-                     (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      __bang_lut((int16_t *)temp9_ram, (uint16_t *)temp9_ram, (int16_t *)table,
+                 actual_compute_box_num, TABLE_LENGTH);
     }
     __bang_band((char *)ious_ram, (char *)ious_ram, (char *)temp9_ram,
                 actual_compute_box_num * sizeof(T));

--- a/kernels/box_iou_rotated/box_iou_rotated_nonaligned.h
+++ b/kernels/box_iou_rotated/box_iou_rotated_nonaligned.h
@@ -358,16 +358,14 @@ __mlu_func__ void MLUUnion1BoxIouRotatedNonAligned(const T *box1, const T *box2,
           __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
           __bang_float2int32((int32_t *)temp9_ram, (float *)temp9_ram,
                              actual_compute_box_num, 0);
-          __bang_lut_s32((int32_t *)temp9_ram, (int32_t *)temp9_ram,
-                         (int32_t *)table, actual_compute_box_num,
-                         TABLE_LENGTH);
+          __bang_lut((int32_t *)temp9_ram, (uint32_t *)temp9_ram,
+                     (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
         } else {
           __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
           __bang_half2int16_rd((int16_t *)temp9_ram, (half *)temp9_ram,
                                actual_compute_box_num, 0);
-          __bang_lut_s16((int16_t *)temp9_ram, (int16_t *)temp9_ram,
-                         (int16_t *)table, actual_compute_box_num,
-                         TABLE_LENGTH);
+          __bang_lut((int16_t *)temp9_ram, (uint16_t *)temp9_ram,
+                     (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
         }
         __bang_band((char *)ious_ram, (char *)ious_ram, (char *)temp9_ram,
                     actual_compute_box_num * sizeof(T));

--- a/kernels/box_iou_rotated/box_iou_rotated_utils.h
+++ b/kernels/box_iou_rotated/box_iou_rotated_utils.h
@@ -248,14 +248,14 @@ __mlu_func__ void getIntersectionPoints(
         __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
         __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                            actual_compute_box_num, 0);
-        __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
-                       (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
+        __bang_lut((int32_t *)temp2_ram, (uint32_t *)temp2_ram,
+                   (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
       } else {
         __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
         __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp2_ram,
                              actual_compute_box_num, 0);
-        __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
-                       (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
+        __bang_lut((int16_t *)temp2_ram, (uint16_t *)temp2_ram,
+                   (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
       }
       __bang_band(
           (char *)((T *)intersect_pts_x + (4 * i + j) * actual_compute_box_num),
@@ -336,14 +336,14 @@ __mlu_func__ void getIntersectionPoints(
       __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
       __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                          actual_compute_box_num, 0);
-      __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
-                     (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      __bang_lut((int32_t *)temp2_ram, (uint32_t *)temp2_ram, (int32_t *)table,
+                 actual_compute_box_num, TABLE_LENGTH);
     } else {
       __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
       __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
                            actual_compute_box_num, 0);
-      __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
-                     (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      __bang_lut((int16_t *)temp2_ram, (uint16_t *)temp2_ram, (int16_t *)table,
+                 actual_compute_box_num, TABLE_LENGTH);
     }
     __bang_band(
         (char *)((T *)intersect_pts_x + (16 + i) * actual_compute_box_num),
@@ -412,14 +412,14 @@ __mlu_func__ void getIntersectionPoints(
       __nram__ int table[TABLE_LENGTH] = {0, FIILED_ONES};
       __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                          actual_compute_box_num, 0);
-      __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
-                     (int32_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      __bang_lut((int32_t *)temp2_ram, (uint32_t *)temp2_ram, (int32_t *)table,
+                 actual_compute_box_num, TABLE_LENGTH);
     } else {
       __nram__ int16_t table[TABLE_LENGTH] = {0, HALF_FILLED_ONES};
       __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
                            actual_compute_box_num, 0);
-      __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
-                     (int16_t *)table, actual_compute_box_num, TABLE_LENGTH);
+      __bang_lut((int16_t *)temp2_ram, (uint16_t *)temp2_ram, (int16_t *)table,
+                 actual_compute_box_num, TABLE_LENGTH);
     }
     __bang_band(
         (char *)((T *)intersect_pts_x + (20 + i) * actual_compute_box_num),

--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -57,7 +57,7 @@ __mlu_func__ void computeLogE(float *nram_dst, float *nram_src,
 #if __BANG_ARCH__ >= 372
   int x2d = 0x3f317217;
   float rlog2e = *(float *)&x2d;
-  __bang_log((float *)nram_dst, (float *)nram_src, deal_num);
+  __bang_log2((float *)nram_dst, (float *)nram_src, deal_num);
   __bang_mul_scalar((float *)nram_dst, (float *)nram_src, (float)rlog2e,
                     deal_num);
 #else

--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid_forward_union1.mlu
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid_forward_union1.mlu
@@ -160,7 +160,7 @@ __mlu_func__ void compute(const focalLossSigmoidPreference_t prefer,
     if (gamma == float(0.0)) {
       __bang_write_value(compute_a, deal_num, (float)1.0);
     } else {
-      __bang_log(compute_a, compute_b, deal_num);
+      __bang_log2(compute_a, compute_b, deal_num);
       __bang_mul_scalar(compute_a, compute_a, (float)gamma, deal_num);
       __bang_pow2(compute_a, compute_a, deal_num);
     }
@@ -200,7 +200,7 @@ __mlu_func__ void compute(const focalLossSigmoidPreference_t prefer,
     if (gamma == float(0.0)) {
       __bang_write_value(compute_a, deal_num, (float)1.0);
     } else {
-      __bang_log(compute_a, compute_b, deal_num);
+      __bang_log2(compute_a, compute_b, deal_num);
       __bang_mul_scalar(compute_a, compute_a, (float)gamma, deal_num);
       __bang_pow2(compute_a, compute_a, deal_num);
     }

--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid_forward_union1.mlu
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid_forward_union1.mlu
@@ -232,8 +232,8 @@ __mlu_func__ void compute(const focalLossSigmoidPreference_t prefer,
     __bang_le_scalar(input, compute_b, (float)FLT_MAX, deal_num);
     __bang_float2int32((int32_t *)input, input, deal_num, 0);
     __nram__ int32_t table[COMPUTE_COUNT_ALIGN] = {0, (int32_t)0xffffffff};
-    __bang_lut_s32((int32_t *)input, (int32_t *)input, table, deal_num,
-                   COMPUTE_COUNT_ALIGN);  // NOLINT
+    __bang_lut((int32_t *)input, (uint32_t *)input, table, (uint32_t)deal_num,
+               COMPUTE_COUNT_ALIGN);  // NOLINT
     __bang_band((char *)compute_b, (char *)compute_b, (char *)input,
                 sizeof(float) * deal_num);  // NOLINT
     __bang_sub(compute_a, compute_a, compute_b, deal_num);

--- a/kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
+++ b/kernels/generate_proposals_v2/generate_proposals_v2_nms_utils.h
@@ -151,14 +151,12 @@ __mlu_func__ void storeResult(T *max_box, T *nram_save, T *&output_boxes_tmp,
         (float(max_box[0]) <= FLOAT_MIN_GPV2) || keep == nms_num - 1) {
       if (nram_save_count != 0) {
         if (clusterId == 0 && coreId == 0) {
-          pvLock();
           // x1, y1, x2, y2
           __memcpy(output_boxes_tmp, nram_save + 1, 4 * sizeof(T), NRAM2GDRAM,
                    4 * sizeof(T), 5 * sizeof(T), nram_save_count - 1);
           // score
           __memcpy(output_scores_tmp, nram_save, sizeof(T), NRAM2GDRAM,
                    sizeof(T), 5 * sizeof(T), nram_save_count - 1);
-          pvUnlock();
           output_boxes_tmp += nram_save_count * 4;
           output_scores_tmp += nram_save_count;
           nram_save_count = 0;

--- a/kernels/lgamma/lgamma_block.mlu
+++ b/kernels/lgamma/lgamma_block.mlu
@@ -65,7 +65,7 @@ __mlu_func__ void isInf(float *dst, float *src, uint32_t sz) {
 }
 
 __mlu_func__ void logHp(float *dst, float *src, uint32_t sz) {
-  __bang_log(dst, src, sz);
+  __bang_log2(dst, src, sz);
   __bang_mul_scalar(dst, dst, log_e_2, sz);
 }
 

--- a/kernels/log/log_union1.mlu
+++ b/kernels/log/log_union1.mlu
@@ -59,7 +59,7 @@ __mlu_func__ void computeLogFloat(char *nram_output, char *nram_input,
                                   char *auxiliary_a, char *auxiliary_b,
                                   size_t deal_num, size_t actual_num,
                                   float coef) {
-  __bang_log((float *)nram_output, (float *)nram_input, actual_num);
+  __bang_log2((float *)nram_output, (float *)nram_input, actual_num);
   __bang_mul_scalar((float *)nram_output, (float *)nram_output, (float)coef,
                     deal_num);
 }
@@ -86,7 +86,7 @@ __mlu_func__ void computeLogHalf(char *nram_output, char *nram_input,
                                  size_t deal_num, size_t actual_num,
                                  float coef) {
   __bang_half2float((float *)nram_output, (half *)nram_input, deal_num);
-  __bang_log((float *)nram_output, (float *)nram_output, actual_num);
+  __bang_log2((float *)nram_output, (float *)nram_output, actual_num);
   __bang_mul_scalar((float *)nram_output, (float *)nram_output, coef, deal_num);
   __mluop_float2half((half *)nram_output, (float *)nram_output, deal_num);
 }

--- a/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward_small_channels_union1.mlu
@@ -378,8 +378,8 @@ void __mlu_func__ loadValue(
   __nram__ int32_t table[64] = {0, (int32_t)0xffffffff};
   __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
                      num_deal_grid * deal_num_real, 0);
-  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
-                 num_deal_grid * deal_num_real, 64);
+  __bang_lut((int32_t *)grad_temp3, (uint32_t *)grad_temp3, (int32_t *)table,
+             num_deal_grid * deal_num_real, 64);
   __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
   __bang_cycle_add(grad_temp1, grad_temp1, mask1, deal_num_real * num_deal_grid,
                    num_deal_grid);
@@ -392,8 +392,8 @@ void __mlu_func__ loadValue(
 
   __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
                      num_deal_grid * deal_num_real, 0);
-  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
-                 num_deal_grid * deal_num_real, 64);
+  __bang_lut((int32_t *)grad_temp3, (uint32_t *)grad_temp3, (int32_t *)table,
+             num_deal_grid * deal_num_real, 64);
   __bang_band((char *)nram_grad_output_tr, (char *)nram_grad_output_tr,
               (char *)grad_temp3,
               num_deal_grid * deal_num_real * sizeof(float));
@@ -405,8 +405,8 @@ void __mlu_func__ loadValue(
 
   __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
                      num_deal_grid * deal_num_real, 0);
-  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
-                 num_deal_grid * deal_num_real, 64);
+  __bang_lut((int32_t *)grad_temp3, (uint32_t *)grad_temp3, (int32_t *)table,
+             num_deal_grid * deal_num_real, 64);
   __bang_band((char *)nram_grad_output_bl, (char *)nram_grad_output_bl,
               (char *)grad_temp3,
               num_deal_grid * deal_num_real * sizeof(float));
@@ -418,8 +418,8 @@ void __mlu_func__ loadValue(
 
   __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
                      num_deal_grid * deal_num_real, 0);
-  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
-                 num_deal_grid * deal_num_real, 64);
+  __bang_lut((int32_t *)grad_temp3, (uint32_t *)grad_temp3, (int32_t *)table,
+             num_deal_grid * deal_num_real, 64);
   __bang_band((char *)nram_grad_output_br, (char *)nram_grad_output_br,
               (char *)grad_temp3,
               num_deal_grid * deal_num_real * sizeof(float));
@@ -690,8 +690,8 @@ void __mlu_func__ computeGradAttnWeight(
   __bang_float2int32((int32_t *)nram_h_high_temp, nram_h_high_temp,
                      num_deal_grid, 0);
   __nram__ int32_t table[64] = {0, (int32_t)0xffffffff};
-  __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
-                 (int32_t *)table, num_deal_grid, 64);
+  __bang_lut((int32_t *)nram_h_high_temp, (uint32_t *)nram_h_high_temp,
+             (int32_t *)table, num_deal_grid, 64);
   __bang_band((char *)nram_grad_output_tr, (char *)nram_grad_output_tr,
               (char *)nram_h_high_temp, num_deal_grid * sizeof(float));
   __bang_atomic_reduce_add((float *)grad_attn_weight + grid_offset,
@@ -746,8 +746,8 @@ void __mlu_func__ computeGradSampingLoc(
                              ALIGN_NUM);
 
   __nram__ int32_t table[64] = {0, (int32_t)0xffffffff};
-  __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
-                 (int32_t *)table, num_deal_grid, 64);
+  __bang_lut((int32_t *)nram_h_high_temp, (uint32_t *)nram_h_high_temp,
+             (int32_t *)table, num_deal_grid, 64);
   __bang_band((char *)grad_h_weight, (char *)grad_h_weight,
               (char *)nram_h_high_temp, num_deal_grid * sizeof(float));
 
@@ -769,8 +769,8 @@ void __mlu_func__ computeGradSampingLoc(
                  num_deal_grid * deal_num_real * sizeof(float), NRAM2NRAM);
   __mluop_recursive_sum_pool(grad_w_weight, num_deal_grid, deal_num_real,
                              ALIGN_NUM);
-  __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
-                 (int32_t *)table, num_deal_grid, 64);
+  __bang_lut((int32_t *)nram_h_high_temp, (uint32_t *)nram_h_high_temp,
+             (int32_t *)table, num_deal_grid, 64);
   __bang_band((char *)grad_w_weight, (char *)grad_w_weight,
               (char *)nram_h_high_temp, num_deal_grid * sizeof(float));
 

--- a/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -206,10 +206,8 @@ __mlu_func__ void nms_detection(
 
     if (nram_save_count == nram_save_limit_count) {
       if (taskId == 0) {
-        pvLock();
         __memcpy(output_data, nram_save, nram_save_count * sizeof(OUT_DT),
                  NRAM2GDRAM);
-        pvUnlock();
       }
       output_data += nram_save_count;
       nram_save_count = 0;
@@ -409,18 +407,14 @@ __mlu_func__ void nms_detection(
       __bang_minequal((IN_DT *)score, (IN_DT *)score, (IN_DT *)temp1_ram,
                       seg_len);
 
-      pvLock();
       __memcpy(input_data_score + input_offset + i * max_seg_iou_pad, score,
                cpy_len * sizeof(IN_DT), scores_store_dir,
                cpy_len * sizeof(IN_DT), cpy_len * sizeof(IN_DT), 0);
-      pvUnlock();
     }
   }
   if (clusterId == 0 && coreId == 0 && nram_save_count) {
-    pvLock();
     __memcpy(output_data, nram_save, nram_save_count * sizeof(OUT_DT),
              NRAM2GDRAM);
-    pvUnlock();
   }
 }
 

--- a/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -370,8 +370,8 @@ __mlu_func__ void nms_detection(
                       (float *)temp10_ram, (float *)temp1_ram,
                       (float *)temp2_ram, /*mode=*/0, seg_len);
       __bang_float2int32((int32_t *)temp9_ram, (float *)temp9_ram, seg_len, 0);
-      __bang_lut_s32((int32_t *)temp9_ram, (int32_t *)temp9_ram,
-                     (int32_t *)table_float, seg_len, TABLE_LENGTH);
+      __bang_lut((int32_t *)temp9_ram, (uint32_t *)temp9_ram,
+                 (int32_t *)table_float, seg_len, TABLE_LENGTH);
       __bang_band((char *)temp2_ram, (char *)temp2_ram, (char *)temp9_ram,
                   seg_len * sizeof(float));
       // temp1: 1 = area_I / area_U > iou_threshold, 0 = else

--- a/kernels/nms_rotated/nms_utils.h
+++ b/kernels/nms_rotated/nms_utils.h
@@ -398,15 +398,14 @@ __mlu_func__ void getIntersectionPoints(
       if (sizeof(T) == sizeof(float)) {
         __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                            actual_compute_box_num, 0);
-        __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
-                       (int32_t *)table_float, actual_compute_box_num,
-                       TABLE_LENGTH);
+        __bang_lut((int32_t *)temp2_ram, (uint32_t *)temp2_ram,
+                   (int32_t *)table_float, actual_compute_box_num,
+                   TABLE_LENGTH);
       } else {
         __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp2_ram,
                              actual_compute_box_num, 0);
-        __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
-                       (int16_t *)table_half, actual_compute_box_num,
-                       TABLE_LENGTH);
+        __bang_lut((int16_t *)temp2_ram, (uint16_t *)temp2_ram,
+                   (int16_t *)table_half, actual_compute_box_num, TABLE_LENGTH);
       }
       __bang_band(
           (char *)((T *)intersect_pts_x + (4 * i + j) * actual_compute_box_num),
@@ -486,15 +485,13 @@ __mlu_func__ void getIntersectionPoints(
     if (sizeof(T) == sizeof(float)) {
       __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                          actual_compute_box_num, 0);
-      __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
-                     (int32_t *)table_float, actual_compute_box_num,
-                     TABLE_LENGTH);
+      __bang_lut((int32_t *)temp2_ram, (uint32_t *)temp2_ram,
+                 (int32_t *)table_float, actual_compute_box_num, TABLE_LENGTH);
     } else {
       __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
                            actual_compute_box_num, 0);
-      __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
-                     (int16_t *)table_half, actual_compute_box_num,
-                     TABLE_LENGTH);
+      __bang_lut((int16_t *)temp2_ram, (uint16_t *)temp2_ram,
+                 (int16_t *)table_half, actual_compute_box_num, TABLE_LENGTH);
     }
     __bang_band(
         (char *)((T *)intersect_pts_x + (16 + i) * actual_compute_box_num),
@@ -562,15 +559,13 @@ __mlu_func__ void getIntersectionPoints(
     if (sizeof(T) == sizeof(float)) {
       __bang_float2int32((int32_t *)temp2_ram, (float *)temp1_ram,
                          actual_compute_box_num, 0);
-      __bang_lut_s32((int32_t *)temp2_ram, (int32_t *)temp2_ram,
-                     (int32_t *)table_float, actual_compute_box_num,
-                     TABLE_LENGTH);
+      __bang_lut((int32_t *)temp2_ram, (uint32_t *)temp2_ram,
+                 (int32_t *)table_float, actual_compute_box_num, TABLE_LENGTH);
     } else {
       __bang_half2int16_rd((int16_t *)temp2_ram, (half *)temp1_ram,
                            actual_compute_box_num, 0);
-      __bang_lut_s16((int16_t *)temp2_ram, (int16_t *)temp2_ram,
-                     (int16_t *)table_half, actual_compute_box_num,
-                     TABLE_LENGTH);
+      __bang_lut((int16_t *)temp2_ram, (uint16_t *)temp2_ram,
+                 (int16_t *)table_half, actual_compute_box_num, TABLE_LENGTH);
     }
     __bang_band(
         (char *)((T *)intersect_pts_x + (20 + i) * actual_compute_box_num),

--- a/kernels/three_nn_forward/three_nn_forward_union1.mlu
+++ b/kernels/three_nn_forward/three_nn_forward_union1.mlu
@@ -58,8 +58,7 @@ __mlu_func__ void auxArgmin(T *nram_dst, T *nram_src, const int num_deal,
   *value = nram_dst[0];
   __bang_write_value(nram_dst, num_deal, *value);
   __bang_eq(nram_dst, nram_src, nram_dst, num_deal);
-  __bang_findfirst1((uint32_t *)nram_dst, nram_dst, num_deal);
-  *index = *((int *)nram_dst);
+  *index = (uint32_t)__bang_findfirst1(nram_dst, num_deal);
 }
 
 template <typename T>

--- a/kernels/unary_op/complex_unary_op_3pipeline.h
+++ b/kernels/unary_op/complex_unary_op_3pipeline.h
@@ -82,11 +82,9 @@
       __asm__ volatile("sync;");                                               \
     }                                                                          \
     for (int i = 0; i < repeat - 2; i++) {                                     \
-      pvLock();                                                                \
       __memcpy_async(output_start + i * span_store_size,                       \
                      ping_output + (i % 2) * ping_pong_gap, span_store_size,   \
                      NRAM2GDRAM);                                              \
-      pvUnlock();                                                              \
       __memcpy_async(ping_input + (i % 2) * ping_pong_gap,                     \
                      input_start + (i + 2) * span_load_size, span_load_size,   \
                      GDRAM2NRAM);                                              \

--- a/kernels/unary_op/unary_op_3pipeline.h
+++ b/kernels/unary_op/unary_op_3pipeline.h
@@ -85,11 +85,9 @@
       __asm__ volatile("sync;");                                               \
     }                                                                          \
     for (int i = 0; i < repeat - 2; i++) {                                     \
-      pvLock();                                                                \
       __memcpy_async(output_start + i * span_store_size,                       \
                      ping_output + (i % 2) * ping_pong_gap, span_store_size,   \
                      NRAM2GDRAM);                                              \
-      pvUnlock();                                                              \
       __memcpy_async(ping_input + (i % 2) * ping_pong_gap,                     \
                      input_start + (i + 2) * span_load_size, span_load_size,   \
                      GDRAM2NRAM);                                              \

--- a/kernels/unary_op/unary_op_4pipeline.h
+++ b/kernels/unary_op/unary_op_4pipeline.h
@@ -115,11 +115,9 @@ __mlu_func__ void strategyOfPartitionCore(size_t remain_num,
     }                                                                          \
     for (int i = 0; i < repeat - 2; i++) {                                     \
       int ping_flag = i % 2, pong_flag = (i + 1) % 2;                          \
-      pvLock();                                                                \
       __memcpy_async(store_start + i * cluster_store_size + sram_store_offset, \
                      ping_output + ping_flag * ping_pong_gap, core_store_size, \
                      NRAM2GDRAM);                                              \
-      pvUnlock();                                                              \
       __memcpy_async(sram_ping + ping_flag * sram_pong_gap,                    \
                      load_start + (i + 2) * cluster_load_size,                 \
                      cluster_load_size, GDRAM2SRAM);                           \
@@ -134,12 +132,10 @@ __mlu_func__ void strategyOfPartitionCore(size_t remain_num,
       __sync_cluster();                                                        \
     }                                                                          \
     if (repeat > 1) {                                                          \
-      pvLock();                                                                \
       __memcpy_async(                                                          \
           store_start + (repeat - 2) * cluster_store_size + sram_store_offset, \
           ping_output + ((repeat - 2) % 2) * ping_pong_gap, core_store_size,   \
           NRAM2GDRAM);                                                         \
-      pvUnlock();                                                              \
     }                                                                          \
     if (cluster_remain > 0) {                                                  \
       __memcpy_async(sram_ping + (repeat % 2) * sram_pong_gap,                 \
@@ -160,12 +156,10 @@ __mlu_func__ void strategyOfPartitionCore(size_t remain_num,
     }                                                                          \
     __sync_cluster();                                                          \
     if (repeat > 0) {                                                          \
-      pvLock();                                                                \
       __memcpy_async(                                                          \
           store_start + (repeat - 1) * cluster_store_size + sram_store_offset, \
           ping_output + ((repeat - 1) % 2) * ping_pong_gap, core_store_size,   \
           NRAM2GDRAM);                                                         \
-      pvUnlock();                                                              \
     }                                                                          \
     if (core_remain_num_deal > 0) {                                            \
       int ping_pong_flag = repeat % 2;                                         \
@@ -179,12 +173,10 @@ __mlu_func__ void strategyOfPartitionCore(size_t remain_num,
           ping_input + ping_pong_flag * ping_pong_gap, auxiliary_a,            \
           auxiliary_b, align_remain_num, core_remain_num_deal, args...);       \
       __asm__ volatile("sync;");                                               \
-      pvLock();                                                                \
       __memcpy_async(store_start + repeat * cluster_store_size +               \
                          core_remain_offset * sizeof(DType_out),               \
                      ping_output + ping_pong_flag * ping_pong_gap,             \
                      core_remain_num_deal * sizeof(DType_out), NRAM2GDRAM);    \
-      pvUnlock();                                                              \
     }                                                                          \
   }
 #else

--- a/kernels/unary_op/unary_op_no_pipeline.h
+++ b/kernels/unary_op/unary_op_no_pipeline.h
@@ -70,20 +70,16 @@
       compute##Op##Prefer<DType_in, DType_out>(output, input, auxiliary_a,   \
                                                auxiliary_b, span_num_deal,   \
                                                span_num_deal, args...);      \
-      pvLock();                                                              \
       __memcpy(output_start + i * span_store_size, output, span_store_size,  \
                NRAM2GDRAM);                                                  \
-      pvUnlock();                                                            \
     }                                                                        \
     if (rem > 0) {                                                           \
       __memcpy(input, input_start + repeat * span_load_size,                 \
                rem * sizeof(DType_in), GDRAM2NRAM);                          \
       compute##Op##Prefer<DType_in, DType_out>(                              \
           output, input, auxiliary_a, auxiliary_b, align_rem, rem, args...); \
-      pvLock();                                                              \
       __memcpy(output_start + repeat * span_store_size, output,              \
                rem * sizeof(DType_out), NRAM2GDRAM);                         \
-      pvUnlock();                                                            \
     }                                                                        \
   }
 

--- a/kernels/utils/common.h
+++ b/kernels/utils/common.h
@@ -507,22 +507,6 @@ __mlu_func__ void __mluop_float2int32(int32_t *dst, float *dst_addition,
 #endif
 }
 
-__mlu_func__ void pvLock() {
-#if __BANG_ARCH__ == 270
-  if (__is_ipu()) {
-    __bang_lock(0, 0);
-  }
-#endif
-}
-
-__mlu_func__ void pvUnlock() {
-#if __BANG_ARCH__ == 270
-  if (__is_ipu()) {
-    __bang_unlock(0, 0);
-  }
-#endif
-}
-
 /******************************************************************************
  * MLUOPS FUNC: __mluop_load_str_2D
  * param 'size' is the getC size.

--- a/kernels/utils/common.h
+++ b/kernels/utils/common.h
@@ -257,14 +257,14 @@ __mlu_func__ void __mluop_log(T *nram_dst, T *nram_src, void *nram_addition,
   if (sizeof(T) == sizeof(float)) {
     int x2d = 0x3f317217;
     float rlog2e = *(float *)&x2d;
-    __bang_log((float *)nram_dst, (float *)nram_src, deal_num);
+    __bang_log2((float *)nram_dst, (float *)nram_src, deal_num);
     __bang_mul_scalar((float *)nram_dst, (float *)nram_dst, (float)rlog2e,
                       deal_num);
   } else if (sizeof(T) == sizeof(half)) {
     int x2d = 0x3f317217;
     float rlog2e = *(float *)&x2d;
     __bang_half2float((float *)nram_addition, (half *)nram_src, deal_num);
-    __bang_log((float *)nram_addition, (float *)nram_addition, deal_num);
+    __bang_log2((float *)nram_addition, (float *)nram_addition, deal_num);
     __mluop_float2half((half *)nram_dst, (float *)nram_addition, deal_num);
     __bang_mul_scalar((half *)nram_dst, (half *)nram_dst, (half)rlog2e,
                       deal_num);

--- a/kernels/voxelization/voxelization_kernel.mlu
+++ b/kernels/voxelization/voxelization_kernel.mlu
@@ -250,7 +250,6 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
   }
 
   for (int32_t i = 0; i < repeat - 2; ++i) {
-    pvLock();
     __memcpy_async(coors_x_start + i * deal_num,
                    points_x + (i % 2) * ping_pong_gap,
                    deal_num * sizeof(int32_t), NRAM2GDRAM);
@@ -260,7 +259,7 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
     __memcpy_async(coors_z_start + i * deal_num,
                    points_z + (i % 2) * ping_pong_gap,
                    deal_num * sizeof(int32_t), NRAM2GDRAM);
-    pvUnlock();
+
     __memcpy_async(points_x + (i % 2) * ping_pong_gap,
                    points + (points_start + (i + 2) * deal_num) * num_features,
                    sizeof(float), GDRAM2NRAM, sizeof(float),
@@ -285,7 +284,6 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
   }
 
   if (repeat >= 2) {
-    pvLock();
     __memcpy_async(coors_x_start + (repeat - 2) * deal_num,
                    points_x + (repeat % 2) * ping_pong_gap,
                    deal_num * sizeof(int32_t), NRAM2GDRAM);
@@ -295,7 +293,6 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
     __memcpy_async(coors_z_start + (repeat - 2) * deal_num,
                    points_z + (repeat % 2) * ping_pong_gap,
                    deal_num * sizeof(int32_t), NRAM2GDRAM);
-    pvUnlock();
   }
   if (rem > 0) {
     __memcpy_async(points_x + (repeat % 2) * ping_pong_gap,
@@ -324,7 +321,6 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
   __sync();
 
   if (repeat > 0) {
-    pvLock();
     __memcpy_async(coors_x_start + (repeat - 1) * deal_num,
                    points_x + ((repeat - 1) % 2) * ping_pong_gap,
                    deal_num * sizeof(int32_t), NRAM2GDRAM);
@@ -334,7 +330,6 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
     __memcpy_async(coors_z_start + (repeat - 1) * deal_num,
                    points_z + ((repeat - 1) % 2) * ping_pong_gap,
                    deal_num * sizeof(int32_t), NRAM2GDRAM);
-    pvUnlock();
   }
   if (rem > 0) {
     computeDynamicVoxelize(points_x + (repeat % 2) * ping_pong_gap,
@@ -344,7 +339,6 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
                            coors_z_min, voxel_x, voxel_y, voxel_z, grid_x,
                            grid_y, grid_z, rem);
     __sync();
-    pvLock();
     __memcpy_async(coors_x_start + repeat * deal_num,
                    points_x + (repeat % 2) * ping_pong_gap,
                    rem * sizeof(int32_t), NRAM2GDRAM);
@@ -354,7 +348,6 @@ __mlu_global__ void mluDynamicVoxelize(const float *points,
     __memcpy_async(coors_z_start + repeat * deal_num,
                    points_z + (repeat % 2) * ping_pong_gap,
                    rem * sizeof(int32_t), NRAM2GDRAM);
-    pvUnlock();
   }
 #endif
 }

--- a/kernels/yolo_box/yolo_box_block.mlu
+++ b/kernels/yolo_box/yolo_box_block.mlu
@@ -157,11 +157,11 @@ __mlu_func__ void compute(T *nram_x, T *nram_y, T *nram_w, T *nram_h,
     } else if ((T)iou_aware_factor == (T)1.0) {
       __bang_write_value(nram_conf_p, deal_num, (T)1.0);
     } else {
-      __bang_log(nram_iou_p, nram_iou_p, deal_num);
+      __bang_log2(nram_iou_p, nram_iou_p, deal_num);
       __bang_mul_scalar(nram_iou_p, nram_iou_p, (T)iou_aware_factor, deal_num);
       __bang_pow2(nram_iou_p, nram_iou_p, deal_num);
 
-      __bang_log(nram_conf_p, nram_conf_p, deal_num);
+      __bang_log2(nram_conf_p, nram_conf_p, deal_num);
       __bang_mul_scalar(nram_conf_p, nram_conf_p, (T)1.0 - (T)iou_aware_factor,
                         deal_num);
       __bang_pow2(nram_conf_p, nram_conf_p, deal_num);
@@ -1154,11 +1154,11 @@ __mlu_func__ void computeScore(T *nram_iou, T *nram_conf, T *nram_cls,
     } else if ((T)iou_aware_factor == (T)1.0) {
       __bang_write_value(nram_conf_p, deal_num, (T)1.0);
     } else {
-      __bang_log(nram_iou_p, nram_iou_p, deal_num);
+      __bang_log2(nram_iou_p, nram_iou_p, deal_num);
       __bang_mul_scalar(nram_iou_p, nram_iou_p, (T)iou_aware_factor, deal_num);
       __bang_pow2(nram_iou_p, nram_iou_p, deal_num);
 
-      __bang_log(nram_conf_p, nram_conf_p, deal_num);
+      __bang_log2(nram_conf_p, nram_conf_p, deal_num);
       __bang_mul_scalar(nram_conf_p, nram_conf_p, (T)1.0 - (T)iou_aware_factor,
                         deal_num);
       __bang_pow2(nram_conf_p, nram_conf_p, deal_num);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.