### PR TITLE
Fix(mluOpFocalLossSigmoidBackward): fix unknown address space warning

### DIFF
--- a/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
+++ b/kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu
@@ -232,7 +232,7 @@ __mlu_func__ void coreCompute(int8_t *nram_input, const T *nram_weight,
       int32_t align_c = PAD_UP(total_c, c_align_num);
       int32_t target_value = ((int32_t *)nram_target)[n];
       if (target_value >= total_c || target_value < 0) continue;
-      T weight_value = nram_weight[target_value];
+      T weight_value = __load_nram(&nram_weight[target_value]);
       __bang_mul_scalar((T *)nram_output + n * align_c,
                         (T *)nram_output + n * align_c, weight_value, align_c);
     }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

kernels/focal_loss_sigmoid/focal_loss_sigmoid_backward_union1.mlu

## 3. Test Report
### 测试流水：http://jenkins.svc.cambricon.com/dist/job/MLUOPS/job/MLU_ALL_PLATFORMS/job/mluops_build_test_adaptable_mlu/667/
### 修改前：
[ 50%] Building CNCC object CMakeFiles/mluops.dir/kernels/focal_loss_sigmoid/mluops_generated_focal_loss_sigmoid_backward_union1.mlu.o
[ 54%] Built target pb2prototxt
[ 56%] Built target prototxt2pb
[ 92%] Built target mluop_pb_gtest_obj
warning: unknown address space, please use addrspace-specified load/store functions.
for example: __load_nram.
warning: unknown address space, please use addrspace-specified load/store functions.
for example: __load_nram.
Consolidate compiler generated dependencies of target mluops
[ 93%] Linking CXX shared library lib/libmluops.so
[ 97%] Built target mluops
[100%] Linking CXX executable ../test/mluop_gtest
[100%] Linking CXX executable ../test/mluop_api_gtest
[100%] Built target mluop_api_gtest
[100%] Built target mluop_gtest
### 修改后无warning：
[ 50%] Built target mluop_gtest_kernels
[ 50%] Building CNCC object CMakeFiles/mluops.dir/kernels/focal_loss_sigmoid/mluops_generated_focal_loss_sigmoid_backward_union1.mlu.o
[ 60%] Built target pb2prototxt
[ 64%] Built target prototxt2pb
[ 92%] Built target mluop_pb_gtest_obj
Consolidate compiler generated dependencies of target mluops
[ 93%] Linking CXX shared library lib/libmluops.so
[ 97%] Built target mluops
[ 98%] Linking CXX executable ../test/mluop_api_gtest
[100%] Linking CXX executable ../test/mluop_gtest
[100%] Built target mluop_api_gtest
[100%] Built target mluop_gtest

