### PR TITLE
[Fix](mluOpRoiAlignRotatedForward): fix race_mem error

### DIFF
--- a/kernels/roi_align_rotated/roi_align_rotated_forward_vector.mlu
+++ b/kernels/roi_align_rotated/roi_align_rotated_forward_vector.mlu
@@ -390,9 +390,9 @@ __mlu_global__ void roiAlignRotatedForward(
     if (params.sample_ratio < bin_order_num) {
       construct_order = false;
       // construct bin_w_idx in bin_loop
-      __memcpy_async(bin_w_order, order, params.sample_ratio * sizeof(T),
-                     NRAM2NRAM, params.sample_ratio * sizeof(T), 0,
-                     params.sample_ratio - 1);
+      __memcpy(bin_w_order, order, params.sample_ratio * sizeof(T),
+               NRAM2NRAM, params.sample_ratio * sizeof(T), 0,
+               params.sample_ratio - 1);
       // construct bin_h_idx in bin_loop
       __bang_write_value(nram_w1, params.sample_ratio,
                          (uint8_t)params.sample_ratio);
@@ -449,9 +449,9 @@ __mlu_global__ void roiAlignRotatedForward(
 
           if (construct_order) {
             // construct bin_w_idx in bin_loop
-            __memcpy_async(bin_w_order, order, deal_bin_w * sizeof(T),
-                           NRAM2NRAM, deal_bin_w * sizeof(T), 0,
-                           deal_bin_h - 1);
+            __memcpy(bin_w_order, order, deal_bin_w * sizeof(T),
+                     NRAM2NRAM, deal_bin_w * sizeof(T), 0,
+                     deal_bin_h - 1);
             // construct bin_h_idx in bin_loop
             __bang_write_value(nram_w1, deal_bin_h, (uint8_t)deal_bin_w);
             __extension(bin_h_order, order, (uint8_t *)nram_w1, sizeof(T),

--- a/kernels/roi_align_rotated/roi_align_rotated_forward_vector.mlu
+++ b/kernels/roi_align_rotated/roi_align_rotated_forward_vector.mlu
@@ -390,9 +390,10 @@ __mlu_global__ void roiAlignRotatedForward(
     if (params.sample_ratio < bin_order_num) {
       construct_order = false;
       // construct bin_w_idx in bin_loop
-      __memcpy(bin_w_order, order, params.sample_ratio * sizeof(T),
-               NRAM2NRAM, params.sample_ratio * sizeof(T), 0,
-               params.sample_ratio - 1);
+      __sync();
+      __memcpy_async(bin_w_order, order, params.sample_ratio * sizeof(T),
+                     NRAM2NRAM, params.sample_ratio * sizeof(T), 0,
+                     params.sample_ratio - 1);
       // construct bin_h_idx in bin_loop
       __bang_write_value(nram_w1, params.sample_ratio,
                          (uint8_t)params.sample_ratio);
@@ -449,9 +450,10 @@ __mlu_global__ void roiAlignRotatedForward(
 
           if (construct_order) {
             // construct bin_w_idx in bin_loop
-            __memcpy(bin_w_order, order, deal_bin_w * sizeof(T),
-                     NRAM2NRAM, deal_bin_w * sizeof(T), 0,
-                     deal_bin_h - 1);
+            __sync();
+            __memcpy_async(bin_w_order, order, deal_bin_w * sizeof(T),
+                           NRAM2NRAM, deal_bin_w * sizeof(T), 0,
+                           deal_bin_h - 1);
             // construct bin_h_idx in bin_loop
             __bang_write_value(nram_w1, deal_bin_h, (uint8_t)deal_bin_w);
             __extension(bin_h_order, order, (uint8_t *)nram_w1, sizeof(T),


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

存在潜在的内存竞争。构造二维坐标序列时没有sync，它依赖的增序队列构造和后续计算指令可能有竞争。

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.
