### PR TITLE
[Fix](mluOpCarafeForward,mluOpCarafeBackward): fix gen_case bug and a…

### DIFF
--- a/kernels/carafe/carafe.cpp
+++ b/kernels/carafe/carafe.cpp
@@ -783,6 +783,11 @@ mluOpStatus_t MLUOP_WIN_API mluOpCarafeForward(
                 &grid_dimG, &grid_dimC, &job_num),
       "Error occured in generating policy.");
 
+  {
+    LARGE_TENSOR_CHECK("[mluOpCarafeForward]", input_desc);
+    LARGE_TENSOR_CHECK("[mluOpCarafeForward]", mask_desc);
+    LARGE_TENSOR_CHECK("[mluOpCarafeForward]", output_desc);
+  }
   // GEN_CASE
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("carafe_forward", "CARAFE_FORWARD");
@@ -790,12 +795,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpCarafeForward(
     GEN_CASE_DATA(true, "input", input, input_desc, 5.1, -5.3);
     GEN_CASE_DATA(true, "mask", mask, mask_desc, 0.0, 1.0);
     GEN_CASE_DATA(false, "output", output, output_desc, 1.7, -1.8);
-    GEN_CASE_OP_PARAM_SINGLE(0, "carafe_forward", "dimnb", carafe_desc->dimNb);
-    GEN_CASE_OP_PARAM_SINGLE(1, "carafe_forward", "kernel_size",
+    GEN_CASE_OP_PARAM_SINGLE(0, "carafe", "dimnb", carafe_desc->dimNb);
+    GEN_CASE_OP_PARAM_SINGLE(1, "carafe", "kernel_size",
                              carafe_desc->kernel_size);
-    GEN_CASE_OP_PARAM_SINGLE(1, "carafe_forward", "group_size",
+    GEN_CASE_OP_PARAM_SINGLE(1, "carafe", "group_size",
                              carafe_desc->group_size);
-    GEN_CASE_OP_PARAM_SINGLE(2, "carafe_forward", "scale_factor",
+    GEN_CASE_OP_PARAM_SINGLE(2, "carafe", "scale_factor",
                              carafe_desc->scale_factor);
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
   }
@@ -840,6 +845,14 @@ mluOpStatus_t MLUOP_WIN_API mluOpCarafeBackward(
     return param_check_status;
   }
 
+  {
+    LARGE_TENSOR_CHECK("[mluOpCarafeBackward]", input_desc);
+    LARGE_TENSOR_CHECK("[mluOpCarafeBackward]", mask_desc);
+    LARGE_TENSOR_CHECK("[mluOpCarafeBackward]", grad_output_desc);
+    LARGE_TENSOR_CHECK("[mluOpCarafeBackward]", grad_input_desc);
+    LARGE_TENSOR_CHECK("[mluOpCarafeBackward]", grad_mask_desc);
+  }
+
   if (MLUOP_GEN_CASE_ON_NEW) {
     GEN_CASE_START("carafe_backward", "CARAFE_BACKWARD");
     GEN_CASE_HANDLE(handle);
@@ -849,12 +862,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpCarafeBackward(
                   -1.8);
     GEN_CASE_DATA(false, "grad_input", grad_input, grad_input_desc, 0, 0);
     GEN_CASE_DATA(false, "grad_mask", grad_mask, grad_mask_desc, 0, 0);
-    GEN_CASE_OP_PARAM_SINGLE(0, "carafe_backward", "dimnb", carafe_desc->dimNb);
-    GEN_CASE_OP_PARAM_SINGLE(1, "carafe_backward", "kernel_size",
+    GEN_CASE_OP_PARAM_SINGLE(0, "carafe", "dimnb", carafe_desc->dimNb);
+    GEN_CASE_OP_PARAM_SINGLE(1, "carafe", "kernel_size",
                              carafe_desc->kernel_size);
-    GEN_CASE_OP_PARAM_SINGLE(1, "carafe_backward", "group_size",
+    GEN_CASE_OP_PARAM_SINGLE(1, "carafe", "group_size",
                              carafe_desc->group_size);
-    GEN_CASE_OP_PARAM_SINGLE(2, "carafe_backward", "scale_factor",
+    GEN_CASE_OP_PARAM_SINGLE(2, "carafe", "scale_factor",
                              carafe_desc->scale_factor);
     GEN_CASE_TEST_PARAM_NEW(true, true, false, 0.003, 0.003, 0);
   }


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

1.fix gen_case bug of carafe_forward and carafe_backward
2.add LARGE_TENSOR_CHECK.

## 2. Modification

modified: kernels/carafe/carafe.cpp

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.