### PR TITLE
[Fix](mluOpExecFFT): fix bug about 2d n0==1 || n1==1.

### DIFF
--- a/kernels/fft/rfft/rfft_host.cpp
+++ b/kernels/fft/rfft/rfft_host.cpp
@@ -1552,44 +1552,128 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     status = makeRFFT2dContiguousInput(handle, fft_plan, input);
     INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-    if (fft_plan->n[0] == 1 && fft_plan->n[1] == 1) {
-      mluOpTensorDescriptor_t input_desc, padded_output_desc;
-      status = mluOpCreateTensorDescriptor(&input_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
-      status = mluOpCreateTensorDescriptor(&padded_output_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    if (fft_plan->n[0] == 1 || fft_plan->n[1] == 1) {
+      if (fft_plan->n[0] != 1 && fft_plan->n[1] == 1) {
+        {
+          mluOpTensorDescriptor_t input_desc, padded_output_desc;
+          status = mluOpCreateTensorDescriptor(&input_desc);
+          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          status = mluOpCreateTensorDescriptor(&padded_output_desc);
+          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-      const int IN_DIM_NUM = 2;
-      int64_t dims[IN_DIM_NUM] = {fft_plan->batch,
-                                  fft_plan->n[0] * fft_plan->n[1]};
-      status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
-                                           MLUOP_DTYPE_FLOAT, IN_DIM_NUM, dims);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          const int IN_DIM_NUM = 3;
+          int64_t dims[IN_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
+                                      fft_plan->n[1]};
+          status =
+              mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
+                                          MLUOP_DTYPE_FLOAT, IN_DIM_NUM, dims);
+          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-      int64_t padded_dims[IN_DIM_NUM] = {fft_plan->batch,
-                                         fft_plan->n[0] * fft_plan->n[1] * 2};
-      status = mluOpSetTensorDescriptor_v2(
-          padded_output_desc, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT, IN_DIM_NUM,
-          padded_dims);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          int64_t padded_dims[IN_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
+                                             fft_plan->n[1] * 2};
+          status = mluOpSetTensorDescriptor_v2(
+              padded_output_desc, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+              IN_DIM_NUM, padded_dims);
+          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
 
-      const int pad_dim_num = 4;
-      int paddings[pad_dim_num] = {0, 0, 0, 1};
-      uint64_t padding_value = 0x00000000;
-      DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
-                                        cnnl_handle);  // convert to cnnl_handle
+          const int pad_dim_num = 6;
+          int paddings[pad_dim_num] = {0, 0, 0, 0, 0, 1};
+          uint64_t padding_value = 0x00000000;
+          DEFINE_CREATE_AND_SET_CNNL_HANDLE(
+              handle,
+              cnnl_handle);  // convert to cnnl_handle
 
-      DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_desc, cnnl_input_desc);
-      DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(padded_output_desc,
-                                                   cnnl_padded_output_desc);
-      CALL_CNNL(cnnlPad(cnnl_handle, cnnl_input_desc, fft_plan->mlu_addrs.input,
-                        paddings, &padding_value, cnnl_padded_output_desc,
-                        fft_plan->mlu_addrs.output));
+          DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_desc,
+                                                       cnnl_input_desc);
+          DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(padded_output_desc,
+                                                       cnnl_padded_output_desc);
+          CALL_CNNL(cnnlPad(cnnl_handle, cnnl_input_desc,
+                            fft_plan->mlu_addrs.input, paddings, &padding_value,
+                            cnnl_padded_output_desc,
+                            fft_plan->mlu_addrs.output));
 
-      DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
-      DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_padded_output_desc);
+          DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
+          DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_padded_output_desc);
 
-      DESTROY_CNNL_HANDLE(cnnl_handle);
+          DESTROY_CNNL_HANDLE(cnnl_handle);
+        }
+        for (int batch_id = 0; batch_id < fft_plan->batch; batch_id++) {
+          status = kernelRFFT2dButterflyColumn(k_dim, k_type, handle->queue,
+                                               fft_plan, FFT_IFFT);
+
+          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+
+          fft_plan->mlu_addrs.input =
+              (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
+          fft_plan->mlu_addrs.output =
+              (void *)((uint64_t)(fft_plan->mlu_addrs.output) + odist);
+        }
+        fft_plan->mlu_addrs.input =
+            (void *)((uint64_t)(fft_plan->mlu_addrs.input) -
+                     fft_plan->batch * idist);
+        fft_plan->mlu_addrs.output =
+            (void *)((uint64_t)(fft_plan->mlu_addrs.output) -
+                     fft_plan->batch * odist);
+      } else if (fft_plan->n[0] == 1 && fft_plan->n[1] != 1) {
+        for (int batch_id = 0; batch_id < fft_plan->batch; batch_id++) {
+          status = kernelRFFT2dButterflyRow(k_dim, k_type, handle->queue,
+                                            fft_plan, RFFT);
+
+          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+
+          fft_plan->mlu_addrs.input =
+              (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
+          fft_plan->mlu_addrs.output =
+              (void *)((uint64_t)(fft_plan->mlu_addrs.output) + odist);
+        }
+        fft_plan->mlu_addrs.input =
+            (void *)((uint64_t)(fft_plan->mlu_addrs.input) -
+                     fft_plan->batch * idist);
+        fft_plan->mlu_addrs.output =
+            (void *)((uint64_t)(fft_plan->mlu_addrs.output) -
+                     fft_plan->batch * odist);
+      } else {
+        mluOpTensorDescriptor_t input_desc, padded_output_desc;
+        status = mluOpCreateTensorDescriptor(&input_desc);
+        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        status = mluOpCreateTensorDescriptor(&padded_output_desc);
+        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+
+        const int IN_DIM_NUM = 2;
+        int64_t dims[IN_DIM_NUM] = {fft_plan->batch,
+                                    fft_plan->n[0] * fft_plan->n[1]};
+        status =
+            mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
+                                        MLUOP_DTYPE_FLOAT, IN_DIM_NUM, dims);
+        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+
+        int64_t padded_dims[IN_DIM_NUM] = {fft_plan->batch,
+                                           fft_plan->n[0] * fft_plan->n[1] * 2};
+        status = mluOpSetTensorDescriptor_v2(
+            padded_output_desc, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
+            IN_DIM_NUM, padded_dims);
+        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+
+        const int pad_dim_num = 4;
+        int paddings[pad_dim_num] = {0, 0, 0, 1};
+        uint64_t padding_value = 0x00000000;
+        DEFINE_CREATE_AND_SET_CNNL_HANDLE(
+            handle,
+            cnnl_handle);  // convert to cnnl_handle
+
+        DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(input_desc,
+                                                     cnnl_input_desc);
+        DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(padded_output_desc,
+                                                     cnnl_padded_output_desc);
+        CALL_CNNL(cnnlPad(cnnl_handle, cnnl_input_desc,
+                          fft_plan->mlu_addrs.input, paddings, &padding_value,
+                          cnnl_padded_output_desc, fft_plan->mlu_addrs.output));
+
+        DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
+        DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_padded_output_desc);
+
+        DESTROY_CNNL_HANDLE(cnnl_handle);
+      }
     } else {
       for (int batch_id = 0; batch_id < fft_plan->batch; batch_id++) {
         status = kernelRFFT2dButterflyRow(k_dim, k_type, handle->queue,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

In 2d, n0==1 || n1==1 is actually a 1d FFT calculation. This part of the case call 2d calculation result error problem is now modified.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.