### PR TITLE
[Feature](mlu-ops): revise cnrt variable to adapt to 4.0

### DIFF
--- a/core/context.h
+++ b/core/context.h
@@ -96,17 +96,17 @@ struct mluOpContext {
     switch (function_type) {
       default:
         return 0;
-      case CNRT_FUNC_TYPE_BLOCK:
+      case cnrtFuncTypeBlock:
         return job_num[0];
-      case CNRT_FUNC_TYPE_UNION1:
+      case cnrtFuncTypeUnion1:
         return job_num[1];
-      case CNRT_FUNC_TYPE_UNION2:
+      case cnrtFuncTypeUnion2:
         return job_num[2];
-      case CNRT_FUNC_TYPE_UNION4:
+      case cnrtFuncTypeUnion4:
         return job_num[3];
-      case CNRT_FUNC_TYPE_UNION8:
+      case cnrtFuncTypeUnion8:
         return job_num[4];
-      case CNRT_FUNC_TYPE_UNION16:
+      case cnrtFuncTypeUnion16:
         return job_num[5];
     }
   }

--- a/core/gen_case.h
+++ b/core/gen_case.h
@@ -472,9 +472,9 @@ class PbNode {
     void *data = malloc(data_size);
     auto memcpy_dir =
         (tensors[index].desc->pointer_mode == MLUOP_POINTER_MODE_HOST
-             ? CNRT_MEM_TRANS_DIR_HOST2HOST
-             : CNRT_MEM_TRANS_DIR_DEV2HOST);
-    if (CNRT_RET_SUCCESS ==
+             ? cnrtMemcpyHostToHost
+             : cnrtMemcpyDevToHost);
+    if (cnrtSuccess ==
         cnrtMemcpy(data, const_cast<void *>(tensors[index].device_ptr),
                    data_size, memcpy_dir)) {
       return data;
@@ -538,9 +538,9 @@ inline void PbNode::appendOpParam<const void *>(std::string param_name,
   int data_width = mluop::getSizeOfDataType(dtype);
   if (attr.type == cnrtMemTypeDevice) {
     void *data = malloc(data_width);
-    if (CNRT_RET_SUCCESS == cnrtMemcpy(data, const_cast<void *>(param_value),
+    if (cnrtSuccess == cnrtMemcpy(data, const_cast<void *>(param_value),
                                        data_width,
-                                       CNRT_MEM_TRANS_DIR_DEV2HOST)) {
+                                       cnrtMemcpyDevToHost)) {
       op_param.params.push_back({param_name, get_data_string(dtype, data, 0)});
     } else {
       LOG(ERROR) << "[gen_case] dump op param failed, param_name is "

--- a/core/logging.h
+++ b/core/logging.h
@@ -95,7 +95,7 @@
     cnrtGetLastError();                                            \
     kernel;                                                        \
     cnrtRet_t ret = cnrtPeekAtLastError();                         \
-    if (MLUOP_PREDICT_FALSE(CNRT_RET_SUCCESS != ret)) {            \
+    if (MLUOP_PREDICT_FALSE(cnrtSuccess != ret)) {            \
       LOG(ERROR) << "Check failed: Found " << cnrtGetErrorStr(ret) \
                  << " after invoke kernel " #kernel;               \
       return MLUOP_STATUS_EXECUTION_FAILED;                        \

--- a/core/runtime/device.h
+++ b/core/runtime/device.h
@@ -121,17 +121,17 @@ inline cnrtFunctionType_t castCnKernelClassToCnrtFuncType(KernelClass jobType) {
     default:
       return CNRT_FUNC_TYPE_MUTABLE;
     case CN_KERNEL_CLASS_BLOCK:
-      return CNRT_FUNC_TYPE_BLOCK;
+      return cnrtFuncTypeBlock;
     case CN_KERNEL_CLASS_UNION:
-      return CNRT_FUNC_TYPE_UNION1;
+      return cnrtFuncTypeUnion1;
     case CN_KERNEL_CLASS_UNION2:
-      return CNRT_FUNC_TYPE_UNION2;
+      return cnrtFuncTypeUnion2;
     case CN_KERNEL_CLASS_UNION4:
-      return CNRT_FUNC_TYPE_UNION4;
+      return cnrtFuncTypeUnion4;
     case CN_KERNEL_CLASS_UNION8:
-      return CNRT_FUNC_TYPE_UNION8;
+      return cnrtFuncTypeUnion8;
     case CN_KERNEL_CLASS_UNION16:
-      return CNRT_FUNC_TYPE_UNION16;
+      return cnrtFuncTypeUnion16;
   }
 }
 

--- a/docs/BANG C OPS-Develop-Guide.md
+++ b/docs/BANG C OPS-Develop-Guide.md
@@ -458,7 +458,7 @@ double get_io_bandwidth() {
 }
 
 void get_policy_function_block(cnrtDim3_t *dim, cnrtFunctionType_t *func_type) {
-  *func_type = CNRT_FUNC_TYPE_BLOCK;
+  *func_type = cnrtFuncTypeBlock;
   dim->x = 1;
   dim->y = 1;
   dim->z = 1;
@@ -466,7 +466,7 @@ void get_policy_function_block(cnrtDim3_t *dim, cnrtFunctionType_t *func_type) {
 }
 
 void get_policy_function_union1(cnrtDim3_t *dim, cnrtFunctionType_t *func_type) {
-  *func_type = CNRT_FUNC_TYPE_UNION1;
+  *func_type = cnrtFuncTypeUnion1;
   dim->x = get_core_num_per_cluster();
   dim->y = get_cluster_num();
   dim->z = 1;
@@ -702,7 +702,7 @@ int main() {
   cnDeviceGetAttribute(&dimX, CN_DEVICE_ATTRIBUTE_MAX_CORE_COUNT_PER_CLUSTER, dev);
 
   cnrtDim3_t dim3 = {dimX, 1, 1};
-  cnrtFunctionType_t ktype = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t ktype = cnrtFuncTypeUnion1;
 
   foo<<<dim3, ktype, queue>>>();
   CHRT_CHECK(cnrtSyncQueue(queue));
@@ -924,7 +924,7 @@ UnionN (N=1, 2, 4, 8, ...) 任务表示一个 Kernel 在执行时至少需要占
 
   ```c++
   void void get_policy_function_union1(cnrtDim3_t *dim, cnrtFunctionType_t *func_type) {
-    *func_type = CNRT_FUNC_TYPE_UNION1;
+    *func_type = cnrtFuncTypeUnion1;
     dim->x = get_core_num_per_cluster();
     dim->y = get_cluster_num();
     dim->z = 1;
@@ -2371,7 +2371,7 @@ mlu_op.h // mluop 接口声明文件
                           cnrtFunctionType_t *k_type) {
      size_t dim = mluOpGetTensorElementNum(desc);
      // Union1 policyFunc
-     *k_type = CNRT_FUNC_TYPE_UNION1;
+     *k_type = cnrtFuncTypeUnion1;
      k_dim->x = handle->core_num_per_cluster;
      k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
      k_dim->z = 1;

--- a/docs/design_docs/ball_query/ball_query.md
+++ b/docs/design_docs/ball_query/ball_query.md
@@ -434,7 +434,7 @@ vec_idx_num[k] += selected_num;
   k_dim->y =
       needed_cluster_num > cluster_num ? cluster_num : needed_cluster_num;
   k_dim->z = 1;
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
 ```
 ![image](ballquery_split.jpg)
 

--- a/docs/design_docs/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.md
+++ b/docs/design_docs/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.md
@@ -319,7 +319,7 @@ KERNEL_CHECK((KernelMaskFillCoorsForward(
   
   CALL_CNNL(cnnlDestroyUniqueDescriptor(unique_desc));
   int32_t num_voxels = 0;
-  cnrtMemcpy(&num_voxels, voxel_num, sizeof(int), CNRT_MEM_TRANS_DIR_DEV2HOST);
+  cnrtMemcpy(&num_voxels, voxel_num, sizeof(int), cnrtMemcpyDevToHost);
 ```
 - kernel3: KernelRemoveFirstForward
 

--- a/docs/design_docs/three_nn_forward/three_nn_forward.md
+++ b/docs/design_docs/three_nn_forward/three_nn_forward.md
@@ -390,7 +390,7 @@ if(deal_offset > 3) {
   k_dims.x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dims.y = mluop::runtime::getClusterLimitCapability(handle);
   k_dims.z = 1;
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
 ```
 数据拆分如图所示：
 

--- a/kernels/adam_w/adam_w.cpp
+++ b/kernels/adam_w/adam_w.cpp
@@ -246,7 +246,7 @@ mluOpAdamW(mluOpHandle_t handle, const mluOpAdamWDescriptor_t adamw_desc,
                            grad_dims_shape);
   mluOpDataType_t k_data_type = grad_dtype;
   cnrtDim3_t k_dim;
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
   k_dim.x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dim.y = mluop::runtime::getClusterLimitCapability(handle);
   k_dim.z = 1;
@@ -261,7 +261,7 @@ mluOpAdamW(mluOpHandle_t handle, const mluOpAdamWDescriptor_t adamw_desc,
       GEN_CASE_END();
       return MLUOP_STATUS_ARCH_MISMATCH;
     }
-    case CNRT_FUNC_TYPE_UNION1: {
+    case cnrtFuncTypeUnion1: {
       VLOG(5) << "Launch Kernel KernelApplyAdamW<<<Union" << k_type / CORE_DIM
               << ", " << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";
       CHECK_RETURN(

--- a/kernels/ball_query/ball_query.cpp
+++ b/kernels/ball_query/ball_query.cpp
@@ -58,7 +58,7 @@ void policyFuncBallQuery(const mluOpHandle_t &handle,
   // element.
   size_t needed_cluster_num =
       (total_data_num + core_in_cluster - 1) / core_in_cluster;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_in_cluster;
   k_dim->y =
       needed_cluster_num > cluster_num ? cluster_num : needed_cluster_num;

--- a/kernels/bbox_overlaps/bbox_overlaps.cpp
+++ b/kernels/bbox_overlaps/bbox_overlaps.cpp
@@ -39,7 +39,7 @@ static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
   uint32_t core_num = union_num * core_dim;
 
   // Union1 policyFunc
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_dim;
   uint32_t need_core_num = (batch_num_all + core_dim - 1) / core_dim * core_dim;
   if (need_core_num < core_num) {

--- a/kernels/binary_op/binary_op_host.cpp
+++ b/kernels/binary_op/binary_op_host.cpp
@@ -49,7 +49,7 @@ void binaryOpPolicyFunc(mluOpHandle_t handle, const int pad_up_size,
   size = PAD_UP(size, pad_up_size);
 
   // Union1 policyFunc
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_dim;
   const uint64_t maximum_partitions = PAD_UP(size / pad_up_size, core_dim);
   if (maximum_partitions < core_number) {
@@ -66,7 +66,7 @@ void binaryOpBlockPolicyFunc(mluOpHandle_t handle,
                              cnrtFunctionType_t &k_type,
                              size_t &normal_core_elem_num,
                              size_t &tail_core_elem_num) {
-  k_type = CNRT_FUNC_TYPE_BLOCK;
+  k_type = cnrtFuncTypeBlock;
   const uint32_t core_number =
       mluop::runtime::getMaxParallelJobNum(handle, k_type);
   const size_t element_num = mluOpGetTensorElementNum(desc);

--- a/kernels/border_align/border_align_backward/border_align_backward.cpp
+++ b/kernels/border_align/border_align_backward/border_align_backward.cpp
@@ -36,7 +36,7 @@
 
 static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
   k_dim->z = 1;

--- a/kernels/border_align/border_align_forward/border_align_forward.cpp
+++ b/kernels/border_align/border_align_forward/border_align_forward.cpp
@@ -34,7 +34,7 @@
 // policyFunc
 static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
   k_dim->z = 1;

--- a/kernels/box_iou_rotated/box_iou_rotated.cpp
+++ b/kernels/box_iou_rotated/box_iou_rotated.cpp
@@ -39,7 +39,7 @@ static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        const int num_box1, const int num_box2) {
   // When current MLU arch only support Block type job
   if (mluop::runtime::getJobLimitCapability(handle) == CN_KERNEL_CLASS_BLOCK) {
-    *k_type = CNRT_FUNC_TYPE_BLOCK;
+    *k_type = cnrtFuncTypeBlock;
     k_dim->x = 1;
     k_dim->y = 1;
     k_dim->z = 1;
@@ -48,7 +48,7 @@ static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
   }
 
   // union1 policy func
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   // dimx equals to num of mlu cores in each cluster
   k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   // dimy equals to num of current available clusters
@@ -59,7 +59,7 @@ static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
   const uint32_t single_core_small_case = 64;
 
   if (single_core_small_case >= num_box1) {  // only 1 mlu core enough
-    *k_type = CNRT_FUNC_TYPE_BLOCK;
+    *k_type = cnrtFuncTypeBlock;
     k_dim->x = 1;
     k_dim->y = 1;
     VLOG(5) << "Launch Kernel MLUKernelBoxIouRotated in BLOCK type";

--- a/kernels/carafe/carafe.cpp
+++ b/kernels/carafe/carafe.cpp
@@ -254,7 +254,7 @@ mluOpStatus_t genPolicy(mluOpHandle_t handle,
           << "NRAM usage (Nb. of dtype_size) = " << nram_usage;
 
   // determine task type and dims
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   k_dim->x = core_dim;
   k_dim->y = union_number;
   k_dim->z = 1;
@@ -883,7 +883,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpCarafeBackward(
   task_dim_x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   task_dim_y = mluop::runtime::getClusterLimitCapability(handle);
   cnrtDim3_t k_dim = {task_dim_x, task_dim_y, 1};
-  cnrtJobType_t k_type = CNRT_FUNC_TYPE_BLOCK;
+  cnrtFunctionType_t k_type = cnrtFuncTypeBlock;
 
   VLOG(5) << "Launch KernelCarafeBackward<<<k_type=" << k_type << ", "
           << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";

--- a/kernels/deform_roi_pool/deform_roi_pool.cpp
+++ b/kernels/deform_roi_pool/deform_roi_pool.cpp
@@ -48,7 +48,7 @@ void policyFunc(const mluOpHandle_t handle,
   k_dim->y = (num_bins / core_limit) > cluster_limit ? cluster_limit
                                                      : (num_bins / core_limit);
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 }
 
 static mluOpStatus_t DeformRoiPoolForwardPreCheck(

--- a/kernels/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
+++ b/kernels/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
@@ -34,7 +34,7 @@
 
 static void policyFunc(const mluOpHandle_t handle, const int bn_num,
                        cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   uint32_t cluster_num = mluop::runtime::getClusterLimitCapability(handle);
   uint32_t core_num_per_cluster =
       mluop::runtime::getCoreNumOfEachUnionCapability(handle);

--- a/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
+++ b/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
@@ -192,19 +192,19 @@ static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
   } else {
     if (N <= 4) {
       k_dim->x = core_num * 1;
-      *k_type = CNRT_FUNC_TYPE_UNION1;
+      *k_type = cnrtFuncTypeUnion1;
     } else if (N <= 8) {
       k_dim->x = core_num * 2;
-      *k_type = CNRT_FUNC_TYPE_UNION2;
+      *k_type = cnrtFuncTypeUnion2;
     } else if (N <= 16) {
       k_dim->x = core_num * 4;
-      *k_type = CNRT_FUNC_TYPE_UNION4;
+      *k_type = cnrtFuncTypeUnion4;
     } else if (N <= 32) {
       k_dim->x = core_num * 8;
-      *k_type = CNRT_FUNC_TYPE_UNION8;
+      *k_type = cnrtFuncTypeUnion8;
     } else if (N <= 64) {
       k_dim->x = core_num * 16;
-      *k_type = CNRT_FUNC_TYPE_UNION16;
+      *k_type = cnrtFuncTypeUnion16;
     } else {
       LOG(ERROR)
           << "[mluOpDynamicPointToVoxelBackward]: failed to choose kernel "

--- a/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -45,22 +45,22 @@ static void policyFuncDynamicPointToVoxelForward(const mluOpHandle_t handle,
   } else {
     if (nums == 1) {
       k_dim->x = 1;
-      *k_type = CNRT_FUNC_TYPE_BLOCK;
+      *k_type = cnrtFuncTypeBlock;
     } else if (nums <= 4) {
       k_dim->x = core_num * 1;
-      *k_type = CNRT_FUNC_TYPE_UNION1;
+      *k_type = cnrtFuncTypeUnion1;
     } else if (nums <= 8) {
       k_dim->x = core_num * 2;
-      *k_type = CNRT_FUNC_TYPE_UNION2;
+      *k_type = cnrtFuncTypeUnion2;
     } else if (nums <= 16) {
       k_dim->x = core_num * 4;
-      *k_type = CNRT_FUNC_TYPE_UNION4;
+      *k_type = cnrtFuncTypeUnion4;
     } else if (nums <= 32) {
       k_dim->x = core_num * 8;
-      *k_type = CNRT_FUNC_TYPE_UNION8;
+      *k_type = cnrtFuncTypeUnion8;
     } else if (nums <= 64) {
       k_dim->x = core_num * 16;
-      *k_type = CNRT_FUNC_TYPE_UNION16;
+      *k_type = cnrtFuncTypeUnion16;
     }
   }
   k_dim->y = 1;

--- a/kernels/fft/c2c_fft/c2c_fft_host.cpp
+++ b/kernels/fft/c2c_fft/c2c_fft_host.cpp
@@ -527,7 +527,7 @@ mluOpStatus_t setFFT1dReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
         mluop::runtime::getClusterLimitCapability(handle);
     const unsigned int core_dim = handle->core_num_per_cluster;
     cnrtDim3_t k_dim = {core_dim, cluster_number, 1};
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_BLOCK;
+    cnrtFunctionType_t k_type = cnrtFuncTypeBlock;
 
     switch (fft_plan->fft_strategy) {
       case CNFFT_FUNC_MATMUL: {
@@ -1644,7 +1644,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
 
 static mluOpStatus_t policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                 cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = handle->core_num_per_cluster;
   k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
   k_dim->z = 1;
@@ -1664,7 +1664,7 @@ mluOpStatus_t mergeFFT1dOutput(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
     VLOG(5) << "launch merge fft1d output";
     // TODO(niyuming) luanch merge kernel
     int core_num = handle->core_num_per_cluster;
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+    cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
     int task_type = mluop::runtime::getJobLimitCapability(handle);
     int task_num = 1;
 
@@ -1672,16 +1672,16 @@ mluOpStatus_t mergeFFT1dOutput(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
       default:
         task_num = core_num;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION2:
+      case (int)cnrtFuncTypeUnion2:
         task_num = core_num * 2;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION4:
+      case (int)cnrtFuncTypeUnion4:
         task_num = core_num * 4;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION8:
+      case (int)cnrtFuncTypeUnion8:
         task_num = core_num * 8;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION16:
+      case (int)cnrtFuncTypeUnion16:
         task_num = core_num * 16;
         break;
     }

--- a/kernels/fft/irfft/irfft_host.cpp
+++ b/kernels/fft/irfft/irfft_host.cpp
@@ -515,7 +515,7 @@ mluOpStatus_t setIRFFT1dReserveArea(mluOpHandle_t handle,
         mluop::runtime::getClusterLimitCapability(handle);
     const unsigned int core_dim = handle->core_num_per_cluster;
     cnrtDim3_t k_dim = {core_dim, cluster_number, 1};
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_BLOCK;
+    cnrtFunctionType_t k_type = cnrtFuncTypeBlock;
 
     switch (fft_plan->fft_strategy) {
       case CNFFT_FUNC_MATMUL: {
@@ -1385,7 +1385,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
 
 static mluOpStatus_t policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                 cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = handle->core_num_per_cluster;
   k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
   k_dim->z = 1;
@@ -1404,7 +1404,7 @@ mluOpStatus_t mergeIRFFT1dOutput(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
   VLOG(5) << "launch merge irfft1d output";
   if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     int core_num = handle->core_num_per_cluster;
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+    cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
     int task_type = mluop::runtime::getJobLimitCapability(handle);
     int task_num = 1;
 
@@ -1412,16 +1412,16 @@ mluOpStatus_t mergeIRFFT1dOutput(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
       default:
         task_num = core_num;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION2:
+      case (int)cnrtFuncTypeUnion2:
         task_num = core_num * 2;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION4:
+      case (int)cnrtFuncTypeUnion4:
         task_num = core_num * 4;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION8:
+      case (int)cnrtFuncTypeUnion8:
         task_num = core_num * 8;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION16:
+      case (int)cnrtFuncTypeUnion16:
         task_num = core_num * 16;
         break;
     }
@@ -1551,7 +1551,7 @@ mluOpStatus_t execIRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
       fft_plan->mlu_addrs.input = fft_plan->mlu_addrs.input_pad_addr;
     }
 
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+    cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
     cnrtDim3_t k_dim;
     k_dim.x = handle->core_num_per_cluster;
     k_dim.y = mluop::runtime::getClusterLimitCapability(handle);

--- a/kernels/fft/rfft/rfft_host.cpp
+++ b/kernels/fft/rfft/rfft_host.cpp
@@ -490,7 +490,7 @@ mluOpStatus_t setRFFT1dReserveArea(mluOpHandle_t handle,
         mluop::runtime::getClusterLimitCapability(handle);
     const unsigned int core_dim = handle->core_num_per_cluster;
     cnrtDim3_t k_dim = {core_dim, cluster_number, 1};
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_BLOCK;
+    cnrtFunctionType_t k_type = cnrtFuncTypeBlock;
 
     switch (fft_plan->fft_strategy) {
       case CNFFT_FUNC_MATMUL: {
@@ -1007,7 +1007,7 @@ static mluOpStatus_t computeRFFT1dMatmulResult(mluOpHandle_t handle,
 
 static mluOpStatus_t policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                 cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = handle->core_num_per_cluster;
   k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
   k_dim->z = 1;
@@ -1026,7 +1026,7 @@ static mluOpStatus_t mergeRFFT1dOutput(mluOpHandle_t handle,
   if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     VLOG(5) << "launch merge rfft1d output";
     int core_num = handle->core_num_per_cluster;
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+    cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
     int task_type = mluop::runtime::getJobLimitCapability(handle);
     int task_num = 1;
 
@@ -1034,16 +1034,16 @@ static mluOpStatus_t mergeRFFT1dOutput(mluOpHandle_t handle,
       default:
         task_num = core_num;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION2:
+      case (int)cnrtFuncTypeUnion2:
         task_num = core_num * 2;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION4:
+      case (int)cnrtFuncTypeUnion4:
         task_num = core_num * 4;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION8:
+      case (int)cnrtFuncTypeUnion8:
         task_num = core_num * 8;
         break;
-      case (int)CNRT_FUNC_TYPE_UNION16:
+      case (int)cnrtFuncTypeUnion16:
         task_num = core_num * 16;
         break;
     }
@@ -1272,7 +1272,7 @@ mluOpStatus_t execRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
       fft_plan->mlu_addrs.input = fft_plan->mlu_addrs.input_pad_addr;
     }
 
-    cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+    cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
     cnrtDim3_t k_dim;
     k_dim.x = handle->core_num_per_cluster;
     k_dim.y = mluop::runtime::getClusterLimitCapability(handle);

--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid.cpp
@@ -35,7 +35,7 @@
 
 static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = handle->core_num_per_cluster;
   k_dim->y = mluop::runtime::getClusterLimitCapability(handle);
   k_dim->z = 1;

--- a/kernels/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/kernels/generate_proposals_v2/generate_proposals_v2.cpp
@@ -51,9 +51,9 @@ static void policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
   k_dim->z = 1;
   if (job < 4) {
     k_dim->x = 1;
-    *k_type = CNRT_FUNC_TYPE_BLOCK;
+    *k_type = cnrtFuncTypeBlock;
   } else {
-    *k_type = CNRT_FUNC_TYPE_UNION1;
+    *k_type = cnrtFuncTypeUnion1;
     k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   }
   return;
@@ -429,7 +429,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpGenerateProposalsV2(
   VLOG(5) << "N : " << n;
   const size_t hwa = h * w * a;
   cnrtDim3_t k_dim;
-  cnrtJobType_t k_type;
+  cnrtFunctionType_t k_type;
   policyFunc(handle, &k_dim, &k_type, hwa);
   VLOG(5) << "Launch Kernel KernelGenerateProposalsV2 <<<k_dim: " << k_type
           << ", " << k_dim.x << ", " << k_dim.y << ", " << k_dim.z << ">>>";

--- a/kernels/masked_im2col/masked_col2im_forward/masked_col2im_forward.cpp
+++ b/kernels/masked_im2col/masked_col2im_forward/masked_col2im_forward.cpp
@@ -42,7 +42,7 @@ static void policyFunc(const mluOpHandle_t handle, const int mask_cnt,
   k_dim->y = (task_dim / core_limit) > cluster_limit ? cluster_limit
                                                      : (task_dim / core_limit);
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 }
 
 static mluOpStatus_t maskedCol2imForwardPreCheck(

--- a/kernels/masked_im2col/masked_im2col_forward/masked_im2col_forward.cpp
+++ b/kernels/masked_im2col/masked_im2col_forward/masked_im2col_forward.cpp
@@ -40,7 +40,7 @@ static void policyFunc(const mluOpHandle_t handle, const int mask_cnt,
   k_dim->y = (task_dim / core_limit) > cluster_limit ? cluster_limit
                                                      : (task_dim / core_limit);
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 }
 
 static mluOpStatus_t maskedIm2colForwardPreCheck(

--- a/kernels/moe_dispatch/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
@@ -36,7 +36,7 @@
 static void PolicyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type) {
   // union1 policy func
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   // dimx equals to num of MLU Cores in each cluster
   k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   // dimy equals to num of current available clusters

--- a/kernels/moe_dispatch/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -40,7 +40,7 @@ static void policyFunc(const mluOpHandle_t handle, const int samples,
   k_dim->y = 1;
   k_dim->z = 1;
   if (samples > max_core_num) {
-    *k_type = CNRT_FUNC_TYPE_UNION1;
+    *k_type = cnrtFuncTypeUnion1;
   } else {
     *k_type = mluop::runtime::getJobLimitCapabilityCnrtFuncType(handle);
   }

--- a/kernels/moe_dispatch/moe_dispatch_forward/moe_dispatch_forward.cpp
+++ b/kernels/moe_dispatch/moe_dispatch_forward/moe_dispatch_forward.cpp
@@ -34,7 +34,7 @@
 static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type) {
   // block policy func
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   // dimx equals to num of mlu cores in each cluster
   k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   // dimy equals to num of current available clusters

--- a/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -68,7 +68,7 @@ static void policyFunc(mluOpHandle_t handle, const int32_t batch,
                  ? cluster_limit
                  : (total_num_align / core_limit);
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 }
 
 mluOpDeformAttnBackwardKernelPolicy_t msDeformAttnBackwardPolicyFunc(

--- a/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_forward/ms_deform_attn_forward.mlu
@@ -56,7 +56,7 @@ MsDeformAttnForwardPolicy msDeformAttnForwardPolicyFunc(
           mluop::runtime::getClusterLimitCapability(handle));
   k_dims->z = 1;
 
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 
   int32_t nlp = num_levels * num_points;
   int32_t nlpc = num_levels * num_points * channels;
@@ -274,7 +274,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
           VLOG(5) << "Not Implemented";
           break;
         }
-        case CNRT_FUNC_TYPE_BLOCK: {
+        case cnrtFuncTypeBlock: {
           VLOG(5)
               << "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Block, "
               << k_dims.x << ", " << k_dims.y << ", " << k_dims.z << ">>>";
@@ -288,7 +288,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
                    num_queries, num_points, (int8_t *)data_col)));
           break;
         }
-        case CNRT_FUNC_TYPE_UNION1: {
+        case cnrtFuncTypeUnion1: {
           VLOG(5) << "Launch Kernel MLUKernelMsDeformAttnForwardDefault<<<Union"
                   << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y
                   << ", " << k_dims.z << ">>>";
@@ -311,7 +311,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
           VLOG(5) << "Not Implemented";
           break;
         }
-        case CNRT_FUNC_TYPE_BLOCK: {
+        case cnrtFuncTypeBlock: {
           VLOG(5) << "Launch Kernel "
                      "MLUKernelMsDeformAttnForwardSmallChannel<<<Block, "
                   << k_dims.x << ", " << k_dims.y << ", " << k_dims.z << ">>>";
@@ -325,7 +325,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMsDeformAttnForward(
                    num_queries, num_points, (int8_t *)data_col)));
           break;
         }
-        case CNRT_FUNC_TYPE_UNION1: {
+        case cnrtFuncTypeUnion1: {
           VLOG(5) << "Launch Kernel "
                      "MLUKernelMsDeformAttnForwardSmallChannel<<<Union"
                   << k_type / CORE_DIM << ", " << k_dims.x << ", " << k_dims.y

--- a/kernels/mutual_information/mutual_information_backward/mutual_information_backward.cpp
+++ b/kernels/mutual_information/mutual_information_backward/mutual_information_backward.cpp
@@ -452,7 +452,7 @@ static void policyFunc3Pipeline(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                 cnrtFunctionType_t *k_type, int batch_size) {
   int core_num = mluop::runtime::getClusterLimitCapability(handle) *
                  mluop::runtime::getCoreNumOfEachUnionCapability(handle);
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   k_dim->x = 1;
   k_dim->y = batch_size < core_num ? batch_size : core_num;
   k_dim->z = 1;
@@ -776,7 +776,7 @@ static mluOpStatus_t launchMutualInformationBackwardDefaultKernel(
   int max_s_t_block_num = std::max(s_block_num, t_block_num);
   int min_s_t_block_num = std::min(s_block_num, t_block_num);
 
-  k_type = CNRT_FUNC_TYPE_BLOCK;
+  k_type = cnrtFuncTypeBlock;
   k_dim.y = 1;
   k_dim.z = 1;
   // Get current arch support max dim_x value

--- a/kernels/mutual_information/mutual_information_forward/mutual_information_forward.cpp
+++ b/kernels/mutual_information/mutual_information_forward/mutual_information_forward.cpp
@@ -365,7 +365,7 @@ static void policyFunc3Pipeline(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                 cnrtFunctionType_t *k_type, int batch_size) {
   int core_num = mluop::runtime::getClusterLimitCapability(handle) *
                  mluop::runtime::getCoreNumOfEachUnionCapability(handle);
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   k_dim->x = 1;
   k_dim->y = batch_size < core_num ? batch_size : core_num;
   k_dim->z = 1;
@@ -662,7 +662,7 @@ static mluOpStatus_t launchMutualInformationForwardDefaultKernel(
   int max_s_t_block_num = std::max(s_block_num, t_block_num);
   int min_s_t_block_num = std::min(s_block_num, t_block_num);
 
-  k_type = CNRT_FUNC_TYPE_BLOCK;
+  k_type = cnrtFuncTypeBlock;
   k_dim.y = 1;
   k_dim.z = 1;
   // Get current arch support max dim_x value

--- a/kernels/nms_rotated/nms_rotated.cpp
+++ b/kernels/nms_rotated/nms_rotated.cpp
@@ -35,7 +35,7 @@ static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type, const int box_num) {
   // When current MLU arch only support Block type job
   if (mluop::runtime::getJobLimitCapability(handle) == CN_KERNEL_CLASS_BLOCK) {
-    *k_type = CNRT_FUNC_TYPE_BLOCK;
+    *k_type = cnrtFuncTypeBlock;
     k_dim->x = 1;
     k_dim->y = 1;
     k_dim->z = 1;
@@ -43,7 +43,7 @@ static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
     return;
   }
   // union1 policy func
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   // dimx equals to num of mlu cores in each cluster
   k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dim->y = 1;

--- a/kernels/points_in_boxes/points_in_boxes.cpp
+++ b/kernels/points_in_boxes/points_in_boxes.cpp
@@ -154,7 +154,7 @@ static bool isPointsInBoxes(const mluOpHandle_t handle, cnrtDim3_t &k_dim,
   uint32_t core_dim = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   uint32_t cluster_used = PAD_UP(points_desc->dims[1], core_dim) / core_dim;
   cluster_used = cluster_used > cluster_num ? cluster_num : cluster_used;
-  k_type = CNRT_FUNC_TYPE_BLOCK;
+  k_type = cnrtFuncTypeBlock;
   k_dim.x = 1;
   k_dim.y = cluster_used * core_dim;
   k_dim.z = 1;

--- a/kernels/prior_box/prior_box.cpp
+++ b/kernels/prior_box/prior_box.cpp
@@ -34,7 +34,7 @@
 // policy function
 static void policyFuncPriorBox(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                cnrtFunctionType_t *k_type, const int count) {
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   uint32_t cluster_max = mluop::runtime::getClusterLimitCapability(handle);
   uint32_t core_num_per_cluster =
       mluop::runtime::getCoreNumOfEachUnionCapability(handle);

--- a/kernels/psamask/psamask.cpp
+++ b/kernels/psamask/psamask.cpp
@@ -261,7 +261,7 @@ mluOpStatus_t mluOpPsamaskForward(mluOpHandle_t handle, const int psa_type,
   // generate mluOpPsamaskForward prototxt end!
 
   mluOpStatus_t ret = MLUOP_STATUS_SUCCESS;
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
   cnrtDim3_t k_dim;
   PartitionSeg partition_info;
   policyFunc(handle, &k_dim, &k_type, &partition_info, n, h_feature);
@@ -331,7 +331,7 @@ mluOpStatus_t mluOpPsamaskBackward(mluOpHandle_t handle, const int psa_type,
   // generate mluOpPsamaskBackward prototxt end!
 
   mluOpStatus_t ret = MLUOP_STATUS_SUCCESS;
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
   cnrtDim3_t k_dim;
   PartitionSeg partition_info;
   policyFunc(handle, &k_dim, &k_type, &partition_info, n, h_feature);

--- a/kernels/psroipool/psroipool.cpp
+++ b/kernels/psroipool/psroipool.cpp
@@ -38,7 +38,7 @@ static void policyFuncPsRoiPool(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                 cnrtFunctionType_t *k_type, const int nums) {
   size_t union_number = mluop::runtime::getClusterLimitCapability(handle);
   size_t core_in_cluster = handle->core_num_per_cluster;
-  *k_type = CNRT_FUNC_TYPE_UNION1;  // default func type
+  *k_type = cnrtFuncTypeUnion1;  // default func type
   k_dim->x = core_in_cluster;
   uint32_t use_cluster = (nums + core_in_cluster - 1) / core_in_cluster;
   k_dim->y = use_cluster > union_number ? union_number : use_cluster;

--- a/kernels/roi_align_rotated/roi_align_rotated.cpp
+++ b/kernels/roi_align_rotated/roi_align_rotated.cpp
@@ -36,7 +36,7 @@ static void policyFunc(const mluOpHandle_t handle, const int bin_num,
                        cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
   size_t core_num = handle->core_num_per_cluster;
   size_t cluster_num = mluop::runtime::getJobLimitCapability(handle) / core_num;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_num;
   size_t use_cluster = (bin_num + core_num - 1) / core_num;
   k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;

--- a/kernels/roi_crop/roi_crop.cpp
+++ b/kernels/roi_crop/roi_crop.cpp
@@ -36,7 +36,7 @@ static void policyFunc(const mluOpHandle_t handle, int bin_num,
                        cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
   uint32_t cluster_num = mluop::runtime::getClusterLimitCapability(handle);
   uint32_t core_in_cluster = handle->core_num_per_cluster;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_in_cluster;
   uint32_t use_cluster = (bin_num + core_in_cluster - 1) / core_in_cluster;
   k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;

--- a/kernels/roiaware_pool3d/roiaware_pool3d.cpp
+++ b/kernels/roiaware_pool3d/roiaware_pool3d.cpp
@@ -51,7 +51,7 @@ static mluOpStatus_t kernelPtsIdxOfVoxelsPolicyFunc(
   k_dim->x = core_limit;
   k_dim->y = (task_dim / core_limit) > 0 ? (task_dim / core_limit) : 1;
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -73,7 +73,7 @@ static mluOpStatus_t kernelRoiawarePool3dForwardPolicyFunc(
   k_dim->x = core_limit;
   k_dim->y = (task_dim / core_limit) > 0 ? (task_dim / core_limit) : 1;
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   return MLUOP_STATUS_SUCCESS;
 }
 
@@ -94,7 +94,7 @@ static mluOpStatus_t kernelRoiawarePool3dBackwardPolicyFunc(
   k_dim->x = core_limit;
   k_dim->y = (task_dim / core_limit) > 0 ? (task_dim / core_limit) : 1;
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   return MLUOP_STATUS_SUCCESS;
 }
 

--- a/kernels/roipoint_pool3d/roipoint_pool3d.cpp
+++ b/kernels/roipoint_pool3d/roipoint_pool3d.cpp
@@ -370,7 +370,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpRoiPointPool3d(
   k_dims.x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dims.y = mluop::runtime::getClusterLimitCapability(handle);
   k_dims.z = 1;
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
 
   if (boxes_num <= 10240) {
     VLOG(5) << "Launch Kernel KernelRoipointPool3d<<<Union" << k_type / CORE_DIM

--- a/kernels/rotated_feature_align/rotated_feature_align.cpp
+++ b/kernels/rotated_feature_align/rotated_feature_align.cpp
@@ -40,7 +40,7 @@ static void policyFunc(const mluOpHandle_t handle,
   const size_t num_bin = num_rois * pooled_height * pooled_width;
   size_t core_num = handle->core_num_per_cluster;
   size_t cluster_num = mluop::runtime::getJobLimitCapability(handle) / core_num;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_num;
   size_t use_cluster = (num_bin + core_num - 1) / core_num;
   k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;

--- a/kernels/sparse_conv/get_indice_pairs/normal_get_indice_pairs.cpp
+++ b/kernels/sparse_conv/get_indice_pairs/normal_get_indice_pairs.cpp
@@ -282,7 +282,7 @@ mluOpStatus_t launchDefaultKernel1(
   int core_num_l = (nram_size - 4 * 4096 * 3) / nums / sizeof(int);
   int jobs = (input_active_site + core_num_l - 1) / core_num_l;
   int job_num = jobs > core_nums ? core_nums : jobs;
-  func_type = CNRT_FUNC_TYPE_BLOCK;
+  func_type = cnrtFuncTypeBlock;
   kDim3.x = 1;
   kDim3.y = job_num;
   kDim3.z = 1;
@@ -348,7 +348,7 @@ mluOpStatus_t launchSubmKernel1(
   int least_jobs = (input_active_site * sizeof(int) + 1024 - 1) / 1024;
   jobs = std::max(jobs, least_jobs);
   int job_num = jobs > core_nums ? core_nums : jobs;
-  func_type = CNRT_FUNC_TYPE_BLOCK;
+  func_type = cnrtFuncTypeBlock;
   kDim3.x = 1;
   kDim3.y = job_num;
   kDim3.z = 1;
@@ -416,7 +416,7 @@ mluOpStatus_t launchSubmKernel2(mluOpHandle_t handle, const void *indices,
   int least_jobs = std::max(least_job_one, least_job_two);
   int jobs = std::max(std::max(jobs_one, jobs_two), least_jobs);
   int job_num = jobs > core_nums ? core_nums : jobs;
-  func_type = CNRT_FUNC_TYPE_BLOCK;
+  func_type = cnrtFuncTypeBlock;
   kDim3.x = 1;
   kDim3.y = job_num;
   kDim3.z = 1;
@@ -529,7 +529,7 @@ mluOpStatus_t launchUniqueOp(mluOpHandle_t handle,
   }
   cnrtQueueSync(handle->queue);
   cnrtMemcpy(return_num_act, unique_output_num_addr, sizeof(float),
-             CNRT_MEM_TRANS_DIR_DEV2HOST);
+             cnrtMemcpyDevToHost);
   CHECK_RETURN(interface_name, mluOpDestroyTensorDescriptor(unique_input_desc));
   CHECK_RETURN(interface_name,
                mluOpDestroyTensorDescriptor(unique_output_desc));
@@ -554,7 +554,7 @@ mluOpStatus_t launchDefaultKernel2(mluOpHandle_t handle,
   int core_num_l = (nram_size - 4 * 4096 * 3) / sizeof(int);
   int jobs = (num_act_out + core_num_l - 1) / core_num_l;
   int job_num = jobs > core_nums ? core_nums : jobs;
-  func_type = CNRT_FUNC_TYPE_BLOCK;
+  func_type = cnrtFuncTypeBlock;
   kDim3.x = 1;
   kDim3.y = job_num;
   kDim3.z = 1;
@@ -592,7 +592,7 @@ mluOpStatus_t launchBalanceKernel(mluOpHandle_t handle,
   int core_num_l = (nram_size - 4 * 4096 * 3) / 8 / sizeof(int);
   int jobs = (input_active_site * kernel_volume + core_num_l - 1) / core_num_l;
   int job_num = jobs > core_nums ? core_nums : jobs;
-  func_type = CNRT_FUNC_TYPE_BLOCK;
+  func_type = cnrtFuncTypeBlock;
   kDim3.x = 1;
   kDim3.y = job_num;
   kDim3.z = 1;
@@ -767,7 +767,7 @@ mluOpStatus_t launchDefaultKernel3(mluOpHandle_t handle, void *output_addr,
   int core_num_l = (nram_size - 4 * 4096 * 3) / 4 / sizeof(int);
   int jobs = 2 * kernel_volume;
   int job_num = jobs > core_nums ? core_nums : jobs;
-  func_type = CNRT_FUNC_TYPE_BLOCK;
+  func_type = cnrtFuncTypeBlock;
   kDim3.x = 1;
   kDim3.y = job_num;
   kDim3.z = 1;
@@ -807,7 +807,7 @@ mluOpStatus_t launchDefaultKernel4(
   int core_num_l = (nram_size - 4 * 4096 * 3) / core_num_split / sizeof(int);
   int jobs = (num_act_out + core_num_l - 1) / core_num_l;
   int job_num = jobs > core_nums ? core_nums : jobs;
-  func_type = CNRT_FUNC_TYPE_BLOCK;
+  func_type = cnrtFuncTypeBlock;
   kDim3.x = 1;
   kDim3.y = job_num;
   kDim3.z = 1;

--- a/kernels/tensor_stride_process/tensor_stride_process_host.cpp
+++ b/kernels/tensor_stride_process/tensor_stride_process_host.cpp
@@ -386,9 +386,9 @@ static mluOpStatus_t policyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
                                 cnrtFunctionType_t *k_type,
                                 uint64_t total_num) {
   if (handle->sram_size <= 0) {
-    *k_type = CNRT_FUNC_TYPE_BLOCK;
+    *k_type = cnrtFuncTypeBlock;
   } else {
-    *k_type = CNRT_FUNC_TYPE_UNION1;
+    *k_type = cnrtFuncTypeUnion1;
   }
   uint32_t union_number = mluop::runtime::getClusterLimitCapability(handle);
 

--- a/kernels/three_interpolate/three_interpolate.cpp
+++ b/kernels/three_interpolate/three_interpolate.cpp
@@ -250,7 +250,7 @@ static void policyFuncThreeInterpolate(
     use_cluster =
         (b * m_aligned_limit / m_limit + core_in_cluster - 1) / core_in_cluster;
   }
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_in_cluster;
   k_dim->y = use_cluster > cluster_num ? cluster_num : use_cluster;
   k_dim->z = 1;

--- a/kernels/three_nn_forward/three_nn_forward.cpp
+++ b/kernels/three_nn_forward/three_nn_forward.cpp
@@ -231,7 +231,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpThreeNNForward(
   k_dims.x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dims.y = mluop::runtime::getClusterLimitCapability(handle);
   k_dims.z = 1;
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
 
   VLOG(5) << "[mluOpThreeNNForward] cnnlTranspose_v2 feature start.";
 

--- a/kernels/tin_shift/tin_shift.cpp
+++ b/kernels/tin_shift/tin_shift.cpp
@@ -71,7 +71,7 @@ static void policyFunc(const mluOpHandle_t handle,
   k_dim->x = core_limit;
   k_dim->y = (task_dim / core_limit) > 0 ? (task_dim / core_limit) : 1;
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 }
 
 static mluOpStatus_t TinShiftPreCheck(

--- a/kernels/unary_op/unary_op_host.cpp
+++ b/kernels/unary_op/unary_op_host.cpp
@@ -47,7 +47,7 @@ void unaryOpPolicyFunc(mluOpHandle_t handle, cnrtDim3_t *k_dim,
   tensor_size = CEIL_ALIGN(tensor_size, NFU_ALIGN_SIZE);
   uint64_t need_core =
       CEIL_ALIGN(tensor_size / NFU_ALIGN_SIZE, core_in_cluster);
-  *k_type = CNRT_FUNC_TYPE_UNION1;  // default func type
+  *k_type = cnrtFuncTypeUnion1;  // default func type
   k_dim->x = core_in_cluster;
   if (need_core < core_number) {
     k_dim->y = need_core / core_in_cluster;
@@ -68,7 +68,7 @@ void unaryOpPolicyFuncBlock(mluOpHandle_t handle, cnrtDim3_t *k_dim,
   uint32_t core_used =
       CEIL_ALIGN(data_size, OPTIMAL_BOUNDARY) / OPTIMAL_BOUNDARY;
   core_used = core_used > core_num ? core_num : core_used;
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   k_dim->x = 1;
   k_dim->y = core_used;
   k_dim->z = 1;
@@ -81,7 +81,7 @@ void unaryOpPolicyFuncBlock_v2(mluOpHandle_t handle,
                                cnrtDim3_t &k_dim, cnrtFunctionType_t &k_type,
                                size_t &normal_core_elem_num,
                                size_t &tail_core_elem_num) {
-  k_type = CNRT_FUNC_TYPE_BLOCK;
+  k_type = cnrtFuncTypeBlock;
   if (MLUOP_MLU590 == handle->arch) {
     const size_t llc_pending_size = 512;
     single_core_min_load_size =

--- a/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
+++ b/kernels/voxel_pooling_forward/voxel_pooling_forward.cpp
@@ -36,7 +36,7 @@ static void policyFunc(const mluOpHandle_t handle, const int num_points_total,
                        cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
   uint32_t cluster_num = mluop::runtime::getClusterLimitCapability(handle);
   uint32_t core_in_cluster = handle->core_num_per_cluster;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
   k_dim->x = core_in_cluster;
   uint32_t use_cluster =
       (num_points_total + core_in_cluster - 1) / core_in_cluster;

--- a/kernels/voxelization/voxelization.cpp
+++ b/kernels/voxelization/voxelization.cpp
@@ -40,7 +40,7 @@ static void policyFuncDefault(const mluOpHandle_t handle,
       std::min((num_points + k_dim->x - 1) / k_dim->x,
                (size_t)mluop::runtime::getClusterLimitCapability(handle));
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 }
 
 static void policyFuncCalcPointsPerVoxel(const mluOpHandle_t handle,
@@ -50,7 +50,7 @@ static void policyFuncCalcPointsPerVoxel(const mluOpHandle_t handle,
   k_dim->x = 1;
   k_dim->y = 1;
   k_dim->z = 1;
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
 }
 
 mluOpStatus_t voxelizationParamCheck(

--- a/kernels/yolo_box/yolo_box.cpp
+++ b/kernels/yolo_box/yolo_box.cpp
@@ -37,7 +37,7 @@
 
 static void policyFunc(const mluOpHandle_t handle, const int kw_num,
                        cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type) {
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
   uint32_t cluster_num = mluop::runtime::getClusterLimitCapability(handle);
   uint32_t core_num_per_cluster =
       mluop::runtime::getCoreNumOfEachUnionCapability(handle);

--- a/samples/mlu-ops/fault_sample/fault_demo.mlu
+++ b/samples/mlu-ops/fault_sample/fault_demo.mlu
@@ -91,12 +91,12 @@ int main(int argc, char *argv[]) {
 
   printf("memcpy input data from host to device\n");
   CNRT_CHECK(cnrtMemcpy(device_ptrs[0], host_ptrs[0], data_size,
-                        CNRT_MEM_TRANS_DIR_HOST2DEV));
+                        cnrtMemcpyHostToDev));
 
   printf("call device kernel\n");
   // set function type and task dim
   cnrtDim3_t k_dim = {4, 1, 1};
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  cnrtFunctionType_t k_type = cnrtFuncTypeUnion1;
   // call device kernel function.
   MLUUnfinishedExampleKernel<<<k_dim, k_type, queue>>>(
       device_ptrs[0], device_ptrs[1], element_num);
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
 
   printf("copy result from device to host\n");
   CNRT_CHECK(cnrtMemcpy(host_ptrs[1], device_ptrs[1], data_size,
-                        CNRT_MEM_TRANS_DIR_DEV2HOST));
+                        cnrtMemcpyDevToHost));
 
   printf("free resources\n");
   for (size_t i = 0; i < TENSOR_NUM; ++i) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/active_rotated_filter_forward/active_rotated_filter_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/active_rotated_filter_forward/active_rotated_filter_forward.cpp
@@ -56,7 +56,7 @@ class active_rotated_filter_forward : public testing::Test {
       } else {
         i_bytes = 12 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       }
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes))
     }
 
     if (indices_desc) {
@@ -76,11 +76,11 @@ class active_rotated_filter_forward : public testing::Test {
       } else {
         id_bytes = 12 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       }
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&indices_, id_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&indices_, id_bytes))
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_))
     }
 
     if (output_desc) {
@@ -100,7 +100,7 @@ class active_rotated_filter_forward : public testing::Test {
       } else {
         o_bytes = 12 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       }
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, o_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, o_bytes))
     }
   }
   mluOpStatus_t compute() {
@@ -140,7 +140,7 @@ class active_rotated_filter_forward : public testing::Test {
       }
       if (input_) {
         VLOG(4) << "Destroy input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
         input_ = nullptr;
       }
       if (indices_desc_) {
@@ -150,12 +150,12 @@ class active_rotated_filter_forward : public testing::Test {
       }
       if (indices_) {
         VLOG(4) << "Destroy indices_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
         indices_ = nullptr;
       }
       if (workspace_) {
         VLOG(4) << "Destroy workspace_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
         workspace_ = nullptr;
       }
       if (output_desc_) {
@@ -165,7 +165,7 @@ class active_rotated_filter_forward : public testing::Test {
       }
       if (output_) {
         VLOG(4) << "Destroy output_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
         output_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/active_rotated_filter_forward/active_rotated_filter_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/active_rotated_filter_forward/active_rotated_filter_forward_general.cpp
@@ -62,7 +62,7 @@ class active_rotated_filter_forward_general
       if (input_elenum > 0) {
         VLOG(4) << "malloc input_";
         uint64_t i_bytes = input_elenum * mluOpDataTypeBytes(input_dtype);
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes))
       }
 
       MLUOpTensorParam indices_desc = std::get<1>(GetParam());
@@ -85,7 +85,7 @@ class active_rotated_filter_forward_general
       if (indices_elenum > 0) {
         VLOG(4) << "malloc indices_";
         uint64_t id_bytes = indices_elenum * mluOpDataTypeBytes(indices_dtype);
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&indices_, id_bytes))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&indices_, id_bytes))
       }
 
       MLUOpTensorParam output_desc = std::get<2>(GetParam());
@@ -108,7 +108,7 @@ class active_rotated_filter_forward_general
       if (output_elenum > 0) {
         VLOG(4) << "malloc output_";
         uint64_t o_bytes = output_elenum * mluOpDataTypeBytes(output_dtype);
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes))
       }
 
       target_device_ = std::get<3>(GetParam());
@@ -132,7 +132,7 @@ class active_rotated_filter_forward_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_))
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_))
     status = mluOpActiveRotatedFilterForward(
         handle_, input_desc_, input_, indices_desc_, indices_, workspace_,
         workspace_size_, output_desc_, output_);
@@ -156,7 +156,7 @@ class active_rotated_filter_forward_general
       }
       if (input_) {
         VLOG(4) << "Destroy input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
         input_ = nullptr;
       }
       if (indices_desc_) {
@@ -166,12 +166,12 @@ class active_rotated_filter_forward_general
       }
       if (indices_) {
         VLOG(4) << "Destroy indices_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
         indices_ = nullptr;
       }
       if (workspace_) {
         VLOG(4) << "Destroy workspace_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
         workspace_ = nullptr;
       }
       if (output_desc_) {
@@ -181,7 +181,7 @@ class active_rotated_filter_forward_general
       }
       if (output_) {
         VLOG(4) << "Destroy output_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
         output_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query.cpp
@@ -51,7 +51,7 @@ class ball_query : public testing::Test {
       size_t new_xyz_ele_num = 2 * 16 * 3;
       size_t new_xyz_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t new_xyz_bytes = new_xyz_ele_num * new_xyz_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&new_xyz_, new_xyz_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&new_xyz_, new_xyz_bytes));
     }
     if (xyz_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&xyz_desc_));
@@ -64,7 +64,7 @@ class ball_query : public testing::Test {
       size_t xyz_ele_num = 2 * 4 * 3;
       size_t xyz_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t xyz_bytes = xyz_ele_num * xyz_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&xyz_, xyz_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&xyz_, xyz_bytes));
     }
     if (idx_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&idx_desc_));
@@ -77,7 +77,7 @@ class ball_query : public testing::Test {
       size_t idx_ele_num = 2 * 4 * 32;
       size_t idx_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t idx_bytes = idx_ele_num * idx_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&idx_, idx_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&idx_, idx_bytes));
     }
   }
 
@@ -101,7 +101,7 @@ class ball_query : public testing::Test {
       new_xyz_desc_ = NULL;
     }
     if (new_xyz_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(new_xyz_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(new_xyz_));
       new_xyz_ = NULL;
     }
     if (xyz_desc_) {
@@ -109,7 +109,7 @@ class ball_query : public testing::Test {
       xyz_desc_ = NULL;
     }
     if (xyz_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(xyz_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(xyz_));
       xyz_ = NULL;
     }
     if (idx_desc_) {
@@ -117,7 +117,7 @@ class ball_query : public testing::Test {
       idx_desc_ = NULL;
     }
     if (idx_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(idx_));
       idx_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/ball_query/ball_query_general.cpp
@@ -64,7 +64,7 @@ class ball_query_general : public testing::TestWithParam<BallQuery> {
     uint64_t xyz_ele_num = mluOpGetTensorElementNum(xyz_desc_);
     uint64_t xyz_bytes = mluOpDataTypeBytes(xyz_dtype) * xyz_ele_num;
     if (xyz_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&xyz_, xyz_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&xyz_, xyz_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&new_xyz_desc_));
@@ -88,7 +88,7 @@ class ball_query_general : public testing::TestWithParam<BallQuery> {
     uint64_t new_xyz_bytes =
         mluOpDataTypeBytes(new_xyz_dtype) * new_xyz_ele_num;
     if (new_xyz_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&new_xyz_, new_xyz_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&new_xyz_, new_xyz_bytes))
     }
 
     min_radius_ = std::get<2>(GetParam());
@@ -113,7 +113,7 @@ class ball_query_general : public testing::TestWithParam<BallQuery> {
     uint64_t idx_ele_num = mluOpGetTensorElementNum(idx_desc_);
     uint64_t idx_bytes = mluOpDataTypeBytes(idx_dtype) * idx_ele_num;
     if (idx_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&idx_, idx_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&idx_, idx_bytes))
     }
 
     PublicParam publicParam = std::get<6>(GetParam());
@@ -145,7 +145,7 @@ class ball_query_general : public testing::TestWithParam<BallQuery> {
       new_xyz_desc_ = NULL;
     }
     if (new_xyz_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(new_xyz_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(new_xyz_));
       new_xyz_ = NULL;
     }
     if (xyz_desc_) {
@@ -153,7 +153,7 @@ class ball_query_general : public testing::TestWithParam<BallQuery> {
       xyz_desc_ = NULL;
     }
     if (xyz_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(xyz_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(xyz_));
       xyz_ = NULL;
     }
     if (idx_desc_) {
@@ -161,7 +161,7 @@ class ball_query_general : public testing::TestWithParam<BallQuery> {
       idx_desc_ = NULL;
     }
     if (idx_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(idx_));
       idx_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/border_align_backward/border_align_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/border_align_backward/border_align_backward.cpp
@@ -49,7 +49,7 @@ class border_align_backward : public testing::Test {
           grad_output_dims.size(), grad_output_dims.data()));
     }
     if (grad_output) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&grad_output_,
                              16 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
@@ -62,7 +62,7 @@ class border_align_backward : public testing::Test {
     }
     if (boxes) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&boxes_, 16 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
     if (argmax_idx_desc) {
@@ -74,7 +74,7 @@ class border_align_backward : public testing::Test {
     }
     if (argmax_idx) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&argmax_idx_, 16 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
     if (grad_input_desc) {
@@ -86,7 +86,7 @@ class border_align_backward : public testing::Test {
     }
     if (grad_input) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&grad_input_, 16 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
   }
@@ -128,7 +128,7 @@ class border_align_backward : public testing::Test {
       }
       if (grad_output_) {
         VLOG(4) << "Destroy grad_output_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
         grad_output_ = nullptr;
       }
       if (boxes_desc_) {
@@ -138,7 +138,7 @@ class border_align_backward : public testing::Test {
       }
       if (boxes_) {
         VLOG(4) << "Destroy boxes_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
         boxes_ = nullptr;
       }
       if (argmax_idx_desc_) {
@@ -148,7 +148,7 @@ class border_align_backward : public testing::Test {
       }
       if (argmax_idx_) {
         VLOG(4) << "Destroy argmax_idx_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_idx_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(argmax_idx_));
         argmax_idx_ = nullptr;
       }
       if (grad_input_desc_) {
@@ -158,7 +158,7 @@ class border_align_backward : public testing::Test {
       }
       if (grad_input_) {
         VLOG(4) << "Destroy grad_input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
         grad_input_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/border_align_backward/border_align_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/border_align_backward/border_align_backward_general.cpp
@@ -60,10 +60,10 @@ class border_align_backward_general
             grad_output_params.get_dim_stride().data()));
       }
       if (mluOpGetTensorElementNum(grad_output_desc_) >= LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_output_, 2 * 16));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_output_, 2 * 16));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_output_,
                        mluOpDataTypeBytes(grad_output_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_output_desc_)));
@@ -82,10 +82,10 @@ class border_align_backward_general
             boxes_params.get_dim_stride().data()));
       }
       if (mluOpGetTensorElementNum(boxes_desc_) >= LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, 2 * 16));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, 2 * 16));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&boxes_, mluOpDataTypeBytes(boxes_params.get_dtype()) *
                                     mluOpGetTensorElementNum(boxes_desc_)));
       }
@@ -105,10 +105,10 @@ class border_align_backward_general
             argmax_idx_params.get_dim_stride().data()));
       }
       if (mluOpGetTensorElementNum(argmax_idx_desc_) >= LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&argmax_idx_, (2 * 16)));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&argmax_idx_, (2 * 16)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&argmax_idx_,
                        mluOpDataTypeBytes(argmax_idx_params.get_dtype()) *
                            mluOpGetTensorElementNum(argmax_idx_desc_)));
@@ -130,10 +130,10 @@ class border_align_backward_general
       }
 
       if (mluOpGetTensorElementNum(grad_input_desc_) >= LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_input_, 2 * 16));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_input_, 2 * 16));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_input_,
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_input_desc_)));
@@ -176,7 +176,7 @@ class border_align_backward_general
       }
       if (grad_output_) {
         VLOG(4) << "Destroy grad_output_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
         grad_output_ = nullptr;
       }
       if (boxes_desc_) {
@@ -186,7 +186,7 @@ class border_align_backward_general
       }
       if (boxes_) {
         VLOG(4) << "Destroy boxes_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
         boxes_ = nullptr;
       }
       if (argmax_idx_desc_) {
@@ -196,7 +196,7 @@ class border_align_backward_general
       }
       if (argmax_idx_) {
         VLOG(4) << "Destroy argmax_idx_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_idx_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(argmax_idx_));
         argmax_idx_ = nullptr;
       }
       if (grad_input_desc_) {
@@ -206,7 +206,7 @@ class border_align_backward_general
       }
       if (grad_input_) {
         VLOG(4) << "Destroy grad_input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
         grad_input_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/border_align_forward/border_align_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/border_align_forward/border_align_forward.cpp
@@ -49,7 +49,7 @@ class border_align_forward_test : public testing::Test {
     }
     if (input) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&input_, 4000 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
     if (boxes_desc) {
@@ -61,7 +61,7 @@ class border_align_forward_test : public testing::Test {
     }
     if (boxes) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&boxes_, 800 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
     if (output_desc) {
@@ -73,7 +73,7 @@ class border_align_forward_test : public testing::Test {
     }
     if (output) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&output_, 4000 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
     if (argmax_idx_desc) {
@@ -84,7 +84,7 @@ class border_align_forward_test : public testing::Test {
                                            argmax_idx_dims.data()));
     }
     if (argmax_idx) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&argmax_idx_,
                              4000 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
     }
@@ -123,7 +123,7 @@ class border_align_forward_test : public testing::Test {
       }
       if (input_) {
         VLOG(4) << "Destroy input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       }
       if (boxes_desc_) {
         VLOG(4) << "Destroy boxes_desc_";
@@ -131,7 +131,7 @@ class border_align_forward_test : public testing::Test {
       }
       if (boxes_) {
         VLOG(4) << "Destroy boxes_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       }
       if (output_desc_) {
         VLOG(4) << "Destroy output_desc_";
@@ -139,7 +139,7 @@ class border_align_forward_test : public testing::Test {
       }
       if (output_) {
         VLOG(4) << "Destroy output_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       }
       if (argmax_idx_desc_) {
         VLOG(4) << "Destroy argmax_idx_desc_";
@@ -147,7 +147,7 @@ class border_align_forward_test : public testing::Test {
       }
       if (argmax_idx_) {
         VLOG(4) << "Destroy argmax_idx_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_idx_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(argmax_idx_));
       }
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()

--- a/test/mlu_op_gtest/api_gtest/src/gtest/border_align_forward/border_align_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/border_align_forward/border_align_forward_general.cpp
@@ -63,7 +63,7 @@ class border_align_forward_general
       int input_elenum = mluOpGetTensorElementNum(input_desc_);
       if (input_elenum > 0) {
         VLOG(4) << "malloc input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_,
                                input_elenum * mluOpDataTypeBytes(input_dtype)));
       }
@@ -86,7 +86,7 @@ class border_align_forward_general
       }
       int boxes_elenum = mluOpGetTensorElementNum(boxes_desc_);
       if (boxes_elenum > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&boxes_,
                                boxes_elenum * mluOpDataTypeBytes(boxes_dtype)));
       }
@@ -109,7 +109,7 @@ class border_align_forward_general
       }
       int output_elenum = mluOpGetTensorElementNum(output_desc_);
       if (output_elenum > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&output_, output_elenum *
                                              mluOpDataTypeBytes(output_dtype)));
       }
@@ -134,7 +134,7 @@ class border_align_forward_general
       int argmax_idx_elenum = mluOpGetTensorElementNum(argmax_idx_desc_);
       if (argmax_idx_elenum > 0) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&argmax_idx_, argmax_idx_elenum *
                                          mluOpDataTypeBytes(argmax_idx_dtype)));
       }
@@ -174,7 +174,7 @@ class border_align_forward_general
       }
       if (input_) {
         VLOG(4) << "Destroy input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       }
       if (boxes_desc_) {
         VLOG(4) << "Destroy boxes_desc_";
@@ -182,7 +182,7 @@ class border_align_forward_general
       }
       if (boxes_) {
         VLOG(4) << "Destroy boxes_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       }
       if (output_desc_) {
         VLOG(4) << "Destroy output_desc_";
@@ -190,7 +190,7 @@ class border_align_forward_general
       }
       if (output_) {
         VLOG(4) << "Destroy output_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       }
       if (argmax_idx_desc_) {
         VLOG(4) << "Destroy argmax_idx_desc_";
@@ -198,7 +198,7 @@ class border_align_forward_general
       }
       if (argmax_idx_) {
         VLOG(4) << "Destroy argmax_idx_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_idx_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(argmax_idx_));
       }
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()

--- a/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_backward/deform_roi_pooling_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_backward/deform_roi_pooling_backward.cpp
@@ -48,7 +48,7 @@ class deform_roi_pooling_backward : public testing::Test {
           std::vector<int>({3, 3, 3, 1}).data()));
     }
     if (grad_output) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_output_, 10));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_output_, 10));
     }
     if (input_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_desc_));
@@ -57,7 +57,7 @@ class deform_roi_pooling_backward : public testing::Test {
           std::vector<int>({1, 5, 5, 1}).data()));
     }
     if (input) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, 10));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, 10));
     }
     if (rois_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&rois_desc_));
@@ -66,7 +66,7 @@ class deform_roi_pooling_backward : public testing::Test {
                                            std::vector<int>({3, 5}).data()));
     }
     if (rois) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, 5));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, 5));
     }
     if (offset_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&offset_desc_));
@@ -75,7 +75,7 @@ class deform_roi_pooling_backward : public testing::Test {
           std::vector<int>({3, 2, 3, 3}).data()));
     }
     if (offset) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&offset_, 5));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&offset_, 5));
     }
     if (grad_input_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_input_desc_));
@@ -84,7 +84,7 @@ class deform_roi_pooling_backward : public testing::Test {
           std::vector<int>({1, 5, 5, 1}).data()));
     }
     if (grad_input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_input_, 10));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_input_, 10));
     }
     if (grad_offset_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_offset_desc_));
@@ -93,7 +93,7 @@ class deform_roi_pooling_backward : public testing::Test {
           std::vector<int>({3, 2, 3, 3}).data()));
     }
     if (grad_offset) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_offset_, 10));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_offset_, 10));
     }
   }
   mluOpStatus_t compute() {
@@ -135,7 +135,7 @@ class deform_roi_pooling_backward : public testing::Test {
     }
     if (grad_output_) {
       VLOG(4) << "Destroy grad_output";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = nullptr;
     }
     if (input_desc_) {
@@ -144,7 +144,7 @@ class deform_roi_pooling_backward : public testing::Test {
     }
     if (input_) {
       VLOG(4) << "Destroy input";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
     if (rois_desc_) {
@@ -153,7 +153,7 @@ class deform_roi_pooling_backward : public testing::Test {
     }
     if (rois_) {
       VLOG(4) << "Destroy rois";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
       rois_ = nullptr;
     }
     if (offset_desc_) {
@@ -162,7 +162,7 @@ class deform_roi_pooling_backward : public testing::Test {
     }
     if (offset_) {
       VLOG(4) << "Destroy offset";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(offset_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(offset_));
       offset_ = nullptr;
     }
     if (grad_input_desc_) {
@@ -171,7 +171,7 @@ class deform_roi_pooling_backward : public testing::Test {
     }
     if (grad_input_) {
       VLOG(4) << "Destroy grad_input";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = nullptr;
     }
     if (grad_offset_desc_) {
@@ -180,7 +180,7 @@ class deform_roi_pooling_backward : public testing::Test {
     }
     if (grad_offset_) {
       VLOG(4) << "Destroy grad_offset";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_offset_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_offset_));
       grad_offset_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_backward/deform_roi_pooling_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_backward/deform_roi_pooling_backward_general.cpp
@@ -64,7 +64,7 @@ class deform_roi_pooling_backward_general
       uint64_t go_ele_num = mluOpGetTensorElementNum(grad_output_desc_);
       uint64_t go_bytes = mluOpDataTypeBytes(grad_output_dtype) * go_ele_num;
       if (go_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_output_, go_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_output_, go_bytes));
       }
 
       MLUOpTensorParam inputDescParam = std::get<1>(GetParam());
@@ -79,7 +79,7 @@ class deform_roi_pooling_backward_general
       uint64_t i_ele_num = mluOpGetTensorElementNum(input_desc_);
       uint64_t i_bytes = mluOpDataTypeBytes(input_dtype) * i_ele_num;
       if (i_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes));
       }
 
       MLUOpTensorParam roisDescParam = std::get<2>(GetParam());
@@ -93,7 +93,7 @@ class deform_roi_pooling_backward_general
       uint64_t roi_ele_num = mluOpGetTensorElementNum(rois_desc_);
       uint64_t roi_bytes = mluOpDataTypeBytes(rois_dtype) * roi_ele_num;
       if (roi_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, roi_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, roi_bytes));
       }
 
       MLUOpTensorParam offsetDescParam = std::get<3>(GetParam());
@@ -108,7 +108,7 @@ class deform_roi_pooling_backward_general
       uint64_t offset_ele_num = mluOpGetTensorElementNum(offset_desc_);
       uint64_t offset_bytes = mluOpDataTypeBytes(offset_dtype) * offset_ele_num;
       if (offset_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&offset_, offset_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&offset_, offset_bytes));
       }
 
       MLUOpTensorParam gradInputDescParam = std::get<4>(GetParam());
@@ -123,7 +123,7 @@ class deform_roi_pooling_backward_general
       uint64_t gi_ele_num = mluOpGetTensorElementNum(grad_input_desc_);
       uint64_t gi_bytes = mluOpDataTypeBytes(grad_input_dtype) * gi_ele_num;
       if (gi_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_input_, gi_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_input_, gi_bytes));
       }
 
       MLUOpTensorParam gradOffsetDescParam = std::get<5>(GetParam());
@@ -138,7 +138,7 @@ class deform_roi_pooling_backward_general
       uint64_t gf_ele_num = mluOpGetTensorElementNum(grad_offset_desc_);
       uint64_t gf_bytes = mluOpDataTypeBytes(grad_offset_dtype) * gf_ele_num;
       if (gf_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_offset_, gf_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_offset_, gf_bytes));
       }
 
       DeformRoiPoolingBackwardAdditionalParam additoinal_param_ =
@@ -180,7 +180,7 @@ class deform_roi_pooling_backward_general
       }
       if (grad_output_) {
         VLOG(4) << "Destroy grad_output";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
         grad_output_ = nullptr;
       }
       if (input_desc_) {
@@ -189,7 +189,7 @@ class deform_roi_pooling_backward_general
       }
       if (input_) {
         VLOG(4) << "Destroy input";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
         input_ = nullptr;
       }
       if (rois_desc_) {
@@ -198,7 +198,7 @@ class deform_roi_pooling_backward_general
       }
       if (rois_) {
         VLOG(4) << "Destroy rois";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
         rois_ = nullptr;
       }
       if (offset_desc_) {
@@ -207,7 +207,7 @@ class deform_roi_pooling_backward_general
       }
       if (offset_) {
         VLOG(4) << "Destroy offset";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(offset_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(offset_));
         offset_ = nullptr;
       }
       if (grad_input_desc_) {
@@ -216,7 +216,7 @@ class deform_roi_pooling_backward_general
       }
       if (grad_input_) {
         VLOG(4) << "Destroy grad_input";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
         grad_input_ = nullptr;
       }
       if (grad_offset_desc_) {
@@ -225,7 +225,7 @@ class deform_roi_pooling_backward_general
       }
       if (grad_offset_) {
         VLOG(4) << "Destroy grad_offset";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_offset_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(grad_offset_));
         grad_offset_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_forward/deform_roi_pooling_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_forward/deform_roi_pooling_forward.cpp
@@ -47,7 +47,7 @@ class deform_roi_pooling_forward : public testing::Test {
           std::vector<int>({1, 5, 5, 1}).data()));
     }
     if (input) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, 10));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, 10));
     }
     if (rois_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&rois_desc_));
@@ -56,7 +56,7 @@ class deform_roi_pooling_forward : public testing::Test {
                                            std::vector<int>({3, 5}).data()));
     }
     if (rois) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, 5));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, 5));
     }
     if (offset_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&offset_desc_));
@@ -65,7 +65,7 @@ class deform_roi_pooling_forward : public testing::Test {
           std::vector<int>({3, 2, 3, 3}).data()));
     }
     if (offset) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&offset_, 5));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&offset_, 5));
     }
     if (output_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -74,7 +74,7 @@ class deform_roi_pooling_forward : public testing::Test {
           std::vector<int>({3, 3, 3, 1}).data()));
     }
     if (output) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, 10));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, 10));
     }
   }
   mluOpStatus_t compute() {
@@ -111,7 +111,7 @@ class deform_roi_pooling_forward : public testing::Test {
     }
     if (input_) {
       VLOG(4) << "Destroy input";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
     if (rois_desc_) {
@@ -120,7 +120,7 @@ class deform_roi_pooling_forward : public testing::Test {
     }
     if (rois_) {
       VLOG(4) << "Destroy rois";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
       rois_ = nullptr;
     }
     if (offset_desc_) {
@@ -129,7 +129,7 @@ class deform_roi_pooling_forward : public testing::Test {
     }
     if (offset_) {
       VLOG(4) << "Destroy offset";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(offset_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(offset_));
       offset_ = nullptr;
     }
     if (output_desc_) {
@@ -138,7 +138,7 @@ class deform_roi_pooling_forward : public testing::Test {
     }
     if (output_) {
       VLOG(4) << "Destroy output";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_forward/deform_roi_pooling_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/deform_roi_pooling_forward/deform_roi_pooling_forward_general.cpp
@@ -62,7 +62,7 @@ class deform_roi_pooling_forward_general
       uint64_t i_ele_num = mluOpGetTensorElementNum(input_desc_);
       uint64_t i_bytes = mluOpDataTypeBytes(input_dtype) * i_ele_num;
       if (i_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes));
       }
 
       MLUOpTensorParam roisDescParam = std::get<1>(GetParam());
@@ -76,7 +76,7 @@ class deform_roi_pooling_forward_general
       uint64_t roi_ele_num = mluOpGetTensorElementNum(rois_desc_);
       uint64_t roi_bytes = mluOpDataTypeBytes(rois_dtype) * roi_ele_num;
       if (roi_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, roi_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, roi_bytes));
       }
 
       MLUOpTensorParam offsetDescParam = std::get<2>(GetParam());
@@ -91,7 +91,7 @@ class deform_roi_pooling_forward_general
       uint64_t offset_ele_num = mluOpGetTensorElementNum(offset_desc_);
       uint64_t offset_bytes = mluOpDataTypeBytes(offset_dtype) * offset_ele_num;
       if (offset_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&offset_, offset_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&offset_, offset_bytes));
       }
 
       DeformRoiPoolingForwardAdditionalParam additoinal_param_ =
@@ -111,7 +111,7 @@ class deform_roi_pooling_forward_general
       uint64_t o_ele_num = mluOpGetTensorElementNum(output_desc_);
       uint64_t o_bytes = mluOpDataTypeBytes(output_dtype) * o_ele_num;
       if (o_bytes > 0) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
       }
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -147,7 +147,7 @@ class deform_roi_pooling_forward_general
       }
       if (input_) {
         VLOG(4) << "Destroy input";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
         input_ = nullptr;
       }
       if (rois_desc_) {
@@ -156,7 +156,7 @@ class deform_roi_pooling_forward_general
       }
       if (rois_) {
         VLOG(4) << "Destroy rois";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
         rois_ = nullptr;
       }
       if (offset_desc_) {
@@ -165,7 +165,7 @@ class deform_roi_pooling_forward_general
       }
       if (offset_) {
         VLOG(4) << "Destroy offset";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(offset_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(offset_));
         offset_ = nullptr;
       }
       if (output_desc_) {
@@ -174,7 +174,7 @@ class deform_roi_pooling_forward_general
       }
       if (output_) {
         VLOG(4) << "Destroy output";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
         output_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward.cpp
@@ -57,12 +57,12 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (vertices) {
       if (vertices_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&vertices_, MLUOP_DTYPE_FLOAT *
                                          mluOpGetTensorElementNum(
                                              vertices_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&vertices_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -77,11 +77,11 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (mask) {
       if (mask_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_, MLUOP_DTYPE_BOOL *
                                          mluOpGetTensorElementNum(mask_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_, MLUOP_DTYPE_BOOL * 2));
       }
     }
@@ -96,12 +96,12 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (num_valid) {
       if (num_valid_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&num_valid_,
                                MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
                                                        num_valid_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&num_valid_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -116,11 +116,11 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (idx) {
       if (idx_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&idx_, MLUOP_DTYPE_INT32 *
                                         mluOpGetTensorElementNum(idx_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&idx_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -151,7 +151,7 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (vertices_) {
       VLOG(4) << "Destroy vertices_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(vertices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(vertices_));
       vertices_ = nullptr;
     }
 
@@ -163,7 +163,7 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (mask_) {
       VLOG(4) << "Destroy mask_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_));
       mask_ = nullptr;
     }
 
@@ -175,7 +175,7 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (num_valid_) {
       VLOG(4) << "Destroy num_valid_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(num_valid_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(num_valid_));
       num_valid_ = nullptr;
     }
 
@@ -187,7 +187,7 @@ class diff_iou_rotated_sort_vertices_forward : public testing::Test {
 
     if (idx_) {
       VLOG(4) << "Destroy idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(idx_));
       idx_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/diff_iou_rotated_sort_vertices_forward/diff_iou_rotated_sort_vertices_forward_general.cpp
@@ -52,12 +52,12 @@ class diff_iou_rotated_sort_vertices_forward_general
           vertices_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(vertices_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&vertices_,
                        mluOpDataTypeBytes(vertices_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-             CNRT_RET_SUCCESS ==
+             cnrtSuccess ==
             cnrtMalloc(&vertices_,
                        mluOpDataTypeBytes(vertices_params.get_dtype()) *
                        mluOpGetTensorElementNum(vertices_desc_)));
@@ -70,12 +70,12 @@ class diff_iou_rotated_sort_vertices_forward_general
           mask_params.get_dim_nb(), mask_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(mask_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_,
                        mluOpDataTypeBytes(mask_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_,
                        mluOpDataTypeBytes(mask_params.get_dtype()) *
                        mluOpGetTensorElementNum(mask_desc_)));
@@ -89,13 +89,13 @@ class diff_iou_rotated_sort_vertices_forward_general
           num_valid_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(num_valid_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &num_valid_,
                 mluOpDataTypeBytes(num_valid_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&num_valid_,
                        mluOpDataTypeBytes(num_valid_params.get_dtype()) *
                            mluOpGetTensorElementNum(num_valid_desc_)));
@@ -108,11 +108,11 @@ class diff_iou_rotated_sort_vertices_forward_general
           idx_params.get_dim_nb(), idx_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(idx_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&idx_, mluOpDataTypeBytes(idx_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&idx_, mluOpDataTypeBytes(idx_params.get_dtype()) *
                               mluOpGetTensorElementNum(idx_desc_)));
       }
@@ -154,7 +154,7 @@ class diff_iou_rotated_sort_vertices_forward_general
 
     if (vertices_) {
       VLOG(4) << "Destroy vertices_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(vertices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(vertices_));
       vertices_ = nullptr;
     }
 
@@ -166,7 +166,7 @@ class diff_iou_rotated_sort_vertices_forward_general
 
     if (mask_) {
       VLOG(4) << "Destroy mask_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_));
       mask_ = nullptr;
     }
 
@@ -178,7 +178,7 @@ class diff_iou_rotated_sort_vertices_forward_general
 
     if (num_valid_) {
       VLOG(4) << "Destroy num_valid_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(num_valid_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(num_valid_));
       num_valid_ = nullptr;
     }
 
@@ -190,7 +190,7 @@ class diff_iou_rotated_sort_vertices_forward_general
 
     if (idx_) {
       VLOG(4) << "Destroy idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(idx_));
       idx_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward.cpp
@@ -55,12 +55,12 @@ class dynamic_point_to_voxel_backward : public testing::Test {
     if (grad_voxel_feats) {
       if (grad_voxel_feats_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_voxel_feats_,
                        MLUOP_DTYPE_FLOAT *
                            mluOpGetTensorElementNum(grad_voxel_feats_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_voxel_feats_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -76,11 +76,11 @@ class dynamic_point_to_voxel_backward : public testing::Test {
     if (feats) {
       if (feats_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feats_, MLUOP_DTYPE_FLOAT *
                                     mluOpGetTensorElementNum(feats_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&feats_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -95,12 +95,12 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (voxel_feats) {
       if (voxel_feats_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_feats_,
                                MLUOP_DTYPE_FLOAT * mluOpGetTensorElementNum(
                                                        voxel_feats_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_feats_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -115,12 +115,12 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (point2voxel_map) {
       if (point2voxel_map_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&point2voxel_map_,
                                MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
                                                        point2voxel_map_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&point2voxel_map_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -136,12 +136,12 @@ class dynamic_point_to_voxel_backward : public testing::Test {
     if (voxel_points_count) {
       if (voxel_points_count_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_points_count_,
                        MLUOP_DTYPE_INT32 *
                            mluOpGetTensorElementNum(voxel_points_count_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_points_count_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -156,18 +156,18 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (voxel_num) {
       if (voxel_num_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_num_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(voxel_num_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_num_, MLUOP_DTYPE_INT32 * 1));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_INT32 * workspace_size_));
     }
 
@@ -181,12 +181,12 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (grad_feats) {
       if (grad_feats_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_feats_,
                                MLUOP_DTYPE_FLOAT *
                                    mluOpGetTensorElementNum(grad_feats_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_feats_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -220,7 +220,7 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (grad_voxel_feats_) {
       VLOG(4) << "Destroy grad_voxel_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_voxel_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_voxel_feats_));
       grad_voxel_feats_ = nullptr;
     }
 
@@ -232,7 +232,7 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (feats_) {
       VLOG(4) << "Destroy feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(feats_));
       feats_ = nullptr;
     }
 
@@ -244,7 +244,7 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (voxel_feats_) {
       VLOG(4) << "Destroy voxel_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_feats_));
       voxel_feats_ = nullptr;
     }
 
@@ -256,7 +256,7 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (point2voxel_map_) {
       VLOG(4) << "Destroy point2voxel_map_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point2voxel_map_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(point2voxel_map_));
       point2voxel_map_ = nullptr;
     }
 
@@ -268,7 +268,7 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (voxel_points_count_) {
       VLOG(4) << "Destroy voxel_points_count_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_points_count_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_points_count_));
       voxel_points_count_ = nullptr;
     }
 
@@ -280,13 +280,13 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (voxel_num_) {
       VLOG(4) << "Destroy voxel_num_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_num_));
       voxel_num_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
 
@@ -298,7 +298,7 @@ class dynamic_point_to_voxel_backward : public testing::Test {
 
     if (grad_feats_) {
       VLOG(4) << "Destroy grad_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_feats_));
       grad_feats_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_backward/dynamic_point_to_voxel_backward_general.cpp
@@ -57,13 +57,13 @@ class dynamic_point_to_voxel_backward_general
       if (mluOpGetTensorElementNum(grad_voxel_feats_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &grad_voxel_feats_,
                 mluOpDataTypeBytes(grad_voxel_feats_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_voxel_feats_,
                        mluOpDataTypeBytes(grad_voxel_feats_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_voxel_feats_desc_)));
@@ -75,12 +75,12 @@ class dynamic_point_to_voxel_backward_general
           feats_params.get_dim_nb(), feats_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(feats_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feats_,
                        mluOpDataTypeBytes(feats_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feats_, mluOpDataTypeBytes(feats_params.get_dtype()) *
                                     mluOpGetTensorElementNum(feats_desc_)));
       }
@@ -93,12 +93,12 @@ class dynamic_point_to_voxel_backward_general
           voxel_feats_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(voxel_feats_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_feats_,
                        mluOpDataTypeBytes(voxel_feats_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_feats_,
                        mluOpDataTypeBytes(voxel_feats_params.get_dtype()) *
                            mluOpGetTensorElementNum(voxel_feats_desc_)));
@@ -113,13 +113,13 @@ class dynamic_point_to_voxel_backward_general
           point2voxel_map_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(point2voxel_map_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &point2voxel_map_,
                 mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&point2voxel_map_,
                        mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) *
                            mluOpGetTensorElementNum(point2voxel_map_desc_)));
@@ -135,13 +135,13 @@ class dynamic_point_to_voxel_backward_general
       if (mluOpGetTensorElementNum(voxel_points_count_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &voxel_points_count_,
                 mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &voxel_points_count_,
                 mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) *
@@ -156,12 +156,12 @@ class dynamic_point_to_voxel_backward_general
           voxel_num_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(voxel_num_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_num_,
                        mluOpDataTypeBytes(voxel_num_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_num_,
                        mluOpDataTypeBytes(voxel_num_params.get_dtype()) *
                            mluOpGetTensorElementNum(voxel_num_desc_)));
@@ -175,12 +175,12 @@ class dynamic_point_to_voxel_backward_general
           grad_feats_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_feats_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_feats_,
                        mluOpDataTypeBytes(grad_feats_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_feats_,
                        mluOpDataTypeBytes(grad_feats_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_feats_desc_)));
@@ -188,7 +188,7 @@ class dynamic_point_to_voxel_backward_general
       target_device_ = std::get<8>(GetParam());
       expected_status_ = std::get<9>(GetParam());
 
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -228,7 +228,7 @@ class dynamic_point_to_voxel_backward_general
 
     if (grad_voxel_feats_) {
       VLOG(4) << "Destroy grad_voxel_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_voxel_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_voxel_feats_));
       grad_voxel_feats_ = nullptr;
     }
 
@@ -240,7 +240,7 @@ class dynamic_point_to_voxel_backward_general
 
     if (feats_) {
       VLOG(4) << "Destroy feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(feats_));
       feats_ = nullptr;
     }
 
@@ -252,7 +252,7 @@ class dynamic_point_to_voxel_backward_general
 
     if (voxel_feats_) {
       VLOG(4) << "Destroy voxel_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_feats_));
       voxel_feats_ = nullptr;
     }
 
@@ -264,7 +264,7 @@ class dynamic_point_to_voxel_backward_general
 
     if (point2voxel_map_) {
       VLOG(4) << "Destroy point2voxel_map_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point2voxel_map_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(point2voxel_map_));
       point2voxel_map_ = nullptr;
     }
 
@@ -276,7 +276,7 @@ class dynamic_point_to_voxel_backward_general
 
     if (voxel_points_count_) {
       VLOG(4) << "Destroy voxel_points_count_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_points_count_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_points_count_));
       voxel_points_count_ = nullptr;
     }
 
@@ -288,13 +288,13 @@ class dynamic_point_to_voxel_backward_general
 
     if (voxel_num_) {
       VLOG(4) << "Destroy voxel_num_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_num_));
       voxel_num_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
 
@@ -306,7 +306,7 @@ class dynamic_point_to_voxel_backward_general
 
     if (grad_feats_) {
       VLOG(4) << "Destroy grad_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_feats_));
       grad_feats_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward.cpp
@@ -55,11 +55,11 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     if (feats) {
       if (feats_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feats_, MLUOP_DTYPE_FLOAT *
                                     mluOpGetTensorElementNum(feats_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&feats_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -75,11 +75,11 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     if (coors) {
       if (coors_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&coors_, MLUOP_DTYPE_INT32 *
                                     mluOpGetTensorElementNum(coors_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&coors_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -94,12 +94,12 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (voxel_feats) {
       if (voxel_feats_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_feats_,
                                MLUOP_DTYPE_FLOAT * mluOpGetTensorElementNum(
                                                        voxel_feats_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_feats_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -114,12 +114,12 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (voxel_coors) {
       if (voxel_coors_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_coors_,
                                MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
                                                        voxel_coors_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_coors_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -134,12 +134,12 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (point2voxel_map) {
       if (point2voxel_map_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&point2voxel_map_,
                                MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
                                                        point2voxel_map_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&point2voxel_map_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -155,12 +155,12 @@ class dynamic_point_to_voxel_forward : public testing::Test {
     if (voxel_points_count) {
       if (voxel_points_count_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_points_count_,
                        MLUOP_DTYPE_INT32 *
                            mluOpGetTensorElementNum(voxel_points_count_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_points_count_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -175,18 +175,18 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (voxel_num) {
       if (voxel_num_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_num_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(voxel_num_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&voxel_num_, MLUOP_DTYPE_INT32 * 1));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_INT32 * workspace_size_));
     }
   }
@@ -219,7 +219,7 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (feats_) {
       VLOG(4) << "Destroy feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(feats_));
       feats_ = nullptr;
     }
 
@@ -231,7 +231,7 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (coors_) {
       VLOG(4) << "Destroy coors_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(coors_));
       coors_ = nullptr;
     }
 
@@ -243,7 +243,7 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (voxel_feats_) {
       VLOG(4) << "Destroy voxel_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_feats_));
       voxel_feats_ = nullptr;
     }
 
@@ -255,7 +255,7 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (voxel_coors_) {
       VLOG(4) << "Destroy voxel_coors_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_coors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_coors_));
       voxel_coors_ = nullptr;
     }
 
@@ -267,7 +267,7 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (point2voxel_map_) {
       VLOG(4) << "Destroy point2voxel_map_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point2voxel_map_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(point2voxel_map_));
       point2voxel_map_ = nullptr;
     }
 
@@ -279,7 +279,7 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (voxel_points_count_) {
       VLOG(4) << "Destroy voxel_points_count_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_points_count_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_points_count_));
       voxel_points_count_ = nullptr;
     }
 
@@ -291,13 +291,13 @@ class dynamic_point_to_voxel_forward : public testing::Test {
 
     if (voxel_num_) {
       VLOG(4) << "Destroy voxel_num_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_num_));
       voxel_num_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_general.cpp
@@ -53,12 +53,12 @@ class dynamic_point_to_voxel_forward_general
           feats_params.get_dim_nb(), feats_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(feats_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feats_,
                        mluOpDataTypeBytes(feats_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feats_, mluOpDataTypeBytes(feats_params.get_dtype()) *
                                     mluOpGetTensorElementNum(feats_desc_)));
       }
@@ -70,12 +70,12 @@ class dynamic_point_to_voxel_forward_general
           coors_params.get_dim_nb(), coors_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(coors_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&coors_,
                        mluOpDataTypeBytes(coors_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&coors_, mluOpDataTypeBytes(coors_params.get_dtype()) *
                                     mluOpGetTensorElementNum(coors_desc_)));
       }
@@ -88,12 +88,12 @@ class dynamic_point_to_voxel_forward_general
           voxel_feats_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(voxel_feats_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_feats_,
                        mluOpDataTypeBytes(voxel_feats_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_feats_,
                        mluOpDataTypeBytes(voxel_feats_params.get_dtype()) *
                            mluOpGetTensorElementNum(voxel_feats_desc_)));
@@ -107,12 +107,12 @@ class dynamic_point_to_voxel_forward_general
           voxel_coors_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(voxel_coors_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_coors_,
                        mluOpDataTypeBytes(voxel_coors_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_coors_,
                        mluOpDataTypeBytes(voxel_coors_params.get_dtype()) *
                            mluOpGetTensorElementNum(voxel_coors_desc_)));
@@ -127,13 +127,13 @@ class dynamic_point_to_voxel_forward_general
           point2voxel_map_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(point2voxel_map_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &point2voxel_map_,
                 mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&point2voxel_map_,
                        mluOpDataTypeBytes(point2voxel_map_params.get_dtype()) *
                            mluOpGetTensorElementNum(point2voxel_map_desc_)));
@@ -149,13 +149,13 @@ class dynamic_point_to_voxel_forward_general
       if (mluOpGetTensorElementNum(voxel_points_count_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &voxel_points_count_,
                 mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &voxel_points_count_,
                 mluOpDataTypeBytes(voxel_points_count_params.get_dtype()) *
@@ -170,12 +170,12 @@ class dynamic_point_to_voxel_forward_general
           voxel_num_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(voxel_num_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_num_,
                        mluOpDataTypeBytes(voxel_num_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&voxel_num_,
                        mluOpDataTypeBytes(voxel_num_params.get_dtype()) *
                            mluOpGetTensorElementNum(voxel_num_desc_)));
@@ -185,7 +185,7 @@ class dynamic_point_to_voxel_forward_general
       target_device_ = std::get<8>(GetParam());
       expected_status_ = std::get<9>(GetParam());
 
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -225,7 +225,7 @@ class dynamic_point_to_voxel_forward_general
 
     if (feats_) {
       VLOG(4) << "Destroy feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(feats_));
       feats_ = nullptr;
     }
 
@@ -237,7 +237,7 @@ class dynamic_point_to_voxel_forward_general
 
     if (coors_) {
       VLOG(4) << "Destroy coors_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(coors_));
       coors_ = nullptr;
     }
 
@@ -249,7 +249,7 @@ class dynamic_point_to_voxel_forward_general
 
     if (voxel_feats_) {
       VLOG(4) << "Destroy voxel_feats_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_feats_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_feats_));
       voxel_feats_ = nullptr;
     }
 
@@ -261,7 +261,7 @@ class dynamic_point_to_voxel_forward_general
 
     if (voxel_coors_) {
       VLOG(4) << "Destroy voxel_coors_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_coors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_coors_));
       voxel_coors_ = nullptr;
     }
 
@@ -273,7 +273,7 @@ class dynamic_point_to_voxel_forward_general
 
     if (point2voxel_map_) {
       VLOG(4) << "Destroy point2voxel_map_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point2voxel_map_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(point2voxel_map_));
       point2voxel_map_ = nullptr;
     }
 
@@ -285,7 +285,7 @@ class dynamic_point_to_voxel_forward_general
 
     if (voxel_points_count_) {
       VLOG(4) << "Destroy voxel_points_count_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_points_count_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_points_count_));
       voxel_points_count_ = nullptr;
     }
 
@@ -297,13 +297,13 @@ class dynamic_point_to_voxel_forward_general
 
     if (voxel_num_) {
       VLOG(4) << "Destroy voxel_num_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_num_));
       voxel_num_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_ExecFFT.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_ExecFFT.cpp
@@ -47,16 +47,16 @@ class fft_ExecFFT : public testing::Test {
 
     if (input) {
       size_t i_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes));
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
 
     if (output) {
       size_t o_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_COMPLEX_FLOAT);
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
   }
 
@@ -136,12 +136,12 @@ class fft_ExecFFT : public testing::Test {
       }
       if (input_) {
         VLOG(4) << "Destroy input_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
         input_ = nullptr;
       }
       if (output_) {
         VLOG(4) << "Destroy output_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
         output_ = nullptr;
       }
       if (fft_plan_) {
@@ -151,7 +151,7 @@ class fft_ExecFFT : public testing::Test {
       }
       if (workspace_) {
         VLOG(4) << "Destroy workspace_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
         workspace_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_SetFFTReserveArea.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_SetFFTReserveArea.cpp
@@ -44,7 +44,7 @@ class fft_SetFFTReserveArea : public testing::Test {
     }
 
     if (reservespace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&reservespace_, reservespace_size));
     }
   }
@@ -79,7 +79,7 @@ class fft_SetFFTReserveArea : public testing::Test {
       }
       if (reservespace_) {
         VLOG(4) << "Destroy reservespace_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(reservespace_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(reservespace_));
         reservespace_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_general.cpp
@@ -106,12 +106,12 @@ class fft_general : public testing::TestWithParam<FFTParams> {
       }
       if (workspace_size_) {
         VLOG(4) << "Destroy workspace_size_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_size_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_size_));
         workspace_size_ = nullptr;
       }
       if (reservespace_size_) {
         VLOG(4) << "Destroy reservespace_size_";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(reservespace_size_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(reservespace_size_));
         reservespace_size_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward.cpp
@@ -52,11 +52,11 @@ class focal_loss_sigmoid_backward : public testing::Test {
     if (input) {
       if (input_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, MLUOP_DTYPE_FLOAT *
                                     mluOpGetTensorElementNum(input_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -72,11 +72,11 @@ class focal_loss_sigmoid_backward : public testing::Test {
     if (target) {
       if (target_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&target_, MLUOP_DTYPE_INT32 *
                                      mluOpGetTensorElementNum(target_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&target_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -88,7 +88,7 @@ class focal_loss_sigmoid_backward : public testing::Test {
                                          weight_desc_dims.data()));
     if (weight) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&weight_, MLUOP_DTYPE_FLOAT *
                                    mluOpGetTensorElementNum(weight_desc_)));
     }
@@ -103,12 +103,12 @@ class focal_loss_sigmoid_backward : public testing::Test {
 
     if (grad_input) {
       if (grad_input_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_input_,
                                MLUOP_DTYPE_FLOAT *
                                    mluOpGetTensorElementNum(grad_input_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_input_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -140,7 +140,7 @@ class focal_loss_sigmoid_backward : public testing::Test {
 
     if (input_) {
       VLOG(4) << "Destroy input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
 
@@ -152,7 +152,7 @@ class focal_loss_sigmoid_backward : public testing::Test {
 
     if (target_) {
       VLOG(4) << "Destroy target_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(target_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(target_));
       target_ = nullptr;
     }
 
@@ -164,7 +164,7 @@ class focal_loss_sigmoid_backward : public testing::Test {
 
     if (weight_) {
       VLOG(4) << "Destroy weight_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = nullptr;
     }
 
@@ -176,7 +176,7 @@ class focal_loss_sigmoid_backward : public testing::Test {
 
     if (grad_input_) {
       VLOG(4) << "Destroy grad_input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_backward/focal_loss_sigmoid_backward_general.cpp
@@ -55,12 +55,12 @@ class focal_loss_sigmoid_backward_general
           input_params.get_dim_nb(), input_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(input_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_,
                        mluOpDataTypeBytes(input_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, mluOpDataTypeBytes(input_params.get_dtype()) *
                                     mluOpGetTensorElementNum(input_desc_)));
       }
@@ -72,12 +72,12 @@ class focal_loss_sigmoid_backward_general
           target_params.get_dim_nb(), target_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(target_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&target_,
                        mluOpDataTypeBytes(target_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&target_, mluOpDataTypeBytes(target_params.get_dtype()) *
                                      mluOpGetTensorElementNum(target_desc_)));
       }
@@ -89,12 +89,12 @@ class focal_loss_sigmoid_backward_general
           weight_params.get_dim_nb(), weight_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(weight_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&weight_,
                        mluOpDataTypeBytes(weight_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&weight_, mluOpDataTypeBytes(weight_params.get_dtype()) *
                                      mluOpGetTensorElementNum(weight_desc_)));
       }
@@ -107,12 +107,12 @@ class focal_loss_sigmoid_backward_general
           grad_input_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_input_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_input_,
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_input_,
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_input_desc_)));
@@ -157,7 +157,7 @@ class focal_loss_sigmoid_backward_general
 
     if (input_) {
       VLOG(4) << "Destroy input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
 
@@ -169,7 +169,7 @@ class focal_loss_sigmoid_backward_general
 
     if (target_) {
       VLOG(4) << "Destroy target_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(target_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(target_));
       target_ = nullptr;
     }
 
@@ -181,7 +181,7 @@ class focal_loss_sigmoid_backward_general
 
     if (weight_) {
       VLOG(4) << "Destroy weight_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = nullptr;
     }
 
@@ -193,7 +193,7 @@ class focal_loss_sigmoid_backward_general
 
     if (grad_input_) {
       VLOG(4) << "Destroy grad_input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward.cpp
@@ -51,11 +51,11 @@ class focal_loss_sigmoid_forward : public testing::Test {
     if (input) {
       if (input_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, MLUOP_DTYPE_FLOAT *
                                     mluOpGetTensorElementNum(input_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -71,11 +71,11 @@ class focal_loss_sigmoid_forward : public testing::Test {
     if (target) {
       if (target_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&target_, MLUOP_DTYPE_INT32 *
                                      mluOpGetTensorElementNum(target_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&target_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -87,7 +87,7 @@ class focal_loss_sigmoid_forward : public testing::Test {
                                          weight_desc_dims.data()));
     if (weight) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&weight_, MLUOP_DTYPE_FLOAT *
                                    mluOpGetTensorElementNum(weight_desc_)));
     }
@@ -103,11 +103,11 @@ class focal_loss_sigmoid_forward : public testing::Test {
     if (output) {
       if (output_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&output_, MLUOP_DTYPE_FLOAT *
                                      mluOpGetTensorElementNum(output_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&output_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -138,7 +138,7 @@ class focal_loss_sigmoid_forward : public testing::Test {
 
     if (input_) {
       VLOG(4) << "Destroy input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
 
@@ -150,7 +150,7 @@ class focal_loss_sigmoid_forward : public testing::Test {
 
     if (target_) {
       VLOG(4) << "Destroy target_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(target_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(target_));
       target_ = nullptr;
     }
 
@@ -162,7 +162,7 @@ class focal_loss_sigmoid_forward : public testing::Test {
 
     if (weight_) {
       VLOG(4) << "Destroy weight_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = nullptr;
     }
 
@@ -174,7 +174,7 @@ class focal_loss_sigmoid_forward : public testing::Test {
 
     if (output_) {
       VLOG(4) << "Destroy output_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/focal_loss_sigmoid_forward/focal_loss_sigmoid_forward_general.cpp
@@ -55,12 +55,12 @@ class focal_loss_sigmoid_forward_general
           input_params.get_dim_nb(), input_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(input_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_,
                        mluOpDataTypeBytes(input_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, mluOpDataTypeBytes(input_params.get_dtype()) *
                                     mluOpGetTensorElementNum(input_desc_)));
       }
@@ -72,12 +72,12 @@ class focal_loss_sigmoid_forward_general
           target_params.get_dim_nb(), target_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(target_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&target_,
                        mluOpDataTypeBytes(target_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&target_, mluOpDataTypeBytes(target_params.get_dtype()) *
                                      mluOpGetTensorElementNum(target_desc_)));
       }
@@ -89,12 +89,12 @@ class focal_loss_sigmoid_forward_general
           weight_params.get_dim_nb(), weight_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(weight_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&weight_,
                        mluOpDataTypeBytes(weight_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&weight_, mluOpDataTypeBytes(weight_params.get_dtype()) *
                                      mluOpGetTensorElementNum(weight_desc_)));
       }
@@ -106,12 +106,12 @@ class focal_loss_sigmoid_forward_general
           output_params.get_dim_nb(), output_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(output_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&output_,
                        mluOpDataTypeBytes(output_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&output_, mluOpDataTypeBytes(output_params.get_dtype()) *
                                      mluOpGetTensorElementNum(output_desc_)));
       }
@@ -154,7 +154,7 @@ class focal_loss_sigmoid_forward_general
 
     if (input_) {
       VLOG(4) << "Destroy input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
 
@@ -166,7 +166,7 @@ class focal_loss_sigmoid_forward_general
 
     if (target_) {
       VLOG(4) << "Destroy target_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(target_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(target_));
       target_ = nullptr;
     }
 
@@ -178,7 +178,7 @@ class focal_loss_sigmoid_forward_general
 
     if (weight_) {
       VLOG(4) << "Destroy weight_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = nullptr;
     }
 
@@ -190,7 +190,7 @@ class focal_loss_sigmoid_forward_general
 
     if (output_) {
       VLOG(4) << "Destroy output_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/generate_proposals_v2/generate_proposals_v2.cpp
@@ -56,7 +56,7 @@ class generate_proposals_v2 : public testing::Test {
       size_t scores_ele_num = 1 * 5 * 5 * 9;
       size_t scores_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t scores_bytes = scores_ele_num * scores_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&scores_, scores_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&scores_, scores_bytes));
     }
     if (bbox_deltas_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&bbox_deltas_desc_));
@@ -69,7 +69,7 @@ class generate_proposals_v2 : public testing::Test {
       size_t bbox_deltas_ele_num = 2 * 32 * 16 * 16;
       size_t bbox_deltas_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t bbox_deltas_bytes = bbox_deltas_ele_num * bbox_deltas_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&bbox_deltas_, bbox_deltas_bytes));
     }
     if (im_shape_desc) {
@@ -83,7 +83,7 @@ class generate_proposals_v2 : public testing::Test {
       size_t im_shape_ele_num = 2 * 2;
       size_t im_shape_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t im_shape_bytes = im_shape_ele_num * im_shape_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&im_shape_, im_shape_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&im_shape_, im_shape_bytes));
     }
     if (anchors_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&anchors_desc_));
@@ -96,7 +96,7 @@ class generate_proposals_v2 : public testing::Test {
       size_t anchors_ele_num = 8 * 16 * 16 * 4;
       size_t anchors_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t anchors_bytes = anchors_ele_num * anchors_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&anchors_, anchors_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&anchors_, anchors_bytes));
     }
     if (variances_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&variances_desc_));
@@ -109,13 +109,13 @@ class generate_proposals_v2 : public testing::Test {
       size_t variances_ele_num = 8 * 16 * 16 * 4;
       size_t variances_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t variances_bytes = variances_ele_num * variances_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&variances_, variances_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&variances_, variances_bytes));
     }
     if (workspace) {
       size_t workspace_ele_num = workspace_size_;
       size_t workspace_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t workspace_bytes = workspace_ele_num * workspace_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_bytes));
     }
     if (rpn_rois_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&rpn_rois_desc_));
@@ -128,7 +128,7 @@ class generate_proposals_v2 : public testing::Test {
       size_t rpn_rois_ele_num = 5 * 4;
       size_t rpn_rois_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t rpn_rois_bytes = rpn_rois_ele_num * rpn_rois_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rpn_rois_, rpn_rois_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rpn_rois_, rpn_rois_bytes));
     }
     if (rpn_roi_probs_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&rpn_roi_probs_desc_));
@@ -142,7 +142,7 @@ class generate_proposals_v2 : public testing::Test {
       size_t rpn_roi_probs_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t rpn_roi_probs_bytes =
           rpn_roi_probs_ele_num * rpn_roi_probs_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&rpn_roi_probs_, rpn_roi_probs_bytes));
     }
     if (rpn_rois_num_desc) {
@@ -157,7 +157,7 @@ class generate_proposals_v2 : public testing::Test {
       size_t rpn_rois_num_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t rpn_rois_num_bytes =
           rpn_rois_num_ele_num * rpn_rois_num_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&rpn_rois_num_, rpn_rois_num_bytes));
     }
     if (rpn_rois_batch_size) {
@@ -166,7 +166,7 @@ class generate_proposals_v2 : public testing::Test {
           mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t rpn_rois_batch_size_bytes =
           rpn_rois_batch_size_ele_num * rpn_rois_batch_size_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&rpn_rois_batch_size_, rpn_rois_batch_size_bytes));
     }
   }
@@ -195,7 +195,7 @@ class generate_proposals_v2 : public testing::Test {
       scores_desc_ = NULL;
     }
     if (scores_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(scores_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(scores_));
       scores_ = NULL;
     }
     if (bbox_deltas_desc_) {
@@ -203,7 +203,7 @@ class generate_proposals_v2 : public testing::Test {
       bbox_deltas_desc_ = NULL;
     }
     if (bbox_deltas_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(bbox_deltas_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(bbox_deltas_));
       bbox_deltas_ = NULL;
     }
     if (im_shape_desc_) {
@@ -211,7 +211,7 @@ class generate_proposals_v2 : public testing::Test {
       im_shape_desc_ = NULL;
     }
     if (im_shape_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(im_shape_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(im_shape_));
       im_shape_ = NULL;
     }
     if (anchors_desc_) {
@@ -219,7 +219,7 @@ class generate_proposals_v2 : public testing::Test {
       anchors_desc_ = NULL;
     }
     if (anchors_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(anchors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(anchors_));
       anchors_ = NULL;
     }
     if (variances_desc_) {
@@ -227,11 +227,11 @@ class generate_proposals_v2 : public testing::Test {
       variances_desc_ = NULL;
     }
     if (variances_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(variances_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(variances_));
       variances_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (rpn_rois_desc_) {
@@ -239,7 +239,7 @@ class generate_proposals_v2 : public testing::Test {
       rpn_rois_desc_ = NULL;
     }
     if (rpn_rois_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_rois_));
       rpn_rois_ = NULL;
     }
     if (rpn_roi_probs_desc_) {
@@ -247,7 +247,7 @@ class generate_proposals_v2 : public testing::Test {
       rpn_roi_probs_desc_ = NULL;
     }
     if (rpn_roi_probs_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_roi_probs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_roi_probs_));
       rpn_roi_probs_ = NULL;
     }
     if (rpn_rois_num_desc_) {
@@ -255,11 +255,11 @@ class generate_proposals_v2 : public testing::Test {
       rpn_rois_num_desc_ = NULL;
     }
     if (rpn_rois_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_rois_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_rois_num_));
       rpn_rois_num_ = NULL;
     }
     if (rpn_rois_batch_size_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_rois_batch_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_rois_batch_size_));
       rpn_rois_batch_size_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/generate_proposals_v2/generate_proposals_v2_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/generate_proposals_v2/generate_proposals_v2_general.cpp
@@ -62,7 +62,7 @@ class generate_proposals_v2_general
     uint64_t scores_ele_num = mluOpGetTensorElementNum(scores_desc_);
     uint64_t scores_bytes = mluOpDataTypeBytes(scores_dtype) * scores_ele_num;
     if (scores_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&scores_, scores_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&scores_, scores_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&bbox_deltas_desc_));
@@ -78,7 +78,7 @@ class generate_proposals_v2_general
     uint64_t bbox_deltas_bytes =
         mluOpDataTypeBytes(bbox_deltas_dtype) * bbox_deltas_ele_num;
     if (bbox_deltas_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&bbox_deltas_, bbox_deltas_bytes))
     }
 
@@ -95,7 +95,7 @@ class generate_proposals_v2_general
     uint64_t im_shape_bytes =
         mluOpDataTypeBytes(im_shape_dtype) * im_shape_ele_num;
     if (im_shape_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&im_shape_, im_shape_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&im_shape_, im_shape_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&anchors_desc_));
@@ -111,7 +111,7 @@ class generate_proposals_v2_general
     uint64_t anchors_bytes =
         mluOpDataTypeBytes(anchors_dtype) * anchors_ele_num;
     if (anchors_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&anchors_, anchors_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&anchors_, anchors_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&variances_desc_));
@@ -127,7 +127,7 @@ class generate_proposals_v2_general
     uint64_t variances_bytes =
         mluOpDataTypeBytes(variances_dtype) * variances_ele_num;
     if (variances_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&variances_, variances_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&variances_, variances_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&rpn_rois_desc_));
@@ -143,7 +143,7 @@ class generate_proposals_v2_general
     uint64_t rpn_rois_bytes =
         mluOpDataTypeBytes(rpn_rois_dtype) * rpn_rois_ele_num;
     if (rpn_rois_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rpn_rois_, rpn_rois_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rpn_rois_, rpn_rois_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&rpn_roi_probs_desc_));
@@ -162,7 +162,7 @@ class generate_proposals_v2_general
     uint64_t rpn_roi_probs_bytes =
         mluOpDataTypeBytes(rpn_roi_probs_dtype) * rpn_roi_probs_ele_num;
     if (rpn_roi_probs_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&rpn_roi_probs_, rpn_roi_probs_bytes))
     }
 
@@ -180,11 +180,11 @@ class generate_proposals_v2_general
     uint64_t rpn_rois_num_bytes =
         mluOpDataTypeBytes(rpn_rois_num_dtype) * rpn_rois_num_ele_num;
     if (rpn_rois_num_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&rpn_rois_num_, rpn_rois_num_bytes))
     }
 
-    GTEST_CHECK(CNRT_RET_SUCCESS ==
+    GTEST_CHECK(cnrtSuccess ==
                 cnrtMalloc(&rpn_rois_batch_size_,
                            mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
 
@@ -208,7 +208,7 @@ class generate_proposals_v2_general
       destroy();
       return status == expected_status_;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     status = mluOpGenerateProposalsV2(
         handle_, pre_nms_top_n_, post_nms_top_n_, nms_thresh_, min_size_, eta_,
         pixel_offset_, scores_desc_, scores_, bbox_deltas_desc_, bbox_deltas_,
@@ -232,7 +232,7 @@ class generate_proposals_v2_general
       scores_desc_ = NULL;
     }
     if (scores_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(scores_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(scores_));
       scores_ = NULL;
     }
     if (bbox_deltas_desc_) {
@@ -240,7 +240,7 @@ class generate_proposals_v2_general
       bbox_deltas_desc_ = NULL;
     }
     if (bbox_deltas_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(bbox_deltas_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(bbox_deltas_));
       bbox_deltas_ = NULL;
     }
     if (im_shape_desc_) {
@@ -248,7 +248,7 @@ class generate_proposals_v2_general
       im_shape_desc_ = NULL;
     }
     if (im_shape_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(im_shape_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(im_shape_));
       im_shape_ = NULL;
     }
     if (anchors_desc_) {
@@ -256,7 +256,7 @@ class generate_proposals_v2_general
       anchors_desc_ = NULL;
     }
     if (anchors_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(anchors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(anchors_));
       anchors_ = NULL;
     }
     if (variances_desc_) {
@@ -264,11 +264,11 @@ class generate_proposals_v2_general
       variances_desc_ = NULL;
     }
     if (variances_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(variances_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(variances_));
       variances_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (rpn_rois_desc_) {
@@ -276,7 +276,7 @@ class generate_proposals_v2_general
       rpn_rois_desc_ = NULL;
     }
     if (rpn_rois_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_rois_));
       rpn_rois_ = NULL;
     }
     if (rpn_roi_probs_desc_) {
@@ -284,7 +284,7 @@ class generate_proposals_v2_general
       rpn_roi_probs_desc_ = NULL;
     }
     if (rpn_roi_probs_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_roi_probs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_roi_probs_));
       rpn_roi_probs_ = NULL;
     }
     if (rpn_rois_num_desc_) {
@@ -292,11 +292,11 @@ class generate_proposals_v2_general
       rpn_rois_num_desc_ = NULL;
     }
     if (rpn_rois_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_rois_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_rois_num_));
       rpn_rois_num_ = NULL;
     }
     if (rpn_rois_batch_size_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rpn_rois_batch_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rpn_rois_batch_size_));
       rpn_rois_batch_size_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/get_indice_pairs/get_indice_pairs.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/get_indice_pairs/get_indice_pairs.cpp
@@ -64,17 +64,17 @@ class get_indice_pairs : public testing::Test {
     if (indices) {
       if (indices_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, mluOpGetTensorElementNum(indices_desc_) *
                                       mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, 4 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
     if (indice_pairs_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&indice_pairs_desc_));
@@ -85,12 +85,12 @@ class get_indice_pairs : public testing::Test {
     }
     if (indice_pairs) {
       if (indice_pairs_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                mluOpGetTensorElementNum(indice_pairs_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                54 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -104,12 +104,12 @@ class get_indice_pairs : public testing::Test {
     }
     if (out_indices) {
       if (out_indices_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&out_indices_,
                                mluOpGetTensorElementNum(out_indices_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&out_indices_,
                                180 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -123,12 +123,12 @@ class get_indice_pairs : public testing::Test {
     }
     if (indice_num) {
       if (indice_num_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_num_,
                                mluOpGetTensorElementNum(indice_num_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_num_,
                                27 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -161,11 +161,11 @@ class get_indice_pairs : public testing::Test {
       indices_desc_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
     if (indice_pairs_desc_) {
@@ -173,7 +173,7 @@ class get_indice_pairs : public testing::Test {
       indice_pairs_desc_ = NULL;
     }
     if (indice_pairs_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
       indice_pairs_ = NULL;
     }
     if (out_indices_desc_) {
@@ -181,7 +181,7 @@ class get_indice_pairs : public testing::Test {
       out_indices_desc_ = NULL;
     }
     if (out_indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(out_indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(out_indices_));
       out_indices_ = NULL;
     }
     if (indice_num_desc_) {
@@ -189,7 +189,7 @@ class get_indice_pairs : public testing::Test {
       indice_num_desc_ = NULL;
     }
     if (indice_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_num_));
       indice_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/get_indice_pairs/get_indice_pairs_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/get_indice_pairs/get_indice_pairs_general.cpp
@@ -85,11 +85,11 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
     uint64_t indices_ele_num = mluOpGetTensorElementNum(indices_desc_);
     if (indices_ele_num > 0) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&indices_, mluOpGetTensorElementNum(indices_desc_) *
                                     mluOpDataTypeBytes(indices_dtype)))
     } else {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&indices_, 4 * mluOpDataTypeBytes(indices_dtype)));
     }
 
@@ -105,12 +105,12 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
     uint64_t indice_pairs_ele_num =
         mluOpGetTensorElementNum(indice_pairs_desc_);
     if (indice_pairs_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&indice_pairs_,
                              mluOpGetTensorElementNum(indice_pairs_desc_) *
                                  mluOpDataTypeBytes(indice_pairs_dtype)));
     } else {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&indice_pairs_,
                              54 * mluOpDataTypeBytes(indice_pairs_dtype)));
     }
@@ -126,12 +126,12 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
                                          out_indices_shape.data()));
     uint64_t out_indices_ele_num = mluOpGetTensorElementNum(out_indices_desc_);
     if (out_indices_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&out_indices_,
                              mluOpGetTensorElementNum(out_indices_desc_) *
                                  mluOpDataTypeBytes(out_indices_dtype)));
     } else {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&out_indices_,
                              108 * mluOpDataTypeBytes(out_indices_dtype)));
     }
@@ -148,12 +148,12 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
     uint64_t indice_num_ele_num = mluOpGetTensorElementNum(indice_num_desc_);
     if (indice_num_ele_num > 0) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&indice_num_, mluOpGetTensorElementNum(indice_num_desc_) *
                                        mluOpDataTypeBytes(indice_num_dtype)));
     } else {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&indice_num_, 27 * mluOpDataTypeBytes(indice_num_dtype)));
     }
   }
@@ -186,7 +186,7 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
 
     status = mluOpGetIndicePairs(
         handle_, sparse_conv_desc_, indices_desc_, indices_, workspace_,
@@ -213,11 +213,11 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
       indices_desc_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
     if (indice_pairs_desc_) {
@@ -225,7 +225,7 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
       indice_pairs_desc_ = NULL;
     }
     if (indice_pairs_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
       indice_pairs_ = NULL;
     }
     if (out_indices_desc_) {
@@ -233,7 +233,7 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
       out_indices_desc_ = NULL;
     }
     if (out_indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(out_indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(out_indices_));
       out_indices_ = NULL;
     }
     if (indice_num_desc_) {
@@ -241,7 +241,7 @@ class get_indice_pairs_general : public testing::TestWithParam<GetIndicePairs> {
       indice_num_desc_ = NULL;
     }
     if (indice_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_num_));
       indice_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_data/indice_convolution_backward_data.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_data/indice_convolution_backward_data.cpp
@@ -50,12 +50,12 @@ class indice_convolution_backward_data : public testing::Test {
     }
     if (output_grad) {
       if (output_grad_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&output_grad_,
                                mluOpGetTensorElementNum(output_grad_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&output_grad_,
                                100 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -70,11 +70,11 @@ class indice_convolution_backward_data : public testing::Test {
     if (filters) {
       if (filters_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&filters_, mluOpGetTensorElementNum(filters_desc_) *
                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&filters_,
                                1890 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -88,12 +88,12 @@ class indice_convolution_backward_data : public testing::Test {
     }
     if (indice_pairs) {
       if (indice_pairs_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                mluOpGetTensorElementNum(indice_pairs_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                180 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -107,18 +107,18 @@ class indice_convolution_backward_data : public testing::Test {
     }
     if (input_grad) {
       if (input_grad_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_grad_,
                                mluOpGetTensorElementNum(input_grad_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_grad_,
                                210 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
 
@@ -144,7 +144,7 @@ class indice_convolution_backward_data : public testing::Test {
       output_grad_desc_ = NULL;
     }
     if (output_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_grad_));
       output_grad_ = NULL;
     }
     if (filters_desc_) {
@@ -152,7 +152,7 @@ class indice_convolution_backward_data : public testing::Test {
       filters_desc_ = NULL;
     }
     if (filters_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(filters_));
       filters_ = NULL;
     }
     if (indice_pairs_desc_) {
@@ -160,11 +160,11 @@ class indice_convolution_backward_data : public testing::Test {
       indice_pairs_desc_ = NULL;
     }
     if (indice_pairs_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
       indice_pairs_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
     if (input_grad_desc_) {
@@ -172,7 +172,7 @@ class indice_convolution_backward_data : public testing::Test {
       input_grad_desc_ = NULL;
     }
     if (input_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_grad_));
       input_grad_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_data/indice_convolution_backward_data_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_data/indice_convolution_backward_data_general.cpp
@@ -65,7 +65,7 @@ class indice_convolution_backward_data_general
                                          output_grad_shape.data()));
     uint64_t output_grad_ele_num = mluOpGetTensorElementNum(output_grad_desc_);
     if (output_grad_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&output_grad_,
                              mluOpGetTensorElementNum(output_grad_desc_) *
                                  mluOpDataTypeBytes(output_grad_dtype)))
@@ -83,7 +83,7 @@ class indice_convolution_backward_data_general
     uint64_t filters_ele_num = mluOpGetTensorElementNum(filters_desc_);
     if (filters_ele_num > 0) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&filters_, mluOpGetTensorElementNum(filters_desc_) *
                                     mluOpDataTypeBytes(filters_dtype)));
     }
@@ -100,7 +100,7 @@ class indice_convolution_backward_data_general
     uint64_t indice_pairs_ele_num =
         mluOpGetTensorElementNum(indice_pairs_desc_);
     if (indice_pairs_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&indice_pairs_,
                              mluOpGetTensorElementNum(indice_pairs_desc_) *
                                  mluOpDataTypeBytes(indice_pairs_dtype)));
@@ -118,7 +118,7 @@ class indice_convolution_backward_data_general
     uint64_t input_grad_ele_num = mluOpGetTensorElementNum(input_grad_desc_);
     if (input_grad_ele_num > 0) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&input_grad_, mluOpGetTensorElementNum(input_grad_desc_) *
                                        mluOpDataTypeBytes(input_grad_dtype)));
     }
@@ -141,7 +141,7 @@ class indice_convolution_backward_data_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     status = mluOpIndiceConvolutionBackwardData(
         handle_, output_grad_desc_, output_grad_, filters_desc_, filters_,
         indice_pairs_desc_, indice_pairs_, indice_num_.data(), inverse_, sub_m_,
@@ -163,7 +163,7 @@ class indice_convolution_backward_data_general
       output_grad_desc_ = NULL;
     }
     if (output_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_grad_));
       output_grad_ = NULL;
     }
     if (filters_desc_) {
@@ -171,7 +171,7 @@ class indice_convolution_backward_data_general
       filters_desc_ = NULL;
     }
     if (filters_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(filters_));
       filters_ = NULL;
     }
     if (indice_pairs_desc_) {
@@ -179,11 +179,11 @@ class indice_convolution_backward_data_general
       indice_pairs_desc_ = NULL;
     }
     if (indice_pairs_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
       indice_pairs_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (input_grad_desc_) {
@@ -191,7 +191,7 @@ class indice_convolution_backward_data_general
       input_grad_desc_ = NULL;
     }
     if (input_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_grad_));
       input_grad_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter.cpp
@@ -53,12 +53,12 @@ class indice_convolution_backward_filter : public testing::Test {
     if (features) {
       if (features_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&features_, mluOpGetTensorElementNum(features_desc_) *
                                        mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&features_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -73,12 +73,12 @@ class indice_convolution_backward_filter : public testing::Test {
 
     if (output_grad) {
       if (output_grad_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&output_grad_,
                                mluOpGetTensorElementNum(output_grad_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&output_grad_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -94,12 +94,12 @@ class indice_convolution_backward_filter : public testing::Test {
 
     if (indice_pairs) {
       if (indice_pairs_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                mluOpGetTensorElementNum(indice_pairs_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -115,12 +115,12 @@ class indice_convolution_backward_filter : public testing::Test {
 
     if (filters_grad) {
       if (filters_grad_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&filters_grad_,
                                mluOpGetTensorElementNum(filters_grad_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&filters_grad_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -134,7 +134,7 @@ class indice_convolution_backward_filter : public testing::Test {
     }
 
     if (worksapce) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
   mluOpStatus_t compute() {
@@ -163,7 +163,7 @@ class indice_convolution_backward_filter : public testing::Test {
 
     if (features_) {
       VLOG(4) << "Destroy features";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(features_));
       features_ = nullptr;
     }
 
@@ -175,7 +175,7 @@ class indice_convolution_backward_filter : public testing::Test {
 
     if (output_grad_) {
       VLOG(4) << "Destroy output_grad";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_grad_));
       output_grad_ = nullptr;
     }
 
@@ -187,13 +187,13 @@ class indice_convolution_backward_filter : public testing::Test {
 
     if (indice_pairs_) {
       VLOG(4) << "Destroy indice_pairs";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
       indice_pairs_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
 
@@ -205,7 +205,7 @@ class indice_convolution_backward_filter : public testing::Test {
 
     if (filters_grad_) {
       VLOG(4) << "Destroy filters_grad";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(filters_grad_));
       filters_grad_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_backward_filter/indice_convolution_backward_filter_general.cpp
@@ -51,11 +51,11 @@ class indice_convolution_backward_filter_general
           features_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(features_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&features_,
                        mluOpDataTypeBytes(features_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&features_,
                                mluOpDataTypeBytes(features_params.get_dtype()) *
                                    mluOpGetTensorElementNum(features_desc_)));
@@ -69,13 +69,13 @@ class indice_convolution_backward_filter_general
           output_grad_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(output_grad_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &output_grad_,
                 mluOpDataTypeBytes(output_grad_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&output_grad_,
                        mluOpDataTypeBytes(output_grad_params.get_dtype()) *
                            mluOpGetTensorElementNum(output_grad_desc_)));
@@ -89,13 +89,13 @@ class indice_convolution_backward_filter_general
           indice_pairs_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(indice_pairs_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &indice_pairs_,
                 mluOpDataTypeBytes(indice_pairs_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indice_pairs_,
                        mluOpDataTypeBytes(indice_pairs_params.get_dtype()) *
                            mluOpGetTensorElementNum(indice_pairs_desc_)));
@@ -109,13 +109,13 @@ class indice_convolution_backward_filter_general
           filters_grad_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(filters_grad_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &filters_grad_,
                 mluOpDataTypeBytes(filters_grad_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&filters_grad_,
                        mluOpDataTypeBytes(filters_grad_params.get_dtype()) *
                            mluOpGetTensorElementNum(filters_grad_desc_)));
@@ -149,7 +149,7 @@ class indice_convolution_backward_filter_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
 
     status = mluOpIndiceConvolutionBackwardFilter(
         handle_, features_desc_, features_, output_grad_desc_, output_grad_,
@@ -175,7 +175,7 @@ class indice_convolution_backward_filter_general
 
       if (features_) {
         VLOG(4) << "Destroy features";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(features_));
         features_ = nullptr;
       }
 
@@ -187,7 +187,7 @@ class indice_convolution_backward_filter_general
 
       if (output_grad_) {
         VLOG(4) << "Destroy output_grad";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_grad_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(output_grad_));
         output_grad_ = nullptr;
       }
 
@@ -199,7 +199,7 @@ class indice_convolution_backward_filter_general
 
       if (indice_pairs_) {
         VLOG(4) << "Destroy indice_pairs";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
         indice_pairs_ = nullptr;
       }
 
@@ -211,7 +211,7 @@ class indice_convolution_backward_filter_general
 
       if (filters_grad_) {
         VLOG(4) << "Destroy filters_grad";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_grad_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(filters_grad_));
         filters_grad_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward.cpp
@@ -53,12 +53,12 @@ class indice_convolution_forward : public testing::Test {
     if (features) {
       if (features_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&features_, mluOpGetTensorElementNum(features_desc_) *
                                        mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&features_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -74,12 +74,12 @@ class indice_convolution_forward : public testing::Test {
     if (filters) {
       if (filters_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&filters_, mluOpGetTensorElementNum(filters_desc_) *
                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&filters_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -94,12 +94,12 @@ class indice_convolution_forward : public testing::Test {
 
     if (indice_pairs) {
       if (indice_pairs_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                mluOpGetTensorElementNum(indice_pairs_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indice_pairs_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -115,12 +115,12 @@ class indice_convolution_forward : public testing::Test {
 
     if (features_out) {
       if (features_out_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&features_out_,
                                mluOpGetTensorElementNum(features_out_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&features_out_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -134,7 +134,7 @@ class indice_convolution_forward : public testing::Test {
     }
 
     if (worksapce) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
   mluOpStatus_t compute() {
@@ -164,7 +164,7 @@ class indice_convolution_forward : public testing::Test {
 
     if (features_) {
       VLOG(4) << "Destroy features";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(features_));
       features_ = nullptr;
     }
 
@@ -176,7 +176,7 @@ class indice_convolution_forward : public testing::Test {
 
     if (filters_) {
       VLOG(4) << "Destroy filters";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(filters_));
       filters_ = nullptr;
     }
 
@@ -188,13 +188,13 @@ class indice_convolution_forward : public testing::Test {
 
     if (indice_pairs_) {
       VLOG(4) << "Destroy indice_pairs";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
       indice_pairs_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
 
@@ -206,7 +206,7 @@ class indice_convolution_forward : public testing::Test {
 
     if (features_out_) {
       VLOG(4) << "Destroy features_out";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_out_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(features_out_));
       features_out_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/indice_convolution_forward/indice_convolution_forward_general.cpp
@@ -54,11 +54,11 @@ class indice_convolution_forward_general
           features_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(features_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&features_,
                        mluOpDataTypeBytes(features_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&features_,
                                mluOpDataTypeBytes(features_params.get_dtype()) *
                                    mluOpGetTensorElementNum(features_desc_)));
@@ -72,11 +72,11 @@ class indice_convolution_forward_general
           filters_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(filters_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&filters_,
                        mluOpDataTypeBytes(filters_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&filters_,
                                mluOpDataTypeBytes(filters_params.get_dtype()) *
                                    mluOpGetTensorElementNum(filters_desc_)));
@@ -90,13 +90,13 @@ class indice_convolution_forward_general
           indice_pairs_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(indice_pairs_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &indice_pairs_,
                 mluOpDataTypeBytes(indice_pairs_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indice_pairs_,
                        mluOpDataTypeBytes(indice_pairs_params.get_dtype()) *
                            mluOpGetTensorElementNum(indice_pairs_desc_)));
@@ -110,13 +110,13 @@ class indice_convolution_forward_general
           features_out_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(features_out_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &features_out_,
                 mluOpDataTypeBytes(features_out_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&features_out_,
                        mluOpDataTypeBytes(features_out_params.get_dtype()) *
                            mluOpGetTensorElementNum(features_out_desc_)));
@@ -149,7 +149,7 @@ class indice_convolution_forward_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
 
     status = mluOpIndiceConvolutionForward(
         handle_, features_desc_, features_, filters_desc_, filters_,
@@ -176,7 +176,7 @@ class indice_convolution_forward_general
 
       if (features_) {
         VLOG(4) << "Destroy features";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(features_));
         features_ = nullptr;
       }
 
@@ -188,7 +188,7 @@ class indice_convolution_forward_general
 
       if (filters_) {
         VLOG(4) << "Destroy filters";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(filters_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(filters_));
         filters_ = nullptr;
       }
 
@@ -200,7 +200,7 @@ class indice_convolution_forward_general
 
       if (indice_pairs_) {
         VLOG(4) << "Destroy indice_pairs";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indice_pairs_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(indice_pairs_));
         indice_pairs_ = nullptr;
       }
 
@@ -212,7 +212,7 @@ class indice_convolution_forward_general
 
       if (features_out_) {
         VLOG(4) << "Destroy features_out";
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_out_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(features_out_));
         features_out_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/masked_col2im_forward/masked_col2im_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/masked_col2im_forward/masked_col2im_forward.cpp
@@ -51,11 +51,11 @@ class masked_col2im_forward : public testing::Test {
 
     if (col) {
       if (col_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&col_, MLUOP_DTYPE_FLOAT *
                                           mluOpGetTensorElementNum(col_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&col_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -70,12 +70,12 @@ class masked_col2im_forward : public testing::Test {
 
     if (mask_h_idx) {
       if (mask_h_idx_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_h_idx_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(mask_h_idx_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_h_idx_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -90,12 +90,12 @@ class masked_col2im_forward : public testing::Test {
 
     if (mask_w_idx) {
       if (mask_w_idx_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_w_idx_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(mask_w_idx_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_w_idx_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -110,17 +110,17 @@ class masked_col2im_forward : public testing::Test {
 
     if (im) {
       if (im_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&im_, MLUOP_DTYPE_FLOAT *
                                          mluOpGetTensorElementNum(im_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&im_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     }
   }
@@ -151,7 +151,7 @@ class masked_col2im_forward : public testing::Test {
 
     if (col_) {
       VLOG(4) << "Destroy col_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(col_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(col_));
       col_ = nullptr;
     }
 
@@ -163,7 +163,7 @@ class masked_col2im_forward : public testing::Test {
 
     if (mask_h_idx_) {
       VLOG(4) << "Destroy mask_h_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_h_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_h_idx_));
       mask_h_idx_ = nullptr;
     }
 
@@ -175,7 +175,7 @@ class masked_col2im_forward : public testing::Test {
 
     if (mask_w_idx_) {
       VLOG(4) << "Destroy mask_w_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_w_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_w_idx_));
       mask_w_idx_ = nullptr;
     }
 
@@ -187,13 +187,13 @@ class masked_col2im_forward : public testing::Test {
 
     if (im_) {
       VLOG(4) << "Destroy im_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(im_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(im_));
       im_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/masked_col2im_forward/masked_col2im_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/masked_col2im_forward/masked_col2im_forward_general.cpp
@@ -51,11 +51,11 @@ class masked_col2im_forward_general
           col_params.get_dim_nb(), col_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(col_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&col_, mluOpDataTypeBytes(col_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&col_, mluOpDataTypeBytes(col_params.get_dtype()) *
                                   mluOpGetTensorElementNum(col_desc_)));
       }
@@ -68,12 +68,12 @@ class masked_col2im_forward_general
           mask_h_idx_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(mask_h_idx_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_h_idx_,
                        mluOpDataTypeBytes(mask_h_idx_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_h_idx_,
                        mluOpDataTypeBytes(mask_h_idx_params.get_dtype()) *
                            mluOpGetTensorElementNum(mask_h_idx_desc_)));
@@ -87,12 +87,12 @@ class masked_col2im_forward_general
           mask_w_idx_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(mask_w_idx_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_w_idx_,
                        mluOpDataTypeBytes(mask_w_idx_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_w_idx_,
                        mluOpDataTypeBytes(mask_w_idx_params.get_dtype()) *
                            mluOpGetTensorElementNum(mask_w_idx_desc_)));
@@ -105,10 +105,10 @@ class masked_col2im_forward_general
           im_params.get_dim_nb(), im_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(im_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&im_, mluOpDataTypeBytes(im_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&im_, mluOpDataTypeBytes(im_params.get_dtype()) *
                                          mluOpGetTensorElementNum(im_desc_)));
       }
@@ -116,7 +116,7 @@ class masked_col2im_forward_general
       target_device_ = std::get<4>(GetParam());
       expected_status_ = std::get<5>(GetParam());
 
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -154,7 +154,7 @@ class masked_col2im_forward_general
 
     if (col_) {
       VLOG(4) << "Destroy col_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(col_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(col_));
       col_ = nullptr;
     }
 
@@ -166,7 +166,7 @@ class masked_col2im_forward_general
 
     if (mask_h_idx_) {
       VLOG(4) << "Destroy mask_h_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_h_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_h_idx_));
       mask_h_idx_ = nullptr;
     }
 
@@ -178,7 +178,7 @@ class masked_col2im_forward_general
 
     if (mask_w_idx_) {
       VLOG(4) << "Destroy mask_w_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_w_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_w_idx_));
       mask_w_idx_ = nullptr;
     }
 
@@ -190,13 +190,13 @@ class masked_col2im_forward_general
 
     if (im_) {
       VLOG(4) << "Destroy im_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(im_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(im_));
       im_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/masked_im2col_forward/masked_im2col_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/masked_im2col_forward/masked_im2col_forward.cpp
@@ -53,11 +53,11 @@ class masked_im2col_forward : public testing::Test {
     if (feature) {
       if (feature_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feature_, MLUOP_DTYPE_FLOAT *
                                       mluOpGetTensorElementNum(feature_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&feature_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -72,12 +72,12 @@ class masked_im2col_forward : public testing::Test {
 
     if (mask_h_idx) {
       if (mask_h_idx_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_h_idx_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(mask_h_idx_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_h_idx_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -92,12 +92,12 @@ class masked_im2col_forward : public testing::Test {
 
     if (mask_w_idx) {
       if (mask_w_idx_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_w_idx_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(mask_w_idx_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&mask_w_idx_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -112,18 +112,18 @@ class masked_im2col_forward : public testing::Test {
 
     if (data_col) {
       if (data_col_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_col_,
                                MLUOP_DTYPE_FLOAT *
                                    mluOpGetTensorElementNum(data_col_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_col_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     }
   }
@@ -154,7 +154,7 @@ class masked_im2col_forward : public testing::Test {
 
     if (feature_) {
       VLOG(4) << "Destroy feature_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feature_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(feature_));
       feature_ = nullptr;
     }
 
@@ -166,7 +166,7 @@ class masked_im2col_forward : public testing::Test {
 
     if (mask_h_idx_) {
       VLOG(4) << "Destroy mask_h_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_h_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_h_idx_));
       mask_h_idx_ = nullptr;
     }
 
@@ -178,7 +178,7 @@ class masked_im2col_forward : public testing::Test {
 
     if (mask_w_idx_) {
       VLOG(4) << "Destroy mask_w_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_w_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_w_idx_));
       mask_w_idx_ = nullptr;
     }
 
@@ -190,13 +190,13 @@ class masked_im2col_forward : public testing::Test {
 
     if (data_col_) {
       VLOG(4) << "Destroy data_col_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_col_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_col_));
       data_col_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/masked_im2col_forward/masked_im2col_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/masked_im2col_forward/masked_im2col_forward_general.cpp
@@ -52,11 +52,11 @@ class masked_im2col_forward_general
           feature_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(feature_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&feature_,
                        mluOpDataTypeBytes(feature_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&feature_,
                                mluOpDataTypeBytes(feature_params.get_dtype()) *
                                    mluOpGetTensorElementNum(feature_desc_)));
@@ -70,12 +70,12 @@ class masked_im2col_forward_general
           mask_h_idx_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(mask_h_idx_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_h_idx_,
                        mluOpDataTypeBytes(mask_h_idx_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_h_idx_,
                        mluOpDataTypeBytes(mask_h_idx_params.get_dtype()) *
                            mluOpGetTensorElementNum(mask_h_idx_desc_)));
@@ -89,12 +89,12 @@ class masked_im2col_forward_general
           mask_w_idx_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(mask_w_idx_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_w_idx_,
                        mluOpDataTypeBytes(mask_w_idx_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&mask_w_idx_,
                        mluOpDataTypeBytes(mask_w_idx_params.get_dtype()) *
                            mluOpGetTensorElementNum(mask_w_idx_desc_)));
@@ -108,11 +108,11 @@ class masked_im2col_forward_general
           data_col_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(data_col_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_col_,
                        mluOpDataTypeBytes(data_col_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_col_,
                                mluOpDataTypeBytes(data_col_params.get_dtype()) *
                                    mluOpGetTensorElementNum(data_col_desc_)));
@@ -123,7 +123,7 @@ class masked_im2col_forward_general
       target_device_ = std::get<6>(GetParam());
       expected_status_ = std::get<7>(GetParam());
 
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -161,7 +161,7 @@ class masked_im2col_forward_general
 
     if (feature_) {
       VLOG(4) << "Destroy feature_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(feature_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(feature_));
       feature_ = nullptr;
     }
 
@@ -173,7 +173,7 @@ class masked_im2col_forward_general
 
     if (mask_h_idx_) {
       VLOG(4) << "Destroy mask_h_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_h_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_h_idx_));
       mask_h_idx_ = nullptr;
     }
 
@@ -185,7 +185,7 @@ class masked_im2col_forward_general
 
     if (mask_w_idx_) {
       VLOG(4) << "Destroy mask_w_idx_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mask_w_idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mask_w_idx_));
       mask_w_idx_ = nullptr;
     }
 
@@ -197,13 +197,13 @@ class masked_im2col_forward_general
 
     if (data_col_) {
       VLOG(4) << "Destroy data_col_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_col_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_col_));
       data_col_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data.cpp
@@ -53,12 +53,12 @@ class moe_dispatch_backward_data : public testing::Test {
     if (gates) {
       if (gates_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&gates_, mluOpGetTensorElementNum(gates_desc_) *
                                     mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&gates_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -74,12 +74,12 @@ class moe_dispatch_backward_data : public testing::Test {
     if (indices) {
       if (indices_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, mluOpGetTensorElementNum(indices_desc_) *
                                       mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
@@ -95,11 +95,11 @@ class moe_dispatch_backward_data : public testing::Test {
     if (locations) {
       if (locations_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_, mluOpGetTensorElementNum(locations_desc_) *
                                         mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&locations_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -116,12 +116,12 @@ class moe_dispatch_backward_data : public testing::Test {
     if (dispatch) {
       if (dispatch_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_, mluOpGetTensorElementNum(dispatch_desc_) *
                                        mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -136,12 +136,12 @@ class moe_dispatch_backward_data : public testing::Test {
 
     if (grad_input) {
       if (grad_input_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_input_,
                                mluOpGetTensorElementNum(grad_input_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_input_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -173,7 +173,7 @@ class moe_dispatch_backward_data : public testing::Test {
 
     if (gates_) {
       VLOG(4) << "Destroy gates_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(gates_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(gates_));
       gates_ = nullptr;
     }
 
@@ -185,7 +185,7 @@ class moe_dispatch_backward_data : public testing::Test {
 
     if (indices_) {
       VLOG(4) << "Destroy indices_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = nullptr;
     }
 
@@ -197,7 +197,7 @@ class moe_dispatch_backward_data : public testing::Test {
 
     if (locations_) {
       VLOG(4) << "Destroy locations_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(locations_));
       locations_ = nullptr;
     }
 
@@ -209,7 +209,7 @@ class moe_dispatch_backward_data : public testing::Test {
 
     if (dispatch_) {
       VLOG(4) << "Destroy dispatch_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dispatch_));
       dispatch_ = nullptr;
     }
 
@@ -221,7 +221,7 @@ class moe_dispatch_backward_data : public testing::Test {
 
     if (grad_input_) {
       VLOG(4) << "Destroy grad_input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_data/moe_dispatch_backward_data_general.cpp
@@ -64,12 +64,12 @@ class moe_dispatch_backward_data_general
 
       if (mluOpGetTensorElementNum(gates_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&gates_,
                        mluOpDataTypeBytes(gates_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&gates_, mluOpDataTypeBytes(gates_params.get_dtype()) *
                                     mluOpGetTensorElementNum(gates_desc_)));
       }
@@ -82,11 +82,11 @@ class moe_dispatch_backward_data_general
           indices_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(indices_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_,
                        mluOpDataTypeBytes(indices_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indices_,
                                mluOpDataTypeBytes(indices_params.get_dtype()) *
                                    mluOpGetTensorElementNum(indices_desc_)));
@@ -100,12 +100,12 @@ class moe_dispatch_backward_data_general
           locations_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(locations_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_,
                        mluOpDataTypeBytes(locations_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_,
                        mluOpDataTypeBytes(locations_params.get_dtype()) *
                            mluOpGetTensorElementNum(locations_desc_)));
@@ -119,11 +119,11 @@ class moe_dispatch_backward_data_general
           dispatch_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(dispatch_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_,
                        mluOpDataTypeBytes(dispatch_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&dispatch_,
                                mluOpDataTypeBytes(dispatch_params.get_dtype()) *
                                    mluOpGetTensorElementNum(dispatch_desc_)));
@@ -137,12 +137,12 @@ class moe_dispatch_backward_data_general
           grad_input_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_input_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_input_,
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_input_,
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_input_desc_)));
@@ -182,7 +182,7 @@ class moe_dispatch_backward_data_general
 
     if (gates_) {
       VLOG(4) << "Destroy gates";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(gates_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(gates_));
       gates_ = nullptr;
     }
 
@@ -194,7 +194,7 @@ class moe_dispatch_backward_data_general
 
     if (indices_) {
       VLOG(4) << "Destroy indices";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = nullptr;
     }
 
@@ -206,7 +206,7 @@ class moe_dispatch_backward_data_general
 
     if (locations_) {
       VLOG(4) << "Destroy locations";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(locations_));
       locations_ = nullptr;
     }
 
@@ -218,7 +218,7 @@ class moe_dispatch_backward_data_general
 
     if (dispatch_) {
       VLOG(4) << "Destroy dispatch";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dispatch_));
       dispatch_ = nullptr;
     }
 
@@ -230,7 +230,7 @@ class moe_dispatch_backward_data_general
 
     if (grad_input_) {
       VLOG(4) << "Destroy dispatch";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -53,12 +53,12 @@ class moe_dispatch_backward_gate : public testing::Test {
     if (indices) {
       if (indices_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, mluOpGetTensorElementNum(indices_desc_) *
                                       mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
@@ -74,11 +74,11 @@ class moe_dispatch_backward_gate : public testing::Test {
     if (locations) {
       if (locations_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_, mluOpGetTensorElementNum(locations_desc_) *
                                         mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&locations_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -95,12 +95,12 @@ class moe_dispatch_backward_gate : public testing::Test {
     if (input) {
       if (input_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, mluOpGetTensorElementNum(input_desc_) *
                                     mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -116,12 +116,12 @@ class moe_dispatch_backward_gate : public testing::Test {
     if (dispatch) {
       if (dispatch_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_, mluOpGetTensorElementNum(dispatch_desc_) *
                                        mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -136,19 +136,19 @@ class moe_dispatch_backward_gate : public testing::Test {
 
     if (grad_gates) {
       if (grad_gates_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_gates_,
                                mluOpGetTensorElementNum(grad_gates_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_gates_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
   mluOpStatus_t compute() {
@@ -178,7 +178,7 @@ class moe_dispatch_backward_gate : public testing::Test {
 
     if (indices_) {
       VLOG(4) << "Destroy indices_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = nullptr;
     }
 
@@ -190,7 +190,7 @@ class moe_dispatch_backward_gate : public testing::Test {
 
     if (locations_) {
       VLOG(4) << "Destroy locations_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(locations_));
       locations_ = nullptr;
     }
 
@@ -202,7 +202,7 @@ class moe_dispatch_backward_gate : public testing::Test {
 
     if (input_) {
       VLOG(4) << "Destroy input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
 
@@ -214,7 +214,7 @@ class moe_dispatch_backward_gate : public testing::Test {
 
     if (dispatch_) {
       VLOG(4) << "Destroy dispatch_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dispatch_));
       dispatch_ = nullptr;
     }
 
@@ -226,13 +226,13 @@ class moe_dispatch_backward_gate : public testing::Test {
 
     if (grad_gates_) {
       VLOG(4) << "Destroy grad_gates_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_gates_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_gates_));
       grad_gates_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_backward_gate/moe_dispatch_backward_gate_general.cpp
@@ -65,11 +65,11 @@ class moe_dispatch_backward_gate_general
           indices_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(indices_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_,
                        mluOpDataTypeBytes(indices_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&indices_,
                                mluOpDataTypeBytes(indices_params.get_dtype()) *
                                    mluOpGetTensorElementNum(indices_desc_)));
@@ -83,12 +83,12 @@ class moe_dispatch_backward_gate_general
           locations_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(locations_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_,
                        mluOpDataTypeBytes(locations_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_,
                        mluOpDataTypeBytes(locations_params.get_dtype()) *
                            mluOpGetTensorElementNum(locations_desc_)));
@@ -102,12 +102,12 @@ class moe_dispatch_backward_gate_general
 
       if (mluOpGetTensorElementNum(input_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_,
                        mluOpDataTypeBytes(input_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, mluOpDataTypeBytes(input_params.get_dtype()) *
                                     mluOpGetTensorElementNum(input_desc_)));
       }
@@ -120,11 +120,11 @@ class moe_dispatch_backward_gate_general
           dispatch_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(dispatch_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_,
                        mluOpDataTypeBytes(dispatch_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&dispatch_,
                                mluOpDataTypeBytes(dispatch_params.get_dtype()) *
                                    mluOpGetTensorElementNum(dispatch_desc_)));
@@ -138,12 +138,12 @@ class moe_dispatch_backward_gate_general
           grad_gates_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_gates_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_gates_,
                        mluOpDataTypeBytes(grad_gates_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_gates_,
                        mluOpDataTypeBytes(grad_gates_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_gates_desc_)));
@@ -167,7 +167,7 @@ class moe_dispatch_backward_gate_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
 
     status = mluOpMoeDispatchBackwardGate(
         handle_, indices_desc_, indices_, locations_desc_, locations_,
@@ -192,7 +192,7 @@ class moe_dispatch_backward_gate_general
 
     if (indices_) {
       VLOG(4) << "Destroy indices_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = nullptr;
     }
 
@@ -204,7 +204,7 @@ class moe_dispatch_backward_gate_general
 
     if (locations_) {
       VLOG(4) << "Destroy locations_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(locations_));
       locations_ = nullptr;
     }
 
@@ -216,7 +216,7 @@ class moe_dispatch_backward_gate_general
 
     if (input_) {
       VLOG(4) << "Destroy input_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = nullptr;
     }
 
@@ -228,7 +228,7 @@ class moe_dispatch_backward_gate_general
 
     if (dispatch_) {
       VLOG(4) << "Destroy dispatch_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dispatch_));
       dispatch_ = nullptr;
     }
 
@@ -240,7 +240,7 @@ class moe_dispatch_backward_gate_general
 
     if (grad_gates_) {
       VLOG(4) << "Destroy grad_gates_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_gates_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_gates_));
       grad_gates_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_forward/moe_dispatch_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_forward/moe_dispatch_forward.cpp
@@ -51,12 +51,12 @@ class moe_dispatch_forward : public testing::Test {
     if (gates) {
       if (gates_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&gates_, mluOpGetTensorElementNum(gates_desc_) *
                                     mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&gates_, 2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -70,12 +70,12 @@ class moe_dispatch_forward : public testing::Test {
     if (indices) {
       if (indices_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, mluOpGetTensorElementNum(indices_desc_) *
                                       mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, 2 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
@@ -89,12 +89,12 @@ class moe_dispatch_forward : public testing::Test {
     if (locations) {
       if (locations_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_, mluOpGetTensorElementNum(locations_desc_) *
                                         mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_, 2 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
@@ -108,12 +108,12 @@ class moe_dispatch_forward : public testing::Test {
     if (input) {
       if (input_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, mluOpGetTensorElementNum(input_desc_) *
                                     mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, 4 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -127,12 +127,12 @@ class moe_dispatch_forward : public testing::Test {
     if (dispatch) {
       if (dispatch_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_, mluOpGetTensorElementNum(dispatch_desc_) *
                                        mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_, 8 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -159,7 +159,7 @@ class moe_dispatch_forward : public testing::Test {
       gates_desc_ = NULL;
     }
     if (gates_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(gates_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(gates_));
       gates_ = NULL;
     }
     if (indices_desc_) {
@@ -167,7 +167,7 @@ class moe_dispatch_forward : public testing::Test {
       indices_desc_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (locations_desc_) {
@@ -175,7 +175,7 @@ class moe_dispatch_forward : public testing::Test {
       locations_desc_ = NULL;
     }
     if (locations_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(locations_));
       locations_ = NULL;
     }
     if (input_desc_) {
@@ -183,7 +183,7 @@ class moe_dispatch_forward : public testing::Test {
       input_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (dispatch_desc_) {
@@ -191,7 +191,7 @@ class moe_dispatch_forward : public testing::Test {
       dispatch_desc_ = NULL;
     }
     if (dispatch_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dispatch_));
       dispatch_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_forward/moe_dispatch_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/moe_dispatch_forward/moe_dispatch_forward_general.cpp
@@ -64,10 +64,10 @@ class moe_dispatch_forward_general
     uint gates_ele_num = mluOpGetTensorElementNum(gates_desc_);
     if (gates_ele_num > 0) {
       if (mluOpGetTensorElementNum(gates_desc_) >= LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&gates_, 12 * mluOpDataTypeBytes(gates_dtype)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&gates_, gates_ele_num *
                                             mluOpDataTypeBytes(gates_dtype)));
       }
@@ -86,11 +86,11 @@ class moe_dispatch_forward_general
     if (indices_ele_num > 0) {
       if (mluOpGetTensorElementNum(indices_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_, 12 * mluOpDataTypeBytes(indices_dtype)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&indices_,
                        indices_ele_num * mluOpDataTypeBytes(indices_dtype)));
       }
@@ -109,11 +109,11 @@ class moe_dispatch_forward_general
     if (locations_ele_num > 0) {
       if (mluOpGetTensorElementNum(locations_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_, 12 * mluOpDataTypeBytes(locations_dtype)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&locations_, locations_ele_num *
                                         mluOpDataTypeBytes(locations_dtype)));
       }
@@ -130,10 +130,10 @@ class moe_dispatch_forward_general
     uint input_ele_num = mluOpGetTensorElementNum(input_desc_);
     if (input_ele_num > 0) {
       if (mluOpGetTensorElementNum(input_desc_) >= LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_, 12 * mluOpDataTypeBytes(input_dtype)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_, input_ele_num *
                                             mluOpDataTypeBytes(input_dtype)));
       }
@@ -155,11 +155,11 @@ class moe_dispatch_forward_general
     if (dispatch_ele_num > 0) {
       if (mluOpGetTensorElementNum(dispatch_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_, 12 * mluOpDataTypeBytes(dispatch_dtype)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&dispatch_,
                        dispatch_ele_num * mluOpDataTypeBytes(dispatch_dtype)));
       }
@@ -193,7 +193,7 @@ class moe_dispatch_forward_general
       gates_desc_ = NULL;
     }
     if (gates_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(gates_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(gates_));
       gates_ = NULL;
     }
     if (indices_desc_) {
@@ -201,7 +201,7 @@ class moe_dispatch_forward_general
       indices_desc_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (locations_desc_) {
@@ -209,7 +209,7 @@ class moe_dispatch_forward_general
       locations_desc_ = NULL;
     }
     if (locations_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(locations_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(locations_));
       locations_ = NULL;
     }
     if (input_desc_) {
@@ -217,7 +217,7 @@ class moe_dispatch_forward_general
       input_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (dispatch_desc_) {
@@ -225,7 +225,7 @@ class moe_dispatch_forward_general
       dispatch_desc_ = NULL;
     }
     if (dispatch_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dispatch_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dispatch_));
       dispatch_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_backward/ms_deform_attn_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_backward/ms_deform_attn_backward.cpp
@@ -57,12 +57,12 @@ class ms_deform_attn_backward : public testing::Test {
     if (value) {
       if (value_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&value_, mluOpGetTensorElementNum(value_desc_) *
                                     mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&value_, 2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -77,12 +77,12 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (spatial_shapes) {
       if (spatial_shapes_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&spatial_shapes_,
                                mluOpGetTensorElementNum(spatial_shapes_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&spatial_shapes_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -99,12 +99,12 @@ class ms_deform_attn_backward : public testing::Test {
     if (level_start_index) {
       if (level_start_index_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&level_start_index_,
                        mluOpGetTensorElementNum(level_start_index_desc_) *
                            mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&level_start_index_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -120,12 +120,12 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (sampling_loc) {
       if (sampling_loc_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&sampling_loc_,
                                mluOpGetTensorElementNum(sampling_loc_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&sampling_loc_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -141,12 +141,12 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (attn_weight) {
       if (attn_weight_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&attn_weight_,
                                mluOpGetTensorElementNum(attn_weight_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&attn_weight_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -162,12 +162,12 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (grad_output) {
       if (grad_output_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_output_,
                                mluOpGetTensorElementNum(grad_output_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_output_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -183,12 +183,12 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (grad_value) {
       if (grad_value_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_value_,
                                mluOpGetTensorElementNum(grad_value_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_value_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -205,12 +205,12 @@ class ms_deform_attn_backward : public testing::Test {
     if (grad_sampling_loc) {
       if (grad_sampling_loc_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_sampling_loc_,
                        mluOpGetTensorElementNum(grad_sampling_loc_desc_) *
                            mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_sampling_loc_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -227,12 +227,12 @@ class ms_deform_attn_backward : public testing::Test {
     if (grad_attn_weight) {
       if (grad_attn_weight_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_attn_weight_,
                        mluOpGetTensorElementNum(grad_attn_weight_desc_) *
                            mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_attn_weight_,
                                2 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -268,7 +268,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (value_) {
       VLOG(4) << "Destroy value";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(value_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(value_));
       value_ = nullptr;
     }
 
@@ -280,7 +280,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (spatial_shapes_) {
       VLOG(4) << "Destroy spatial_shapes";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(spatial_shapes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(spatial_shapes_));
       spatial_shapes_ = nullptr;
     }
 
@@ -292,7 +292,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (level_start_index_) {
       VLOG(4) << "Destroy level_start_index";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(level_start_index_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(level_start_index_));
       level_start_index_ = nullptr;
     }
 
@@ -304,7 +304,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (sampling_loc_) {
       VLOG(4) << "Destroy sampling_loc";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(sampling_loc_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(sampling_loc_));
       sampling_loc_ = nullptr;
     }
 
@@ -316,7 +316,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (attn_weight_) {
       VLOG(4) << "Destroy attn_weight";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(attn_weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(attn_weight_));
       attn_weight_ = nullptr;
     }
 
@@ -328,7 +328,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (grad_output_) {
       VLOG(4) << "Destroy grad_output";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = nullptr;
     }
 
@@ -340,7 +340,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (grad_value_) {
       VLOG(4) << "Destroy grad_value";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_value_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_value_));
       grad_value_ = nullptr;
     }
 
@@ -352,7 +352,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (grad_sampling_loc_) {
       VLOG(4) << "Destroy grad_sampling_loc";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_sampling_loc_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_sampling_loc_));
       grad_sampling_loc_ = nullptr;
     }
 
@@ -364,7 +364,7 @@ class ms_deform_attn_backward : public testing::Test {
 
     if (grad_attn_weight_) {
       VLOG(4) << "Destroy grad_attn_weight";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_attn_weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_attn_weight_));
       grad_attn_weight_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_backward/ms_deform_attn_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_backward/ms_deform_attn_backward_general.cpp
@@ -58,12 +58,12 @@ class ms_deform_attn_backward_general
 
       if (mluOpGetTensorElementNum(value_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&value_,
                        mluOpDataTypeBytes(value_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&value_, mluOpDataTypeBytes(value_params.get_dtype()) *
                                     mluOpGetTensorElementNum(value_desc_)));
       }
@@ -76,13 +76,13 @@ class ms_deform_attn_backward_general
           spatial_shapes_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(spatial_shapes_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &spatial_shapes_,
                 mluOpDataTypeBytes(spatial_shapes_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&spatial_shapes_,
                        mluOpDataTypeBytes(spatial_shapes_params.get_dtype()) *
                            mluOpGetTensorElementNum(spatial_shapes_desc_)));
@@ -99,13 +99,13 @@ class ms_deform_attn_backward_general
       if (mluOpGetTensorElementNum(level_start_index_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &level_start_index_,
                 mluOpDataTypeBytes(level_start_index_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &level_start_index_,
                 mluOpDataTypeBytes(level_start_index_params.get_dtype()) *
@@ -120,13 +120,13 @@ class ms_deform_attn_backward_general
           sampling_loc_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(sampling_loc_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &sampling_loc_,
                 mluOpDataTypeBytes(sampling_loc_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&sampling_loc_,
                        mluOpDataTypeBytes(sampling_loc_params.get_dtype()) *
                            mluOpGetTensorElementNum(sampling_loc_desc_)));
@@ -140,12 +140,12 @@ class ms_deform_attn_backward_general
           attn_weight_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(attn_weight_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&attn_weight_,
                        mluOpDataTypeBytes(attn_weight_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&attn_weight_,
                        mluOpDataTypeBytes(attn_weight_params.get_dtype()) *
                            mluOpGetTensorElementNum(attn_weight_desc_)));
@@ -159,12 +159,12 @@ class ms_deform_attn_backward_general
           grad_output_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_output_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_output_,
                        mluOpDataTypeBytes(grad_output_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_output_,
                        mluOpDataTypeBytes(grad_output_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_output_desc_)));
@@ -178,12 +178,12 @@ class ms_deform_attn_backward_general
           grad_value_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_value_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_value_,
                        mluOpDataTypeBytes(grad_value_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_value_,
                        mluOpDataTypeBytes(grad_value_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_value_desc_)));
@@ -199,13 +199,13 @@ class ms_deform_attn_backward_general
       if (mluOpGetTensorElementNum(grad_sampling_loc_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &grad_sampling_loc_,
                 mluOpDataTypeBytes(grad_sampling_loc_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &grad_sampling_loc_,
                 mluOpDataTypeBytes(grad_sampling_loc_params.get_dtype()) *
@@ -222,13 +222,13 @@ class ms_deform_attn_backward_general
       if (mluOpGetTensorElementNum(grad_attn_weight_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &grad_attn_weight_,
                 mluOpDataTypeBytes(grad_attn_weight_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_attn_weight_,
                        mluOpDataTypeBytes(grad_attn_weight_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_attn_weight_desc_)));
@@ -277,7 +277,7 @@ class ms_deform_attn_backward_general
 
     if (value_) {
       VLOG(4) << "Destroy value";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(value_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(value_));
       value_ = nullptr;
     }
 
@@ -289,7 +289,7 @@ class ms_deform_attn_backward_general
 
     if (spatial_shapes_) {
       VLOG(4) << "Destroy spatial_shapes";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(spatial_shapes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(spatial_shapes_));
       spatial_shapes_ = nullptr;
     }
 
@@ -301,7 +301,7 @@ class ms_deform_attn_backward_general
 
     if (level_start_index_) {
       VLOG(4) << "Destroy level_start_index";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(level_start_index_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(level_start_index_));
       level_start_index_ = nullptr;
     }
 
@@ -313,7 +313,7 @@ class ms_deform_attn_backward_general
 
     if (sampling_loc_) {
       VLOG(4) << "Destroy sampling_loc";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(sampling_loc_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(sampling_loc_));
       sampling_loc_ = nullptr;
     }
 
@@ -325,7 +325,7 @@ class ms_deform_attn_backward_general
 
     if (attn_weight_) {
       VLOG(4) << "Destroy attn_weight";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(attn_weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(attn_weight_));
       attn_weight_ = nullptr;
     }
 
@@ -337,7 +337,7 @@ class ms_deform_attn_backward_general
 
     if (grad_output_) {
       VLOG(4) << "Destroy grad_output";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = nullptr;
     }
 
@@ -349,7 +349,7 @@ class ms_deform_attn_backward_general
 
     if (grad_value_) {
       VLOG(4) << "Destroy grad_value";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_value_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_value_));
       grad_value_ = nullptr;
     }
 
@@ -361,7 +361,7 @@ class ms_deform_attn_backward_general
 
     if (grad_sampling_loc_) {
       VLOG(4) << "Destroy grad_sampling_loc";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_sampling_loc_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_sampling_loc_));
       grad_sampling_loc_ = nullptr;
     }
 
@@ -373,7 +373,7 @@ class ms_deform_attn_backward_general
 
     if (grad_attn_weight_) {
       VLOG(4) << "Destroy grad_attn_weight";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_attn_weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_attn_weight_));
       grad_attn_weight_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_forward/ms_deform_attn_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_forward/ms_deform_attn_forward.cpp
@@ -54,12 +54,12 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_value) {
       if (data_value_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_value_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(data_value_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_value_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -75,12 +75,12 @@ class ms_deform_attn_forward : public testing::Test {
     if (data_spatial_shapes) {
       if (data_spatial_shapes_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_spatial_shapes_,
                        MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
                                                data_spatial_shapes_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_spatial_shapes_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -96,12 +96,12 @@ class ms_deform_attn_forward : public testing::Test {
     if (data_level_start_index) {
       if (data_level_start_index_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_level_start_index_,
                        MLUOP_DTYPE_INT32 * mluOpGetTensorElementNum(
                                                data_level_start_index_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&data_level_start_index_,
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&data_level_start_index_,
                                                    MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -117,12 +117,12 @@ class ms_deform_attn_forward : public testing::Test {
     if (data_sampling_loc) {
       if (data_sampling_loc_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_sampling_loc_,
                        MLUOP_DTYPE_INT32 *
                            mluOpGetTensorElementNum(data_sampling_loc_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_sampling_loc_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -138,12 +138,12 @@ class ms_deform_attn_forward : public testing::Test {
     if (data_attn_weight) {
       if (data_attn_weight_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_attn_weight_,
                        MLUOP_DTYPE_INT32 *
                            mluOpGetTensorElementNum(data_attn_weight_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_attn_weight_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -158,12 +158,12 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_col) {
       if (data_col_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_col_,
                                MLUOP_DTYPE_INT32 *
                                    mluOpGetTensorElementNum(data_col_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_col_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -197,7 +197,7 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_value_) {
       VLOG(4) << "Destroy data_value";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_value_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_value_));
       data_value_ = nullptr;
     }
 
@@ -209,7 +209,7 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_spatial_shapes_) {
       VLOG(4) << "Destroy data_spatial_shapes";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_spatial_shapes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_spatial_shapes_));
       data_spatial_shapes_ = nullptr;
     }
 
@@ -221,7 +221,7 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_level_start_index_) {
       VLOG(4) << "Destroy data_level_start_index";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_level_start_index_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_level_start_index_));
       data_level_start_index_ = nullptr;
     }
 
@@ -233,7 +233,7 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_sampling_loc_) {
       VLOG(4) << "Destroy data_sampling_loc";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_sampling_loc_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_sampling_loc_));
       data_sampling_loc_ = nullptr;
     }
 
@@ -245,7 +245,7 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_attn_weight_) {
       VLOG(4) << "Destroy data_attn_weight";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_attn_weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_attn_weight_));
       data_attn_weight_ = nullptr;
     }
 
@@ -257,7 +257,7 @@ class ms_deform_attn_forward : public testing::Test {
 
     if (data_col_) {
       VLOG(4) << "Destroy data_col";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_col_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_col_));
       data_col_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_forward/ms_deform_attn_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/ms_deform_attn_forward/ms_deform_attn_forward_general.cpp
@@ -54,12 +54,12 @@ class ms_deform_attn_forward_general
           data_value_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(data_value_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_value_,
                        mluOpDataTypeBytes(data_value_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_value_,
                        mluOpDataTypeBytes(data_value_params.get_dtype()) *
                            mluOpGetTensorElementNum(data_value_desc_)));
@@ -75,14 +75,14 @@ class ms_deform_attn_forward_general
 
       if (mluOpGetTensorElementNum(data_spatial_shapes_desc_) >=
           LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_spatial_shapes_,
                                mluOpDataTypeBytes(
                                    data_spatial_shapes_params.get_dtype()) *
                                    2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &data_spatial_shapes_,
                 mluOpDataTypeBytes(data_spatial_shapes_params.get_dtype()) *
@@ -100,14 +100,14 @@ class ms_deform_attn_forward_general
 
       if (mluOpGetTensorElementNum(data_level_start_index_desc_) >=
           LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_level_start_index_,
                                mluOpDataTypeBytes(
                                    data_level_start_index_params.get_dtype()) *
                                    2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &data_level_start_index_,
                 mluOpDataTypeBytes(data_level_start_index_params.get_dtype()) *
@@ -125,13 +125,13 @@ class ms_deform_attn_forward_general
       if (mluOpGetTensorElementNum(data_sampling_loc_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &data_sampling_loc_,
                 mluOpDataTypeBytes(data_sampling_loc_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &data_sampling_loc_,
                 mluOpDataTypeBytes(data_sampling_loc_params.get_dtype()) *
@@ -149,13 +149,13 @@ class ms_deform_attn_forward_general
       if (mluOpGetTensorElementNum(data_attn_weight_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &data_attn_weight_,
                 mluOpDataTypeBytes(data_attn_weight_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_attn_weight_,
                        mluOpDataTypeBytes(data_attn_weight_params.get_dtype()) *
                            mluOpGetTensorElementNum(data_attn_weight_desc_)));
@@ -170,11 +170,11 @@ class ms_deform_attn_forward_general
 
       if (mluOpGetTensorElementNum(data_col_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&data_col_,
                        mluOpDataTypeBytes(data_col_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&data_col_,
                                mluOpDataTypeBytes(data_col_params.get_dtype()) *
                                    mluOpGetTensorElementNum(data_col_desc_)));
@@ -218,7 +218,7 @@ class ms_deform_attn_forward_general
     }
 
     if (data_value_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_value_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_value_));
       data_value_ = nullptr;
     }
 
@@ -228,7 +228,7 @@ class ms_deform_attn_forward_general
     }
 
     if (data_spatial_shapes_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_spatial_shapes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_spatial_shapes_));
       data_spatial_shapes_ = nullptr;
     }
 
@@ -238,7 +238,7 @@ class ms_deform_attn_forward_general
     }
 
     if (data_level_start_index_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_level_start_index_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_level_start_index_));
       data_level_start_index_ = nullptr;
     }
 
@@ -248,7 +248,7 @@ class ms_deform_attn_forward_general
     }
 
     if (data_sampling_loc_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_sampling_loc_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_sampling_loc_));
       data_sampling_loc_ = nullptr;
     }
 
@@ -258,7 +258,7 @@ class ms_deform_attn_forward_general
     }
 
     if (data_attn_weight_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_attn_weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_attn_weight_));
       data_attn_weight_ = nullptr;
     }
 
@@ -268,7 +268,7 @@ class ms_deform_attn_forward_general
     }
 
     if (data_col_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(data_col_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(data_col_));
       data_col_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_backward/mutual_information_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_backward/mutual_information_backward.cpp
@@ -52,11 +52,11 @@ class mutual_information_backward : public testing::Test {
 
     if (px) {
       if (px_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_, MLUOP_DTYPE_FLOAT *
                                          mluOpGetTensorElementNum(px_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -71,11 +71,11 @@ class mutual_information_backward : public testing::Test {
 
     if (py) {
       if (py_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_, MLUOP_DTYPE_FLOAT *
                                          mluOpGetTensorElementNum(py_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -90,12 +90,12 @@ class mutual_information_backward : public testing::Test {
 
     if (opt_boundary) {
       if (opt_boundary_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&opt_boundary_,
                                MLUOP_DTYPE_INT64 * mluOpGetTensorElementNum(
                                                        opt_boundary_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&opt_boundary_, MLUOP_DTYPE_INT64 * 2));
       }
     }
@@ -110,11 +110,11 @@ class mutual_information_backward : public testing::Test {
 
     if (p) {
       if (p_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&p_, MLUOP_DTYPE_FLOAT *
                                         mluOpGetTensorElementNum(p_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&p_, MLUOP_DTYPE_FLOAT * 2));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&p_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
 
@@ -128,12 +128,12 @@ class mutual_information_backward : public testing::Test {
 
     if (ans_grad) {
       if (ans_grad_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&ans_grad_,
                                MLUOP_DTYPE_FLOAT *
                                    mluOpGetTensorElementNum(ans_grad_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&ans_grad_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -149,11 +149,11 @@ class mutual_information_backward : public testing::Test {
     if (px_grad) {
       if (px_grad_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&px_grad_, MLUOP_DTYPE_FLOAT *
                                       mluOpGetTensorElementNum(px_grad_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_grad_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -169,17 +169,17 @@ class mutual_information_backward : public testing::Test {
     if (py_grad) {
       if (py_grad_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&py_grad_, MLUOP_DTYPE_FLOAT *
                                       mluOpGetTensorElementNum(py_grad_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_grad_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     }
   }
@@ -211,7 +211,7 @@ class mutual_information_backward : public testing::Test {
 
     if (px_) {
       VLOG(4) << "Destroy px_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(px_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(px_));
       px_ = nullptr;
     }
 
@@ -223,7 +223,7 @@ class mutual_information_backward : public testing::Test {
 
     if (py_) {
       VLOG(4) << "Destroy py_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(py_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(py_));
       py_ = nullptr;
     }
 
@@ -235,7 +235,7 @@ class mutual_information_backward : public testing::Test {
 
     if (opt_boundary_) {
       VLOG(4) << "Destroy opt_boundary_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(opt_boundary_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(opt_boundary_));
       opt_boundary_ = nullptr;
     }
 
@@ -247,7 +247,7 @@ class mutual_information_backward : public testing::Test {
 
     if (p_) {
       VLOG(4) << "Destroy p_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(p_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(p_));
       p_ = nullptr;
     }
 
@@ -259,7 +259,7 @@ class mutual_information_backward : public testing::Test {
 
     if (ans_grad_) {
       VLOG(4) << "Destroy ans_grad_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(ans_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(ans_grad_));
       ans_grad_ = nullptr;
     }
 
@@ -271,7 +271,7 @@ class mutual_information_backward : public testing::Test {
 
     if (px_grad_) {
       VLOG(4) << "Destroy px_grad_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(px_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(px_grad_));
       px_grad_ = nullptr;
     }
 
@@ -283,13 +283,13 @@ class mutual_information_backward : public testing::Test {
 
     if (py_grad_) {
       VLOG(4) << "Destroy py_grad_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(py_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(py_grad_));
       py_grad_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_backward/mutual_information_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_backward/mutual_information_backward_general.cpp
@@ -52,10 +52,10 @@ class mutual_information_backward_general
           px_params.get_dim_nb(), px_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(px_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&px_, mluOpDataTypeBytes(px_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_, mluOpDataTypeBytes(px_params.get_dtype()) *
                                          mluOpGetTensorElementNum(px_desc_)));
       }
@@ -67,10 +67,10 @@ class mutual_information_backward_general
           py_params.get_dim_nb(), py_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(py_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&py_, mluOpDataTypeBytes(py_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_, mluOpDataTypeBytes(py_params.get_dtype()) *
                                          mluOpGetTensorElementNum(py_desc_)));
       }
@@ -83,13 +83,13 @@ class mutual_information_backward_general
           opt_boundary_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(opt_boundary_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &opt_boundary_,
                 mluOpDataTypeBytes(opt_boundary_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&opt_boundary_,
                        mluOpDataTypeBytes(opt_boundary_params.get_dtype()) *
                            mluOpGetTensorElementNum(opt_boundary_desc_)));
@@ -102,10 +102,10 @@ class mutual_information_backward_general
           p_params.get_dim_nb(), p_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(p_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&p_, mluOpDataTypeBytes(p_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&p_, mluOpDataTypeBytes(p_params.get_dtype()) *
                                         mluOpGetTensorElementNum(p_desc_)));
       }
@@ -118,11 +118,11 @@ class mutual_information_backward_general
           ans_grad_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(ans_grad_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&ans_grad_,
                        mluOpDataTypeBytes(ans_grad_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&ans_grad_,
                                mluOpDataTypeBytes(ans_grad_params.get_dtype()) *
                                    mluOpGetTensorElementNum(ans_grad_desc_)));
@@ -136,11 +136,11 @@ class mutual_information_backward_general
           px_grad_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(px_grad_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&px_grad_,
                        mluOpDataTypeBytes(px_grad_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_grad_,
                                mluOpDataTypeBytes(px_grad_params.get_dtype()) *
                                    mluOpGetTensorElementNum(px_grad_desc_)));
@@ -154,11 +154,11 @@ class mutual_information_backward_general
           py_grad_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(py_grad_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&py_grad_,
                        mluOpDataTypeBytes(py_grad_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_grad_,
                                mluOpDataTypeBytes(py_grad_params.get_dtype()) *
                                    mluOpGetTensorElementNum(py_grad_desc_)));
@@ -167,7 +167,7 @@ class mutual_information_backward_general
       target_device_ = std::get<7>(GetParam());
       expected_status_ = std::get<8>(GetParam());
 
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -206,7 +206,7 @@ class mutual_information_backward_general
 
     if (px_) {
       VLOG(4) << "Destroy px_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(px_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(px_));
       px_ = nullptr;
     }
 
@@ -218,7 +218,7 @@ class mutual_information_backward_general
 
     if (py_) {
       VLOG(4) << "Destroy py_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(py_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(py_));
       py_ = nullptr;
     }
 
@@ -230,7 +230,7 @@ class mutual_information_backward_general
 
     if (opt_boundary_) {
       VLOG(4) << "Destroy opt_boundary_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(opt_boundary_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(opt_boundary_));
       opt_boundary_ = nullptr;
     }
 
@@ -242,7 +242,7 @@ class mutual_information_backward_general
 
     if (p_) {
       VLOG(4) << "Destroy p_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(p_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(p_));
       p_ = nullptr;
     }
 
@@ -254,7 +254,7 @@ class mutual_information_backward_general
 
     if (ans_grad_) {
       VLOG(4) << "Destroy ans_grad_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(ans_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(ans_grad_));
       ans_grad_ = nullptr;
     }
 
@@ -266,7 +266,7 @@ class mutual_information_backward_general
 
     if (px_grad_) {
       VLOG(4) << "Destroy px_grad_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(px_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(px_grad_));
       px_grad_ = nullptr;
     }
 
@@ -278,13 +278,13 @@ class mutual_information_backward_general
 
     if (py_) {
       VLOG(4) << "Destroy py_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(py_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(py_));
       py_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_forward/mutual_information_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_forward/mutual_information_forward.cpp
@@ -51,11 +51,11 @@ class mutual_information_forward : public testing::Test {
 
     if (px) {
       if (px_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_, MLUOP_DTYPE_FLOAT *
                                          mluOpGetTensorElementNum(px_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -70,11 +70,11 @@ class mutual_information_forward : public testing::Test {
 
     if (py) {
       if (py_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_, MLUOP_DTYPE_FLOAT *
                                          mluOpGetTensorElementNum(py_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -89,12 +89,12 @@ class mutual_information_forward : public testing::Test {
 
     if (opt_boundary) {
       if (opt_boundary_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&opt_boundary_,
                                MLUOP_DTYPE_INT64 * mluOpGetTensorElementNum(
                                                        opt_boundary_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&opt_boundary_, MLUOP_DTYPE_INT64 * 2));
       }
     }
@@ -109,11 +109,11 @@ class mutual_information_forward : public testing::Test {
 
     if (p) {
       if (p_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&p_, MLUOP_DTYPE_FLOAT *
                                         mluOpGetTensorElementNum(p_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&p_, MLUOP_DTYPE_FLOAT * 2));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&p_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
 
@@ -127,17 +127,17 @@ class mutual_information_forward : public testing::Test {
 
     if (ans) {
       if (ans_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&ans_, MLUOP_DTYPE_FLOAT *
                                           mluOpGetTensorElementNum(ans_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&ans_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     }
   }
@@ -168,7 +168,7 @@ class mutual_information_forward : public testing::Test {
 
     if (px_) {
       VLOG(4) << "Destroy px_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(px_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(px_));
       px_ = nullptr;
     }
 
@@ -180,7 +180,7 @@ class mutual_information_forward : public testing::Test {
 
     if (py_) {
       VLOG(4) << "Destroy py_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(py_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(py_));
       py_ = nullptr;
     }
 
@@ -192,7 +192,7 @@ class mutual_information_forward : public testing::Test {
 
     if (opt_boundary_) {
       VLOG(4) << "Destroy opt_boundary_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(opt_boundary_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(opt_boundary_));
       opt_boundary_ = nullptr;
     }
 
@@ -204,7 +204,7 @@ class mutual_information_forward : public testing::Test {
 
     if (p_) {
       VLOG(4) << "Destroy p_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(p_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(p_));
       p_ = nullptr;
     }
 
@@ -216,13 +216,13 @@ class mutual_information_forward : public testing::Test {
 
     if (ans_) {
       VLOG(4) << "Destroy ans_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(ans_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(ans_));
       ans_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_forward/mutual_information_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/mutual_information_forward/mutual_information_forward_general.cpp
@@ -52,10 +52,10 @@ class mutual_information_forward_general
           px_params.get_dim_nb(), px_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(px_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&px_, mluOpDataTypeBytes(px_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&px_, mluOpDataTypeBytes(px_params.get_dtype()) *
                                          mluOpGetTensorElementNum(px_desc_)));
       }
@@ -67,10 +67,10 @@ class mutual_information_forward_general
           py_params.get_dim_nb(), py_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(py_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&py_, mluOpDataTypeBytes(py_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&py_, mluOpDataTypeBytes(py_params.get_dtype()) *
                                          mluOpGetTensorElementNum(py_desc_)));
       }
@@ -83,13 +83,13 @@ class mutual_information_forward_general
           opt_boundary_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(opt_boundary_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &opt_boundary_,
                 mluOpDataTypeBytes(opt_boundary_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&opt_boundary_,
                        mluOpDataTypeBytes(opt_boundary_params.get_dtype()) *
                            mluOpGetTensorElementNum(opt_boundary_desc_)));
@@ -102,10 +102,10 @@ class mutual_information_forward_general
           p_params.get_dim_nb(), p_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(p_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&p_, mluOpDataTypeBytes(p_params.get_dtype()) * 2));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&p_, mluOpDataTypeBytes(p_params.get_dtype()) *
                                         mluOpGetTensorElementNum(p_desc_)));
       }
@@ -117,11 +117,11 @@ class mutual_information_forward_general
           ans_params.get_dim_nb(), ans_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(ans_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&ans_, mluOpDataTypeBytes(ans_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&ans_, mluOpDataTypeBytes(ans_params.get_dtype()) *
                                   mluOpGetTensorElementNum(ans_desc_)));
       }
@@ -129,7 +129,7 @@ class mutual_information_forward_general
       target_device_ = std::get<5>(GetParam());
       expected_status_ = std::get<6>(GetParam());
 
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&workspace_, MLUOP_DTYPE_FLOAT * workspace_size_));
     } catch (const std::exception &e) {
       FAIL() << "MLUOPAPIGTEST: catched " << e.what()
@@ -167,7 +167,7 @@ class mutual_information_forward_general
 
     if (px_) {
       VLOG(4) << "Destroy px_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(px_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(px_));
       px_ = nullptr;
     }
 
@@ -179,7 +179,7 @@ class mutual_information_forward_general
 
     if (py_) {
       VLOG(4) << "Destroy py_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(py_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(py_));
       py_ = nullptr;
     }
 
@@ -191,7 +191,7 @@ class mutual_information_forward_general
 
     if (opt_boundary_) {
       VLOG(4) << "Destroy opt_boundary_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(opt_boundary_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(opt_boundary_));
       opt_boundary_ = nullptr;
     }
 
@@ -203,7 +203,7 @@ class mutual_information_forward_general
 
     if (p_) {
       VLOG(4) << "Destroy p_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(p_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(p_));
       p_ = nullptr;
     }
 
@@ -215,13 +215,13 @@ class mutual_information_forward_general
 
     if (ans_) {
       VLOG(4) << "Destroy ans_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(ans_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(ans_));
       ans_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/nms_rotated/nms_rotated.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/nms_rotated/nms_rotated.cpp
@@ -51,7 +51,7 @@ class nms_rotated : public testing::Test {
       size_t b_ele_num = 2 * 5;
       size_t b_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t b_bytes = b_ele_num * b_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, b_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, b_bytes));
     }
     if (scores_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&scores_desc_));
@@ -64,10 +64,10 @@ class nms_rotated : public testing::Test {
       size_t s_ele_num = 2;
       size_t s_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t s_bytes = s_ele_num * s_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&scores_, s_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&scores_, s_bytes));
     }
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
     if (output_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -80,11 +80,11 @@ class nms_rotated : public testing::Test {
       size_t o_ele_num = 2;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
     if (result_num) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&result_num_, mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
     }
   }
@@ -110,7 +110,7 @@ class nms_rotated : public testing::Test {
       boxes_desc_ = NULL;
     }
     if (boxes_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       boxes_ = NULL;
     }
     if (scores_desc_) {
@@ -118,11 +118,11 @@ class nms_rotated : public testing::Test {
       scores_desc_ = NULL;
     }
     if (scores_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(scores_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(scores_));
       scores_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (output_desc_) {
@@ -130,11 +130,11 @@ class nms_rotated : public testing::Test {
       output_desc_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (result_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(result_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(result_num_));
       result_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/nms_rotated/nms_rotated_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/nms_rotated/nms_rotated_general.cpp
@@ -57,9 +57,9 @@ class nms_rotated_general : public testing::TestWithParam<MmsRotatedParam> {
     uint64_t b_bytes = mluOpDataTypeBytes(b_dtype) * b_ele_num;
     if (b_bytes > 0) {
       if (b_bytes < LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, b_bytes))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, b_bytes))
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, 8))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, 8))
       }
     }
 
@@ -75,9 +75,9 @@ class nms_rotated_general : public testing::TestWithParam<MmsRotatedParam> {
     uint64_t s_bytes = mluOpDataTypeBytes(s_dtype) * s_ele_num;
     if (s_bytes > 0) {
       if (s_bytes < LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&scores_, s_bytes))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&scores_, s_bytes))
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&scores_, 8))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&scores_, 8))
       }
     }
 
@@ -93,13 +93,13 @@ class nms_rotated_general : public testing::TestWithParam<MmsRotatedParam> {
     uint64_t o_bytes = mluOpDataTypeBytes(o_dtype) * o_ele_num;
     if (o_bytes > 0) {
       if (o_bytes < LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes))
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, 8))
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, 8))
       }
     }
     GTEST_CHECK(
-        CNRT_RET_SUCCESS ==
+        cnrtSuccess ==
         cnrtMalloc(&result_num_, mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
   }
 
@@ -117,10 +117,10 @@ class nms_rotated_general : public testing::TestWithParam<MmsRotatedParam> {
     }
     if (workspace_size_ > 0) {
       if (workspace_size_ < LARGE_TENSOR_NUM) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&workspace_, workspace_size_));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, 8));
+        GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, 8));
       }
     }
     status = mluOpNmsRotated(handle_, iou_threshold_, boxes_desc_, boxes_,
@@ -142,7 +142,7 @@ class nms_rotated_general : public testing::TestWithParam<MmsRotatedParam> {
       boxes_desc_ = NULL;
     }
     if (boxes_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       boxes_ = NULL;
     }
     if (scores_desc_) {
@@ -150,11 +150,11 @@ class nms_rotated_general : public testing::TestWithParam<MmsRotatedParam> {
       scores_desc_ = NULL;
     }
     if (scores_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(scores_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(scores_));
       scores_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (output_desc_) {
@@ -162,11 +162,11 @@ class nms_rotated_general : public testing::TestWithParam<MmsRotatedParam> {
       output_desc_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (result_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(result_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(result_num_));
       result_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/poly_nms/poly_nms.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/poly_nms/poly_nms.cpp
@@ -50,10 +50,10 @@ class poly_nms : public testing::Test {
       size_t i_ele_num = 2 * 9;
       size_t i_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t i_bytes = i_ele_num * i_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, i_bytes));
     }
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
     if (output_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -66,11 +66,11 @@ class poly_nms : public testing::Test {
       size_t o_ele_num = 2;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
     if (result_num) {
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&result_num_, mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
     }
   }
@@ -95,11 +95,11 @@ class poly_nms : public testing::Test {
       boxes_desc_ = NULL;
     }
     if (boxes_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       boxes_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (output_desc_) {
@@ -107,11 +107,11 @@ class poly_nms : public testing::Test {
       output_desc_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (result_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(result_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(result_num_));
       result_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/poly_nms/poly_nms_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/poly_nms/poly_nms_general.cpp
@@ -56,7 +56,7 @@ class poly_nms_general : public testing::TestWithParam<PolyNmsParam> {
     uint64_t b_ele_num = mluOpGetTensorElementNum(boxes_desc_);
     uint64_t b_bytes = mluOpDataTypeBytes(b_dtype) * b_ele_num;
     if (b_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, b_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, b_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -70,10 +70,10 @@ class poly_nms_general : public testing::TestWithParam<PolyNmsParam> {
     uint64_t o_ele_num = mluOpGetTensorElementNum(output_desc_);
     uint64_t o_bytes = mluOpDataTypeBytes(o_dtype) * o_ele_num;
     if (o_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
     GTEST_CHECK(
-        CNRT_RET_SUCCESS ==
+        cnrtSuccess ==
         cnrtMalloc(&result_num_, mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
   }
 
@@ -89,7 +89,7 @@ class poly_nms_general : public testing::TestWithParam<PolyNmsParam> {
       destroy();
       return status == expected_status_;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     status =
         mluOpPolyNms(handle_, boxes_desc_, boxes_, iou_threshold_, workspace_,
                      workspace_size_, output_desc_, output_, result_num_);
@@ -109,11 +109,11 @@ class poly_nms_general : public testing::TestWithParam<PolyNmsParam> {
       boxes_desc_ = NULL;
     }
     if (boxes_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       boxes_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (output_desc_) {
@@ -121,11 +121,11 @@ class poly_nms_general : public testing::TestWithParam<PolyNmsParam> {
       output_desc_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (result_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(result_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(result_num_));
       result_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/prior_box/prior_box.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/prior_box/prior_box.cpp
@@ -50,7 +50,7 @@ class prior_box : public testing::Test {
                                            dim_size.data()));
     }
     if (min) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&min_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&min_, 8));
     }
     if (aspect_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&aspect_ratios_desc_));
@@ -60,7 +60,7 @@ class prior_box : public testing::Test {
                                    MLUOP_DTYPE_FLOAT, 1, dim_size.data()));
     }
     if (aspect) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&aspect_ratios_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&aspect_ratios_, 8));
     }
     if (variance_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&variance_desc_));
@@ -70,7 +70,7 @@ class prior_box : public testing::Test {
                                            dim_size.data()));
     }
     if (variance) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&variance_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&variance_, 8));
     }
     if (max_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&max_desc_));
@@ -80,7 +80,7 @@ class prior_box : public testing::Test {
                                            dim_size.data()));
     }
     if (max) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&max_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&max_, 8));
     }
     if (output_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -90,7 +90,7 @@ class prior_box : public testing::Test {
                                            dim_size.data()));
     }
     if (output) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, 8));
     }
     if (var_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&var_desc_));
@@ -100,7 +100,7 @@ class prior_box : public testing::Test {
                                            dim_size.data()));
     }
     if (var) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&var_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&var_, 8));
     }
   }
 
@@ -147,27 +147,27 @@ class prior_box : public testing::Test {
       var_desc_ = NULL;
     }
     if (min_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(min_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(min_));
       min_ = NULL;
     }
     if (aspect_ratios_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(aspect_ratios_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(aspect_ratios_));
       aspect_ratios_ = NULL;
     }
     if (variance_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(variance_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(variance_));
       variance_ = NULL;
     }
     if (max_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(max_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(max_));
       max_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (var_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(var_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(var_));
       var_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/prior_box/prior_box_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/prior_box/prior_box_general.cpp
@@ -60,7 +60,7 @@ class prior_box_general : public testing::TestWithParam<PriorBoxParam> {
                                          min_dim, min_dim_size.data()));
     const uint64_t min_ele_num = mluOpGetTensorElementNum(min_desc_);
     if (min_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&min_, 8))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&min_, 8))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&aspect_ratios_desc_));
@@ -75,7 +75,7 @@ class prior_box_general : public testing::TestWithParam<PriorBoxParam> {
     const uint64_t aspect_ele_num =
         mluOpGetTensorElementNum(aspect_ratios_desc_);
     if (aspect_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&aspect_ratios_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&aspect_ratios_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&variance_desc_));
@@ -89,7 +89,7 @@ class prior_box_general : public testing::TestWithParam<PriorBoxParam> {
                                          variance_dim_size.data()));
     const uint64_t variance_ele_num = mluOpGetTensorElementNum(variance_desc_);
     if (variance_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&variance_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&variance_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&max_desc_));
@@ -102,7 +102,7 @@ class prior_box_general : public testing::TestWithParam<PriorBoxParam> {
                                          max_dim, max_dim_size.data()));
     const uint64_t max_ele_num = mluOpGetTensorElementNum(max_desc_);
     if (max_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&max_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&max_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -115,7 +115,7 @@ class prior_box_general : public testing::TestWithParam<PriorBoxParam> {
                                          o_dim_size.data()));
     const uint64_t o_ele_num = mluOpGetTensorElementNum(output_desc_);
     if (o_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&var_desc_));
@@ -128,7 +128,7 @@ class prior_box_general : public testing::TestWithParam<PriorBoxParam> {
                                          var_dim, var_dim_size.data()));
     const uint64_t var_ele_num = mluOpGetTensorElementNum(var_desc_);
     if (var_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&var_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&var_, 8));
     }
 
     PriorBoxDescParam params = std::get<6>(GetParam());
@@ -184,27 +184,27 @@ class prior_box_general : public testing::TestWithParam<PriorBoxParam> {
       var_desc_ = NULL;
     }
     if (min_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(min_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(min_));
       min_ = NULL;
     }
     if (aspect_ratios_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(aspect_ratios_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(aspect_ratios_));
       aspect_ratios_ = NULL;
     }
     if (variance_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(variance_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(variance_));
       variance_ = NULL;
     }
     if (max_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(max_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(max_));
       max_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (var_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(var_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(var_));
       var_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_backward/psroipool_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_backward/psroipool_backward.cpp
@@ -52,7 +52,7 @@ class psroipool_backward : public testing::Test {
       size_t b_ele_num = 1 * 5 * 5 * 9;
       size_t b_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t b_bytes = b_ele_num * b_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&bottom_grad_, b_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&bottom_grad_, b_bytes));
     }
     if (rois_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&rois_desc_));
@@ -64,7 +64,7 @@ class psroipool_backward : public testing::Test {
       size_t r_ele_num = 1 * 5;
       size_t r_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t r_bytes = r_ele_num * r_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, r_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, r_bytes));
     }
     if (top_grad_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&top_grad_desc_));
@@ -77,7 +77,7 @@ class psroipool_backward : public testing::Test {
       size_t o_ele_num = 1 * 3 * 3 * 1;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&top_grad_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&top_grad_, o_bytes));
     }
     if (mapping_channel_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&mapping_channel_desc_));
@@ -90,7 +90,7 @@ class psroipool_backward : public testing::Test {
       size_t m_ele_num = 1 * 3 * 3 * 1;
       size_t m_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t m_bytes = m_ele_num * m_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&mapping_channel_, m_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&mapping_channel_, m_bytes));
     }
   }
 
@@ -115,7 +115,7 @@ class psroipool_backward : public testing::Test {
       bottom_grad_desc_ = NULL;
     }
     if (bottom_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(bottom_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(bottom_grad_));
       bottom_grad_ = NULL;
     }
     if (rois_desc_) {
@@ -123,7 +123,7 @@ class psroipool_backward : public testing::Test {
       rois_desc_ = NULL;
     }
     if (rois_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
       rois_ = NULL;
     }
     if (top_grad_desc_) {
@@ -131,7 +131,7 @@ class psroipool_backward : public testing::Test {
       top_grad_desc_ = NULL;
     }
     if (top_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(top_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(top_grad_));
       top_grad_ = NULL;
     }
     if (mapping_channel_desc_) {
@@ -139,7 +139,7 @@ class psroipool_backward : public testing::Test {
       mapping_channel_desc_ = NULL;
     }
     if (mapping_channel_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mapping_channel_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mapping_channel_));
       mapping_channel_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_backward/psroipool_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_backward/psroipool_backward_general.cpp
@@ -64,7 +64,7 @@ class psroipool_backward_general
     uint64_t b_ele_num = mluOpGetTensorElementNum(bottom_grad_desc_);
     uint64_t b_bytes = mluOpDataTypeBytes(b_dtype) * b_ele_num;
     if (b_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&bottom_grad_, b_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&bottom_grad_, b_bytes))
     }
 
     MLUOpTensorParam r_params = std::get<2>(GetParam());
@@ -78,7 +78,7 @@ class psroipool_backward_general
     uint64_t r_ele_num = mluOpGetTensorElementNum(rois_desc_);
     uint64_t r_bytes = mluOpDataTypeBytes(r_dtype) * r_ele_num;
     if (r_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, r_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, r_bytes))
     }
 
     MLUOpTensorParam o_params = std::get<3>(GetParam());
@@ -92,7 +92,7 @@ class psroipool_backward_general
     uint64_t o_ele_num = mluOpGetTensorElementNum(top_grad_desc_);
     uint64_t o_bytes = mluOpDataTypeBytes(o_dtype) * o_ele_num;
     if (o_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&top_grad_, o_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&top_grad_, o_bytes))
     }
 
     MLUOpTensorParam m_params = std::get<4>(GetParam());
@@ -106,7 +106,7 @@ class psroipool_backward_general
     uint64_t m_ele_num = mluOpGetTensorElementNum(mapping_channel_desc_);
     uint64_t m_bytes = mluOpDataTypeBytes(m_dtype) * m_ele_num;
     if (m_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&mapping_channel_, m_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&mapping_channel_, m_bytes))
     }
   }
 
@@ -136,7 +136,7 @@ class psroipool_backward_general
       bottom_grad_desc_ = NULL;
     }
     if (bottom_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(bottom_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(bottom_grad_));
       bottom_grad_ = NULL;
     }
     if (rois_desc_) {
@@ -144,7 +144,7 @@ class psroipool_backward_general
       rois_desc_ = NULL;
     }
     if (rois_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
       rois_ = NULL;
     }
     if (top_grad_desc_) {
@@ -152,7 +152,7 @@ class psroipool_backward_general
       top_grad_desc_ = NULL;
     }
     if (top_grad_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(top_grad_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(top_grad_));
       top_grad_ = NULL;
     }
     if (mapping_channel_desc_) {
@@ -160,7 +160,7 @@ class psroipool_backward_general
       mapping_channel_desc_ = NULL;
     }
     if (mapping_channel_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mapping_channel_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mapping_channel_));
       mapping_channel_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_forward/psroipool_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_forward/psroipool_forward.cpp
@@ -51,7 +51,7 @@ class psroipool_forward : public testing::Test {
       size_t i_ele_num = 1 * 5 * 5 * 9;
       size_t i_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t i_bytes = i_ele_num * i_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes));
     }
     if (rois_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&rois_desc_));
@@ -63,7 +63,7 @@ class psroipool_forward : public testing::Test {
       size_t r_ele_num = 1 * 5;
       size_t r_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t r_bytes = r_ele_num * r_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, r_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, r_bytes));
     }
     if (output_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -76,7 +76,7 @@ class psroipool_forward : public testing::Test {
       size_t o_ele_num = 1 * 3 * 3 * 1;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
     if (mapping_channel_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&mapping_channel_desc_));
@@ -89,7 +89,7 @@ class psroipool_forward : public testing::Test {
       size_t m_ele_num = 1 * 3 * 3 * 1;
       size_t m_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t m_bytes = m_ele_num * m_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&mapping_channel_, m_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&mapping_channel_, m_bytes));
     }
   }
 
@@ -114,7 +114,7 @@ class psroipool_forward : public testing::Test {
       input_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (rois_desc_) {
@@ -122,7 +122,7 @@ class psroipool_forward : public testing::Test {
       rois_desc_ = NULL;
     }
     if (rois_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
       rois_ = NULL;
     }
     if (output_desc_) {
@@ -130,7 +130,7 @@ class psroipool_forward : public testing::Test {
       output_desc_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (mapping_channel_desc_) {
@@ -138,7 +138,7 @@ class psroipool_forward : public testing::Test {
       mapping_channel_desc_ = NULL;
     }
     if (mapping_channel_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mapping_channel_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mapping_channel_));
       mapping_channel_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_forward/psroipool_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/psroipool_forward/psroipool_forward_general.cpp
@@ -64,7 +64,7 @@ class psroipool_forward_general
     uint64_t i_ele_num = mluOpGetTensorElementNum(input_desc_);
     uint64_t i_bytes = mluOpDataTypeBytes(i_dtype) * i_ele_num;
     if (i_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes))
     }
 
     MLUOpTensorParam r_params = std::get<2>(GetParam());
@@ -78,7 +78,7 @@ class psroipool_forward_general
     uint64_t r_ele_num = mluOpGetTensorElementNum(rois_desc_);
     uint64_t r_bytes = mluOpDataTypeBytes(r_dtype) * r_ele_num;
     if (r_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&rois_, r_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&rois_, r_bytes))
     }
 
     MLUOpTensorParam o_params = std::get<3>(GetParam());
@@ -92,7 +92,7 @@ class psroipool_forward_general
     uint64_t o_ele_num = mluOpGetTensorElementNum(output_desc_);
     uint64_t o_bytes = mluOpDataTypeBytes(o_dtype) * o_ele_num;
     if (o_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes))
     }
 
     MLUOpTensorParam m_params = std::get<4>(GetParam());
@@ -106,7 +106,7 @@ class psroipool_forward_general
     uint64_t m_ele_num = mluOpGetTensorElementNum(mapping_channel_desc_);
     uint64_t m_bytes = mluOpDataTypeBytes(m_dtype) * m_ele_num;
     if (m_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&mapping_channel_, m_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&mapping_channel_, m_bytes))
     }
   }
 
@@ -136,7 +136,7 @@ class psroipool_forward_general
       input_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (rois_desc_) {
@@ -144,7 +144,7 @@ class psroipool_forward_general
       rois_desc_ = NULL;
     }
     if (rois_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
       rois_ = NULL;
     }
     if (output_desc_) {
@@ -152,7 +152,7 @@ class psroipool_forward_general
       output_desc_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
     if (mapping_channel_desc_) {
@@ -160,7 +160,7 @@ class psroipool_forward_general
       mapping_channel_desc_ = NULL;
     }
     if (mapping_channel_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(mapping_channel_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(mapping_channel_));
       mapping_channel_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_backward/roi_crop_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_backward/roi_crop_backward.cpp
@@ -65,19 +65,19 @@ class roi_crop_backward : public testing::Test {
       size_t o_ele_num = 1 * 7 * 7 * 9;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_output_, o_bytes));
     }
     if (grid) {
       size_t g_ele_num = 1 * 7 * 7 * 2;
       size_t g_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t g_bytes = g_ele_num * g_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grid_, g_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grid_, g_bytes));
     }
     if (grad_input) {
       size_t i_ele_num = 1 * 7 * 7 * 9;
       size_t i_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t i_bytes = i_ele_num * i_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_input_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_input_, i_bytes));
     }
   }
 
@@ -110,15 +110,15 @@ class roi_crop_backward : public testing::Test {
       grad_input_desc_ = NULL;
     }
     if (grad_input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = NULL;
     }
     if (grid_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grid_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grid_));
       grid_ = NULL;
     }
     if (grad_output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_backward/roi_crop_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_backward/roi_crop_backward_general.cpp
@@ -58,7 +58,7 @@ class roi_crop_backward_general
     uint64_t o_ele_num = mluOpGetTensorElementNum(grad_output_desc_);
     uint64_t o_bytes = mluOpDataTypeBytes(o_dtype) * o_ele_num;
     if (o_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_output_, o_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&grid_desc_));
@@ -72,7 +72,7 @@ class roi_crop_backward_general
     uint64_t g_ele_num = mluOpGetTensorElementNum(grid_desc_);
     uint64_t g_bytes = mluOpDataTypeBytes(g_dtype) * g_ele_num;
     if (g_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grid_, g_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grid_, g_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_input_desc_));
@@ -86,7 +86,7 @@ class roi_crop_backward_general
     uint64_t i_ele_num = mluOpGetTensorElementNum(grad_input_desc_);
     uint64_t i_bytes = mluOpDataTypeBytes(i_dtype) * i_ele_num;
     if (i_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_input_, i_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_input_, i_bytes))
     }
   }
 
@@ -124,15 +124,15 @@ class roi_crop_backward_general
       grad_input_desc_ = NULL;
     }
     if (grad_output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = NULL;
     }
     if (grid_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grid_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grid_));
       grid_ = NULL;
     }
     if (grad_input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_forward/roi_crop_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_forward/roi_crop_forward.cpp
@@ -63,19 +63,19 @@ class roi_crop_forward : public testing::Test {
       size_t i_ele_num = 1 * 7 * 7 * 9;
       size_t i_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t i_bytes = i_ele_num * i_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes));
     }
     if (grid) {
       size_t g_ele_num = 1 * 7 * 7 * 2;
       size_t g_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t g_bytes = g_ele_num * g_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grid_, g_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grid_, g_bytes));
     }
     if (output) {
       size_t o_ele_num = 1 * 7 * 7 * 9;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
   }
 
@@ -107,15 +107,15 @@ class roi_crop_forward : public testing::Test {
       output_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (grid_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grid_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grid_));
       grid_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_forward/roi_crop_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roi_crop_forward/roi_crop_forward_general.cpp
@@ -60,7 +60,7 @@ class roi_crop_forward_general
     uint64_t i_ele_num = mluOpGetTensorElementNum(input_desc_);
     uint64_t i_bytes = mluOpDataTypeBytes(i_dtype) * i_ele_num;
     if (i_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_, i_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&grid_desc_));
@@ -74,7 +74,7 @@ class roi_crop_forward_general
     uint64_t g_ele_num = mluOpGetTensorElementNum(grid_desc_);
     uint64_t g_bytes = mluOpDataTypeBytes(g_dtype) * g_ele_num;
     if (g_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grid_, g_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grid_, g_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -88,7 +88,7 @@ class roi_crop_forward_general
     uint64_t o_ele_num = mluOpGetTensorElementNum(output_desc_);
     uint64_t o_bytes = mluOpDataTypeBytes(o_dtype) * o_ele_num;
     if (o_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
   }
 
@@ -125,15 +125,15 @@ class roi_crop_forward_general
       output_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (grid_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grid_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grid_));
       grid_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward.cpp
@@ -54,12 +54,12 @@ class roiaware_pool3d_forward : public testing::Test {
     if (rois) {
       if (rois_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&rois_, mluOpGetTensorElementNum(rois_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&rois_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -75,12 +75,12 @@ class roiaware_pool3d_forward : public testing::Test {
     if (pts) {
       if (pts_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&pts_, mluOpGetTensorElementNum(pts_desc_) *
                                   mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&pts_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -95,12 +95,12 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (pts_feature) {
       if (pts_feature_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pts_feature_,
                                mluOpGetTensorElementNum(pts_feature_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pts_feature_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -116,12 +116,12 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (pooled_features) {
       if (pooled_features_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pooled_features_,
                                mluOpGetTensorElementNum(pooled_features_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pooled_features_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -138,12 +138,12 @@ class roiaware_pool3d_forward : public testing::Test {
     if (argmax) {
       if (argmax_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&argmax_, mluOpGetTensorElementNum(argmax_desc_) *
                                      mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&argmax_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
@@ -159,19 +159,19 @@ class roiaware_pool3d_forward : public testing::Test {
     if (pts_idx_of_voxels) {
       if (pts_idx_of_voxels_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&pts_idx_of_voxels_,
                        mluOpGetTensorElementNum(pts_idx_of_voxels_desc_) *
                            mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pts_idx_of_voxels_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
 
     if (worksapce) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
 
@@ -203,7 +203,7 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (rois_) {
       VLOG(4) << "Destroy rois";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
       rois_ = nullptr;
     }
 
@@ -215,7 +215,7 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (pts_) {
       VLOG(4) << "Destroy pts";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pts_));
       pts_ = nullptr;
     }
 
@@ -227,13 +227,13 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (pts_feature_) {
       VLOG(4) << "Destroy pts_feature";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_feature_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pts_feature_));
       pts_feature_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
 
@@ -245,7 +245,7 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (argmax_) {
       VLOG(4) << "Destroy argmax";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(argmax_));
       argmax_ = nullptr;
     }
 
@@ -257,7 +257,7 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (pts_idx_of_voxels_) {
       VLOG(4) << "Destroy pts_idx_of_voxels";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_idx_of_voxels_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pts_idx_of_voxels_));
       pts_idx_of_voxels_ = nullptr;
     }
 
@@ -269,7 +269,7 @@ class roiaware_pool3d_forward : public testing::Test {
 
     if (pooled_features_) {
       VLOG(4) << "Destroy pooled_features";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pooled_features_));
       pooled_features_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roiaware_pool3d_forward/roiaware_pool3d_forward_general.cpp
@@ -53,7 +53,7 @@ class roiaware_pool3d_forward_general
           rois_desc_, rois_params.get_layout(), rois_params.get_dtype(),
           rois_params.get_dim_nb(), rois_params.get_dim_size().data()));
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&rois_, mluOpDataTypeBytes(rois_params.get_dtype()) * 10));
 
       MLUOpTensorParam pts_params = std::get<1>(GetParam());
@@ -62,7 +62,7 @@ class roiaware_pool3d_forward_general
           pts_desc_, pts_params.get_layout(), pts_params.get_dtype(),
           pts_params.get_dim_nb(), pts_params.get_dim_size().data()));
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&pts_, mluOpDataTypeBytes(pts_params.get_dtype()) * 10));
 
       MLUOpTensorParam pts_feature_params = std::get<2>(GetParam());
@@ -72,7 +72,7 @@ class roiaware_pool3d_forward_general
           pts_feature_params.get_dtype(), pts_feature_params.get_dim_nb(),
           pts_feature_params.get_dim_size().data()));
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&pts_feature_,
                      mluOpDataTypeBytes(pts_feature_params.get_dtype()) * 10));
 
@@ -84,7 +84,7 @@ class roiaware_pool3d_forward_general
           pooled_features_params.get_dim_nb(),
           pooled_features_params.get_dim_size().data()));
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(
               &pooled_features_,
               mluOpDataTypeBytes(pooled_features_params.get_dtype()) * 10));
@@ -95,7 +95,7 @@ class roiaware_pool3d_forward_general
           argmax_desc_, argmax_params.get_layout(), argmax_params.get_dtype(),
           argmax_params.get_dim_nb(), argmax_params.get_dim_size().data()));
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(&argmax_,
                      mluOpDataTypeBytes(argmax_params.get_dtype()) * 10));
 
@@ -107,7 +107,7 @@ class roiaware_pool3d_forward_general
           pts_idx_of_voxels_params.get_dim_nb(),
           pts_idx_of_voxels_params.get_dim_size().data()));
       GTEST_CHECK(
-          CNRT_RET_SUCCESS ==
+          cnrtSuccess ==
           cnrtMalloc(
               &pts_idx_of_voxels_,
               mluOpDataTypeBytes(pts_idx_of_voxels_params.get_dtype()) * 10));
@@ -137,7 +137,7 @@ class roiaware_pool3d_forward_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     status = mluOpRoiAwarePool3dForward(
         handle_, pool_method_, boxes_num_, pts_num_, channels_, rois_desc_,
         rois_, pts_desc_, pts_, pts_feature_desc_, pts_feature_, workspace_,
@@ -162,7 +162,7 @@ class roiaware_pool3d_forward_general
       }
 
       if (rois_) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(rois_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(rois_));
         rois_ = nullptr;
       }
 
@@ -172,7 +172,7 @@ class roiaware_pool3d_forward_general
       }
 
       if (pts_) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(pts_));
         pts_ = nullptr;
       }
 
@@ -182,12 +182,12 @@ class roiaware_pool3d_forward_general
       }
 
       if (pts_feature_) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_feature_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(pts_feature_));
         pts_feature_ = nullptr;
       }
 
       if (workspace_) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
         workspace_ = nullptr;
       }
 
@@ -197,7 +197,7 @@ class roiaware_pool3d_forward_general
       }
 
       if (argmax_) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(argmax_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(argmax_));
         argmax_ = nullptr;
       }
 
@@ -207,7 +207,7 @@ class roiaware_pool3d_forward_general
       }
 
       if (pts_idx_of_voxels_) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pts_idx_of_voxels_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(pts_idx_of_voxels_));
         pts_idx_of_voxels_ = nullptr;
       }
 
@@ -217,7 +217,7 @@ class roiaware_pool3d_forward_general
       }
 
       if (pooled_features_) {
-        GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+        GTEST_CHECK(cnrtSuccess == cnrtFree(pooled_features_));
         pooled_features_ = nullptr;
       }
     } catch (const std::exception &e) {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d.cpp
@@ -54,12 +54,12 @@ class roipoint_pool3d : public testing::Test {
     if (points) {
       if (points_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&points_, mluOpGetTensorElementNum(points_desc_) *
                                      mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&points_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -74,12 +74,12 @@ class roipoint_pool3d : public testing::Test {
 
     if (point_features) {
       if (point_features_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&point_features_,
                                mluOpGetTensorElementNum(point_features_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&point_features_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
@@ -96,12 +96,12 @@ class roipoint_pool3d : public testing::Test {
     if (boxes3d) {
       if (boxes3d_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&boxes3d_, mluOpGetTensorElementNum(boxes3d_desc_) *
                                       mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&boxes3d_, 64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
     }
@@ -116,12 +116,12 @@ class roipoint_pool3d : public testing::Test {
 
     if (pooled_features) {
       if (pooled_features_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pooled_features_,
                                mluOpGetTensorElementNum(pooled_features_desc_) *
                                    mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pooled_features_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT)));
       }
@@ -138,19 +138,19 @@ class roipoint_pool3d : public testing::Test {
     if (pooled_empty_flag) {
       if (pooled_empty_flag_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&pooled_empty_flag_,
                        mluOpGetTensorElementNum(pooled_empty_flag_desc_) *
                            mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&pooled_empty_flag_,
                                64 * mluOpDataTypeBytes(MLUOP_DTYPE_INT32)));
       }
     }
 
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     }
   }
   mluOpStatus_t compute() {
@@ -181,7 +181,7 @@ class roipoint_pool3d : public testing::Test {
 
     if (points_) {
       VLOG(4) << "Destroy points_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(points_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(points_));
       points_ = nullptr;
     }
 
@@ -193,7 +193,7 @@ class roipoint_pool3d : public testing::Test {
 
     if (point_features_) {
       VLOG(4) << "Destroy point_features_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(point_features_));
       point_features_ = nullptr;
     }
 
@@ -205,7 +205,7 @@ class roipoint_pool3d : public testing::Test {
 
     if (boxes3d_) {
       VLOG(4) << "Destroy boxes3d_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes3d_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes3d_));
       boxes3d_ = nullptr;
     }
 
@@ -217,7 +217,7 @@ class roipoint_pool3d : public testing::Test {
 
     if (pooled_features_) {
       VLOG(4) << "Destroy pooled_features_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pooled_features_));
       pooled_features_ = nullptr;
     }
 
@@ -229,13 +229,13 @@ class roipoint_pool3d : public testing::Test {
 
     if (pooled_empty_flag_) {
       VLOG(4) << "Destroy pooled_empty_flag_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_empty_flag_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pooled_empty_flag_));
       pooled_empty_flag_ = nullptr;
     }
 
     if (workspace_) {
       VLOG(4) << "Destroy workspace";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/roipoint_pool3d/roipoint_pool3d_general.cpp
@@ -65,12 +65,12 @@ class roipoint_pool3d_general
           points_params.get_dim_nb(), points_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(points_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&points_,
                        mluOpDataTypeBytes(points_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&points_, mluOpDataTypeBytes(points_params.get_dtype()) *
                                      mluOpGetTensorElementNum(points_desc_)));
       }
@@ -83,13 +83,13 @@ class roipoint_pool3d_general
           point_features_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(point_features_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &point_features_,
                 mluOpDataTypeBytes(point_features_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&point_features_,
                        mluOpDataTypeBytes(point_features_params.get_dtype()) *
                            mluOpGetTensorElementNum(point_features_desc_)));
@@ -104,11 +104,11 @@ class roipoint_pool3d_general
 
       if (mluOpGetTensorElementNum(boxes3d_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&boxes3d_,
                        mluOpDataTypeBytes(boxes3d_params.get_dtype()) * 10));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&boxes3d_,
                                mluOpDataTypeBytes(boxes3d_params.get_dtype()) *
                                    mluOpGetTensorElementNum(boxes3d_desc_)));
@@ -123,13 +123,13 @@ class roipoint_pool3d_general
           pooled_features_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(pooled_features_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &pooled_features_,
                 mluOpDataTypeBytes(pooled_features_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&pooled_features_,
                        mluOpDataTypeBytes(pooled_features_params.get_dtype()) *
                            mluOpGetTensorElementNum(pooled_features_desc_)));
@@ -145,13 +145,13 @@ class roipoint_pool3d_general
       if (mluOpGetTensorElementNum(pooled_empty_flag_desc_) >=
           LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &pooled_empty_flag_,
                 mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) * 10));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(
                 &pooled_empty_flag_,
                 mluOpDataTypeBytes(pooled_empty_flag_params.get_dtype()) *
@@ -178,7 +178,7 @@ class roipoint_pool3d_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
 
     status = mluOpRoiPointPool3d(
         handle_, batch_size_, pts_num_, boxes_num_, feature_in_len_,
@@ -204,7 +204,7 @@ class roipoint_pool3d_general
 
     if (points_) {
       VLOG(4) << "Destroy points_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(points_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(points_));
       points_ = nullptr;
     }
 
@@ -216,7 +216,7 @@ class roipoint_pool3d_general
 
     if (point_features_) {
       VLOG(4) << "Destroy point_features_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(point_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(point_features_));
       point_features_ = nullptr;
     }
 
@@ -228,7 +228,7 @@ class roipoint_pool3d_general
 
     if (boxes3d_) {
       VLOG(4) << "Destroy boxes3d_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes3d_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes3d_));
       boxes3d_ = nullptr;
     }
 
@@ -240,7 +240,7 @@ class roipoint_pool3d_general
 
     if (pooled_features_) {
       VLOG(4) << "Destroy pooled_features_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pooled_features_));
       pooled_features_ = nullptr;
     }
 
@@ -252,7 +252,7 @@ class roipoint_pool3d_general
 
     if (pooled_empty_flag_) {
       VLOG(4) << "Destroy pooled_empty_flag_";
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pooled_empty_flag_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pooled_empty_flag_));
       pooled_empty_flag_ = nullptr;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/test_env.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/test_env.cpp
@@ -28,7 +28,7 @@ void TestEnvironment::SetUp() {
 
   // 2. get device num
   unsigned int dev_num = 0;
-  ASSERT_EQ(cnrtGetDeviceCount(&dev_num), CNRT_RET_SUCCESS);
+  ASSERT_EQ(cnrtGetDeviceCount(&dev_num), cnrtSuccess);
   if (dev_num <= 0) {  // dev_num_ should > 0
     FAIL() << "Can't find device";
   } else {
@@ -43,8 +43,8 @@ void TestEnvironment::SetUp() {
   // cnrt set current device using CNRT_DEFAULT_DEVICE
   // in cnrtGetDevice() CNRT_DEFAULT_DEVICE > id
   VLOG(4) << "Set current device as device: " << dev_id;
-  ASSERT_EQ(cnrtGetDevice(&dev_id), CNRT_RET_SUCCESS);
-  ASSERT_EQ(cnrtSetDevice(dev_id), CNRT_RET_SUCCESS);
+  ASSERT_EQ(cnrtGetDevice(&dev_id), cnrtSuccess);
+  ASSERT_EQ(cnrtSetDevice(dev_id), cnrtSuccess);
 }
 
 void TestEnvironment::TearDown() {

--- a/test/mlu_op_gtest/api_gtest/src/gtest/three_interpolate_backward/three_interpolate_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/three_interpolate_backward/three_interpolate_backward.cpp
@@ -71,27 +71,27 @@ class three_interprolate_backward : public testing::Test {
       size_t grad_output_ele_num = 1 * 2 * 4;
       size_t grad_output_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t grad_output_bytes = grad_output_ele_num * grad_output_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&grad_output_, grad_output_bytes));
     }
     if (indices) {
       size_t indices_ele_num = 1 * 4 * 3;
       size_t indices_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t indices_bytes = indices_ele_num * indices_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&indices_, indices_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&indices_, indices_bytes));
     }
     if (weight) {
       size_t weight_ele_num = 1 * 4 * 3;
       size_t weight_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t weight_bytes = weight_ele_num * weight_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&weight_, weight_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&weight_, weight_bytes));
     }
     if (grad_features) {
       size_t grad_features_ele_num = 1 * 2 * 4;
       size_t grad_features_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t grad_features_bytes =
           grad_features_ele_num * grad_features_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&grad_features_, grad_features_bytes));
     }
   }
@@ -129,19 +129,19 @@ class three_interprolate_backward : public testing::Test {
       grad_features_desc_ = NULL;
     }
     if (grad_output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (weight_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = NULL;
     }
     if (grad_features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_features_));
       grad_features_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/three_interpolate_backward/three_interpolate_backward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/three_interpolate_backward/three_interpolate_backward_general.cpp
@@ -60,7 +60,7 @@ class three_interprolate_backward_general
                                          grad_output_shape.data()));
     uint64_t grad_output_ele_num = mluOpGetTensorElementNum(grad_output_desc_);
     if (grad_output_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_output_, 8))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_output_, 8))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&indices_desc_));
@@ -74,7 +74,7 @@ class three_interprolate_backward_general
                                          indices_shape.data()));
     uint64_t indices_ele_num = mluOpGetTensorElementNum(indices_desc_);
     if (indices_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&indices_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&indices_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&weight_desc_));
@@ -88,7 +88,7 @@ class three_interprolate_backward_general
                                          weight_shape.data()));
     uint64_t weight_ele_num = mluOpGetTensorElementNum(weight_desc_);
     if (weight_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&weight_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&weight_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&grad_features_desc_));
@@ -104,7 +104,7 @@ class three_interprolate_backward_general
     uint64_t grad_features_ele_num =
         mluOpGetTensorElementNum(grad_features_desc_);
     if (grad_features_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&grad_features_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&grad_features_, 8));
     }
   }
 
@@ -146,19 +146,19 @@ class three_interprolate_backward_general
       grad_features_desc_ = NULL;
     }
     if (grad_output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (weight_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = NULL;
     }
     if (grad_features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_features_));
       grad_features_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/three_interprolate_forward/three_interprolate_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/three_interprolate_forward/three_interprolate_forward.cpp
@@ -71,25 +71,25 @@ class three_interprolate_forward : public testing::Test {
       size_t f_ele_num = 1 * 2 * 5;
       size_t f_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t f_bytes = f_ele_num * f_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&features_, f_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&features_, f_bytes));
     }
     if (indices) {
       size_t i_ele_num = 1 * 4 * 3;
       size_t i_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t i_bytes = i_ele_num * i_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&indices_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&indices_, i_bytes));
     }
     if (weight) {
       size_t w_ele_num = 1 * 4 * 3;
       size_t w_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t w_bytes = w_ele_num * w_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&weight_, w_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&weight_, w_bytes));
     }
     if (output) {
       size_t o_ele_num = 1 * 2 * 4;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, o_bytes));
     }
   }
 
@@ -126,19 +126,19 @@ class three_interprolate_forward : public testing::Test {
       output_desc_ = NULL;
     }
     if (features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(features_));
       features_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (weight_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/three_interprolate_forward/three_interprolate_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/three_interprolate_forward/three_interprolate_forward_general.cpp
@@ -59,7 +59,7 @@ class three_interprolate_forward_general
                                          f_dim, f_shape.data()));
     uint64_t f_ele_num = mluOpGetTensorElementNum(features_desc_);
     if (f_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&features_, 8))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&features_, 8))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&indices_desc_));
@@ -72,7 +72,7 @@ class three_interprolate_forward_general
                                          i_dim, i_shape.data()));
     uint64_t i_ele_num = mluOpGetTensorElementNum(indices_desc_);
     if (i_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&indices_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&indices_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&weight_desc_));
@@ -85,7 +85,7 @@ class three_interprolate_forward_general
                                          w_shape.data()));
     uint64_t w_ele_num = mluOpGetTensorElementNum(weight_desc_);
     if (w_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&weight_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&weight_, 8));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_desc_));
@@ -98,7 +98,7 @@ class three_interprolate_forward_general
                                          o_shape.data()));
     uint64_t o_ele_num = mluOpGetTensorElementNum(output_desc_);
     if (o_ele_num > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_, 8));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_, 8));
     }
   }
 
@@ -140,19 +140,19 @@ class three_interprolate_forward_general
       output_desc_ = NULL;
     }
     if (features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(features_));
       features_ = NULL;
     }
     if (indices_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(indices_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(indices_));
       indices_ = NULL;
     }
     if (weight_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(weight_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(weight_));
       weight_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/three_nn_forward/three_nn_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/three_nn_forward/three_nn_forward.cpp
@@ -47,7 +47,7 @@ class three_nn_forward : public testing::Test {
                                            unknown_dims.data()));
     }
     if (unknown) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&unknown_, 6 * 4))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&unknown_, 6 * 4))
     }
     if (known_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&known_desc_));
@@ -57,10 +57,10 @@ class three_nn_forward : public testing::Test {
                                            known_dims.data()));
     }
     if (known) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&known_, 30 * 4))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&known_, 30 * 4))
     }
     if (workspace) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_))
     }
     if (dist2_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&dist2_desc_));
@@ -70,7 +70,7 @@ class three_nn_forward : public testing::Test {
                                            dist2_dims.data()));
     }
     if (dist2) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&dist2_, 6 * 4))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&dist2_, 6 * 4))
     }
     if (idx_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&idx_desc_));
@@ -80,7 +80,7 @@ class three_nn_forward : public testing::Test {
                                            idx_dims.data()));
     }
     if (idx) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&idx_, 6 * 4))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&idx_, 6 * 4))
     }
   }
 
@@ -104,7 +104,7 @@ class three_nn_forward : public testing::Test {
       unknown_desc_ = NULL;
     }
     if (unknown_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(unknown_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(unknown_));
       unknown_ = NULL;
     }
     if (known_desc_) {
@@ -112,11 +112,11 @@ class three_nn_forward : public testing::Test {
       known_desc_ = NULL;
     }
     if (known_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(known_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(known_));
       known_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (dist2_desc_) {
@@ -124,7 +124,7 @@ class three_nn_forward : public testing::Test {
       dist2_desc_ = NULL;
     }
     if (dist2_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dist2_))
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dist2_))
       dist2_ = NULL;
     }
     if (idx_desc_) {
@@ -132,7 +132,7 @@ class three_nn_forward : public testing::Test {
       idx_desc_ = NULL;
     }
     if (idx_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(idx_));
       idx_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/three_nn_forward/three_nn_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/three_nn_forward/three_nn_forward_general.cpp
@@ -57,7 +57,7 @@ class three_nn_forward_general
       size_t u_dtype_size;
       MLUOP_CHECK(mluOpGetSizeOfDataType(u_dtype, &u_dtype_size));
       uint64_t u_bytes = u_dtype_size * mluOpGetTensorElementNum(unknown_desc_);
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&unknown_, u_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&unknown_, u_bytes))
     }
 
     MLUOpTensorParam k_params = std::get<1>(GetParam());
@@ -70,7 +70,7 @@ class three_nn_forward_general
       size_t k_dtype_size;
       MLUOP_CHECK(mluOpGetSizeOfDataType(k_dtype, &k_dtype_size));
       uint64_t k_bytes = k_dtype_size * mluOpGetTensorElementNum(known_desc_);
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&known_, k_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&known_, k_bytes))
     }
 
     MLUOpTensorParam d_params = std::get<2>(GetParam());
@@ -83,7 +83,7 @@ class three_nn_forward_general
       size_t d_dtype_size;
       MLUOP_CHECK(mluOpGetSizeOfDataType(d_dtype, &d_dtype_size));
       uint64_t d_bytes = d_dtype_size * mluOpGetTensorElementNum(dist2_desc_);
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&dist2_, d_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&dist2_, d_bytes))
     }
 
     MLUOpTensorParam id_params = std::get<3>(GetParam());
@@ -96,7 +96,7 @@ class three_nn_forward_general
       size_t id_dtype_size;
       MLUOP_CHECK(mluOpGetSizeOfDataType(id_dtype, &id_dtype_size));
       uint64_t id_bytes = id_dtype_size * mluOpGetTensorElementNum(dist2_desc_);
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&idx_, id_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&idx_, id_bytes))
     }
   }
   bool compute() {
@@ -111,7 +111,7 @@ class three_nn_forward_general
       destroy();
       return expected_status_ == status;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_))
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_))
     status = mluOpThreeNNForward(handle_, unknown_desc_, unknown_, known_desc_,
                                  known_, workspace_, workspace_size_,
                                  dist2_desc_, dist2_, idx_desc_, idx_);
@@ -131,7 +131,7 @@ class three_nn_forward_general
       unknown_desc_ = NULL;
     }
     if (unknown_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(unknown_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(unknown_));
       unknown_ = NULL;
     }
     if (known_desc_) {
@@ -139,11 +139,11 @@ class three_nn_forward_general
       known_desc_ = NULL;
     }
     if (known_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(known_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(known_));
       known_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (dist2_desc_) {
@@ -151,7 +151,7 @@ class three_nn_forward_general
       dist2_desc_ = NULL;
     }
     if (dist2_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(dist2_))
+      GTEST_CHECK(cnrtSuccess == cnrtFree(dist2_))
       dist2_ = NULL;
     }
     if (idx_desc_) {
@@ -159,7 +159,7 @@ class three_nn_forward_general
       idx_desc_ = NULL;
     }
     if (idx_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(idx_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(idx_));
       idx_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_backward/tin_shift_backward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_backward/tin_shift_backward.cpp
@@ -49,12 +49,12 @@ class tin_shift_backward : public testing::Test {
     }
     if (grad_output) {
       if (grad_output_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_output_,
                                MLUOP_DTYPE_FLOAT * mluOpGetTensorElementNum(
                                                        grad_output_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_output_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -68,11 +68,11 @@ class tin_shift_backward : public testing::Test {
     if (shifts) {
       if (shifts_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&shifts_, MLUOP_DTYPE_INT32 *
                                      mluOpGetTensorElementNum(shifts_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&shifts_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -85,12 +85,12 @@ class tin_shift_backward : public testing::Test {
     }
     if (grad_input) {
       if (grad_input_desc) {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_input_,
                                MLUOP_DTYPE_FLOAT *
                                    mluOpGetTensorElementNum(grad_input_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&grad_input_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -125,15 +125,15 @@ class tin_shift_backward : public testing::Test {
       grad_input_desc_ = NULL;
     }
     if (grad_output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = NULL;
     }
     if (shifts_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(shifts_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(shifts_));
       shifts_ = NULL;
     }
     if (grad_input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_backward/tin_shift_backward.general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_backward/tin_shift_backward.general.cpp
@@ -52,12 +52,12 @@ class tin_shift_backward_general
           grad_output_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_output_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_output_,
                        mluOpDataTypeBytes(grad_output_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_output_,
                        mluOpDataTypeBytes(grad_output_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_output_desc_)));
@@ -70,12 +70,12 @@ class tin_shift_backward_general
           shifts_params.get_dim_nb(), shifts_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(shifts_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&shifts_,
                        mluOpDataTypeBytes(shifts_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&shifts_, mluOpDataTypeBytes(shifts_params.get_dtype()) *
                                      mluOpGetTensorElementNum(shifts_desc_)));
       }
@@ -88,12 +88,12 @@ class tin_shift_backward_general
           grad_input_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(grad_input_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_input_,
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&grad_input_,
                        mluOpDataTypeBytes(grad_input_params.get_dtype()) *
                            mluOpGetTensorElementNum(grad_input_desc_)));
@@ -140,15 +140,15 @@ class tin_shift_backward_general
       grad_input_desc_ = NULL;
     }
     if (grad_output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_output_));
       grad_output_ = NULL;
     }
     if (shifts_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(shifts_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(shifts_));
       shifts_ = NULL;
     }
     if (grad_input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(grad_input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(grad_input_));
       grad_input_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_forward/tin_shift_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_forward/tin_shift_forward.cpp
@@ -49,11 +49,11 @@ class tin_shift_forward : public testing::Test {
     if (input) {
       if (input_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, MLUOP_DTYPE_FLOAT *
                                     mluOpGetTensorElementNum(input_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&input_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -67,11 +67,11 @@ class tin_shift_forward : public testing::Test {
     if (shifts) {
       if (shifts_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&shifts_, MLUOP_DTYPE_INT32 *
                                      mluOpGetTensorElementNum(shifts_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&shifts_, MLUOP_DTYPE_INT32 * 2));
       }
     }
@@ -85,11 +85,11 @@ class tin_shift_forward : public testing::Test {
     if (output) {
       if (output_desc) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&output_, MLUOP_DTYPE_FLOAT *
                                      mluOpGetTensorElementNum(output_desc_)));
       } else {
-        GTEST_CHECK(CNRT_RET_SUCCESS ==
+        GTEST_CHECK(cnrtSuccess ==
                     cnrtMalloc(&output_, MLUOP_DTYPE_FLOAT * 2));
       }
     }
@@ -124,15 +124,15 @@ class tin_shift_forward : public testing::Test {
       output_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (shifts_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(shifts_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(shifts_));
       shifts_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_forward/tin_shift_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/tin_shift_forward/tin_shift_forward_general.cpp
@@ -51,12 +51,12 @@ class tin_shift_forward_general
           input_params.get_dim_nb(), input_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(input_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_,
                        mluOpDataTypeBytes(input_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&input_, mluOpDataTypeBytes(input_params.get_dtype()) *
                                     mluOpGetTensorElementNum(input_desc_)));
       }
@@ -68,12 +68,12 @@ class tin_shift_forward_general
           shifts_params.get_dim_nb(), shifts_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(shifts_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&shifts_,
                        mluOpDataTypeBytes(shifts_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&shifts_, mluOpDataTypeBytes(shifts_params.get_dtype()) *
                                      mluOpGetTensorElementNum(shifts_desc_)));
       }
@@ -85,12 +85,12 @@ class tin_shift_forward_general
           output_params.get_dim_nb(), output_params.get_dim_size().data()));
       if (mluOpGetTensorElementNum(output_desc_) >= LARGE_TENSOR_NUM) {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&output_,
                        mluOpDataTypeBytes(output_params.get_dtype()) * 2));
       } else {
         GTEST_CHECK(
-            CNRT_RET_SUCCESS ==
+            cnrtSuccess ==
             cnrtMalloc(&output_, mluOpDataTypeBytes(output_params.get_dtype()) *
                                      mluOpGetTensorElementNum(output_desc_)));
       }
@@ -136,15 +136,15 @@ class tin_shift_forward_general
       output_desc_ = NULL;
     }
     if (input_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_));
       input_ = NULL;
     }
     if (shifts_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(shifts_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(shifts_));
       shifts_ = NULL;
     }
     if (output_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_));
       output_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward.cpp
@@ -72,25 +72,25 @@ class voxel_pooling_forward : public testing::Test {
       size_t g_ele_num = 2 * 4 * 3;
       size_t g_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t g_bytes = g_ele_num * g_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&geom_xyz_, g_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&geom_xyz_, g_bytes));
     }
     if (input_features) {
       size_t i_ele_num = 2 * 4 * 10;
       size_t i_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t i_bytes = i_ele_num * i_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_features_, i_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_features_, i_bytes));
     }
     if (output_features) {
       size_t o_ele_num = 2 * 5 * 6 * 10;
       size_t o_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t o_bytes = o_ele_num * o_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_features_, o_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_features_, o_bytes));
     }
     if (pos_memo) {
       size_t p_ele_num = 2 * 4 * 3;
       size_t p_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t p_bytes = p_ele_num * p_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&pos_memo_, p_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&pos_memo_, p_bytes));
     }
   }
 
@@ -129,19 +129,19 @@ class voxel_pooling_forward : public testing::Test {
       pos_memo_desc_ = NULL;
     }
     if (geom_xyz_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(geom_xyz_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(geom_xyz_));
       geom_xyz_ = NULL;
     }
     if (input_features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_features_));
       input_features_ = NULL;
     }
     if (output_features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_features_));
       output_features_ = NULL;
     }
     if (pos_memo_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pos_memo_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pos_memo_));
       output_features_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/voxel_pooling_forward/voxel_pooling_forward_general.cpp
@@ -71,7 +71,7 @@ class voxel_pooling_forward_general
       g_bytes = mluOpDataTypeBytes(g_dtype) * 36;
     }
     if (g_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&geom_xyz_, g_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&geom_xyz_, g_bytes))
     }
 
     MLUOpTensorParam i_params = std::get<2>(GetParam());
@@ -90,7 +90,7 @@ class voxel_pooling_forward_general
       i_bytes = mluOpDataTypeBytes(g_dtype) * 80;
     }
     if (i_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&input_features_, i_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&input_features_, i_bytes))
     }
 
     MLUOpTensorParam o_params = std::get<3>(GetParam());
@@ -109,7 +109,7 @@ class voxel_pooling_forward_general
       o_bytes = mluOpDataTypeBytes(g_dtype) * 600;
     }
     if (o_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&output_features_, o_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&output_features_, o_bytes))
     }
 
     MLUOpTensorParam p_params = std::get<4>(GetParam());
@@ -128,7 +128,7 @@ class voxel_pooling_forward_general
       p_bytes = mluOpDataTypeBytes(p_dtype) * 600;
     }
     if (p_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&pos_memo_, p_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&pos_memo_, p_bytes))
     }
   }
 
@@ -171,19 +171,19 @@ class voxel_pooling_forward_general
       pos_memo_desc_ = NULL;
     }
     if (geom_xyz_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(geom_xyz_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(geom_xyz_));
       geom_xyz_ = NULL;
     }
     if (input_features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(input_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(input_features_));
       input_features_ = NULL;
     }
     if (output_features_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(output_features_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(output_features_));
       output_features_ = NULL;
     }
     if (pos_memo_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(pos_memo_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(pos_memo_));
       output_features_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization.cpp
@@ -55,7 +55,7 @@ class voxelization : public testing::Test {
       size_t points_ele_num = 1 * 2;
       size_t points_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t points_bytes = points_ele_num * points_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&points_, points_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&points_, points_bytes));
     }
     if (voxel_size_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_size_desc_));
@@ -68,7 +68,7 @@ class voxelization : public testing::Test {
       size_t voxel_size_ele_num = 3;
       size_t voxel_size_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t voxel_size_bytes = voxel_size_ele_num * voxel_size_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&voxel_size_, voxel_size_bytes));
     }
     if (coors_range_desc) {
@@ -82,14 +82,14 @@ class voxelization : public testing::Test {
       size_t coors_range_ele_num = 6;
       size_t coors_range_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t coors_range_bytes = coors_range_ele_num * coors_range_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&coors_range_, coors_range_bytes));
     }
     if (workspace) {
       size_t workspace_ele_num = workspace_size_;
       size_t workspace_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t workspace_bytes = workspace_ele_num * workspace_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_bytes));
     }
     if (voxels_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxels_desc_));
@@ -102,7 +102,7 @@ class voxelization : public testing::Test {
       size_t voxels_ele_num = 5 * 4 * 2;
       size_t voxels_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t voxels_bytes = voxels_ele_num * voxels_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&voxels_, voxels_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&voxels_, voxels_bytes));
     }
     if (coors_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&coors_desc_));
@@ -115,7 +115,7 @@ class voxelization : public testing::Test {
       size_t coors_ele_num = 5 * 3;
       size_t coors_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t coors_bytes = coors_ele_num * coors_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&coors_, coors_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&coors_, coors_bytes));
     }
     if (num_points_per_voxel_desc) {
       MLUOP_CHECK(mluOpCreateTensorDescriptor(&num_points_per_voxel_desc_));
@@ -130,7 +130,7 @@ class voxelization : public testing::Test {
           mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t num_points_per_voxel_bytes =
           num_points_per_voxel_ele_num * num_points_per_voxel_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&num_points_per_voxel_,
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&num_points_per_voxel_,
                                                  num_points_per_voxel_bytes));
     }
     if (voxel_num_desc) {
@@ -144,7 +144,7 @@ class voxelization : public testing::Test {
       size_t voxel_num_ele_num = 1;
       size_t voxel_num_dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t voxel_num_bytes = voxel_num_ele_num * voxel_num_dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&voxel_num_, voxel_num_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&voxel_num_, voxel_num_bytes));
     }
   }
 
@@ -171,7 +171,7 @@ class voxelization : public testing::Test {
       points_desc_ = NULL;
     }
     if (points_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(points_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(points_));
       points_ = NULL;
     }
     if (voxel_size_desc_) {
@@ -179,7 +179,7 @@ class voxelization : public testing::Test {
       voxel_size_desc_ = NULL;
     }
     if (voxel_size_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_size_));
       voxel_size_ = NULL;
     }
     if (coors_range_desc_) {
@@ -187,11 +187,11 @@ class voxelization : public testing::Test {
       coors_range_desc_ = NULL;
     }
     if (coors_range_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_range_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(coors_range_));
       coors_range_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (voxels_desc_) {
@@ -199,7 +199,7 @@ class voxelization : public testing::Test {
       voxels_desc_ = NULL;
     }
     if (voxels_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxels_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxels_));
       voxels_ = NULL;
     }
     if (coors_desc_) {
@@ -207,7 +207,7 @@ class voxelization : public testing::Test {
       coors_desc_ = NULL;
     }
     if (coors_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(coors_));
       coors_ = NULL;
     }
     if (num_points_per_voxel_desc_) {
@@ -215,7 +215,7 @@ class voxelization : public testing::Test {
       num_points_per_voxel_desc_ = NULL;
     }
     if (num_points_per_voxel_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(num_points_per_voxel_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(num_points_per_voxel_));
       num_points_per_voxel_ = NULL;
     }
     if (voxel_num_desc_) {
@@ -223,7 +223,7 @@ class voxelization : public testing::Test {
       voxel_num_desc_ = NULL;
     }
     if (voxel_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_num_));
       voxel_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/voxelization/voxelization_general.cpp
@@ -59,7 +59,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     uint64_t points_ele_num = mluOpGetTensorElementNum(points_desc_);
     uint64_t points_bytes = mluOpDataTypeBytes(points_dtype) * points_ele_num;
     if (points_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&points_, points_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&points_, points_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&voxel_size_desc_));
@@ -75,7 +75,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     uint64_t voxel_size_bytes =
         mluOpDataTypeBytes(voxel_size_dtype) * voxel_size_ele_num;
     if (voxel_size_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&voxel_size_, voxel_size_bytes))
     }
 
@@ -92,7 +92,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     uint64_t coors_range_bytes =
         mluOpDataTypeBytes(coors_range_dtype) * coors_range_ele_num;
     if (coors_range_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS ==
+      GTEST_CHECK(cnrtSuccess ==
                   cnrtMalloc(&coors_range_, coors_range_bytes))
     }
 
@@ -112,7 +112,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     uint64_t voxels_ele_num = mluOpGetTensorElementNum(voxels_desc_);
     uint64_t voxels_bytes = mluOpDataTypeBytes(voxels_dtype) * voxels_ele_num;
     if (voxels_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&voxels_, voxels_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&voxels_, voxels_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&coors_desc_));
@@ -126,7 +126,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     uint64_t coors_ele_num = mluOpGetTensorElementNum(coors_desc_);
     uint64_t coors_bytes = mluOpDataTypeBytes(coors_dtype) * coors_ele_num;
     if (coors_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&coors_, coors_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&coors_, coors_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&num_points_per_voxel_desc_));
@@ -148,7 +148,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
         mluOpDataTypeBytes(num_points_per_voxel_dtype) *
         num_points_per_voxel_ele_num;
     if (num_points_per_voxel_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&num_points_per_voxel_,
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&num_points_per_voxel_,
                                                  num_points_per_voxel_bytes))
     }
 
@@ -165,7 +165,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
     uint64_t voxel_num_bytes =
         mluOpDataTypeBytes(voxel_num_dtype) * voxel_num_ele_num;
     if (voxel_num_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&voxel_num_, voxel_num_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&voxel_num_, voxel_num_bytes))
     }
 
     PublicParam publicParam = std::get<8>(GetParam());
@@ -186,7 +186,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       destroy();
       return status == expected_status_;
     }
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&workspace_, workspace_size_));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&workspace_, workspace_size_));
     status = mluOpVoxelization(
         handle_, points_desc_, points_, voxel_size_desc_, voxel_size_,
         coors_range_desc_, coors_range_, max_points_, max_voxels_, NDim_,
@@ -209,7 +209,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       points_desc_ = NULL;
     }
     if (points_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(points_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(points_));
       points_ = NULL;
     }
     if (voxel_size_desc_) {
@@ -217,7 +217,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       voxel_size_desc_ = NULL;
     }
     if (voxel_size_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_size_));
       voxel_size_ = NULL;
     }
     if (coors_range_desc_) {
@@ -225,11 +225,11 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       coors_range_desc_ = NULL;
     }
     if (coors_range_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_range_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(coors_range_));
       coors_range_ = NULL;
     }
     if (workspace_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(workspace_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(workspace_));
       workspace_ = NULL;
     }
     if (voxels_desc_) {
@@ -237,7 +237,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       voxels_desc_ = NULL;
     }
     if (voxels_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxels_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxels_));
       voxels_ = NULL;
     }
     if (coors_desc_) {
@@ -245,7 +245,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       coors_desc_ = NULL;
     }
     if (coors_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(coors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(coors_));
       coors_ = NULL;
     }
     if (num_points_per_voxel_desc_) {
@@ -253,7 +253,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       num_points_per_voxel_desc_ = NULL;
     }
     if (num_points_per_voxel_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(num_points_per_voxel_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(num_points_per_voxel_));
       num_points_per_voxel_ = NULL;
     }
     if (voxel_num_desc_) {
@@ -261,7 +261,7 @@ class voxelization_general : public testing::TestWithParam<Voxelization> {
       voxel_num_desc_ = NULL;
     }
     if (voxel_num_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(voxel_num_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(voxel_num_));
       voxel_num_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/yolo_box/yolo_box.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/yolo_box/yolo_box.cpp
@@ -78,31 +78,31 @@ class yolo_box : public testing::Test {
       size_t ele_num = 8;
       size_t dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t bytes = ele_num * dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&x_, bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&x_, bytes));
     }
     if (img_size) {
       size_t ele_num = 8;
       size_t dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t bytes = ele_num * dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&img_size_, bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&img_size_, bytes));
     }
     if (anchors) {
       size_t ele_num = 8;
       size_t dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_INT32);
       size_t bytes = ele_num * dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&anchors_, bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&anchors_, bytes));
     }
     if (boxes) {
       size_t ele_num = 8;
       size_t dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t bytes = ele_num * dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, bytes));
     }
     if (scores) {
       size_t ele_num = 8;
       size_t dtype_bytes = mluOpDataTypeBytes(MLUOP_DTYPE_FLOAT);
       size_t bytes = ele_num * dtype_bytes;
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&scores_, bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&scores_, bytes));
     }
   }
 
@@ -145,23 +145,23 @@ class yolo_box : public testing::Test {
       scores_desc_ = NULL;
     }
     if (x_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(x_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(x_));
       x_ = NULL;
     }
     if (img_size_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(img_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(img_size_));
       img_size_ = NULL;
     }
     if (anchors_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(anchors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(anchors_));
       anchors_ = NULL;
     }
     if (boxes_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       boxes_ = NULL;
     }
     if (scores_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(scores_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(scores_));
       scores_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/api_gtest/src/gtest/yolo_box/yolo_box_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/yolo_box/yolo_box_general.cpp
@@ -61,7 +61,7 @@ class yolo_box_general : public testing::TestWithParam<YoloBoxParam> {
     uint64_t x_ele_num = mluOpGetTensorElementNum(x_desc_);
     uint64_t x_bytes = mluOpDataTypeBytes(x_dtype) * x_ele_num;
     if (x_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&x_, x_bytes))
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&x_, x_bytes))
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&img_size_desc_));
@@ -75,7 +75,7 @@ class yolo_box_general : public testing::TestWithParam<YoloBoxParam> {
     uint64_t img_ele_num = mluOpGetTensorElementNum(img_size_desc_);
     uint64_t img_bytes = mluOpDataTypeBytes(img_dtype) * img_ele_num;
     if (img_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&img_size_, img_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&img_size_, img_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&anchors_desc_));
@@ -89,7 +89,7 @@ class yolo_box_general : public testing::TestWithParam<YoloBoxParam> {
     uint64_t an_ele_num = mluOpGetTensorElementNum(anchors_desc_);
     uint64_t an_bytes = mluOpDataTypeBytes(an_dtype) * an_ele_num;
     if (an_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&anchors_, an_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&anchors_, an_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&boxes_desc_));
@@ -103,7 +103,7 @@ class yolo_box_general : public testing::TestWithParam<YoloBoxParam> {
     uint64_t b_ele_num = mluOpGetTensorElementNum(boxes_desc_);
     uint64_t b_bytes = mluOpDataTypeBytes(b_dtype) * b_ele_num;
     if (b_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&boxes_, b_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&boxes_, b_bytes));
     }
 
     MLUOP_CHECK(mluOpCreateTensorDescriptor(&scores_desc_));
@@ -117,7 +117,7 @@ class yolo_box_general : public testing::TestWithParam<YoloBoxParam> {
     uint64_t s_ele_num = mluOpGetTensorElementNum(scores_desc_);
     uint64_t s_bytes = mluOpDataTypeBytes(s_dtype) * s_ele_num;
     if (s_bytes > 0) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&scores_, s_bytes));
+      GTEST_CHECK(cnrtSuccess == cnrtMalloc(&scores_, s_bytes));
     }
 
     YoloBoxDescParam params = std::get<5>(GetParam());
@@ -169,23 +169,23 @@ class yolo_box_general : public testing::TestWithParam<YoloBoxParam> {
       scores_desc_ = NULL;
     }
     if (x_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(x_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(x_));
       x_ = NULL;
     }
     if (img_size_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(img_size_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(img_size_));
       img_size_ = NULL;
     }
     if (anchors_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(anchors_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(anchors_));
       anchors_ = NULL;
     }
     if (boxes_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(boxes_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(boxes_));
       boxes_ = NULL;
     }
     if (scores_) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(scores_));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(scores_));
       scores_ = NULL;
     }
   }

--- a/test/mlu_op_gtest/include/tools.h
+++ b/test/mlu_op_gtest/include/tools.h
@@ -67,7 +67,6 @@ size_t shapeStrideCount(const Shape *shape);
 // not include stride
 size_t shapeElementCount(const Shape *shape);
 
-cnrtDataType_t cvtMluOpDtypeToCnrt(mluOpDataType_t dtype);
 cnrtDataType_V2_t cvtMluOpDtypeToCnrt_V2(mluOpDataType_t dtype);
 mluOpDataType_t cvtProtoDtypeToMluOp(DataType dtype);
 mluOpTensorLayout_t cvtProtoLayoutToMluOp(TensorLayout order);

--- a/test/mlu_op_gtest/pb_gtest/include/runtime.h
+++ b/test/mlu_op_gtest/pb_gtest/include/runtime.h
@@ -37,6 +37,10 @@
 #include "tools.h"
 #include "memory_pool.h"
 
+#ifndef CNRT_RET_ERR_INVALID
+#define CNRT_RET_ERR_INVALID (632007)
+#endif
+
 namespace mluoptest {
 
 class Runtime {
@@ -49,11 +53,11 @@ class Runtime {
   void *allocate(size_t num_bytes, std::string name = "") { return NULL; }
 
   // this function will throw exception
-  cnrtRet_t deallocate(void *ptr) { return CNRT_RET_SUCCESS; }
+  cnrtRet_t deallocate(void *ptr) { return cnrtSuccess; }
 
   // this function won't throw exception
   // so only this function can be called in dtor
-  cnrtRet_t destroy() { return CNRT_RET_SUCCESS; }
+  cnrtRet_t destroy() { return cnrtSuccess; }
   // use cnrtRet_t, cuz when call cnrtFree .. can return directly.
 };
 
@@ -98,7 +102,7 @@ class CPURuntime : public Runtime {
   template <typename T>
   cnrtRet_t deallocate(T object) {
     if (NULL == (void *)object) {
-      return CNRT_RET_SUCCESS;
+      return cnrtSuccess;
     }
     auto it = std::find_if(memory_blocks_.begin(), memory_blocks_.end(),
                            [=](std::shared_ptr<MemBlockBase> b) {
@@ -115,7 +119,7 @@ class CPURuntime : public Runtime {
     // XXX(zhaolianshui): since using erase rather frequently, memory_blocks_
     // should be std::list?
     memory_blocks_.erase(it);
-    return CNRT_RET_SUCCESS;
+    return cnrtSuccess;
   }
 
   // so only this function can be called in dtor

--- a/test/mlu_op_gtest/pb_gtest/src/executor.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/executor.cpp
@@ -1882,24 +1882,17 @@ void Executor::cnrtCastDataTypeWrap(void *src_data,
   size_t count_remain = count % INT_MAX;
   char *src = reinterpret_cast<char *>(src_data);
   char *dst = reinterpret_cast<char *>(dst_data);
-  cnrtRoundingMode_t round_mode = (dst_dtype == MLUOP_DTYPE_HALF ||
-                                   dst_dtype == MLUOP_DTYPE_FLOAT ||
-                                   dst_dtype == MLUOP_DTYPE_BFLOAT16 ||
-                                   dst_dtype == MLUOP_DTYPE_DOUBLE ||
-                                   dst_dtype == MLUOP_DTYPE_COMPLEX_HALF ||
-                                   dst_dtype == MLUOP_DTYPE_COMPLEX_FLOAT) ?
-                                   cnrtRounding_rn : cnrtRounding_rz;
   for (size_t i = 0; i < count_repeat; ++i) {
     GTEST_CHECK(cnrtSuccess ==
                 cnrtCastDataType_V2(src, in_dtype, dst, out_dtype, INT_MAX,
-                                    quant_param, round_mode));
+                                    quant_param, cnrtRounding_rm));
     src += INT_MAX * mluop::getSizeOfDataType(src_dtype);
     dst += INT_MAX * mluop::getSizeOfDataType(dst_dtype);
   }
   if (count_remain) {
     GTEST_CHECK(cnrtSuccess ==
                 cnrtCastDataType_V2(src, in_dtype, dst, out_dtype, count_remain,
-                                    quant_param, round_mode));
+                                    quant_param, cnrtRounding_rm));
   }
 }
 

--- a/test/mlu_op_gtest/pb_gtest/src/gtest/mlu_op_gtest.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/gtest/mlu_op_gtest.cpp
@@ -249,7 +249,7 @@ void TestSuite::ThreadX() {
   // in current thread, We should ensure different thread access the same device
   // when we use default queue. Sadly, CNRT have other multithread restriction,
   // we may need to write new thread model.
-  ASSERT_EQ(cnrtSetDevice(global_var.dev_id_), CNRT_RET_SUCCESS);
+  ASSERT_EQ(cnrtSetDevice(global_var.dev_id_), cnrtSuccess);
 
   size_t thread_num = global_var.thread_num_;
   size_t max_exe_vec_num = thread_num * 1.5;
@@ -262,7 +262,7 @@ void TestSuite::ThreadX() {
     auto it = ctx->been_initialized.find(std::this_thread::get_id());
     if (it == ctx->been_initialized
                   .end()) {  // if current thread has not been set device.
-      ASSERT_EQ(cnrtSetDevice(global_var.dev_id_), CNRT_RET_SUCCESS);
+      ASSERT_EQ(cnrtSetDevice(global_var.dev_id_), cnrtSuccess);
       ctx->been_initialized.insert(std::this_thread::get_id());
     }
   };

--- a/test/mlu_op_gtest/pb_gtest/src/gtest/test_env.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/gtest/test_env.cpp
@@ -389,7 +389,7 @@ bool TestEnvironment::getBusId(int device_id, std::string &bus_id_str) {
     VLOG(4) << "Device " << device_id << "'s mlu id=" << str;
   } else {
     cnrtRet_t ret = cnrtDeviceGetPCIBusId(str, 100, device_id);
-    if (ret != CNRT_RET_SUCCESS) {
+    if (ret != cnrtSuccess) {
       LOG(WARNING) << "Fail to get device " << device_id << "'s bus id.";
       return false;
     } else {
@@ -444,7 +444,7 @@ bool TestEnvironment::getComputeMode(std::string bus_id_str, char &mode) {
 void TestEnvironment::setDevice() {
   // 1.get device num
   unsigned int dev_num = 0;
-  ASSERT_EQ(cnrtGetDeviceCount(&dev_num), CNRT_RET_SUCCESS);
+  ASSERT_EQ(cnrtGetDeviceCount(&dev_num), cnrtSuccess);
   if (dev_num <= 0) {  // dev_num_ should > 0
     FAIL() << "Can't find device.";
   } else {

--- a/test/mlu_op_gtest/pb_gtest/src/hardware_monitor.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/hardware_monitor.cpp
@@ -48,7 +48,7 @@ hardwareMonitor::~hardwareMonitor() {
 
 void hardwareMonitor::setDevice() const {
   GTEST_CHECK(cndevInit(0) == CNDEV_SUCCESS);
-  ASSERT_EQ(cnrtSetDevice(global_var.dev_id_), CNRT_RET_SUCCESS);
+  ASSERT_EQ(cnrtSetDevice(global_var.dev_id_), cnrtSuccess);
 }
 
 void hardwareMonitor::start() {
@@ -130,7 +130,7 @@ void hardwareMonitor::monitorFrequencyOneGRepeat() {
                                std::ios::app);
   frequency_file << "relative_time(ns),IPU_frequency(MHz)\n";
   cndevDevice_t dev_id;
-  GTEST_CHECK(cnrtGetDevice(&dev_id) == CNRT_RET_SUCCESS);
+  GTEST_CHECK(cnrtGetDevice(&dev_id) == cnrtSuccess);
   int i = 1;
 
   cndevFrequencyInfo_t freq_info_prev, freq_info_curr;
@@ -172,7 +172,7 @@ void hardwareMonitor::monitorPowerOneGRepeat() {
                            std::ios::app);
   power_file << "relative_time(ns),instantaneous_power(W),average_power(W)\n";
   cndevDevice_t dev_id;
-  GTEST_CHECK(cnrtGetDevice(&dev_id) == CNRT_RET_SUCCESS);
+  GTEST_CHECK(cnrtGetDevice(&dev_id) == cnrtSuccess);
   GTEST_CHECK(cndevInit(0) == CNDEV_SUCCESS);
   int i = 1;
 

--- a/test/mlu_op_gtest/pb_gtest/src/internal_kernel/fill_llc/fill_llc.mlu
+++ b/test/mlu_op_gtest/pb_gtest/src/internal_kernel/fill_llc/fill_llc.mlu
@@ -30,7 +30,7 @@ mluOpStatus_t mluOpFillLLC(mluOpHandle_t handle, void *const_addr,
     return MLUOP_STATUS_SUCCESS;
   }
   cnrtDim3_t k_dim{1, 1, 1};
-  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_BLOCK;
+  cnrtFunctionType_t k_type = cnrtFuncTypeBlock;
   KERNEL_CHECK(
       (flushLLC<<<k_dim, k_type, handle->queue>>>(const_addr, llc_size)));
   return MLUOP_STATUS_SUCCESS;

--- a/test/mlu_op_gtest/pb_gtest/src/internal_kernel/fill_ram/fill_ram.mlu
+++ b/test/mlu_op_gtest/pb_gtest/src/internal_kernel/fill_ram/fill_ram.mlu
@@ -33,9 +33,9 @@
 static void policyFunc(const mluOpHandle_t handle, cnrtDim3_t *k_dim,
                        cnrtFunctionType_t *k_type) {
 #if TARGET_MLU_ARCH == 520
-  *k_type = CNRT_FUNC_TYPE_BLOCK;
+  *k_type = cnrtFuncTypeBlock;
 #else
-  *k_type = CNRT_FUNC_TYPE_UNION1;
+  *k_type = cnrtFuncTypeUnion1;
 #endif
   k_dim->x = mluop::runtime::getCoreNumOfEachUnionCapability(handle);
   k_dim->y = mluop::runtime::getClusterLimitCapability(handle);

--- a/test/mlu_op_gtest/pb_gtest/src/memory_pool.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/memory_pool.cpp
@@ -276,7 +276,7 @@ void *MLUMemoryPool::allocate(size_t num_bytes, const std::string &name) {
 #endif
     while (maxFreeSize > 0) {
       auto result = cnrtMalloc(&ptr, maxFreeSize);
-      if (CNRT_RET_SUCCESS == result) {
+      if (cnrtSuccess == result) {
         cnGetMemAttribute((void *)&is_linear, CN_MEM_ATTRIBUTE_ISLINEAR,
                           (CNaddr)ptr);
         if (is_linear)
@@ -288,7 +288,7 @@ void *MLUMemoryPool::allocate(size_t num_bytes, const std::string &name) {
     }
     num_bytes = maxFreeSize;
   } else {
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMalloc(&ptr, num_bytes));
+    GTEST_CHECK(cnrtSuccess == cnrtMalloc(&ptr, num_bytes));
   }
 
   ctx_->chunks.emplace_back(Chunk(num_bytes, num_bytes, ptr));
@@ -300,7 +300,7 @@ void *MLUMemoryPool::allocate(size_t num_bytes, const std::string &name) {
 void MLUMemoryPool::deallocate(void *ptr) {
   for (auto it = ctx_->chunks.begin(); it != ctx_->chunks.end(); ++it) {
     if ((*it).ptr == ptr) {
-      GTEST_CHECK(CNRT_RET_SUCCESS == cnrtFree(ptr));
+      GTEST_CHECK(cnrtSuccess == cnrtFree(ptr));
       ctx_->total_allocated_size -= (*it).allocated_size;
       it = ctx_->chunks.erase(it);
       return;
@@ -311,7 +311,7 @@ void MLUMemoryPool::deallocate(void *ptr) {
 void MLUMemoryPool::destroy() {
   for (auto it = ctx_->chunks.begin(); it != ctx_->chunks.end(); ++it) {
     if (it->ptr != nullptr) {
-      GTEST_WARNING(CNRT_RET_SUCCESS == cnrtFree(it->ptr));
+      GTEST_WARNING(cnrtSuccess == cnrtFree(it->ptr));
       it->ptr = nullptr;
       ctx_->total_allocated_size -= it->allocated_size;
     }

--- a/test/mlu_op_gtest/pb_gtest/src/tools.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/tools.cpp
@@ -347,37 +347,6 @@ void saveHexDataToFile(const std::string &file, void *data,
   fout.close();
 }
 
-cnrtDataType_t cvtMluOpDtypeToCnrt(mluOpDataType_t dtype) {
-  switch (dtype) {
-    case MLUOP_DTYPE_HALF:
-      return cnrtFloat16;
-    case MLUOP_DTYPE_FLOAT:
-      return cnrtFloat32;
-    case MLUOP_DTYPE_DOUBLE:
-      return cnrtFloat64;
-    case MLUOP_DTYPE_INT8:
-      return cnrtInt8;
-    case MLUOP_DTYPE_INT16:
-      return cnrtInt16;
-    case MLUOP_DTYPE_INT32:
-      return cnrtInt32;
-    case MLUOP_DTYPE_INT64:
-      return cnrtInt64;
-    case MLUOP_DTYPE_BOOL:
-      return cnrtBool;
-    case MLUOP_DTYPE_UINT8:
-      return cnrtUchar;
-    case MLUOP_DTYPE_UINT16:
-      return cnrtUshort;
-    case MLUOP_DTYPE_UINT32:
-      return cnrtUint;
-    default:
-      LOG(ERROR) << "NOT support this dtype yet";
-      throw std::invalid_argument(std::string(__FILE__) + " +" +
-                                  std::to_string(__LINE__));
-  }
-}
-
 cnrtDataType_V2_t cvtMluOpDtypeToCnrt_V2(mluOpDataType_t dtype) {
   switch (dtype) {
     case MLUOP_DTYPE_HALF:

--- a/test/mlu_op_gtest/pb_gtest/src/tools.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/tools.cpp
@@ -350,21 +350,21 @@ void saveHexDataToFile(const std::string &file, void *data,
 cnrtDataType_t cvtMluOpDtypeToCnrt(mluOpDataType_t dtype) {
   switch (dtype) {
     case MLUOP_DTYPE_HALF:
-      return CNRT_FLOAT16;
+      return cnrtFloat16;
     case MLUOP_DTYPE_FLOAT:
-      return CNRT_FLOAT32;
+      return cnrtFloat32;
     case MLUOP_DTYPE_DOUBLE:
-      return CNRT_FLOAT64;
+      return cnrtFloat64;
     case MLUOP_DTYPE_INT8:
-      return CNRT_INT8;
+      return cnrtInt8;
     case MLUOP_DTYPE_INT16:
-      return CNRT_INT16;
+      return cnrtInt16;
     case MLUOP_DTYPE_INT32:
-      return CNRT_INT32;
+      return cnrtInt32;
     case MLUOP_DTYPE_INT64:
-      return CNRT_INT64;
+      return cnrtInt64;
     case MLUOP_DTYPE_BOOL:
-      return CNRT_BOOL;
+      return cnrtBool;
     case MLUOP_DTYPE_UINT8:
       return CNRT_UINT8;
     case MLUOP_DTYPE_UINT16:

--- a/test/mlu_op_gtest/pb_gtest/src/tools.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/tools.cpp
@@ -366,11 +366,11 @@ cnrtDataType_t cvtMluOpDtypeToCnrt(mluOpDataType_t dtype) {
     case MLUOP_DTYPE_BOOL:
       return cnrtBool;
     case MLUOP_DTYPE_UINT8:
-      return CNRT_UINT8;
+      return cnrtUchar;
     case MLUOP_DTYPE_UINT16:
-      return CNRT_UINT16;
+      return cnrtUshort;
     case MLUOP_DTYPE_UINT32:
-      return CNRT_UINT32;
+      return cnrtUint;
     default:
       LOG(ERROR) << "NOT support this dtype yet";
       throw std::invalid_argument(std::string(__FILE__) + " +" +

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/ball_query/ball_query.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/ball_query/ball_query.cpp
@@ -52,7 +52,7 @@ void BallQueryExecutor::compute() {
   auto data_vector = (int *)data_vector_[2].host_ptr;
   // set idx to 0
   size_t output_total_bytes = data_vector_[2].count * sizeof(int32_t);
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(idx_ptr, 0, output_total_bytes));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(idx_ptr, 0, output_total_bytes));
   interface_timer_.start();
   MLUOP_CHECK(mluOpBallQuery(handle_, new_xyz_desc, new_xyz_ptr, xyz_desc,
                              xyz_ptr, min_radius_, max_radius_, nsample_,

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/generate_proposals_v2/generate_proposals_v2.cpp
@@ -54,25 +54,25 @@ void GenerateProposalsV2Executor::workspaceMalloc() {
 
   void *output_ptr = parser_->getMetaTensor("output1").dev_origin_ptr;
   size_t output_size = parser_->getMetaTensor("output1").size_in_bytes;
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(output_ptr, 0, output_size));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(output_ptr, 0, output_size));
 
   void *output_ptr1 = parser_->getMetaTensor("output2").dev_origin_ptr;
   size_t output_size1 = parser_->getMetaTensor("output2").size_in_bytes;
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(output_ptr1, 0, output_size1));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(output_ptr1, 0, output_size1));
 
   void *output_ptr2 = parser_->getMetaTensor("output3").dev_origin_ptr;
   size_t output_size2 = parser_->getMetaTensor("output3").size_in_bytes;
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(output_ptr2, 0, output_size2));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(output_ptr2, 0, output_size2));
 
   void *output_ptr3 = parser_->getMetaTensor("output4").dev_origin_ptr;
   size_t output_size3 = parser_->getMetaTensor("output4").size_in_bytes;
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(output_ptr3, 0, output_size3));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(output_ptr3, 0, output_size3));
 }
 
 void GenerateProposalsV2Executor::workspaceFree() {
   if (workspace_[0]) {
     VLOG(4) << "Free device workspace space.";
-    GTEST_CHECK(CNRT_RET_SUCCESS == mlu_runtime_.deallocate(workspace_[0]));
+    GTEST_CHECK(cnrtSuccess == mlu_runtime_.deallocate(workspace_[0]));
     workspace_[0] = nullptr;
   }
 }

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/moe_dispatch_backward_gate/moe_dispatch_backward_gate.cpp
@@ -65,7 +65,7 @@ void MoeDispatchBackwardGateExecutor::workspaceMalloc() {
 void MoeDispatchBackwardGateExecutor::workspaceFree() {
   if (workspace_size_ > 0) {
     VLOG(4) << "[MoeDispatchBackwardGateExecutor] Free device workspace space.";
-    GTEST_CHECK(CNRT_RET_SUCCESS == mlu_runtime_.deallocate(workspace_[0]));
+    GTEST_CHECK(cnrtSuccess == mlu_runtime_.deallocate(workspace_[0]));
     workspace_[0] = nullptr;
   }
 }

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/nms/nms.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/nms/nms.cpp
@@ -80,12 +80,12 @@ void NmsExecutor::workspaceMalloc() {
        parser_->getMetaTensor("input1").size_in_bytes == 0) &&
       output_size > 0) {
     void *output_ptr = parser_->getMetaTensor("output1").dev_origin_ptr;
-    GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(output_ptr, 0, output_size));
+    GTEST_CHECK(cnrtSuccess == cnrtMemset(output_ptr, 0, output_size));
   }
 
   void *output2_ptr = parser_->getMetaTensor("output2").dev_origin_ptr;
   size_t output2_size = parser_->getMetaTensor("output2").size_in_bytes;
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(output2_ptr, 0, output2_size));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(output2_ptr, 0, output2_size));
 
   eva_->setMluWorkspaceSize(workspace_size_);
 }

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/nms_rotated/nms_rotated.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/nms_rotated/nms_rotated.cpp
@@ -101,10 +101,10 @@ void NmsRotatedExecutor::compute() {
   auto result_num = data_vector_[3].device_ptr;
   size_t workspace_size = 0;
   size_t output_size = parser_->getMetaTensor("output1").size_in_bytes;
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(dev_output, 0, output_size));
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(result_num, 0, sizeof(int32_t)));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(dev_output, 0, output_size));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(result_num, 0, sizeof(int32_t)));
 
-  // GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(dev_output, 0,
+  // GTEST_CHECK(cnrtSuccess == cnrtMemset(dev_output, 0,
   //   output->dims[0] * sizeof(int64_t)));
   VLOG(4) << "call mluOpNmsRotated()";
   interface_timer_.start();

--- a/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/zoo/poly_nms/poly_nms.cpp
@@ -54,13 +54,13 @@ void PolyNmsExecutor::workspaceMalloc() {
   auto output_tensor = parser_->getMetaTensor("output1").tensor;
   void *output_ptr = parser_->getMetaTensor("output1").dev_origin_ptr;
   size_t output_size = parser_->getMetaTensor("output1").size_in_bytes;
-  GTEST_CHECK(CNRT_RET_SUCCESS == cnrtMemset(output_ptr, 0, output_size));
+  GTEST_CHECK(cnrtSuccess == cnrtMemset(output_ptr, 0, output_size));
 }
 
 void PolyNmsExecutor::workspaceFree() {
   if (workspace_[0]) {
     VLOG(4) << "Free device workspace space.";
-    GTEST_CHECK(CNRT_RET_SUCCESS == mlu_runtime_.deallocate(workspace_[0]));
+    GTEST_CHECK(cnrtSuccess == mlu_runtime_.deallocate(workspace_[0]));
     workspace_[0] = nullptr;
   }
 }

--- a/test/mlu_op_gtest/pb_gtest/tests/cnrt_test.h
+++ b/test/mlu_op_gtest/pb_gtest/tests/cnrt_test.h
@@ -40,7 +40,7 @@
 //
 //   int dev        = 0;  // not ptr, it's long unsigned int
 //   unsigned int dev_num = 0;
-//   ASSERT_TRUE(CNRT_RET_SUCCESS == cnrtGetDeviceCount(&dev_num));
+//   ASSERT_TRUE(cnrtSuccess == cnrtGetDeviceCount(&dev_num));
 //   ASSERT_GT(dev_num, 0);  // dev_num > 0
 //
 //   ASSERT_TRUE(cnrtSuccess == cnrtGetDevice(&dev));  // use device: 0
@@ -83,7 +83,7 @@
 
 TEST(DISABLED_CNRT, cnrtMemGetInfo) {
   unsigned int dev_num = 0;
-  ASSERT_TRUE(CNRT_RET_SUCCESS == cnrtGetDeviceCount(&dev_num));
+  ASSERT_TRUE(cnrtSuccess == cnrtGetDeviceCount(&dev_num));
   ASSERT_GT(dev_num, 0);  // dev_num > 0
 
   int dev_id;
@@ -100,18 +100,18 @@ TEST(DISABLED_CNRT, cnrtMemGetInfo) {
 
 // example,
 // this test is useless
-// test cnrtNotifier:
+// test cnrtNotifier_t:
 // 1.create notifier
 // 2.place notifier
 // 3.get duration
 // 4.destroy notifier
 // multi-thread create and place notifier to 1 queue.
 // and multi-thread destroy these notifier
-TEST(DISABLED_CNRT, cnrtNotifier) {
+TEST(DISABLED_CNRT, cnrtNotifier_t) {
   const size_t thread_num = 4;
 
   unsigned int dev_num = 0;
-  ASSERT_TRUE(CNRT_RET_SUCCESS == cnrtGetDeviceCount(&dev_num));
+  ASSERT_TRUE(cnrtSuccess == cnrtGetDeviceCount(&dev_num));
   ASSERT_GT(dev_num, 0);
 
   int dev_id;
@@ -130,15 +130,15 @@ TEST(DISABLED_CNRT, cnrtNotifier) {
   auto task_part1 = [&queue, &ctxs](int idx) {
     ASSERT_TRUE(cnrtSuccess == cnrtNotifierCreate(&(ctxs.at(idx).na)));
     ASSERT_TRUE(cnrtSuccess == cnrtNotifierCreate(&(ctxs.at(idx).nb)));
-    ASSERT_TRUE(CNRT_RET_SUCCESS == cnrtPlaceNotifier(ctxs.at(idx).na, queue));
-    ASSERT_TRUE(CNRT_RET_SUCCESS == cnrtPlaceNotifier(ctxs.at(idx).nb, queue));
+    ASSERT_TRUE(cnrtSuccess == cnrtPlaceNotifier(ctxs.at(idx).na, queue));
+    ASSERT_TRUE(cnrtSuccess == cnrtPlaceNotifier(ctxs.at(idx).nb, queue));
   };
 
   auto task_part2 = [&queue, &ctxs](int idx) {
     ASSERT_TRUE(cnrtSuccess == cnrtQueueSync(queue));
 
     float hwt = -1.0f;
-    ASSERT_TRUE(CNRT_RET_SUCCESS ==
+    ASSERT_TRUE(cnrtSuccess ==
                 cnrtNotifierDuration(ctxs.at(idx).na, ctxs.at(idx).nb, &hwt));
     ASSERT_EQ(0.0f, hwt);
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.