### PR TITLE
[Fix](mluOpExecFFT): fix memory leak and wrong using of check marco.

### DIFF
--- a/kernels/fft/c2c_fft/c2c_fft_host.cpp
+++ b/kernels/fft/c2c_fft/c2c_fft_host.cpp
@@ -50,8 +50,7 @@ static mluOpStatus_t selectFFT1dStrategy(mluOpHandle_t handle,
 mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
   std::string api = "[mluOpMakeFFTPlanMany]";
   mluOpStatus_t status = MLUOP_STATUS_SUCCESS;
-  INTERNAL_CHECK(api,
-                 selectFFT1dStrategy(handle, fft_plan) == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, selectFFT1dStrategy(handle, fft_plan));
 
   mluOpDataType_t in_c_dtype = fft_plan->input_dtype;
   mluOpDataType_t in_r_dtype = (in_c_dtype == MLUOP_DTYPE_COMPLEX_HALF)
@@ -542,8 +541,7 @@ mluOpStatus_t setFFT1dReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
             fft_plan->matmul_addrs.dft_scale_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
-        INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
-                       status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN("[mluOpSetFFTReserveArea]", status);
       }; break;
       case CNFFT_FUNC_COOLEY_TUKEY:
       case CNFFT_FUNC_STOCKHAM: {
@@ -559,8 +557,7 @@ mluOpStatus_t setFFT1dReserveArea(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
             fft_plan->matmul_addrs.dft_scale_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
-        INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
-                       status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN("[mluOpSetFFTReserveArea]", status);
       }; break;
       default: {
         status = MLUOP_STATUS_NOT_SUPPORTED;
@@ -1121,7 +1118,7 @@ static mluOpStatus_t makeFFT1dContiguousInput(mluOpHandle_t handle,
       VLOG(5) << "launch mluOpContiguous for fft1d input";
       mluOpTensorDescriptor_t input_desc;
       status = mluOpCreateTensorDescriptor(&input_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       const int IN_DIM_NUM = 2;
       int64_t dims[IN_DIM_NUM] = {fft_plan->batch, fft_plan->inembed[0]};
@@ -1129,14 +1126,14 @@ static mluOpStatus_t makeFFT1dContiguousInput(mluOpHandle_t handle,
       status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                              fft_plan->input_dtype, IN_DIM_NUM,
                                              dims, strides);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status = mluOpContiguous(handle, input_desc, input,
                                fft_plan->matmul_addrs.input_contiguous_addr);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status = mluOpDestroyTensorDescriptor(input_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
     }
 
   } else {
@@ -1146,7 +1143,7 @@ static mluOpStatus_t makeFFT1dContiguousInput(mluOpHandle_t handle,
       VLOG(5) << "launch mluOpContiguous for fft1d input";
       mluOpTensorDescriptor_t input_desc;
       status = mluOpCreateTensorDescriptor(&input_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       const int IN_DIM_NUM = 2;
       int64_t dims[IN_DIM_NUM] = {
@@ -1155,14 +1152,14 @@ static mluOpStatus_t makeFFT1dContiguousInput(mluOpHandle_t handle,
       status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                              fft_plan->input_dtype, IN_DIM_NUM,
                                              dims, strides);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status =
           mluOpContiguous(handle, input_desc, input, fft_plan->mlu_addrs.input);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status = mluOpDestroyTensorDescriptor(input_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
     }
   }
   return status;
@@ -1182,7 +1179,7 @@ static mluOpStatus_t makeFFT2dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpContiguous for fft2d input";
     mluOpTensorDescriptor_t input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 3;
     int64_t dims[IN_DIM_NUM] = {fft_plan->batch,
@@ -1196,13 +1193,13 @@ static mluOpStatus_t makeFFT2dContiguousInput(mluOpHandle_t handle,
     status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->input_dtype, IN_DIM_NUM,
                                            dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mluOpContiguous(handle, input_desc, input, input_contiguous);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mluOpDestroyTensorDescriptor(input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }
@@ -1226,20 +1223,20 @@ static mluOpStatus_t padFFT1dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch cnnlOpPad for input pad";
     mluOpTensorDescriptor_t input_desc, padded_input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&padded_input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 2;
     int64_t dims[IN_DIM_NUM] = {batch, fft_plan->inembed[0] * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     int64_t padded_dims[IN_DIM_NUM] = {batch, n * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, padded_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int pad_dim_num = 4;
     int paddings[pad_dim_num] = {0, 0, 0, (n - fft_plan->inembed[0]) * COMPLEX};
@@ -1290,21 +1287,21 @@ static mluOpStatus_t padFFT2dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch cnnlOpPad for input pad";
     mluOpTensorDescriptor_t input_desc, padded_input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&padded_input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 3;
     int64_t dims[IN_DIM_NUM] = {batch, std::min(fft_plan->inembed[0], n0),
                                 std::min(fft_plan->inembed[1], n1) * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     int64_t padded_dims[IN_DIM_NUM] = {batch, n0, n1 * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, padded_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int pad_dim_num = 6;
     int paddings[pad_dim_num] = {
@@ -1400,7 +1397,7 @@ static mluOpStatus_t transposeFFT1dPaddedInput(mluOpHandle_t handle,
                      fft_plan->matmul_addrs.input_re_addr, in_r_dtype,
                      fft_plan->matmul_addrs.internal_workspace_addr,
                      fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     VLOG(5) << "launch mluOpTranspose for input CNFFT_FUNC_COOLEY_TUKEY";
     int L = fft_plan->L;
@@ -1513,7 +1510,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input imag matmul dft imag
     status = fftQuantMatMul(
@@ -1526,7 +1523,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input real matmul dft imag
     status = fftQuantMatMul(
@@ -1539,7 +1536,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input imag matmul dft real
     status = fftQuantMatMul(
@@ -1552,7 +1549,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // real mul real sub imag mul imag
     int per_matmul_output_num = batch * n;
@@ -1563,7 +1560,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
                          0.0, in_r_dtype, CNNL_OP_TENSOR_SUB,
                          fft_plan->matmul_addrs.internal_workspace_addr,
                          fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // real mul imag add imag mul real
     status = fftOptensor(handle, per_matmul_output_num,
@@ -1573,7 +1570,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
                          0.0, in_r_dtype, CNNL_OP_TENSOR_ADD,
                          fft_plan->matmul_addrs.internal_workspace_addr,
                          fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     int L = fft_plan->L;
     int m = (1 << fft_plan->m);
@@ -1589,7 +1586,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input imag matmul dft imag
     status = fftQuantMatMul(
@@ -1602,7 +1599,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input real matmul dft imag
     status = fftQuantMatMul(
@@ -1615,7 +1612,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input imag matmul dft real
     status = fftQuantMatMul(
@@ -1628,7 +1625,7 @@ static mluOpStatus_t computeFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_STOCKHAM) {
     int L = fft_plan->L;
     int m = (1 << fft_plan->m);
@@ -1743,7 +1740,7 @@ static mluOpStatus_t transposeFFT1dOutput(mluOpHandle_t handle,
         fft_plan->matmul_addrs.output_contiguous_addr, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }
@@ -1761,9 +1758,9 @@ static mluOpStatus_t makeFFT1dContiguousOutput(mluOpHandle_t handle,
     // create tensor desc
     mluOpTensorDescriptor_t copy_src_desc, copy_dst_desc;
     status = mluOpCreateTensorDescriptor(&copy_src_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&copy_dst_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set up tensor desc
     const int OUT_DIM_NUM = 2;
@@ -1773,11 +1770,11 @@ static mluOpStatus_t makeFFT1dContiguousOutput(mluOpHandle_t handle,
     int64_t strides[OUT_DIM_NUM] = {fft_plan->odist, fft_plan->ostride};
     status = mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
                                          out_c_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status =
         mluOpSetTensorDescriptorEx_v2(copy_dst_desc, MLUOP_LAYOUT_ARRAY,
                                       out_c_dtype, OUT_DIM_NUM, dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     void *copy_src_addr = (fft_plan->prime)
                               ? fft_plan->matmul_addrs.output_contiguous_addr
@@ -1811,9 +1808,9 @@ static mluOpStatus_t makeFFT2dContiguousOutput(mluOpHandle_t handle,
     // create tensor desc
     mluOpTensorDescriptor_t copy_src_desc, copy_dst_desc;
     status = mluOpCreateTensorDescriptor(&copy_src_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&copy_dst_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set up tensor desc
     const int OUT_DIM_NUM = 3;
@@ -1825,11 +1822,11 @@ static mluOpStatus_t makeFFT2dContiguousOutput(mluOpHandle_t handle,
     }
     status = mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
                                          out_c_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status =
         mluOpSetTensorDescriptorEx_v2(copy_dst_desc, MLUOP_LAYOUT_ARRAY,
                                       out_c_dtype, OUT_DIM_NUM, dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // void *copy_src_addr = fft_plan->matmul_addrs.output_contiguous_addr;
     void *copy_src_addr = output_contiguous;
@@ -1891,20 +1888,20 @@ mluOpStatus_t execFFTc2c2d(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
       if (direction == FFT_FORWARD) {
         status = kernelFFT2dButterflyRow(k_dim, k_type, handle->queue, fft_plan,
                                          direction, FFT_IFFT);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         status = kernelFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                             fft_plan, direction, FFT_IFFT);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
       } else {
         status = kernelFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                             fft_plan, direction, FFT_IFFT);
 
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         status = kernelFFT2dButterflyRow(k_dim, k_type, handle->queue, fft_plan,
                                          direction, FFT_IFFT);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
       }
 
       fft_plan->mlu_addrs.input =
@@ -1922,18 +1919,18 @@ mluOpStatus_t execFFTc2c2d(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
   if (fft_plan->fft_strategy == CNFFT_FUNC_MANY_DIST1_2D) {
     if (direction == FFT_FORWARD) {
       status = computeFFT2dMatMulRow(handle, fft_plan, scale_factor, direction);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status =
           computeFFT2dMatMulColumn(handle, fft_plan, scale_factor, direction);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
     } else {
       status =
           computeFFT2dMatMulColumn(handle, fft_plan, scale_factor, direction);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status = computeFFT2dMatMulRow(handle, fft_plan, scale_factor, direction);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
     }
   }
   return status;
@@ -1950,61 +1947,61 @@ mluOpStatus_t execFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                        workspace, output);
 
     status = makeFFT1dContiguousInput(handle, fft_plan, input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = padFFT1dContiguousInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = transposeFFT1dPaddedInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = quantizeFFT1dPaddedInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status =
         computeFFT1dMatmulResult(handle, fft_plan, scale_factor, direction);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mergeFFT1dOutput(handle, fft_plan, scale_factor, direction);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = transposeFFT1dOutput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = makeFFT1dContiguousOutput(handle, fft_plan, output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else {
     configureFFT1dWorkspaceAddrs(handle, fft_plan, (void *)input, workspace,
                                  output);
 
     status = makeFFT1dContiguousInput(handle, fft_plan, input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (fft_plan->n[0] > fft_plan->inembed[0]) {
       status = padFFT1dContiguousInput(handle, fft_plan);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       fft_plan->mlu_addrs.input = fft_plan->mlu_addrs.input_pad_addr;
     }
 
     status = execFFTc2c1d(handle, fft_plan, scale_factor, direction);
 
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (scale_factor != 1.0) {
       const float alpha[2] = {scale_factor, 0.0};
       const float beta[2] = {0.0, 0.0};
       mluOpTensorDescriptor_t c_desc = nullptr;
       status = mluOpCreateTensorDescriptor(&c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       const int OUT_DIM_NUM = 2;
       int64_t dims[OUT_DIM_NUM] = {fft_plan->batch, fft_plan->n[0]};
       status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->output_dtype, OUT_DIM_NUM,
                                            dims);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       status = mluOpSetTensorDescriptorOnchipDataType(
           c_desc, fft_plan->execution_dtype);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                         cnnl_handle);  // convert to cnnl_handle
@@ -2016,13 +2013,13 @@ mluOpStatus_t execFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                  &beta, cnnl_output_desc,
                                  fft_plan->mlu_addrs.output));
       status = mluOpDestroyTensorDescriptor(c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
       DESTROY_CNNL_HANDLE(cnnl_handle);
     }
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = makeFFT1dContiguousOutput(handle, fft_plan, output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   return status;
@@ -2041,13 +2038,13 @@ mluOpStatus_t execFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
   if (fft_plan->fft_strategy != CNFFT_FUNC_MANY_DIST1_2D) {
     status = makeFFT2dContiguousInput(handle, fft_plan, input,
                                       fft_plan->mlu_addrs.input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   if (fft_plan->n[0] > fft_plan->inembed[0] ||
       fft_plan->n[1] > fft_plan->inembed[1]) {
     status = padFFT2dContiguousInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     fft_plan->mlu_addrs.input = fft_plan->mlu_addrs.input_pad_addr;
   }
 
@@ -2066,17 +2063,17 @@ mluOpStatus_t execFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         (fft_plan->n[0] != 1 && direction == FFT_FORWARD)) {
       mluOpTensorDescriptor_t c_desc = nullptr;
       status = mluOpCreateTensorDescriptor(&c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       const int OUT_DIM_NUM = 3;
       int64_t dims[OUT_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
                                    fft_plan->n[1]};
       status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->output_dtype, OUT_DIM_NUM,
                                            dims);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       status = mluOpSetTensorDescriptorOnchipDataType(
           c_desc, fft_plan->execution_dtype);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                         cnnl_handle);  // convert to cnnl_handle
@@ -2086,7 +2083,7 @@ mluOpStatus_t execFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                             fft_plan->mlu_addrs.input, cnnl_output_desc,
                             fft_plan->mlu_addrs.output, NULL, 0));
       status = mluOpDestroyTensorDescriptor(c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
       DESTROY_CNNL_HANDLE(cnnl_handle);
     }
@@ -2096,11 +2093,11 @@ mluOpStatus_t execFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         if (direction == FFT_FORWARD) {
           status = kernelFFT2dButterflyRow(k_dim, k_type, handle->queue,
                                            fft_plan, direction, FFT_IFFT);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
         } else {
           status = kernelFFT2dButterflyRow(k_dim, k_type, handle->queue,
                                            fft_plan, direction, FFT_IFFT);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
         }
 
         fft_plan->mlu_addrs.input =
@@ -2120,11 +2117,11 @@ mluOpStatus_t execFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         if (direction == FFT_FORWARD) {
           status = kernelFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                               fft_plan, direction, FFT_IFFT);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
         } else {
           status = kernelFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                               fft_plan, direction, FFT_IFFT);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
         }
 
         fft_plan->mlu_addrs.input =
@@ -2143,23 +2140,23 @@ mluOpStatus_t execFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     status = execFFTc2c2d(handle, fft_plan, scale_factor, direction);
   }
 
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   if (scale_factor != 1.0) {
     const float alpha[2] = {scale_factor, 0.0};
     const float beta[2] = {0.0, 0.0};
     mluOpTensorDescriptor_t c_desc = nullptr;
     status = mluOpCreateTensorDescriptor(&c_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     const int OUT_DIM_NUM = 3;
     int64_t dims[OUT_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
                                  fft_plan->n[1]};
     status = mluOpSetTensorDescriptor_v2(
         c_desc, MLUOP_LAYOUT_ARRAY, fft_plan->output_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc,
                                                     fft_plan->execution_dtype);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                       cnnl_handle);  // convert to cnnl_handle
@@ -2171,17 +2168,17 @@ mluOpStatus_t execFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                &beta, cnnl_output_desc,
                                fft_plan->mlu_addrs.output));
     status = mluOpDestroyTensorDescriptor(c_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
   }
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   if (!fft_plan->is_output_contiguous &&
       fft_plan->fft_strategy != CNFFT_FUNC_MANY_DIST1_2D) {
     status = makeFFT2dContiguousOutput(handle, fft_plan, output,
                                        fft_plan->mlu_addrs.output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   return status;
@@ -2213,11 +2210,11 @@ mluOpStatus_t computeFFT2dMatMulColumn(mluOpHandle_t handle,
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2] = {m, k};
@@ -2226,19 +2223,19 @@ mluOpStatus_t computeFFT2dMatMulColumn(mluOpHandle_t handle,
 
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(c_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -2276,7 +2273,16 @@ mluOpStatus_t computeFFT2dMatMulColumn(mluOpHandle_t handle,
                           &beta, cnnl_c_desc, out_addr, workspace,
                           workspace_size, cnnl_d_desc, out_addr));
 
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
+  CALL_CNNL(cnnlMatMulDescDestroy(matmul_desc));
+  CALL_CNNL(cnnlMatMulAlgoDestroy(matmul_algo));
+  CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_c_desc);
@@ -2338,11 +2344,11 @@ mluOpStatus_t computeFFT2dMatMulRow(mluOpHandle_t handle,
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2] = {m, k};
@@ -2351,19 +2357,19 @@ mluOpStatus_t computeFFT2dMatMulRow(mluOpHandle_t handle,
 
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        3, b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        3, c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(c_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -2405,7 +2411,17 @@ mluOpStatus_t computeFFT2dMatMulRow(mluOpHandle_t handle,
                               cnnl_a_desc, dft_matrix_addr, cnnl_b_desc,
                               in_addr, &beta, cnnl_c_desc, out_addr,
                               (void *)workspace, workspace_size));
+
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
+  CALL_CNNL(cnnlMatMulDescDestroy(bmm_bcast_desc));
+  CALL_CNNL(cnnlMatMulAlgoDestroy(algo));
+  CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_c_desc);

--- a/kernels/fft/c2c_fft/c2c_fft_host.cpp
+++ b/kernels/fft/c2c_fft/c2c_fft_host.cpp
@@ -1257,6 +1257,10 @@ static mluOpStatus_t padFFT1dContiguousInput(mluOpHandle_t handle,
                       fft_plan->prime ? fft_plan->matmul_addrs.input_pad_addr
                                       : fft_plan->mlu_addrs.input_pad_addr));
 
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(padded_input_desc);
+    CHECK_RETURN(api, status);
     // destroy cnnl descriptor
     VLOG(5) << "c2cfft cnnlOpPad end";
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
@@ -1329,6 +1333,10 @@ static mluOpStatus_t padFFT2dContiguousInput(mluOpHandle_t handle,
                           ? fft_plan->mlu_addrs.input_pad_addr
                           : fft_plan->matmul_addrs.input_pad_addr));
 
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(padded_input_desc);
+    CHECK_RETURN(api, status);
     // destroy cnnl descriptor
     VLOG(5) << "c2cfft cnnlOpPad end";
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
@@ -1788,6 +1796,10 @@ static mluOpStatus_t makeFFT1dContiguousOutput(mluOpHandle_t handle,
                                                  cnnl_copy_dst_desc);
     CALL_CNNL(cnnlCopy_v2(cnnl_handle, cnnl_copy_src_desc, copy_src_addr,
                           cnnl_copy_dst_desc, output, NULL, 0));
+    status = mluOpDestroyTensorDescriptor(copy_src_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(copy_dst_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_src_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_dst_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
@@ -1839,7 +1851,10 @@ static mluOpStatus_t makeFFT2dContiguousOutput(mluOpHandle_t handle,
                                                  cnnl_copy_dst_desc);
     CALL_CNNL(cnnlCopy_v2(cnnl_handle, cnnl_copy_src_desc, copy_src_addr,
                           cnnl_copy_dst_desc, output, NULL, 0));
-
+    status = mluOpDestroyTensorDescriptor(copy_src_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(copy_dst_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_src_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_dst_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -836,6 +836,12 @@ mluOpStatus_t fftOptensor(mluOpHandle_t handle, int elem_num, void *in1_ptr,
   // destroy descriptor
   CALL_CNNL(cnnlDestroyOpTensorDescriptor(opTensor_desc));
 
+  status = mluOpDestroyTensorDescriptor(in1_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(in2_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(out_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_in1_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_in2_desc);

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -69,6 +69,8 @@ mluOpStatus_t fftGetQuantizeParamWorkspaceSize(mluOpHandle_t handle,
     CALL_CNNL(cnnlGetQuantizeParamWorkspaceSize(cnnl_handle, cnnl_input_desc,
                                                 &required_size));
 
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
   }
@@ -107,7 +109,8 @@ mluOpStatus_t fftQuantizePositionScale(mluOpHandle_t handle, int array_length,
     CALL_CNNL(cnnlQuantizeParam(cnnl_handle, mode, cnnl_quant_desc, input,
                                 bit_width, workspace, workspace_size, position,
                                 scale, nullptr));
-
+    status = mluOpDestroyTensorDescriptor(quant_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_quant_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
   }
@@ -672,6 +675,8 @@ mluOpStatus_t fftGetTransposeWorkspaceSize(mluOpHandle_t handle,
   CALL_CNNL(cnnlGetTransposeWorkspaceSize(cnnl_handle, cnnl_input_desc,
                                           trans_desc, &workspace_size));
 
+  status = mluOpDestroyTensorDescriptor(input_desc);
+  CHECK_RETURN(api, status);
   // destroy descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   CALL_CNNL(cnnlDestroyTransposeDescriptor(trans_desc));
@@ -722,6 +727,8 @@ mluOpStatus_t fftTranspose(mluOpHandle_t handle, int dim_num,
                              cnnl_transed_input_desc, transed_ptr, workspace,
                              workspace_size));
 
+  status = mluOpDestroyTensorDescriptor(input_desc);
+  CHECK_RETURN(api, status);
   // destroy descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_transed_input_desc);
@@ -774,7 +781,12 @@ mluOpStatus_t fftGetOptensorWorkspaceSize(mluOpHandle_t handle,
                                          cnnl_in2_desc, cnnl_out_desc,
                                          &workspace_size));
   CHECK_RETURN(api, status);
-
+  status = mluOpDestroyTensorDescriptor(in1_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(in2_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(out_desc);
+  CHECK_RETURN(api, status);
   // destroy descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_in1_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_in2_desc);

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -52,13 +52,13 @@ mluOpStatus_t fftGetQuantizeParamWorkspaceSize(mluOpHandle_t handle,
     // create descriptor
     mluOpTensorDescriptor_t input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set descriptor
     int64_t input_dims[1] = {array_length};
     status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                          data_type, 1, input_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                       cnnl_handle);  // convert to cnnl_handle
@@ -87,13 +87,13 @@ mluOpStatus_t fftQuantizePositionScale(mluOpHandle_t handle, int array_length,
     // create descriptor
     mluOpTensorDescriptor_t quant_desc;
     status = mluOpCreateTensorDescriptor(&quant_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set descriptor
     int64_t quant_dims[1] = {array_length};
     status = mluOpSetTensorDescriptor_v2(quant_desc, MLUOP_LAYOUT_ARRAY,
                                          data_type, 1, quant_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                       cnnl_handle);  // convert to cnnl_handle
@@ -128,11 +128,11 @@ mluOpStatus_t fftGetQuantizeMatMulWorkspaceSize(
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2];
@@ -154,28 +154,28 @@ mluOpStatus_t fftGetQuantizeMatMulWorkspaceSize(
   }
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   if (a_compute_type == MLUOP_DTYPE_INT31 ||
       b_compute_type == MLUOP_DTYPE_INT31) {
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fftIsIntDtype(a_compute_type) && fftIsIntDtype(b_compute_type) &&
              c_desc->getDtype() == MLUOP_DTYPE_HALF) {
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else {
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc, data_type);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
@@ -246,6 +246,12 @@ mluOpStatus_t fftGetQuantizeMatMulWorkspaceSize(
     CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   }
 
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
@@ -273,11 +279,11 @@ mluOpStatus_t fftQuantMatMul(mluOpHandle_t handle, int m, int k, int n,
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2];
@@ -300,28 +306,28 @@ mluOpStatus_t fftQuantMatMul(mluOpHandle_t handle, int m, int k, int n,
 
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   if (a_compute_type == MLUOP_DTYPE_INT31 ||
       b_compute_type == MLUOP_DTYPE_INT31) {
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fftIsIntDtype(a_compute_type) && fftIsIntDtype(b_compute_type) &&
              c_desc->getDtype() == MLUOP_DTYPE_HALF) {
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc, MLUOP_DTYPE_FLOAT);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else {
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc, data_type);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
@@ -406,6 +412,12 @@ mluOpStatus_t fftQuantMatMul(mluOpHandle_t handle, int m, int k, int n,
     CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   }
 
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
@@ -435,11 +447,11 @@ mluOpStatus_t fftGetBatchMatMulBcastWorkspaceSize(
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2];
@@ -461,19 +473,18 @@ mluOpStatus_t fftGetBatchMatMulBcastWorkspaceSize(
   }
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, data_type, 3,
                                        b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, data_type, 3,
                                        c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   c_desc->setOnchipDtype(MLUOP_DTYPE_FLOAT);
-
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
 
@@ -500,6 +511,12 @@ mluOpStatus_t fftGetBatchMatMulBcastWorkspaceSize(
       requested_algo_count, &heuristic_result, &return_algo_count);
   cnnlGetBatchMatMulExHeuristicResult(heuristic_result, algo, &workspace_size);
   // destroy descriptor
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
@@ -532,11 +549,11 @@ mluOpStatus_t fftBatchMatMulBcast(
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2];
@@ -558,17 +575,17 @@ mluOpStatus_t fftBatchMatMulBcast(
   }
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, data_type, 2,
                                        a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, a_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, data_type, 3,
                                        b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, b_compute_type);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, data_type, 3,
                                        c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   c_desc->setOnchipDtype(MLUOP_DTYPE_FLOAT);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
@@ -610,6 +627,12 @@ mluOpStatus_t fftBatchMatMulBcast(
                               cnnl_c_desc, c_ptr, (void *)workspace,
                               workspace_size));
   // destroy descriptor
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
@@ -632,7 +655,7 @@ mluOpStatus_t fftGetTransposeWorkspaceSize(mluOpHandle_t handle,
   // create descriptor
   mluOpTensorDescriptor_t input_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&input_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   cnnlTransposeDescriptor_t trans_desc = nullptr;
   CALL_CNNL(cnnlCreateTransposeDescriptor(&trans_desc));
@@ -642,7 +665,7 @@ mluOpStatus_t fftGetTransposeWorkspaceSize(mluOpHandle_t handle,
   // set descriptor
   status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                        data_type, dim_num, ori_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR_v2(input_desc, cnnl_input_desc);
   CALL_CNNL(cnnlSetTransposeDescriptor(trans_desc, dim_num, permute));
   // get workspace
@@ -667,17 +690,17 @@ mluOpStatus_t fftTranspose(mluOpHandle_t handle, int dim_num,
   mluOpTensorDescriptor_t input_desc = nullptr;
   mluOpTensorDescriptor_t transed_input_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&input_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&transed_input_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                        data_type, dim_num, ori_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(transed_input_desc, MLUOP_LAYOUT_ARRAY,
                                        data_type, dim_num, transed_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -720,23 +743,23 @@ mluOpStatus_t fftGetOptensorWorkspaceSize(mluOpHandle_t handle,
   mluOpTensorDescriptor_t in2_desc = nullptr;
   mluOpTensorDescriptor_t out_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&in1_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&in2_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&out_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t dims[1] = {elem_num};
   status = mluOpSetTensorDescriptor_v2(in1_desc, MLUOP_LAYOUT_ARRAY, data_type,
                                        1, dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(in2_desc, MLUOP_LAYOUT_ARRAY, data_type,
                                        1, dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(out_desc, MLUOP_LAYOUT_ARRAY, data_type,
                                        1, dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -750,7 +773,7 @@ mluOpStatus_t fftGetOptensorWorkspaceSize(mluOpHandle_t handle,
   CALL_CNNL(cnnlGetOpTensorWorkspaceSize(cnnl_handle, cnnl_in1_desc,
                                          cnnl_in2_desc, cnnl_out_desc,
                                          &workspace_size));
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // destroy descriptor
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_in1_desc);
@@ -774,23 +797,23 @@ mluOpStatus_t fftOptensor(mluOpHandle_t handle, int elem_num, void *in1_ptr,
   mluOpTensorDescriptor_t in2_desc = nullptr;
   mluOpTensorDescriptor_t out_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&in1_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&in2_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&out_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t dims[1] = {elem_num};
   status = mluOpSetTensorDescriptor_v2(in1_desc, MLUOP_LAYOUT_ARRAY, data_type,
                                        1, dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(in2_desc, MLUOP_LAYOUT_ARRAY, data_type,
                                        1, dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(out_desc, MLUOP_LAYOUT_ARRAY, data_type,
                                        1, dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle

--- a/kernels/fft/fft.cpp
+++ b/kernels/fft/fft.cpp
@@ -2619,7 +2619,7 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
           fft_input_desc, input_desc->getLayout(), input_desc->getDtype(),
           input_desc->getDim(), input_desc->getDims(),
           input_desc->getStrides()));
-  INTERNAL_CHECK(make_plan_api,
+  CHECK_RETURN(make_plan_api,
                  mluOpSetTensorDescriptorOnchipDataType(
                      fft_input_desc, input_desc->getOnchipDtype()));
   CHECK_RETURN(

--- a/kernels/fft/fft.cpp
+++ b/kernels/fft/fft.cpp
@@ -1064,10 +1064,10 @@ mluOpStatus_t MLUOP_WIN_API fftTwoStepFactor(mluOpHandle_t handle,
     int *cur_facbuf = &facbuf[small_factors_offset];
     status =
         fftFactor(r, facbuf, small_factors_offset, factor_type, large_count);
-    INTERNAL_CHECK("[fftTwoStepFactor]", status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN("[fftTwoStepFactor]", status);
     status = setMaxParallelNum(handle, fft_plan, cur_facbuf, stage_num, r,
                                is_row_major);
-    INTERNAL_CHECK("[fftTwoStepFactor]", status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN("[fftTwoStepFactor]", status);
     out_stride *= r;
     large_count++;
   }
@@ -2611,26 +2611,23 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
   // create input and output descriptor for gen_case
   // because mluOpExecFFT don't have input and output descriptor
   mluOpTensorDescriptor_t fft_input_desc, fft_output_desc;
-  INTERNAL_CHECK(make_plan_api, mluOpCreateTensorDescriptor(&fft_input_desc) ==
-                                    MLUOP_STATUS_SUCCESS);
-  INTERNAL_CHECK(make_plan_api, mluOpCreateTensorDescriptor(&fft_output_desc) ==
-                                    MLUOP_STATUS_SUCCESS);
-  INTERNAL_CHECK(
+  CHECK_RETURN(make_plan_api, mluOpCreateTensorDescriptor(&fft_input_desc));
+  CHECK_RETURN(make_plan_api, mluOpCreateTensorDescriptor(&fft_output_desc));
+  CHECK_RETURN(
       make_plan_api,
       mluOpSetTensorDescriptorEx_v2(
           fft_input_desc, input_desc->getLayout(), input_desc->getDtype(),
           input_desc->getDim(), input_desc->getDims(),
-          input_desc->getStrides()) == MLUOP_STATUS_SUCCESS);
+          input_desc->getStrides()));
   INTERNAL_CHECK(make_plan_api,
                  mluOpSetTensorDescriptorOnchipDataType(
-                     fft_input_desc, input_desc->getOnchipDtype()) ==
-                     MLUOP_STATUS_SUCCESS);
-  INTERNAL_CHECK(
+                     fft_input_desc, input_desc->getOnchipDtype()));
+  CHECK_RETURN(
       make_plan_api,
       mluOpSetTensorDescriptorEx_v2(
           fft_output_desc, output_desc->getLayout(), output_desc->getDtype(),
           output_desc->getDim(), output_desc->getDims(),
-          output_desc->getStrides()) == MLUOP_STATUS_SUCCESS);
+          output_desc->getStrides()));
   fft_plan->input_desc = fft_input_desc;
   fft_plan->output_desc = fft_output_desc;
 
@@ -2887,14 +2884,12 @@ mluOpStatus_t MLUOP_WIN_API mluOpDestroyFFTPlan(mluOpFFTPlan_t fft_plan) {
   const std::string destroy_api = "[mluOpDestroyFFTPlan]";
   PARAM_CHECK_NE("[mluOpDestroyFFTPlan]", fft_plan, NULL);
   if (fft_plan->input_desc != NULL) {
-    INTERNAL_CHECK(destroy_api,
-                   mluOpDestroyTensorDescriptor(fft_plan->input_desc) ==
-                       MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(destroy_api,
+                 mluOpDestroyTensorDescriptor(fft_plan->input_desc));
   }
   if (fft_plan->output_desc != NULL) {
-    INTERNAL_CHECK(destroy_api,
-                   mluOpDestroyTensorDescriptor(fft_plan->output_desc) ==
-                       MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(destroy_api,
+                 mluOpDestroyTensorDescriptor(fft_plan->output_desc));
   }
   mluOpStatus_t status = MLUOP_STATUS_SUCCESS;
   switch (fft_plan->fft_type) {

--- a/kernels/fft/irfft/irfft_host.cpp
+++ b/kernels/fft/irfft/irfft_host.cpp
@@ -49,8 +49,7 @@ static mluOpStatus_t selectIRFFT1dStrategy(mluOpHandle_t handle,
 mluOpStatus_t makeIRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
   std::string api = "[mluOpMakeFFTPlanMany]";
   mluOpStatus_t status = MLUOP_STATUS_SUCCESS;
-  INTERNAL_CHECK(
-      api, selectIRFFT1dStrategy(handle, fft_plan) == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, selectIRFFT1dStrategy(handle, fft_plan));
 
   mluOpDataType_t in_c_dtype = fft_plan->input_dtype;
   mluOpDataType_t in_r_dtype = (in_c_dtype == MLUOP_DTYPE_COMPLEX_HALF)
@@ -532,8 +531,7 @@ mluOpStatus_t setIRFFT1dReserveArea(mluOpHandle_t handle,
             fft_plan->matmul_addrs.dft_scale_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
-        INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
-                       status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN("[mluOpSetFFTReserveArea]", status);
       }; break;
       case CNFFT_FUNC_COOLEY_TUKEY:
       case CNFFT_FUNC_STOCKHAM: {
@@ -552,8 +550,7 @@ mluOpStatus_t setIRFFT1dReserveArea(mluOpHandle_t handle,
             fft_plan->matmul_addrs.dft_scale_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
-        INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
-                       status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN("[mluOpSetFFTReserveArea]", status);
       }; break;
       default: {
         status = MLUOP_STATUS_NOT_SUPPORTED;
@@ -793,7 +790,7 @@ static mluOpStatus_t makeIRFFT1dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpContiguous for irfft1d input";
     mluOpTensorDescriptor_t input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 2;
     int64_t dims[IN_DIM_NUM] = {
@@ -804,16 +801,16 @@ static mluOpStatus_t makeIRFFT1dContiguousInput(mluOpHandle_t handle,
     status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->input_dtype, IN_DIM_NUM,
                                            dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mluOpContiguous(handle, input_desc, input,
                              (fft_plan->prime)
                                  ? fft_plan->matmul_addrs.input_contiguous_addr
                                  : fft_plan->mlu_addrs.input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mluOpDestroyTensorDescriptor(input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }
@@ -836,20 +833,20 @@ static mluOpStatus_t padIRFFT1dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch cnnlOpPad for input pad";
     mluOpTensorDescriptor_t input_desc, padded_input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&padded_input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 2;
     int64_t dims[IN_DIM_NUM] = {batch, fft_plan->inembed[0] * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     int64_t padded_dims[IN_DIM_NUM] = {batch, FFT_HALF(n) * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, padded_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int pad_dim_num = 4;
 
@@ -904,9 +901,9 @@ static mluOpStatus_t padIRFFT2dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch cnnlOpPad for input pad";
     mluOpTensorDescriptor_t input_desc, padded_input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&padded_input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 3;
     int64_t dims[IN_DIM_NUM] = {
@@ -914,12 +911,12 @@ static mluOpStatus_t padIRFFT2dContiguousInput(mluOpHandle_t handle,
         std::min(fft_plan->inembed[1], FFT_HALF(n1)) * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     int64_t padded_dims[IN_DIM_NUM] = {batch, n0, FFT_HALF(n1) * COMPLEX};
     status = mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, padded_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int pad_dim_num = 6;
     int paddings[pad_dim_num] = {
@@ -1013,26 +1010,26 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
                      fft_plan->matmul_addrs.input_transed_addr, in_r_dtype,
                      fft_plan->matmul_addrs.internal_workspace_addr,
                      fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // stridedslice: [a, b, c, d]    --> [d, c, b]
     // stridedslice: [a, b, c, d, e] --> [d, c, b]
     VLOG(5) << "launch mluOpStridedSlice for input";
     mluOpTensorDescriptor_t ss_input_desc, ss_output_desc;
     status = mluOpCreateTensorDescriptor(&ss_input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&ss_output_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int ss_dim_num = 2;
     int64_t ss_in_dims[ss_dim_num] = {COMPLEX * batch, FFT_HALF(n)};
     status = mluOpSetTensorDescriptor_v2(ss_input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, ss_dim_num, ss_in_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     int64_t ss_out_dims[ss_dim_num] = {COMPLEX * batch, (n - FFT_HALF(n))};
     status = mluOpSetTensorDescriptor_v2(ss_output_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, ss_dim_num, ss_out_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     int dim1_begin = (n % 2) ? -1 : -2;
     int dim1_end = -FFT_HALF(n);
@@ -1074,14 +1071,14 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpConcat for input";
     mluOpTensorDescriptor_t concat_output_desc;
     status = mluOpCreateTensorDescriptor(&concat_output_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int concat_dim_num = 2;
     int64_t concat_out_dims[concat_dim_num] = {COMPLEX * batch, n};
     status = mluOpSetTensorDescriptor_v2(concat_output_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, concat_dim_num,
                                          concat_out_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // convert to cnnl_tensor_descriptor
     DEFINE_CREATE_AND_SET_CNNL_TENSOR_DESCRIPTOR(concat_output_desc,
@@ -1163,7 +1160,7 @@ static mluOpStatus_t transposeIRFFT1dPaddedInput(mluOpHandle_t handle,
                      fft_plan->matmul_addrs.input_re_addr, in_r_dtype,
                      fft_plan->matmul_addrs.internal_workspace_addr,
                      fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     VLOG(5) << "launch mluOpTranspose for input COOLEY_TUKEY";
     int L = fft_plan->L;
@@ -1181,7 +1178,7 @@ static mluOpStatus_t transposeIRFFT1dPaddedInput(mluOpHandle_t handle,
                      fft_plan->matmul_addrs.input_re_addr, in_r_dtype,
                      fft_plan->matmul_addrs.internal_workspace_addr,
                      fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }
@@ -1275,7 +1272,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input imag matmul dft imag
     status = fftQuantMatMul(
@@ -1289,7 +1286,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // real mul real add imag mul imag
     int per_matmul_output_num = batch * n;
@@ -1300,7 +1297,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
                          1.0, 0.0, in_r_dtype, CNNL_OP_TENSOR_ADD,
                          fft_plan->matmul_addrs.internal_workspace_addr,
                          fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     VLOG(5) << "into computeIRFFT1dMatmulResult CNFFT_FUNC_COOLEY_TUKEY";
     int L = fft_plan->L;
@@ -1318,7 +1315,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input imag matmul dft imag
     status = fftQuantMatMul(
@@ -1332,7 +1329,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input real matmul dft imag
     status = fftQuantMatMul(
@@ -1346,7 +1343,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input imag matmul dft real
     status = fftQuantMatMul(
@@ -1360,7 +1357,7 @@ static mluOpStatus_t computeIRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_STOCKHAM) {
     int L = fft_plan->L;
     int m = (1 << fft_plan->m);
@@ -1456,9 +1453,9 @@ static mluOpStatus_t makeIRFFT1dContiguousOutput(mluOpHandle_t handle,
     // create tensor desc
     mluOpTensorDescriptor_t copy_src_desc, copy_dst_desc;
     status = mluOpCreateTensorDescriptor(&copy_src_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&copy_dst_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set up tensor desc
     const int OUT_DIM_NUM = 2;
@@ -1468,11 +1465,11 @@ static mluOpStatus_t makeIRFFT1dContiguousOutput(mluOpHandle_t handle,
     int64_t strides[OUT_DIM_NUM] = {fft_plan->odist, fft_plan->ostride};
     status = mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
                                          out_r_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status =
         mluOpSetTensorDescriptorEx_v2(copy_dst_desc, MLUOP_LAYOUT_ARRAY,
                                       out_r_dtype, OUT_DIM_NUM, dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // copy
     void *copy_src_addr = fft_plan->prime
@@ -1508,37 +1505,37 @@ mluOpStatus_t execIRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                          workspace, output);
 
     status = makeIRFFT1dContiguousInput(handle, fft_plan, input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = padIRFFT1dContiguousInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mergeIRFFT1dInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = transposeIRFFT1dPaddedInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = quantizeIRFFT1dPaddedInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = computeIRFFT1dMatmulResult(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mergeIRFFT1dOutput(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = makeIRFFT1dContiguousOutput(handle, fft_plan, output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else {
     configureIRFFT1dWorkspaceAddrs(handle, fft_plan, (void *)input, workspace,
                                    output);
     status = makeIRFFT1dContiguousInput(handle, fft_plan, input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (FFT_HALF(fft_plan->n[0]) > fft_plan->inembed[0]) {
       status = padIRFFT1dContiguousInput(handle, fft_plan);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       fft_plan->mlu_addrs.input = fft_plan->mlu_addrs.input_pad_addr;
     }
 
@@ -1551,23 +1548,23 @@ mluOpStatus_t execIRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     status = kernelFFT1dButterflyRowC2R(k_dim, k_type, handle->queue, fft_plan,
                                         FFT_IFFT);
 
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (scale_factor != 1.0) {
       const float alpha = scale_factor;
       const float beta = 0.0;
       mluOpTensorDescriptor_t c_desc = nullptr;
       status = mluOpCreateTensorDescriptor(&c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       const int OUT_DIM_NUM = 2;
       int64_t dims[OUT_DIM_NUM] = {fft_plan->batch, fft_plan->n[0]};
       status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->output_dtype, OUT_DIM_NUM,
                                            dims);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       status = mluOpSetTensorDescriptorOnchipDataType(
           c_desc, fft_plan->execution_dtype);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                         cnnl_handle);  // convert to cnnl_handle
@@ -1579,14 +1576,14 @@ mluOpStatus_t execIRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                  &beta, cnnl_output_desc,
                                  fft_plan->mlu_addrs.output));
       status = mluOpDestroyTensorDescriptor(c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
       DESTROY_CNNL_HANDLE(cnnl_handle);
     }
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = makeIRFFT1dContiguousOutput(handle, fft_plan, output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }
@@ -1673,11 +1670,11 @@ mluOpStatus_t computeFFT2dMatMulColumnC2R(mluOpHandle_t handle,
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2] = {m, k};
@@ -1686,19 +1683,19 @@ mluOpStatus_t computeFFT2dMatMulColumnC2R(mluOpHandle_t handle,
 
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(c_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -1735,8 +1732,16 @@ mluOpStatus_t computeFFT2dMatMulColumnC2R(mluOpHandle_t handle,
                           cnnl_a_desc, dft_matrix_addr, cnnl_b_desc, in_addr,
                           &beta, cnnl_c_desc, out_addr, workspace,
                           workspace_size, cnnl_d_desc, out_addr));
-
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
+  CALL_CNNL(cnnlMatMulDescDestroy(matmul_desc));
+  CALL_CNNL(cnnlMatMulAlgoDestroy(matmul_algo));
+  CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_c_desc);
@@ -1777,11 +1782,11 @@ mluOpStatus_t computeFFT2dMatMulRowC2R(mluOpHandle_t handle,
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2] = {m, k};
@@ -1790,19 +1795,19 @@ mluOpStatus_t computeFFT2dMatMulRowC2R(mluOpHandle_t handle,
 
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        3, b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        3, c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(c_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -1844,7 +1849,17 @@ mluOpStatus_t computeFFT2dMatMulRowC2R(mluOpHandle_t handle,
                               cnnl_a_desc, dft_matrix_addr, cnnl_b_desc,
                               in_addr, &beta, cnnl_c_desc, out_addr,
                               (void *)workspace, workspace_size));
+
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
+  CALL_CNNL(cnnlMatMulDescDestroy(bmm_bcast_desc));
+  CALL_CNNL(cnnlMatMulAlgoDestroy(algo));
+  CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_c_desc);
@@ -1871,7 +1886,7 @@ static mluOpStatus_t makeIRFFT2dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpContiguous for irfft2d input";
     mluOpTensorDescriptor_t input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 3;
     int64_t dims[IN_DIM_NUM] = {
@@ -1884,13 +1899,13 @@ static mluOpStatus_t makeIRFFT2dContiguousInput(mluOpHandle_t handle,
     status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->input_dtype, IN_DIM_NUM,
                                            dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mluOpContiguous(handle, input_desc, input, input_contiguous);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mluOpDestroyTensorDescriptor(input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }
@@ -1908,9 +1923,9 @@ static mluOpStatus_t makeIRFFT2dContiguousOutput(mluOpHandle_t handle,
     // create tensor desc
     mluOpTensorDescriptor_t copy_src_desc, copy_dst_desc;
     status = mluOpCreateTensorDescriptor(&copy_src_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&copy_dst_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set up tensor desc
     const int OUT_DIM_NUM = 3;
@@ -1922,11 +1937,11 @@ static mluOpStatus_t makeIRFFT2dContiguousOutput(mluOpHandle_t handle,
     }
     status = mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
                                          out_c_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status =
         mluOpSetTensorDescriptorEx_v2(copy_dst_desc, MLUOP_LAYOUT_ARRAY,
                                       out_c_dtype, OUT_DIM_NUM, dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // void *copy_src_addr = fft_plan->matmul_addrs.output_contiguous_addr;
     void *copy_src_addr = output_contiguous;
@@ -1969,12 +1984,12 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     odist = in_r_dtype_size * fft_plan->n[0] * fft_plan->n[1];
     status = makeIRFFT2dContiguousInput(handle, fft_plan, input,
                                         fft_plan->mlu_addrs.input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (fft_plan->n[0] > fft_plan->inembed[0] ||
         FFT_HALF(fft_plan->n[1]) > fft_plan->inembed[1]) {
       status = padIRFFT2dContiguousInput(handle, fft_plan);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       fft_plan->mlu_addrs.input = fft_plan->mlu_addrs.input_pad_addr;
     }
@@ -1983,7 +1998,7 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
       if (fft_plan->n[0] == 1 && fft_plan->n[1] == 1) {
         mluOpTensorDescriptor_t input_desc;
         status = mluOpCreateTensorDescriptor(&input_desc);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         const int IN_DIM_NUM = 2;
         int64_t dims[IN_DIM_NUM] = {
@@ -1992,20 +2007,20 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                                MLUOP_DTYPE_FLOAT, IN_DIM_NUM,
                                                dims, strides);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         status = mluOpContiguous(handle, input_desc, fft_plan->mlu_addrs.input,
                                  fft_plan->mlu_addrs.output);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         status = mluOpDestroyTensorDescriptor(input_desc);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
       } else if (fft_plan->n[0] != 1 && fft_plan->n[1] == 1) {
         for (int batch_id = 0; batch_id < fft_plan->batch; batch_id++) {
           status = kernelIRFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                                 fft_plan, FFT_IFFT);
 
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
 
           fft_plan->mlu_addrs.input =
               (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
@@ -2021,7 +2036,7 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
 
         mluOpTensorDescriptor_t input_desc;
         status = mluOpCreateTensorDescriptor(&input_desc);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         const int IN_DIM_NUM = 2;
         int64_t dims[IN_DIM_NUM] = {
@@ -2030,23 +2045,23 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                                MLUOP_DTYPE_FLOAT, IN_DIM_NUM,
                                                dims, strides);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         status = mluOpContiguous(handle, input_desc, fft_plan->mlu_addrs.input,
                                  fft_plan->mlu_addrs.output);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         status = mluOpDestroyTensorDescriptor(input_desc);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
       } else {
         for (int batch_id = 0; batch_id < fft_plan->batch; batch_id++) {
           status = kernelIRFFT2dButterflyRow(k_dim, k_type, handle->queue,
                                              fft_plan, FFT_IFFT);
 
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
           status = kernelIRFFT2dButterflyRow(k_dim, k_type, handle->queue,
                                              fft_plan, FFT_IFFT);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
 
           fft_plan->mlu_addrs.input =
               (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
@@ -2065,10 +2080,10 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         status = kernelIRFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                               fft_plan, FFT_IFFT);
 
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
         status = kernelIRFFT2dButterflyRow(k_dim, k_type, handle->queue,
                                            fft_plan, FFT_IFFT);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         fft_plan->mlu_addrs.input =
             (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
@@ -2084,10 +2099,10 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     }
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_MANY_DIST1_2D) {
     status = computeFFT2dMatMulColumnC2R(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = computeFFT2dMatMulRowC2R(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   if (scale_factor != 1.0) {
@@ -2095,16 +2110,16 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     const float beta[2] = {0.0, 0.0};
     mluOpTensorDescriptor_t c_desc = nullptr;
     status = mluOpCreateTensorDescriptor(&c_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     const int OUT_DIM_NUM = 3;
     int64_t dims[OUT_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
                                  fft_plan->n[1]};
     status = mluOpSetTensorDescriptor_v2(
         c_desc, MLUOP_LAYOUT_ARRAY, fft_plan->output_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc,
                                                     fft_plan->execution_dtype);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                       cnnl_handle);  // convert to cnnl_handle
@@ -2116,16 +2131,16 @@ mluOpStatus_t execIRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                &beta, cnnl_output_desc,
                                fft_plan->mlu_addrs.output));
     status = mluOpDestroyTensorDescriptor(c_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
   }
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   if (fft_plan->fft_strategy == CNFFT_FUNC_TWO_LEVEL_STOCKHAM) {
     status = makeIRFFT2dContiguousOutput(handle, fft_plan, output,
                                          fft_plan->mlu_addrs.output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }

--- a/kernels/fft/irfft/irfft_host.cpp
+++ b/kernels/fft/irfft/irfft_host.cpp
@@ -869,6 +869,10 @@ static mluOpStatus_t padIRFFT1dContiguousInput(mluOpHandle_t handle,
                       (fft_plan->prime) ? fft_plan->matmul_addrs.input_pad_addr
                                         : fft_plan->mlu_addrs.input_pad_addr));
 
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(padded_input_desc);
+    CHECK_RETURN(api, status);
     // destroy cnnl descriptor
     VLOG(5) << "irfft cnnlOpPad end";
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
@@ -942,7 +946,10 @@ static mluOpStatus_t padIRFFT2dContiguousInput(mluOpHandle_t handle,
                        FFT_HALF(n1) > fft_plan->inembed[1])
                           ? fft_plan->mlu_addrs.input_pad_addr
                           : fft_plan->matmul_addrs.input_pad_addr));
-
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(padded_input_desc);
+    CHECK_RETURN(api, status);
     // destroy cnnl descriptor
     VLOG(5) << "irfft cnnlOpPad end";
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
@@ -1097,6 +1104,10 @@ static mluOpStatus_t mergeIRFFT1dInput(mluOpHandle_t handle,
                          cnnl_concat_output_desc, concat_out_addr));
     VLOG(5) << "launch mluOpConcat end";
 
+    status = mluOpDestroyTensorDescriptor(ss_input_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(ss_output_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_ss_input_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_ss_output_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_concat_output_desc);
@@ -1485,7 +1496,10 @@ static mluOpStatus_t makeIRFFT1dContiguousOutput(mluOpHandle_t handle,
 
     CALL_CNNL(cnnlCopy_v2(cnnl_handle, cnnl_copy_src_desc, copy_src_addr,
                           cnnl_copy_dst_desc, output, NULL, 0));
-
+    status = mluOpDestroyTensorDescriptor(copy_src_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(copy_dst_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_src_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_dst_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
@@ -1955,7 +1969,10 @@ static mluOpStatus_t makeIRFFT2dContiguousOutput(mluOpHandle_t handle,
 
     CALL_CNNL(cnnlCopy_v2(cnnl_handle, cnnl_copy_src_desc, copy_src_addr,
                           cnnl_copy_dst_desc, output, NULL, 0));
-
+    status = mluOpDestroyTensorDescriptor(copy_src_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(copy_dst_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_src_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_dst_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);

--- a/kernels/fft/rfft/rfft_host.cpp
+++ b/kernels/fft/rfft/rfft_host.cpp
@@ -789,6 +789,10 @@ static mluOpStatus_t padRFFT1dContiguousInput(mluOpHandle_t handle,
                       (fft_plan->prime) ? fft_plan->matmul_addrs.input_pad_addr
                                         : fft_plan->mlu_addrs.input_pad_addr));
 
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(padded_input_desc);
+    CHECK_RETURN(api, status);
     // destroy cnnl descriptor
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_padded_input_desc);
@@ -847,7 +851,10 @@ static mluOpStatus_t padRFFT2dContiguousInput(mluOpHandle_t handle,
                       paddings, &padding_value, cnnl_padded_input_desc,
                       (fft_plan->prime) ? fft_plan->matmul_addrs.input_pad_addr
                                         : fft_plan->mlu_addrs.input_pad_addr));
-
+    status = mluOpDestroyTensorDescriptor(input_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(padded_input_desc);
+    CHECK_RETURN(api, status);
     // destroy cnnl descriptor
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_padded_input_desc);
@@ -1110,6 +1117,10 @@ static mluOpStatus_t makeRFFT1dContiguousOutput(mluOpHandle_t handle,
     CALL_CNNL(cnnlCopy_v2(cnnl_handle, cnnl_copy_src_desc, copy_src_addr,
                           cnnl_copy_dst_desc, output, NULL, 0));
 
+    status = mluOpDestroyTensorDescriptor(copy_src_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(copy_dst_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_src_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_dst_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
@@ -1203,7 +1214,10 @@ static mluOpStatus_t makeRFFT2dContiguousOutput(mluOpHandle_t handle,
 
     CALL_CNNL(cnnlCopy_v2(cnnl_handle, cnnl_copy_src_desc, copy_src_addr,
                           cnnl_copy_dst_desc, output, NULL, 0));
-
+    status = mluOpDestroyTensorDescriptor(copy_src_desc);
+    CHECK_RETURN(api, status);
+    status = mluOpDestroyTensorDescriptor(copy_dst_desc);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_src_desc);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_copy_dst_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
@@ -1606,7 +1620,10 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                             fft_plan->mlu_addrs.input, paddings, &padding_value,
                             cnnl_padded_output_desc,
                             fft_plan->mlu_addrs.output));
-
+          status = mluOpDestroyTensorDescriptor(input_desc);
+          CHECK_RETURN(api, status);
+          status = mluOpDestroyTensorDescriptor(padded_output_desc);
+          CHECK_RETURN(api, status);
           DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
           DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_padded_output_desc);
 
@@ -1683,7 +1700,10 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         CALL_CNNL(cnnlPad(cnnl_handle, cnnl_input_desc,
                           fft_plan->mlu_addrs.input, paddings, &padding_value,
                           cnnl_padded_output_desc, fft_plan->mlu_addrs.output));
-
+        status = mluOpDestroyTensorDescriptor(input_desc);
+        CHECK_RETURN(api, status);
+        status = mluOpDestroyTensorDescriptor(padded_output_desc);
+        CHECK_RETURN(api, status);
         DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_input_desc);
         DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_padded_output_desc);
 

--- a/kernels/fft/rfft/rfft_host.cpp
+++ b/kernels/fft/rfft/rfft_host.cpp
@@ -48,8 +48,7 @@ static mluOpStatus_t selectRFFT1dStrategy(mluOpHandle_t handle,
 mluOpStatus_t makeRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
   std::string api = "[mluOpMakeFFTPlanMany]";
   mluOpStatus_t status = MLUOP_STATUS_SUCCESS;
-  INTERNAL_CHECK(
-      api, selectRFFT1dStrategy(handle, fft_plan) == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, selectRFFT1dStrategy(handle, fft_plan));
 
   mluOpDataType_t in_r_dtype = fft_plan->input_dtype;
   mluOpDataType_t in_e_dtype = fft_plan->execution_dtype;
@@ -510,8 +509,7 @@ mluOpStatus_t setRFFT1dReserveArea(mluOpHandle_t handle,
             fft_plan->matmul_addrs.dft_scale_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
-        INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
-                       status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN("[mluOpSetFFTReserveArea]", status);
       }; break;
       case CNFFT_FUNC_COOLEY_TUKEY: {
         // Matmul Matrix : 2 * [L, L]
@@ -527,8 +525,7 @@ mluOpStatus_t setRFFT1dReserveArea(mluOpHandle_t handle,
             fft_plan->matmul_addrs.dft_scale_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
-        INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
-                       status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN("[mluOpSetFFTReserveArea]", status);
       }; break;
       case CNFFT_FUNC_STOCKHAM: {
         // Matmul Matrix : 2 * [L, L]
@@ -547,8 +544,7 @@ mluOpStatus_t setRFFT1dReserveArea(mluOpHandle_t handle,
             fft_plan->matmul_addrs.dft_scale_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_addr,
             fft_plan->matmul_addrs.dft_quantize_workspace_size, api);
-        INTERNAL_CHECK("[mluOpSetFFTReserveArea]",
-                       status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN("[mluOpSetFFTReserveArea]", status);
       }; break;
       default: {
         status = MLUOP_STATUS_NOT_SUPPORTED;
@@ -707,7 +703,7 @@ static mluOpStatus_t makeRFFT1dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpContiguous";
     mluOpTensorDescriptor_t input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 2;
     if (fft_plan->prime) {
@@ -716,14 +712,14 @@ static mluOpStatus_t makeRFFT1dContiguousInput(mluOpHandle_t handle,
       status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                              fft_plan->input_dtype, IN_DIM_NUM,
                                              dims, strides);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status = mluOpContiguous(handle, input_desc, input,
                                fft_plan->matmul_addrs.input_contiguous_addr);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status = mluOpDestroyTensorDescriptor(input_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
     } else {
       int64_t dims[IN_DIM_NUM] = {
@@ -732,14 +728,14 @@ static mluOpStatus_t makeRFFT1dContiguousInput(mluOpHandle_t handle,
       status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                              fft_plan->input_dtype, IN_DIM_NUM,
                                              dims, strides);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status =
           mluOpContiguous(handle, input_desc, input, fft_plan->mlu_addrs.input);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       status = mluOpDestroyTensorDescriptor(input_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
     }
   }
   return status;
@@ -760,20 +756,20 @@ static mluOpStatus_t padRFFT1dContiguousInput(mluOpHandle_t handle,
   if (need_pad) {
     mluOpTensorDescriptor_t input_desc, padded_input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&padded_input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 2;
     int64_t dims[IN_DIM_NUM] = {batch, fft_plan->inembed[0]};
     status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     int64_t padded_dims[IN_DIM_NUM] = {batch, n};
     status = mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, padded_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int pad_dim_num = 4;
     int paddings[pad_dim_num] = {0, 0, 0, n - fft_plan->inembed[0]};
@@ -816,21 +812,21 @@ static mluOpStatus_t padRFFT2dContiguousInput(mluOpHandle_t handle,
   if (need_pad) {
     mluOpTensorDescriptor_t input_desc, padded_input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&padded_input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 3;
     int64_t dims[IN_DIM_NUM] = {batch, std::min(n0, fft_plan->inembed[0]),
                                 std::min(n1, fft_plan->inembed[1])};
     status = mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     int64_t padded_dims[IN_DIM_NUM] = {batch, n0, n1};
     status = mluOpSetTensorDescriptor_v2(padded_input_desc, MLUOP_LAYOUT_ARRAY,
                                          in_r_dtype, IN_DIM_NUM, padded_dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int pad_dim_num = 6;
     int paddings[pad_dim_num] = {0, 0,
@@ -948,7 +944,7 @@ static mluOpStatus_t computeRFFT1dMatmulResult(mluOpHandle_t handle,
         scale_factor, 0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_COOLEY_TUKEY) {
     VLOG(5) << "into CNFFT_FUNC_COOLEY_TUKEY";
     int L = fft_plan->L;
@@ -965,7 +961,7 @@ static mluOpStatus_t computeRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // input re matmul dft imag
     status = fftQuantMatMul(
@@ -979,7 +975,7 @@ static mluOpStatus_t computeRFFT1dMatmulResult(mluOpHandle_t handle,
         0.0, in_e_dtype, in_e_dtype, in_r_dtype,
         fft_plan->matmul_addrs.internal_workspace_addr,
         fft_plan->matmul_addrs.internal_workspace_size, api);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_STOCKHAM) {
     VLOG(5) << "into CNFFT_FUNC_STOCKHAM";
     int L = fft_plan->L;
@@ -1080,9 +1076,9 @@ static mluOpStatus_t makeRFFT1dContiguousOutput(mluOpHandle_t handle,
     // create tensor desc
     mluOpTensorDescriptor_t copy_src_desc, copy_dst_desc;
     status = mluOpCreateTensorDescriptor(&copy_src_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&copy_dst_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set up tensor desc
     const int OUT_DIM_NUM = 2;
@@ -1092,11 +1088,11 @@ static mluOpStatus_t makeRFFT1dContiguousOutput(mluOpHandle_t handle,
     int64_t strides[OUT_DIM_NUM] = {fft_plan->odist, fft_plan->ostride};
     status = mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
                                          out_c_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status =
         mluOpSetTensorDescriptorEx_v2(copy_dst_desc, MLUOP_LAYOUT_ARRAY,
                                       out_c_dtype, OUT_DIM_NUM, dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // copy
     void *copy_src_addr = (fft_plan->prime)
@@ -1136,7 +1132,7 @@ static mluOpStatus_t makeRFFT2dContiguousInput(mluOpHandle_t handle,
     VLOG(5) << "launch mluOpContiguous for rfft2d input";
     mluOpTensorDescriptor_t input_desc;
     status = mluOpCreateTensorDescriptor(&input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     const int IN_DIM_NUM = 3;
     int64_t dims[IN_DIM_NUM] = {
@@ -1152,14 +1148,14 @@ static mluOpStatus_t makeRFFT2dContiguousInput(mluOpHandle_t handle,
     status = mluOpSetTensorDescriptorEx_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->input_dtype, IN_DIM_NUM,
                                            dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status =
         mluOpContiguous(handle, input_desc, input, fft_plan->mlu_addrs.input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mluOpDestroyTensorDescriptor(input_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }
@@ -1176,9 +1172,9 @@ static mluOpStatus_t makeRFFT2dContiguousOutput(mluOpHandle_t handle,
     // create tensor desc
     mluOpTensorDescriptor_t copy_src_desc, copy_dst_desc;
     status = mluOpCreateTensorDescriptor(&copy_src_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpCreateTensorDescriptor(&copy_dst_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     // set up tensor desc
     const int OUT_DIM_NUM = 3;
@@ -1190,11 +1186,11 @@ static mluOpStatus_t makeRFFT2dContiguousOutput(mluOpHandle_t handle,
     }
     status = mluOpSetTensorDescriptor_v2(copy_src_desc, MLUOP_LAYOUT_ARRAY,
                                          out_c_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status =
         mluOpSetTensorDescriptorEx_v2(copy_dst_desc, MLUOP_LAYOUT_ARRAY,
                                       out_c_dtype, OUT_DIM_NUM, dims, strides);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     void *copy_src_addr = fft_plan->mlu_addrs.output;
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
@@ -1225,35 +1221,35 @@ mluOpStatus_t execRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                         workspace, output);
 
     status = makeRFFT1dContiguousInput(handle, fft_plan, input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = padRFFT1dContiguousInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = transposeRFFT1dPaddedInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = quantizeRFFT1dPaddedInput(handle, fft_plan);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = computeRFFT1dMatmulResult(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = mergeRFFT1dOutput(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     status = makeRFFT1dContiguousOutput(handle, fft_plan, output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   } else {
     configureRFFT1dWorkspaceAddrs(handle, fft_plan, (void *)input, workspace,
                                   output);
 
     status = makeRFFT1dContiguousInput(handle, fft_plan, input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (fft_plan->n[0] > fft_plan->inembed[0]) {
       status = padRFFT1dContiguousInput(handle, fft_plan);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       fft_plan->mlu_addrs.input = fft_plan->mlu_addrs.input_pad_addr;
     }
 
@@ -1265,23 +1261,23 @@ mluOpStatus_t execRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
 
     status = execFFTr2c1d(handle, fft_plan, scale_factor);
 
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (scale_factor != 1.0) {
       const float alpha[2] = {scale_factor, 0.0};
       const float beta[2] = {0.0, 0.0};
       mluOpTensorDescriptor_t c_desc = nullptr;
       status = mluOpCreateTensorDescriptor(&c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       const int OUT_DIM_NUM = 2;
       int64_t dims[OUT_DIM_NUM] = {fft_plan->batch, (fft_plan->n[0] / 2 + 1)};
       status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY,
                                            fft_plan->output_dtype, OUT_DIM_NUM,
                                            dims);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       status = mluOpSetTensorDescriptorOnchipDataType(
           c_desc, fft_plan->execution_dtype);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
 
       DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                         cnnl_handle);  // convert to cnnl_handle
@@ -1293,14 +1289,14 @@ mluOpStatus_t execRFFT1d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                  &beta, cnnl_output_desc,
                                  fft_plan->mlu_addrs.output));
       status = mluOpDestroyTensorDescriptor(c_desc);
-      INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+      CHECK_RETURN(api, status);
       DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
       DESTROY_CNNL_HANDLE(cnnl_handle);
     }
 
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = makeRFFT1dContiguousOutput(handle, fft_plan, output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   return status;
@@ -1346,11 +1342,11 @@ mluOpStatus_t computeFFT2dMatMulColumnR2C(mluOpHandle_t handle,
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2] = {m, k};
@@ -1360,19 +1356,19 @@ mluOpStatus_t computeFFT2dMatMulColumnR2C(mluOpHandle_t handle,
 
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(c_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -1408,7 +1404,16 @@ mluOpStatus_t computeFFT2dMatMulColumnR2C(mluOpHandle_t handle,
                           &beta, cnnl_c_desc, out_addr, workspace,
                           workspace_size, cnnl_d_desc, out_addr));
 
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
+  CALL_CNNL(cnnlMatMulDescDestroy(matmul_desc));
+  CALL_CNNL(cnnlMatMulAlgoDestroy(matmul_algo));
+  CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_c_desc);
@@ -1451,11 +1456,11 @@ mluOpStatus_t computeFFT2dMatMulRowR2C(mluOpHandle_t handle,
   mluOpTensorDescriptor_t b_desc = nullptr;
   mluOpTensorDescriptor_t c_desc = nullptr;
   status = mluOpCreateTensorDescriptor(&a_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&b_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpCreateTensorDescriptor(&c_desc);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   // set descriptor
   int64_t a_dims[2] = {m, k};
@@ -1464,19 +1469,19 @@ mluOpStatus_t computeFFT2dMatMulRowR2C(mluOpHandle_t handle,
 
   status = mluOpSetTensorDescriptor_v2(a_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        2, a_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(a_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(b_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        3, b_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(b_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptor_v2(c_desc, MLUOP_LAYOUT_ARRAY, in_e_dtype,
                                        3, c_dims);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
   status = mluOpSetTensorDescriptorOnchipDataType(c_desc, in_e_dtype);
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                     cnnl_handle);  // convert to cnnl_handle
@@ -1517,7 +1522,17 @@ mluOpStatus_t computeFFT2dMatMulRowR2C(mluOpHandle_t handle,
                               cnnl_a_desc, dft_matrix_addr, cnnl_b_desc,
                               in_addr, &beta, cnnl_c_desc, out_addr,
                               (void *)workspace, workspace_size));
+
+  status = mluOpDestroyTensorDescriptor(a_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(b_desc);
+  CHECK_RETURN(api, status);
+  status = mluOpDestroyTensorDescriptor(c_desc);
+  CHECK_RETURN(api, status);
   // destroy cnnl descriptor
+  CALL_CNNL(cnnlMatMulDescDestroy(bmm_bcast_desc));
+  CALL_CNNL(cnnlMatMulAlgoDestroy(algo));
+  CALL_CNNL(cnnlDestroyMatMulHeuristicResult(heuristic_result));
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_a_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_b_desc);
   DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_c_desc);
@@ -1550,16 +1565,16 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     idist = in_r_dtype_size * fft_plan->n[0] * fft_plan->n[1];
     odist = in_c_dtype_size * fft_plan->n[0] * (fft_plan->n[1] / 2 + 1);
     status = makeRFFT2dContiguousInput(handle, fft_plan, input);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     if (fft_plan->n[0] == 1 || fft_plan->n[1] == 1) {
       if (fft_plan->n[0] != 1 && fft_plan->n[1] == 1) {
         {
           mluOpTensorDescriptor_t input_desc, padded_output_desc;
           status = mluOpCreateTensorDescriptor(&input_desc);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
           status = mluOpCreateTensorDescriptor(&padded_output_desc);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
 
           const int IN_DIM_NUM = 3;
           int64_t dims[IN_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
@@ -1567,14 +1582,14 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
           status =
               mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                           MLUOP_DTYPE_FLOAT, IN_DIM_NUM, dims);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
 
           int64_t padded_dims[IN_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
                                              fft_plan->n[1] * 2};
           status = mluOpSetTensorDescriptor_v2(
               padded_output_desc, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
               IN_DIM_NUM, padded_dims);
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
 
           const int pad_dim_num = 6;
           int paddings[pad_dim_num] = {0, 0, 0, 0, 0, 1};
@@ -1601,7 +1616,7 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
           status = kernelRFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                                fft_plan, FFT_IFFT);
 
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
 
           fft_plan->mlu_addrs.input =
               (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
@@ -1619,7 +1634,7 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
           status = kernelRFFT2dButterflyRow(k_dim, k_type, handle->queue,
                                             fft_plan, RFFT);
 
-          INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+          CHECK_RETURN(api, status);
 
           fft_plan->mlu_addrs.input =
               (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
@@ -1635,9 +1650,9 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
       } else {
         mluOpTensorDescriptor_t input_desc, padded_output_desc;
         status = mluOpCreateTensorDescriptor(&input_desc);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
         status = mluOpCreateTensorDescriptor(&padded_output_desc);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         const int IN_DIM_NUM = 2;
         int64_t dims[IN_DIM_NUM] = {fft_plan->batch,
@@ -1645,14 +1660,14 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         status =
             mluOpSetTensorDescriptor_v2(input_desc, MLUOP_LAYOUT_ARRAY,
                                         MLUOP_DTYPE_FLOAT, IN_DIM_NUM, dims);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         int64_t padded_dims[IN_DIM_NUM] = {fft_plan->batch,
                                            fft_plan->n[0] * fft_plan->n[1] * 2};
         status = mluOpSetTensorDescriptor_v2(
             padded_output_desc, MLUOP_LAYOUT_ARRAY, MLUOP_DTYPE_FLOAT,
             IN_DIM_NUM, padded_dims);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         const int pad_dim_num = 4;
         int paddings[pad_dim_num] = {0, 0, 0, 1};
@@ -1679,11 +1694,11 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
         status = kernelRFFT2dButterflyRow(k_dim, k_type, handle->queue,
                                           fft_plan, RFFT);
 
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         status = kernelRFFT2dButterflyColumn(k_dim, k_type, handle->queue,
                                              fft_plan, FFT_IFFT);
-        INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+        CHECK_RETURN(api, status);
 
         fft_plan->mlu_addrs.input =
             (void *)((uint64_t)(fft_plan->mlu_addrs.input) + idist);
@@ -1699,9 +1714,9 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     }
   } else if (fft_plan->fft_strategy == CNFFT_FUNC_MANY_DIST1_2D) {
     status = computeFFT2dMatMulRowR2C(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = computeFFT2dMatMulColumnR2C(handle, fft_plan, scale_factor);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
 
   if (scale_factor != 1.0) {
@@ -1709,16 +1724,16 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
     const float beta[2] = {0.0, 0.0};
     mluOpTensorDescriptor_t c_desc = nullptr;
     status = mluOpCreateTensorDescriptor(&c_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     const int OUT_DIM_NUM = 3;
     int64_t dims[OUT_DIM_NUM] = {fft_plan->batch, fft_plan->n[0],
                                  fft_plan->n[1] / 2 + 1};
     status = mluOpSetTensorDescriptor_v2(
         c_desc, MLUOP_LAYOUT_ARRAY, fft_plan->output_dtype, OUT_DIM_NUM, dims);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     status = mluOpSetTensorDescriptorOnchipDataType(c_desc,
                                                     fft_plan->execution_dtype);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
 
     DEFINE_CREATE_AND_SET_CNNL_HANDLE(handle,
                                       cnnl_handle);  // convert to cnnl_handle
@@ -1730,15 +1745,15 @@ mluOpStatus_t execRFFT2d(mluOpHandle_t handle, const mluOpFFTPlan_t fft_plan,
                                &beta, cnnl_output_desc,
                                fft_plan->mlu_addrs.output));
     status = mluOpDestroyTensorDescriptor(c_desc);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
     DESTROY_CNNL_TENSOR_DESCRIPTOR(cnnl_output_desc);
     DESTROY_CNNL_HANDLE(cnnl_handle);
   }
-  INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+  CHECK_RETURN(api, status);
 
   if (fft_plan->fft_strategy == CNFFT_FUNC_TWO_LEVEL_STOCKHAM) {
     status = makeRFFT2dContiguousOutput(handle, fft_plan, output);
-    INTERNAL_CHECK(api, status == MLUOP_STATUS_SUCCESS);
+    CHECK_RETURN(api, status);
   }
   return status;
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.