### PR TITLE
fix spelling errors and formats

### DIFF
--- a/kernels/fft/common/fft_common_kernels.mlu
+++ b/kernels/fft/common/fft_common_kernels.mlu
@@ -99,9 +99,8 @@ __mlu_func__ void genSinCosVec(float *src_addr, float *sin_addr,
  */
 __mlu_func__ void genSelectOffsetVec(float *offset_addr,
                                      int32_t *offset_int_addr, int deal_size) {
-  for (int i = 0; i < deal_size; i++) {
-    offset_int_addr[i] = (int)(offset_addr[i]);
-  }
+  __bang_mul_scalar(offset_addr, offset_addr, (float)sizeof(float), deal_size);
+  __bang_float2int32((int32_t *)offset_int_addr, offset_addr, deal_size, 0);
 }
 
 /*
@@ -115,9 +114,16 @@ __mlu_func__ void genSelectOffsetVec(float *offset_addr,
  */
 __mlu_func__ void selectVec(float *src_addr, int32_t *offset_int_addr,
                             float *dst_addr, int deal_size) {
+#if __BANG_ARCH__ >= 372 && __BANG_ARCH__ != 520
+  __asm__ volatile(
+      "gather.clean.nram.nram.nram.b32.u32 "
+      "[%[dst]], [%[src]], [%[offset]], %[data_num];\n\t" ::[dst] "r"(dst_addr),
+      [src] "r"(src_addr), [offset] "r"(offset_int_addr), [data_num] "r"(deal_size));
+#else
   for (auto i = 0; i < deal_size; i++) {
     dst_addr[i] = src_addr[offset_int_addr[i]];
   }
+#endif
 }
 
 /*
@@ -152,7 +158,7 @@ __mlu_func__ void generateRFFTHalfDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mlu_op_gen_stage_index(inc_addr, deal_size, 0.0f, 1.0f);
 
   // generate sin and cos vectors
   const float scale = -2.0 * M_PI / n;
@@ -236,7 +242,7 @@ __mlu_func__ void generateRFFTFullDFTMatrixImpl(int row, int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mlu_op_gen_stage_index(inc_addr, deal_size, 0.0f, 1.0f);
 
   // generate sin and cos vectors
   const float scale = -2.0 * M_PI / n;
@@ -325,7 +331,7 @@ __mlu_func__ void generateIRFFTHalfDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mlu_op_gen_stage_index(inc_addr, deal_size, 0.0f, 1.0f);
 
   // generate sin and cos coefficient vectors
   __bang_write_value((float *)cos_coeff_addr, deal_size, (float)2.0);
@@ -420,7 +426,7 @@ __mlu_func__ void generateIRFFTFullDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mlu_op_gen_stage_index(inc_addr, deal_size, 0.0f, 1.0f);
 
   // generate sin and cos vectors
   const float scale = 2.0 * M_PI / n;
@@ -516,7 +522,7 @@ __mlu_func__ void generateC2CFFTDFTMatrixImpl(int n, void *output) {
   float *row_addr = temp_addr;
 
   // generate 0 to n indices
-  __mluop_get_indices(inc_addr, (float)0.0, deal_size);
+  __mlu_op_gen_stage_index(inc_addr, deal_size, 0.0f, 1.0f);
 
   // generate sin and cos vectors
   const float forward_scale = -2.0 * M_PI / n;

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -14328,6 +14328,24 @@ mluOpSetFFTReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan, void *rese
  *   output is n/2 + 1 non-redundant complex numbers. This requires a padding of input array.
  * - For in-place N-D real-to-complex FFTs, extra padding of the real-data array on the innermost
  *   dimension is necessary to accommodate the size of the complex-data output.
+ * - For 2D FFTs, cases with strides that meet the following conditions have
+ *   better performance:
+ *     - real-to-complex:
+ *       - n[0] < 200, n[0] == inembed[0], onembed[0] == n[0]
+ *       - n[1] < 200, n[1] == inembed[1], onembed[1] == n[1]/2+1
+ *       - input:  dims[batch, n0, n1], strides[1, batch*n1, batch]
+ *       - output: dims[batch, n0, n1/2+1], strides[1, batch*(n1/2+1), batch]
+ *     - complex-to-complex:
+ *       - n[0] < 200, n[0] == inembed[0], onembed[0] == n[0]
+ *       - n[1] < 200, n[1] == inembed[1], onembed[1] == n[1]
+ *       - input:  dims[batch, n0, n1], strides[1, batch*n1, batch]
+ *       - output: dims[batch, n0, n1], strides[1, batch*n1, batch]
+ *     - complex-to-real:
+ *       - n[0] < 200, n[0] == inembed[0], onembed[0] == n[0]
+ *       - n[1] < 200, n[1]/2+1 == inembed[1], onembed[1] == n[1]
+ *       - input:  dims[batch, n0, n1/2+1], strides[1, batch*(n1/2+1), batch]
+ *       - output: dims[batch, n0, n1], strides[1, batch*n1, batch]
+ *
  * - When \p input contains NaN or infinity and the input onchip data type of FFT is not quantized
  *   data type, the output is computed through the FFT formula with computation rules of NaN or
  *   infinity based on IEEE 754.

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -14333,17 +14333,17 @@ mluOpSetFFTReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan, void *rese
  *     - real-to-complex:
  *       - n[0] < 200, n[0] == inembed[0], onembed[0] == n[0]
  *       - n[1] < 200, n[1] == inembed[1], onembed[1] == n[1]/2+1
- *       - input:  dims[batch, n0, n1], strides[1, batch*n1, batch]
+ *       - input: dims[batch, n0, n1], strides[1, batch*n1, batch]
  *       - output: dims[batch, n0, n1/2+1], strides[1, batch*(n1/2+1), batch]
  *     - complex-to-complex:
  *       - n[0] < 200, n[0] == inembed[0], onembed[0] == n[0]
  *       - n[1] < 200, n[1] == inembed[1], onembed[1] == n[1]
- *       - input:  dims[batch, n0, n1], strides[1, batch*n1, batch]
+ *       - input: dims[batch, n0, n1], strides[1, batch*n1, batch]
  *       - output: dims[batch, n0, n1], strides[1, batch*n1, batch]
  *     - complex-to-real:
  *       - n[0] < 200, n[0] == inembed[0], onembed[0] == n[0]
  *       - n[1] < 200, n[1]/2+1 == inembed[1], onembed[1] == n[1]
- *       - input:  dims[batch, n0, n1/2+1], strides[1, batch*(n1/2+1), batch]
+ *       - input: dims[batch, n0, n1/2+1], strides[1, batch*(n1/2+1), batch]
  *       - output: dims[batch, n0, n1], strides[1, batch*n1, batch]
  *
  * - When \p input contains NaN or infinity and the input onchip data type of FFT is not quantized

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -362,7 +362,7 @@ typedef enum {
 typedef enum {
   MLUOP_REDUCE_DSUM  = 0, /*!< Computes the sum value. */
   MLUOP_REDUCE_DMEAN = 1, /*!< Computes the mean value. */
-  MLUOP_REDUCE_DMAX  = 2, /*!< Computes the maximun value. */
+  MLUOP_REDUCE_DMAX  = 2, /*!< Computes the maximum value. */
 } mluOpReduceMode_t;
 
 /*!
@@ -804,7 +804,7 @@ mluOpGetQuantizeRoundMode(mluOpHandle_t handle, mluOpQuantizeRoundMode_t *round_
 /*!
  * @brief Updates the specific atomics mode of MLU-OPS context information that is held by the
  * \b handle. This function should be called if you want to change the atomics mode that is
- * used to cumulate the results.For detailed information, see "Cambricon CNDrv Developer Guide".
+ * used to cumulate the results. For detailed information, see "Cambricon CNDrv Developer Guide".
  *
  * @param[in] handle
  * Pointer to a Cambricon MLU-OPS context that is used to manage MLU devices and queues. For detailed
@@ -1417,7 +1417,7 @@ mluOpSetTensorDescriptor(
  *   The descriptor of the tensor. For detailed information,
  *   see ::mluOpTensorDescriptor_t.
  * @param[in] pointer_mode
- *   The pointer mode of the input tensor. For detailed information, seee ::mluOpPointerMode_t.
+ *   The pointer mode of the input tensor. For detailed information, see ::mluOpPointerMode_t.
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
  *
@@ -1571,13 +1571,13 @@ mluOpSetTensorDescriptor_v2(mluOpTensorDescriptor_t desc,
  * convolution operation. If \b dimNb is set to 4, the output_space should be set in height and width
  * dimension. If \b dimNb is set to 5, the output_space should be set in depth, height and width dimension.
  * @param[in] sub_m
- * An value that determine the algorithms for sparse convolution. If \b sub_m is set to 0, the
+ * A value that determine the algorithms for sparse convolution. If \b sub_m is set to 0, the
  * algorithms will be the default sparse convolution. If \b sub_m is set to 0, the algorithms will be the
  * submanifold sparse convolution.
  * @param[in] transpose
- * An value that determines transpose.
+ * A value that determines transpose.
  * @param[in] inverse
- * An value that determines inverse.
+ * A value that determines inverse.
  *
  * @par Return
  * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_EXECUTION_FAILED
@@ -1979,7 +1979,7 @@ mluOpSetTensorDescriptorDim_v2(mluOpTensorDescriptor_t desc, int dimNb, const in
  * @param[in] desc
  * The descriptor of the tensor desc. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] onchip_dtype
- * The on-chip data type of the tensor is used in the functon that supports fixed-point
+ * The on-chip data type of the tensor is used in the function that supports fixed-point
  * computing.
  *
  * @par Return
@@ -2831,9 +2831,9 @@ mluOpInitTensorSetMemberDescriptor(mluOpTensorSetDescriptor_t tensorSetDesc,
  * - None.
  *
  * @par Note
- * - If the member tensor is in floating-point data type, and  you need to call
+ * - If the member tensor is in floating-point data type, and you need to call
  *   this function.
- * - If the member tensor is in fixed-point data type, and  you need to call
+ * - If the member tensor is in fixed-point data type, and you need to call
  *   this function.
  * - Before calling this function,
  *   You need to call ::mluOpCreateTensorSetDescriptor to create
@@ -3077,7 +3077,7 @@ mluOpLog(mluOpHandle_t handle,
 // Group: Carafe
 /*!
  * @brief Creates a descriptor pointed by \b carafe_desc for CARAFE upsampling forward and backward operations,
- * and allocates memory holding the configuration parameters.The information is defined in ::mluOpCarafeDescriptor_t.
+ * and allocates memory holding the configuration parameters. The information is defined in ::mluOpCarafeDescriptor_t.
  * For more information about descriptor, see "Cambricon MLU-OPS User Guide".
  *
  * @param[in] carafe_desc
@@ -3797,7 +3797,7 @@ mluOpGetDynamicPointToVoxelForwardWorkspaceSize(mluOpHandle_t handle,
  * - The first dimension of \b voxel_num tensor must be equal to \b voxel_feats_desc[0].
  *
  * @par API Dependency
- * - Before calling this function to perform unique operater, you need to get
+ * - Before calling this function to perform unique operator, you need to get
  *   the size of workspace by ::mluOpGetDynamicPointToVoxelForwardWorkspaceSize.
  *
  * @par Note
@@ -4051,7 +4051,7 @@ mluOpGetGenerateProposalsV2WorkspaceSize_v2(mluOpHandle_t handle,
  * - None.
  *
  * @par Note
- * - The operater does not support adaptive NMS.
+ * - The operator does not support adaptive NMS.
  * - The attribute `eta` should not be less than 1.
  * - ``nms_thresh`` should be more than 0.
  * - On MLU300 series and above:
@@ -4381,7 +4381,7 @@ mluOpSetNmsDescriptor(mluOpNmsDescriptor_t nms_desc,
  * @param[in] nms_desc
  * The descriptor of the Nms function. For detailed information, see ::mluOpNmsDescriptor_t.
  * @param[in] boxes_desc
- * The descriptor of the tensor \b boxes , including the information of dimension, data type, and
+ * The descriptor of the tensor \b boxes, including the information of dimension, data type, and
  * layout of input boxes. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] boxes
  * Pointer to the MLU memory that stores the input boxes tensor.
@@ -4485,7 +4485,7 @@ mluOpNms(mluOpHandle_t handle,
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and
  * queues in the Nms operation. For detailed information, see ::mluOpHandle_t.
  * @param[in] boxes_desc
- * The descriptor of the tensor \b boxes , which contains dimension, data type, and
+ * The descriptor of the tensor \b boxes, which contains dimension, data type, and
  * data layout of input \b boxes. For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] confidence_desc
  * The descriptor of the tensor \b confidence , which contains dimension, data type, and
@@ -4574,7 +4574,7 @@ mluOpGetNmsWorkspaceSize(mluOpHandle_t handle,
  * @param[in] offset
  * The prior box center offset.
  * @param[in] clip
- * A bool value whether to clip out-of-boundary boxes.
+ * A Boolean value whether to clip out-of-boundary boxes.
  * @param[in] min_max_aspect_ratios_order
  * If the value is set as True, the \b output prior box is in
  * the order of [min, max, aspect_ratios]; otherwise the order is
@@ -4794,7 +4794,7 @@ mluOpPsRoiPoolForward(mluOpHandle_t handle,
 // Group: PsRoiPool
 /*!
  * @brief Computes the gradients of feature map \b bottom_grad based on the
- * inputs \b top_grad , \b rois , and \b mapping_channel to perform the backpropagation
+ * inputs \b top_grad, \b rois, and \b mapping_channel to perform the backpropagation
  * of ::mluOpPsRoiPoolForward.
  *
  * @param[in] handle
@@ -4952,7 +4952,7 @@ mluOpCreateRoiAlignForwardDescriptor(mluOpRoiAlignForwardDescriptor_t *desc);
  * If \b pool_mode is 1, the average pooling mode is used.
  * If \b pool_mode is 0, the maximum pooling mode is used.
  * @param[in] aligned
- * A boolean value which determines whether to shift the boxes by 0.5 pixel. If \b aligned
+ * A Boolean value which determines whether to shift the boxes by 0.5 pixel. If \b aligned
  * is true, the boxes is shifted by 0.5. If \b aligned is false, the boxes is not shifted.
  *
  * @par Return
@@ -5113,7 +5113,7 @@ mluOpDestroyRoiAlignForwardDescriptor(mluOpRoiAlignForwardDescriptor_t desc);
  *
  * @par Note
  * - When \b input contains NaN. If \b pool_mode is maximum pooling_mode, \b output is positive
- *   saturation value on MLU200 series, and \b output gets more NaN than ieee754 on MLU300 series.
+ *   saturation value on MLU200 series, and \b output gets more NaN than IEEE 754 on MLU300 series.
  *
  * @par Example
  * - The example of ::mluOpRoiAlignForward_v2 is as follows:
@@ -5181,11 +5181,11 @@ mluOpRoiAlignForward_v2(mluOpHandle_t handle,
  * @param[in] spatial_scale
  * The spatial scale of each ROI in the output.
  * @param[in] aligned
- * A boolean value which determines whether to shift the ROI by 0.5 pixel. If the
+ * A Boolean value which determines whether to shift the ROI by 0.5 pixel. If the
  * value of \b aligned is set to true, the ROI is shifted by 0.5. If the value of \b aligned
  * is set to false, the ROI is not shifted.
  * @param[in] clockwise
- * A boolean value which determines whether the rotation of ROI is clockwise.
+ * A Boolean value which determines whether the rotation of ROI is clockwise.
  * @param[out] output_desc
  * The descriptor of output, which contains dimension and the layout of output.
  * @param[out] output
@@ -5291,11 +5291,11 @@ mluOpRoiAlignRotatedForward(mluOpHandle_t handle,
  * @param[in] spatial_scale
  * The spatial scale of each ROI in the output.
  * @param[in] aligned
- * A boolean value which determines whether to shift the ROI by 0.5 pixel.
+ * A Boolean value which determines whether to shift the ROI by 0.5 pixel.
  * If the value of \b aligned is set to true, the ROI is shifted by 0.5. If the value
  * of \b aligned is set to false, the ROI is not shifted.
  * @param[in] clockwise
- * A boolean value which determines whether the rotation of ROI is clockwise.
+ * A Boolean value which determines whether the rotation of ROI is clockwise.
  * @param[in] bottom_grad_desc
  * The descriptor of the tensor \b bottom_grad.
  * @param[out] bottom_grad
@@ -5850,7 +5850,7 @@ mluOpSqrtBackward(mluOpHandle_t handle,
  * @param[in] NDim
  * An integer value which is the second dimension of coors.
  * @param[in] deterministic
- * A bool value whether to invoke the non-deterministic
+ * A Boolean value whether to invoke the non-deterministic
  * version of hard-voxelization implementations. Currently,
  * non-deterministic mode is not supported.
  * @param[in] voxels_desc
@@ -5940,11 +5940,11 @@ mluOpGetVoxelizationWorkspaceSize(mluOpHandle_t handle,
  * in a voxel.
  * @param[in] max_voxels
  * An integer value which is the maximum number of voxels this
- * function create.
+ * function creates.
  * @param[in] NDim
  * An integer value which is the second dimension of coors.
  * @param[in] deterministic
- * A bool value whether to invoke the non-deterministic
+ * A Boolean value whether to invoke the non-deterministic
  * version of hard-voxelization implementations. Currently,
  * non-deterministic mode is not supported.
  * @param[in] workspace
@@ -6093,7 +6093,7 @@ mluOpVoxelization(mluOpHandle_t handle,
  * @par Scale Limitation
  * - The first dimension of x tensor, img_size tensor, boxes tensor and scores
  *   tensor must be the same size.
- * - The second dimension (the channel dimension) of x tensor , C should be equal to S * (5 +
+ * - The second dimension (the channel dimension) of x tensor, C should be equal to S * (5 +
  *   class_num) if \b iou_aware is false, otherwise C should be equal to S * (6 + class_num),
  *   the value S is equal to the anchors tensor size divided by 2.
  * - The first dimension of anchors tensor should be larger than 0.
@@ -6214,7 +6214,7 @@ mluOpYoloBox(mluOpHandle_t handle,
  *
  * @par Note
  * - The function does not support MLU200 series.
- * - You need to set the initial value for the output \b pos_memo before calling the funtion, and initialize it to a
+ * - You need to set the initial value for the output \b pos_memo before calling the function, and initialize it to a
  *   negative number.
  *
  * @par Reference
@@ -6255,7 +6255,7 @@ mluOpVoxelPoolingForward(mluOpHandle_t handle,
  * IOU (Intersection Over Union) or IOF (Intersection Over Foreground).
  * The integer 0 represents IOU and 1 represents IOF.
  * @param[in] aligned
- * A boolean value. If it is false, then calculate the IOU[i][j]
+ * A Boolean value. If it is false, then calculate the IOU[i][j]
  * or IOF[i][j] between the row i of \b bbox1 and the row j of \b bbox2,
  * otherwise calculate the IOU[i] or IOFs[i] between the row i of \b bbox1
  * and the row i of \b bbox2. Significantly, the numbers of rows of \b bbox1
@@ -6409,7 +6409,7 @@ mluOpGetNmsRotatedWorkspaceSize(mluOpHandle_t handle, const mluOpTensorDescripto
  *
  * @par Data Type
  * - By the order of \b boxes - \b scores - \b output, the supported data types of
- *   \b boxes , \b scores , and \b output tensors are as follows:
+ *   \b boxes, \b scores, and \b output tensors are as follows:
  *   - float - float - int32
  *
  * @par Scale Limitation
@@ -6459,9 +6459,9 @@ mluOpNmsRotated(mluOpHandle_t handle,
  * An integer value which decides to return a result IOU or IOF.
  * The integer 0 represents IOU and 1 represents IOF.
  * @param[in] aligned
- * A boolean value. If it is false, this operation calculates the IOUs[i][j] or IOFs[i][j] between
+ * A Boolean value. If it is false, this operation calculates the IOUs[i][j] or IOFs[i][j] between
  * the row i of \b bbox1 and the row j of \b bbox2, otherwise the IOU[i] or IOF[i] between
- * the row i of \b bbox1 and the row i of \b bbox2 are calculated. The number of row of \b bbox1
+ * the row i of \b bbox1 and the row i of \b bbox2 are calculated. The number of rows of \b bbox1
  * and \b bbox2 must be equal if \b aligned is true.
  * @param[in] offset
  * An integer value determines whether to increase the length and the width of the bounding-box by 0 or 1
@@ -6617,12 +6617,12 @@ mluOpBboxOverlaps(mluOpHandle_t handle,
  *   - output tensor: \p MLUOP_LAYOUT_ARRAY
  *
  * @par Scale Limitation
- * - The dimension of \b features , \b indices , \b weights , and \b output
+ * - The dimension of \b features, \b indices, \b weights, and \b output
  *   should be equal to 3.
- * - The shape[0] of \b features , \b indices , \b weights , and \b output
+ * - The shape[0] of \b features, \b indices, \b weights, and \b output
  *   should be the same.
  * - The shape[1] of \b features and \b output should be the same.
- * - The shape[1] of \b indices , \b weights , and the shape[2] of \b output
+ * - The shape[1] of \b indices, \b weights, and the shape[2] of \b output
  *   should be the same.
  * - The shape[2] of \b indices and \b weights should be equal to 3.
  *
@@ -6655,7 +6655,7 @@ mluOpThreeInterpolateForward(mluOpHandle_t handle,
 // Group: ThreeInterpolate
 /*!
  * @brief Computes the gradients of feature map \b grad_features based on the
- * inputs \b grad_output , \b indices , and \b weights to perform the backpropagation
+ * inputs \b grad_output, \b indices, and \b weights to perform the backpropagation
  * of ::mluOpThreeInterpolateForward.
  *
  * @param[in] handle
@@ -6880,7 +6880,7 @@ mluOpBallQuery(mluOpHandle_t handle,
  *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
- * - The supported data types of input tensors \b input, \b target, \b weight , and output
+ * - The supported data types of input tensors \b input, \b target, \b weight, and output
  *   tensor \b output are as follows:
  *   - input: half, float
  *   - target: int32
@@ -6994,7 +6994,7 @@ mluOpFocalLossSigmoidForward(mluOpHandle_t handle,
  *   ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
- * - The supported data types of input tensor \b input, \b target, \b weight , and output
+ * - The supported data types of input tensor \b input, \b target, \b weight, and output
  *   tensor \b output are as follows:
  *   - input: float, half
  *   - target: int32
@@ -7170,7 +7170,7 @@ mluOpGetMaskedIm2colForwardWorkspaceSize(mluOpHandle_t handle,
  *   - data_col tensor: half, float.
  *
  * @par Data Layout
- * - The supported data layouts of \b feature , \b mask_h_idx , \b mask_w_idx , and \b data_col are as follows:
+ * - The supported data layouts of \b feature, \b mask_h_idx, \b mask_w_idx, and \b data_col are as follows:
  *   - feature tensor: \p MLUOP_LAYOUT_NCHW.
  *   - mask_h_idx tensor: \p MLUOP_LAYOUT_ARRAY.
  *   - mask_w_idx tensor: \p MLUOP_LAYOUT_ARRAY.
@@ -7291,8 +7291,8 @@ mluOpMaskedIm2colForward(mluOpHandle_t handle,
  *   tensor must be the same size and equal to \b samples .
  * - The second dimension of \b grad_input tensor and \b dispatch tensor must be equal to \b hidden .
  * - The first dimension of \b dispatch tensor must be equal to the multiplication result of
- *   the \b capacity and \b num_experts .
- * - The value of the input parameters \b samples , \b capacity , \b hidden , and \b num_experts
+ *   the \b capacity and \b num_experts.
+ * - The value of the input parameters \b samples, \b capacity , \b hidden , and \b num_experts
  *   must be greater than or equal to 0.
  * - The value range of the input parameter \b indices tensor must be greater than or equal to 0 and less than
  *   \b num_experts.
@@ -7304,7 +7304,7 @@ mluOpMaskedIm2colForward(mluOpHandle_t handle,
  *
  * @par Note
  * - This function is only supported on MLU300 series or above platforms.
- * - The parameter \b samples , \b capacity , \b hidden , and \b num_experts should not be negative.
+ * - The parameter \b samples, \b capacity , \b hidden , and \b num_experts should not be negative.
  *
  * @par Example
  * - The example of the function is as follows:
@@ -7475,7 +7475,7 @@ mluOpMsDeformAttnBackward(mluOpHandle_t handle,
  * The descriptor of the tensor \b ans_grad containing dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[in] overwrite_ans_grad
- * A boolean value indicating whether to overwrite \b ans_grad.
+ * A Boolean value indicating whether to overwrite \b ans_grad.
  * @param[out] workspace_size
  * Pointer to the MLU memory that stores the returned size of the extra workspace in bytes.
  *
@@ -7546,7 +7546,7 @@ mluOpGetMutualInformationBackwardWorkspaceSize(mluOpHandle_t handle,
  * @param[in] ans_grad
  * Pointer to the MLU memory that stores the tensor \b ans_grad.
  * @param[in] overwrite_ans_grad
- * A boolean value indicating whether to overwrite \b ans_grad.
+ * A Boolean value indicating whether to overwrite \b ans_grad.
  * @param[in] workspace
  * Pointer to the MLU memory as an extra workspace for the mutual_information_backward operation.
  * For more information about the workspace, see "Cambricon MLU-OPS User Guide".
@@ -7897,7 +7897,7 @@ mluOpGetRoiAwarePool3dForwardWorkspaceSize(mluOpHandle_t handle,
  * @brief Returns \b argmax, \b pts_idx_of_voxels and \b pooled_features calculated by
  * this operator.
  *
- * The operator determine the points in each box based on input coordinates. The collection
+ * The operator determines the points in each box based on input coordinates. The collection
  * of points in boxes are named as voxels and recorded as \b pts_idx_of_voxels. The operator
  * also performs max pooling or average pooling on the voxels and results in \b argmax
  * and \b pooled_features.
@@ -8032,7 +8032,7 @@ mluOpRoiawarePool3dForward(mluOpHandle_t handle,
  * @brief Returns \b argmax, \b pts_idx_of_voxels and \b pooled_features calculated by
  * this operator.
  *
- * The operator determine the points in each box based on input coordinates. The collection
+ * The operator determines the points in each box based on input coordinates. The collection
  * of points in boxes are named as voxels and recorded as \b pts_idx_of_voxels. The operator
  * also performs max pooling or average pooling on the voxels and results in \b argmax
  * and \b pooled_features.
@@ -8350,7 +8350,7 @@ mluOpRoiAwarePool3dBackward(mluOpHandle_t handle,
 
 // Group: Psamask
 /*!
- * @brief Moves the \b x tensor to \b y tensor according to \b h_mask , \b w_mask , and \b psa_type.
+ * @brief Moves the \b x tensor to \b y tensor according to \b h_mask, \b w_mask, and \b psa_type.
  *
  *
  * @param[in] handle
@@ -8430,7 +8430,7 @@ mluOpPsamaskForward(mluOpHandle_t handle,
 // Group: Psamask
 /*!
  * @brief Computes the gradients of input tensor \b dx with the gradients of output tensor \b dy
- * according to \b h_mask , \b w_mask , and \b psa_type.
+ * according to \b h_mask, \b w_mask, and \b psa_type.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and
@@ -8509,7 +8509,7 @@ mluOpPsamaskBackward(mluOpHandle_t handle,
 // Group: SparseConv
 /*!
  * @brief Computes the get_indice_paris operation, then returns the results in the output
- * tensor \b out_indices , \b indice_pairs and \b ind, ice_num.
+ * tensor \b out_indices, \b indice_pairs and \b ind, ice_num.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in the
@@ -8553,7 +8553,7 @@ mluOpPsamaskBackward(mluOpHandle_t handle,
  * @par Data Type
  * - This function supports the combinations of the following data types for
  *   input tensor \b indices and output tensor \b out_indices, \b indice_pairs and \b indice_num.
- * - \b indices , \b out_indices , \b indice_pairs , and \b indice_num data type: int32, int32, int32, int32
+ * - \b indices, \b out_indices, \b indice_pairs, and \b indice_num data type: int32, int32, int32, int32
  *
  * @par Data Layout
  * - None.
@@ -8611,8 +8611,8 @@ mluOpGetIndicePairs(mluOpHandle_t handle,
  * to optimize the get_indice_pairs operation.
  *
  * The size of extra workspace is based on the given information of the get_indice_pairs
- * operation, including the input tensor descriptor \b sparse_conv_desc , and \b indices_desc, output
- * tensor descriptor \b out_indices_desc , \b indice_pairs_desc , and \b indice_num_desc.
+ * operation, including the input tensor descriptor \b sparse_conv_desc, and \b indices_desc, output
+ * tensor descriptor \b out_indices_desc, \b indice_pairs_desc, and \b indice_num_desc.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in the
@@ -8650,7 +8650,7 @@ mluOpGetIndicePairs(mluOpHandle_t handle,
  *
  * @par API Dependency
  * - You need to call ::mluOpCreateTensorDescriptor and ::mluOpSetTensorDescriptor to create and set
- *   tensor descriptors \b indices_desc , \b out_indices_desc , \b indice_pairs_desc , and \b indice_num_desc before
+ *   tensor descriptors \b indices_desc, \b out_indices_desc, \b indice_pairs_desc, and \b indice_num_desc before
  *   calling this function.
  * - You need to call ::mluOpCreateSparseConvolutionDescriptor to create a descriptor,
  *   and call ::mluOpSetSparseConvolutionDescriptor to set the tensor information for
@@ -8963,7 +8963,7 @@ mluOpCreateAdamWDescriptor(mluOpAdamWDescriptor_t *adamw_desc);
 /*!
  * @brief Initializes the descriptor \b adamw_desc that was previously created with
  * ::mluOpCreateAdamWDescriptor function, and sets AdamW information
- * to the descriptor \b adamw_desc. The information includes \b weight_decay , \b grad_scale
+ * to the descriptor \b adamw_desc. The information includes \b weight_decay, \b grad_scale
  * and \b use_nesterov for AdamW operation.
  *
  * @param[in] adamw_desc
@@ -9147,7 +9147,7 @@ mluOpDeformRoiPoolForward(const mluOpHandle_t handle,
 // Group: DeformRoiPool
 /*!
  * @brief Computes the gradient of input \b grad_input and the gradient of offset \b grad_offset
- * based on the gradient of output \b grad_output , input \b input , ROI \b rois , and offset \b offset.
+ * based on the gradient of output \b grad_output, input \b input, ROI \b rois, and offset \b offset.
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in
@@ -9314,11 +9314,11 @@ mluOpDeformRoiPoolBackward(const mluOpHandle_t handle,
  *   - boxes tensor: half, float
  *   - output tensor: half, float
  *   - argmax_idx tensor: int32_t
- *   Note that the data type of \b input , \b boxes , and \b output
+ *   Note that the data type of \b input, \b boxes, and \b output
  *   must be the same.
  *
  * @par Data Layout
- * - The supported data layout of \b input , \b boxes , \b output , and
+ * - The supported data layout of \b input, \b boxes, \b output, and
  *   \b argmax_idx are as follows:
  *   - input tensor: \p MLUOP_LAYOUT_NHWC
  *   - boxes tensor: \p MLUOP_LAYOUT_ARRAY
@@ -9414,7 +9414,7 @@ mluOpBorderAlignForward(mluOpHandle_t handle,
 // Group: BorderAlign
 /*!
  * @brief Computes the gradient of the input tensor of ::mluOpBorderAlignForward
- * according to the output gradient \b grad_output , the maximum pooling index \b
+ * according to the output gradient \b grad_output, the maximum pooling index \b
  * argmax_idx and bounding boxes \b boxes .
  *
  * @param[in] handle
@@ -9435,14 +9435,14 @@ mluOpBorderAlignForward(mluOpHandle_t handle,
  * Pointer to the MLU memory that stores \b boxes tensors. The shape of \b boxes is
  * [N, H * W, 4].
  * @param[in] argmax_idx_desc
- * Descriptor of \b argmax_idx , containing dimension and the layout of \b argmax_idx .
+ * Descriptor of \b argmax_idx, containing dimension and the layout of \b argmax_idx .
  * @param[in] argmax_idx
  * Pointer to the MLU memory that stores the \b argmax_idx tensor, which is the result
  * of max pooling index. The shape of argmax_idx is [N, K, 4, C].
  * @param[in] pool_size
  * Number of positions sampled over the boxes borders.
  * @param[in] grad_input_desc
- * Descriptor of \b grad_input , containing dimension and the layout of output.
+ * Descriptor of \b grad_input, containing dimension and the layout of output.
  * @param[out] grad_input
  * Pointer to the MLU memory that stores the gradient of the input
  * tensor of ::mluOpBorderAlignForward. The shape of \b grad_input is [N, H, W, 4C],
@@ -9459,11 +9459,11 @@ mluOpBorderAlignForward(mluOpHandle_t handle,
  *   - boxes tensor: half, float
  *   - argmax_idx tensor: int32_t
  *   - grad_input tensor: half, float
- *   Note that the data type of \b grad_output , \b boxes , and \b grad_input
+ *   Note that the data type of \b grad_output, \b boxes, and \b grad_input
  *   must be the same.
  *
  * @par Data Layout
- * - The supported data layout of \b grad_output , \b boxes , \b argmax_idx and,
+ * - The supported data layout of \b grad_output, \b boxes, \b argmax_idx and,
  *   \b grad_input are as follows:
  *   - grad_output tensor: \p MLUOP_LAYOUT_NHWC
  *   - boxes tensor: \p MLUOP_LAYOUT_ARRAY
@@ -9471,7 +9471,7 @@ mluOpBorderAlignForward(mluOpHandle_t handle,
  *   - grad_input tensor: \p MLUOP_LAYOUT_NHWC
  *
  * @par Scale Limitation
- * - The \b grad_output , \b argmax_idx and \b grad_input are 4D tensor.
+ * - The \b grad_output, \b argmax_idx and \b grad_input are 4D tensor.
  * - The \b boxes is 3D tensor.
  * - The dims[3] of \b boxes should be equal to 4.
  * - The shape of \b grad_output and \b argmax_idx must be the same.
@@ -9561,9 +9561,9 @@ mluOpBorderAlignBackward(mluOpHandle_t handle,
  *
  * The size of extra workspace is based on the given information of the indice
  * convolution backward data operation, including the input descriptor
- * \b input_grad_desc, the filter descriptor \b filter_desc , the indice pairs
- * descriptor \b indice_pairs_desc , the output descriptor \b indice_pairs_desc ,
- * the array \b indice_num , and the scaler \b inverse. For more information
+ * \b input_grad_desc, the filter descriptor \b filter_desc, the indice pairs
+ * descriptor \b indice_pairs_desc, the output descriptor \b indice_pairs_desc,
+ * the array \b indice_num, and the scaler \b inverse. For more information
  * about the workspace, see "Cambricon MLU-OPS User Guide".
  *
  * @param[in] handle
@@ -9605,7 +9605,7 @@ mluOpBorderAlignBackward(mluOpHandle_t handle,
  * @par API Dependency
  * - This function must be called before ::mluOpIndiceConvolutionBackwardData.
  * - ::mluOpCreateTensorDescriptor and ::mluOpSetTensorDescriptor
- *   create and set the tensor descriptor \b output_grad_desc , \b filters_desc ,
+ *   create and set the tensor descriptor \b output_grad_desc, \b filters_desc,
  *   \b indice_pairs_desc and \b input_grad_desc before this function is called.
  *
  * @par Note
@@ -9631,7 +9631,7 @@ mluOpGetIndiceConvolutionBackwardDataWorkspaceSize(mluOpHandle_t handle,
 /*!
  * @brief Performs the back propagation of an indice convolution operation to
  * compute the gradient of input \b input_grad based on the gradient of response
- * \b output_grad , the filter tensor \b filter , the indice tensor \b indice_pairs ,
+ * \b output_grad, the filter tensor \b filter, the indice tensor \b indice_pairs, 
  * and helper parameters: array \b indice_num, scaler \b inverse and \b sub_m.
  *
  * The tensors \b input_grad and \b output_grad are reordered from origin input
@@ -9773,8 +9773,8 @@ mluOpIndiceConvolutionBackwardData(mluOpHandle_t handle,
  * to optimize the indice_convolution_backward_filter operation.
  *
  * The size of extra workspace is based on the given information of the indice_convolution_backward_filter
- * operation, including the input tensor descriptor \b features_desc , \b output_grad_desc , and \b indice_pairs_desc ,
- * output tensor descriptor \b filters_grad_desc , and the array \b indice_num[].
+ * operation, including the input tensor descriptor \b features_desc, \b output_grad_desc, and \b indice_pairs_desc,
+ * output tensor descriptor \b filters_grad_desc, and the array \b indice_num[].
  *
  * @param[in] handle
  * Handle to a Cambricon MLU-OPS context that is used to manage MLU devices and queues in the
@@ -9815,7 +9815,7 @@ mluOpIndiceConvolutionBackwardData(mluOpHandle_t handle,
  *
  * @par API Dependency
  * - You need to call ::mluOpCreateTensorDescriptor and ::mluOpSetTensorDescriptor to create and set
- *   tensor descriptors \b features_desc , \b output_grad_desc , \b indice_pairs_desc , and \b filters_grad_desc before
+ *   tensor descriptors \b features_desc, \b output_grad_desc, \b indice_pairs_desc, and \b filters_grad_desc before
  *   calling this function.
  * - The allocated extra workspace should be passed to ::mluOpIndiceConvolutionBackwardFilter to
  *   perform the indice_convolution_backward_filter operation.
@@ -9887,9 +9887,9 @@ mluOpGetIndiceConvolutionBackwardFilterWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Data Type
  * - This function supports the combinations of the following data types for
- *   input tensor \b features , \b output_grad , \b indice_pairs_num , and output tensor \b filters_grad.
- *   - \b features , \b output_grad , \b indice_pairs , \b filters_grad data type: half, half, int32, half
- *   - \b features , \b output_grad , \b indice_pairs , \b filters_grad data type: float, float, int32, float
+ *   input tensor \b features, \b output_grad, \b indice_pairs_num, and output tensor \b filters_grad.
+ *   - \b features, \b output_grad, \b indice_pairs, \b filters_grad data type: half, half, int32, half
+ *   - \b features, \b output_grad, \b indice_pairs, \b filters_grad data type: float, float, int32, float
  *
  * @par Data Layout
  * - None.
@@ -10077,7 +10077,7 @@ mluOpGetRoiPointPool3dWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Data Type
  * - The supported data types for input and output are as follows:
- *   Note that the data type of \b points , \b point_features , \b boxes3d , and
+ *   Note that the data type of \b points, \b point_features, \b boxes3d , and
  *   \b pooled_features must be the same.
  *   - points: half, float
  *   - point_features: half, float
@@ -10218,9 +10218,9 @@ mluOpGetThreeNNForwardWorkspaceSize(const mluOpHandle_t handle,
  * @par Scale Limitation
  * - The shape of \b unknown, \b dist2 and \b idx should be [b, n, 3].
  * - The shape of \b known should be [b, m, 3].
- * - The shape of \b unknown , \b dist2 , \b idx , and \b known dims[0](b) should be equal.
- * - The shape of \b unknown , \b dist2 , \b idx , and \b known dims[2](3) should be equal to 3.
- * - The shape of \b unknown , \b dist2 , \b idx , and \b known dims[1](n) should be equal and larger
+ * - The shape of \b unknown , \b dist2 , \b idx, and \b known dims[0](b) should be equal.
+ * - The shape of \b unknown , \b dist2 , \b idx, and \b known dims[2](3) should be equal to 3.
+ * - The shape of \b unknown , \b dist2 , \b idx, and \b known dims[1](n) should be equal and larger
  *   than 0.
  *
  * @par API Dependency
@@ -10374,9 +10374,9 @@ mluOpGetIndiceConvolutionForwardWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Data Type
  * - This function supports the combination of the following data types:
- *   - input tensor \b features , \b filters , \b indice_pairs , and output tensor \b features_out: half, half, int32,
+ *   - input tensor \b features, \b filters, \b indice_pairs, and output tensor \b features_out: half, half, int32,
  * half
- *   - input tensor \b features , \b filters , \b indice_pairs , and output tensor \b features_out: float, float, int32,
+ *   - input tensor \b features, \b filters, \b indice_pairs, and output tensor \b features_out: float, float, int32,
  * float
  * - The supported data type of array \b indice_num , scalar \b inverse , and \b sub_m is int64.
  *
@@ -10489,8 +10489,8 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
  *   ::MLUOP_STATUS_NOT_SUPPORTED, ::MLUOP_STATUS_EXECUTION_FAILED
  *
  * @par Data Type
- * - This function supports the following data types for input tensors \b gates , \b indices ,
- *   \b locations , \b input , and \b dispatch.
+ * - This function supports the following data types for input tensors \b gates, \b indices,
+ *   \b locations, \b input , and \b dispatch.
  *   - gates tensor: float
  *   - indices tensor: int32
  *   - locations tensor: int32
@@ -10505,7 +10505,7 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
  *   tensor must be the same size and equal to \b samples.
  * - The second dimension of \b input tensor and \b dispatch tensor must be equal to \b hidden .
  * - The first dimension of \b dispatch tensor must be equal to the multiplication result of
- *   the \b capacity and \b num_experts .
+ *   the \b capacity and \b num_experts.
  * - The samples must be less than or equal to the multiplication result of the \b capacity and \b
  *   num_experts.
  * - The values of indices must be between 0 and (num_experts-1) .
@@ -10516,7 +10516,7 @@ mluOpIndiceConvolutionForward(mluOpHandle_t handle,
  *
  * @par Note
  * - This function is only supported on MLU300 series or above platforms.
- * - The parameters \b samples , \b capacity , \b hidden , and \b num_experts should not be negative.
+ * - The parameters \b samples, \b capacity , \b hidden , and \b num_experts should not be negative.
  *
  * @par Example
  * - The example of the function is as follows:
@@ -10637,7 +10637,7 @@ mluOpGetMoeDispatchBackwardGateWorkspaceSize(mluOpHandle_t handle,
  * @param[in] workspace_size
  * The size of the extra workspace in bytes.
  * @param[in] grad_gates_desc
- * The descriptor of the tensor \b grad_gates , which contains dimension, data type, and data layout.
+ * The descriptor of the tensor \b grad_gates, which contains dimension, data type, and data layout.
  * For detailed information, see ::mluOpTensorDescriptor_t.
  * @param[out] grad_gates
  * Pointer to the MLU memory that stores the \b grad_gates tensor.
@@ -10663,7 +10663,7 @@ mluOpGetMoeDispatchBackwardGateWorkspaceSize(mluOpHandle_t handle,
  * - The second dimension of \b input tensor and \b dispatch tensor must be equal to \b hidden.
  * - The first dimension of \b dispatch tensor must be equal to the multiplication result of
  *   the \b capacity and \b num_experts.
- * - The value of the input parameters \b samples , \b capacity , \b hidden , and \b num_experts
+ * - The value of the input parameters \b samples, \b capacity , \b hidden , and \b num_experts
  *   must be greater than or equal to 0.
  * - The value range of the input parameter \b indices tensor must be greater than or equal to 0 and less than
  *   \b num_experts.
@@ -10676,7 +10676,7 @@ mluOpGetMoeDispatchBackwardGateWorkspaceSize(mluOpHandle_t handle,
  *
  * @par Note
  * - This function is only supported on MLU300 series or above platforms.
- * - The parameters \b samples , \b capacity , \b hidden , and \b num_experts should not be negative.
+ * - The parameters \b samples, \b capacity , \b hidden , and \b num_experts should not be negative.
  *
  * @par Example
  * - The example of the operation is as follows:
@@ -10800,7 +10800,7 @@ mluOpPointsInBoxes(mluOpHandle_t handle,
  * @param[in] sampling_ratio
  * The number of sampling points in the grid used to compute the output.
  * @param[in] aligned
- * A boolean value which determines whether to shift the boxes by 0.5 pixel.
+ * A Boolean value which determines whether to shift the boxes by 0.5 pixel.
  * @param[in] grads_image_desc
  * The descriptor of the tensor \b grads_image of the original images.
  * @param[out] grads_image
@@ -10912,7 +10912,7 @@ mluOpRoiAlignBackward(mluOpHandle_t handle,
  * @param[in] sampling_ratio
  * The number of sampling points in the grid used to compute the output.
  * @param[in] aligned
- * A boolean value which determines whether to shift the boxes by 0.5 pixel. If the value
+ * A Boolean value which determines whether to shift the boxes by 0.5 pixel. If the value
  * of \b aligned is set to true, the boxes are shifted by 0.5. If the value of \b aligned is set
  * to false, the boxes are not shifted.
  * @param[in] pool_mode


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.