### PR TITLE
[Fix](mluOpNmsRotated): fix warning.

### DIFF
--- a/kernels/nms_rotated/nms_rotated_union1.mlu
+++ b/kernels/nms_rotated/nms_rotated_union1.mlu
@@ -215,7 +215,7 @@ __mlu_func__ void nms_detection(
 
     // suppress max_box's score as -inf
     if (!__is_mpu()) {
-      input_data_score[global_max_index] = IN_DT(-INFINITY);
+      storeGpr(input_data_score + global_max_index, IN_DT(-INFINITY));
     }
 
     // prepare box1, also is the max_box
@@ -233,7 +233,7 @@ __mlu_func__ void nms_detection(
     // angle
     if (!__is_mpu()) {
       __bang_write_value((float *)box1 + 4 * max_seg_iou_pad, max_seg_iou_pad,
-                         float(input_angle_ptr[global_max_index]));
+                         (float)loadGpr(input_angle_ptr + global_max_index));
     }
 
     // box1 5xN
@@ -438,34 +438,42 @@ __mlu_global__ void MLUKernelNmsRotated(const T *boxes, T *input_boxes,
   int32_t output_box_num = 0;
   int32_t cluster_score_size = box_num * sizeof(T);
   int32_t cluster_boxes_size = box_num * SINGLE_BOX_DIM * sizeof(T);
+  T *scores_data_sram = NULL;
+  T *boxes_data_sram = NULL;
 
   if (clusterDim == 1 &&
       (SIZE_SRAM_BUF - REDUCE_NUM * sizeof(T)) > cluster_score_size) {
-    scores_data = sram + REDUCE_NUM * coreDim;
+    scores_data_sram = sram + REDUCE_NUM * coreDim;
     scores_load_dir = SRAM2NRAM;
     scores_store_dir = NRAM2SRAM;
     if (__is_mpu()) {
-      __memcpy(scores_data, scores, cluster_score_size, GDRAM2SRAM);
+      __memcpy(scores_data_sram, scores, cluster_score_size, GDRAM2SRAM);
     }
   } else {
     if (taskId == 0) {
       __memcpy(scores_data, scores, cluster_score_size, GDRAM2GDRAM);
     }
   }
-
   if (clusterDim == 1 && (SIZE_SRAM_BUF - REDUCE_NUM * sizeof(T) -
                           cluster_score_size) >= cluster_boxes_size) {
     boxes_load_dir = SRAM2NRAM;
-    boxes_data = sram + REDUCE_NUM * coreDim + box_num;
+    boxes_data_sram = sram + REDUCE_NUM * coreDim + box_num;
     if (__is_mpu()) {
-      __memcpy(boxes_data, input_boxes, cluster_boxes_size, GDRAM2SRAM);
+      __memcpy(boxes_data_sram, input_boxes, cluster_boxes_size, GDRAM2SRAM);
     }
   }
   __sync_cluster();
 
-  nms_detection(output_box_num, output, scores_data, boxes_data, sram, taskDim,
-                box_num, iou_threshold, scores_load_dir, scores_store_dir,
-                boxes_load_dir, exit);
+  if (clusterDim == 1 && (SIZE_SRAM_BUF - REDUCE_NUM * sizeof(T) -
+                          cluster_score_size) >= cluster_boxes_size) {
+    nms_detection(output_box_num, output, scores_data_sram, boxes_data_sram,
+                  sram, taskDim, box_num, iou_threshold, scores_load_dir,
+                  scores_store_dir, boxes_load_dir, exit);
+  } else {
+    nms_detection(output_box_num, output, scores_data, boxes_data, sram,
+                  taskDim, box_num, iou_threshold, scores_load_dir,
+                  scores_store_dir, boxes_load_dir, exit);
+  }
 
   result_num[0] = output_box_num;
   // PERF_TIME_END();

--- a/kernels/nms_rotated/nms_utils.h
+++ b/kernels/nms_rotated/nms_utils.h
@@ -45,15 +45,15 @@ __nram__ int8_t nram_buffer[MAX_NRAM_SIZE];
 
 template <typename IN_DT>
 __mlu_func__ IN_DT loadGpr(IN_DT *p_value) {
-  bool b = __is_dram(p_value);
+  bool is_dram = __is_dram(p_value);
   if (std::is_same<IN_DT, half>::value) {
-    if (b) {
+    if (is_dram) {
       return __load_gdram((half *)p_value);
     } else {
       return __load_sram((half *)p_value);
     }
   } else {
-    if (b) {
+    if (is_dram) {
       return __load_gdram((float *)p_value);
     } else {
       return __load_sram((float *)p_value);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

fix warning

## 2. Modification

kernels/nms_rotated/nms_rotated_union1.mlu
kernels/nms_rotated/nms_utils.h

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

性能流水通过