### PR TITLE
[Fix](mluOpRotatedFeatureAlignForward): Fix memset warning

### DIFF
--- a/kernels/rotated_feature_align/rotated_feature_align_block.mlu
+++ b/kernels/rotated_feature_align/rotated_feature_align_block.mlu
@@ -125,8 +125,12 @@ __mlu_global__ void MLUKernelRotatedFeatureAlignForward(
   const int channel_rem = channels % deal_num;
   const int channel_loops = channels / deal_num + (channel_rem != 0 ? 1 : 0);
   const int pixel_end = batches * height * width;
-  T px[5] = {0, 0, 0, 0, 0};
-  T py[5] = {0, 0, 0, 0, 0};
+  T px[5];
+  T py[5];
+  for (int i = 0; i < 5; ++i) {
+    px[i] = (T)0;
+    py[i] = (T)0;
+  }
   int pixel_i = 0;
   T *ping_out = NULL;
   T *pong_out = NULL;
@@ -450,8 +454,12 @@ __mlu_global__ void MLUKernelRotatedFeatureAlignBackward(
   const int channel_rem = channels % deal_num;
   const int channel_loops = channels / deal_num + (channel_rem != 0 ? 1 : 0);
   const int pixel_end = batches * height * width;
-  T px[5] = {0, 0, 0, 0, 0};
-  T py[5] = {0, 0, 0, 0, 0};
+  T px[5];
+  T py[5];
+  for (int i = 0; i < 5; ++i) {
+    px[i] = (T)0;
+    py[i] = (T)0;
+  }
   int pixel_i = 0;
   T *ping_out = NULL;
   T *pong_out = NULL;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

fix the compile warning of "llvm.memset"

## 2. Modification

kernels/rotated_feature_align/rotated_feature_align_block.mlu

## 3. Test Report

use CI as simple test