### PR TITLE
[Fix](mlu-ops): replace deprecated instructions for 4.0.0.

### DIFF
--- a/docs/design_docs/roi_align_rotated/roi_align_rotated_forward_vector.md
+++ b/docs/design_docs/roi_align_rotated/roi_align_rotated_forward_vector.md
@@ -224,11 +224,11 @@ __mlu_func__ void getRoiInfo(const T *rois_dram, int roi_idx,
     roi_bin_grid_w = params.sample_ratio;
   } else {
     if constexpr (std::is_same<T, half>::value) {
-      roi_bin_grid_h = __half2int_up(bin_size_h);
-      roi_bin_grid_w = __half2int_up(bin_size_w);
+      roi_bin_grid_h = __half2int32_up(bin_size_h);
+      roi_bin_grid_w = __half2int32_up(bin_size_w);
     } else {
-      roi_bin_grid_h = __float2int_up(bin_size_h);
-      roi_bin_grid_w = __float2int_up(bin_size_w);
+      roi_bin_grid_h = __float2int32_up(bin_size_h);
+      roi_bin_grid_w = __float2int32_up(bin_size_w);
     }
   }
 
@@ -286,11 +286,11 @@ __mlu_func__ void bilinearInterpolatePosWeight(
 
     int y_low, x_low, y_high, x_high;
     if constexpr (std::is_same<T, half>::value) {
-      y_low = __half2int(y);
-      x_low = __half2int(x);
+      y_low = __half2int32(y);
+      x_low = __half2int32(x);
     } else {
-      y_low = __float2int(y);
-      x_low = __float2int(x);
+      y_low = __float2int32(y);
+      x_low = __float2int32(x);
     }
 
     if (y_low >= height - 1) {

--- a/docs/design_docs/roiaware_pool3d_forward/roiaware_pool3d_forward.md
+++ b/docs/design_docs/roiaware_pool3d_forward/roiaware_pool3d_forward.md
@@ -314,9 +314,9 @@ __device__ get_pts_idx_of_voxels(int max_pts_each_voxel, int out_x, int out_y, i
   float voxels_y_res = y_size / out_y;
   float voxels_z_res = z_size / out_z;
 
-  nram float X_idx = float2int((local_X + x_size / 2) / voxels_x_res);
-  nram float Y_idx = float2int((local_Y + y_size / 2) / voxels_y_res);
-  nram float Z_idx = float2int(local_Z                / voxels_z_res);
+  nram float X_idx = float2int32((local_X + x_size / 2) / voxels_x_res);
+  nram float Y_idx = float2int32((local_Y + y_size / 2) / voxels_y_res);
+  nram float Z_idx = float2int32(local_Z                / voxels_z_res);
   nram voxels_index = X_idx * out_y * out_z +
                       Y_idx * out_z +
                       Z_idx ;

--- a/kernels/psroipool/psroipool_block.mlu
+++ b/kernels/psroipool/psroipool_block.mlu
@@ -35,9 +35,9 @@ __nram__ int8_t nram_ptr[MAX_NRAM_SIZE];
 template <typename T>
 __mlu_func__ T scalarRound(T key) {
   if (sizeof(T) == 2) {
-    return (T)(__half2int_rd(T(key)));
+    return (T)(__half2int32_rd(T(key)));
   } else {
-    return (T)(__float2int_rd(T(key)));
+    return (T)(__float2int32_rd(T(key)));
   }
 }
 

--- a/kernels/roi_align_rotated/roi_align_rotated_block.mlu
+++ b/kernels/roi_align_rotated/roi_align_rotated_block.mlu
@@ -59,8 +59,8 @@ __mlu_func__ void bilinearInterpolate(const int input_height,
   if (y <= 0) y = (T)0;
   if (x <= 0) x = (T)0;
 
-  *y_low = __float2int((float)y);
-  *x_low = __float2int((float)x);
+  *y_low = __float2int32((float)y);
+  *x_low = __float2int32((float)x);
 
   if (*y_low >= input_height - 1) {
     *y_high = *y_low = input_height - 1;
@@ -145,11 +145,11 @@ __mlu_global__ void roiAlignRotatedForward(
     int roi_bin_grid_h =
         (params.sample_ratio > 0)
             ? params.sample_ratio
-            : __float2int_up((float)roi_height / params.pooled_height);
+            : __float2int32_up((float)roi_height / params.pooled_height);
     int roi_bin_grid_w =
         (params.sample_ratio > 0)
             ? params.sample_ratio
-            : __float2int_up((float)roi_width / params.pooled_width);
+            : __float2int32_up((float)roi_width / params.pooled_width);
     T roi_start_y = -roi_height / 2;
     T roi_start_x = -roi_width / 2;
     const int bin_dim = __mluop_max(roi_bin_grid_h * roi_bin_grid_w, 1);
@@ -342,11 +342,11 @@ __mlu_global__ void roiAlignRotatedBackward(
     int roi_bin_grid_h =
         (params.sample_ratio > 0)
             ? params.sample_ratio
-            : __float2int_up((float)roi_height / params.pooled_height);
+            : __float2int32_up((float)roi_height / params.pooled_height);
     int roi_bin_grid_w =
         (params.sample_ratio > 0)
             ? params.sample_ratio
-            : __float2int_up((float)roi_width / params.pooled_width);
+            : __float2int32_up((float)roi_width / params.pooled_width);
     T roi_start_y = -roi_height / 2;
     T roi_start_x = -roi_width / 2;
     const int bin_dim = __mluop_max(roi_bin_grid_h * roi_bin_grid_w, 1);

--- a/kernels/roi_align_rotated/roi_align_rotated_forward_vector.mlu
+++ b/kernels/roi_align_rotated/roi_align_rotated_forward_vector.mlu
@@ -79,11 +79,11 @@ __mlu_func__ void getRoiInfo(const T *rois_dram, int roi_idx,
     roi_bin_grid_w = params.sample_ratio;
   } else {
     if constexpr (std::is_same<T, half>::value) {
-      roi_bin_grid_h = __half2int_up(bin_size_h);
-      roi_bin_grid_w = __half2int_up(bin_size_w);
+      roi_bin_grid_h = __half2int32_up(bin_size_h);
+      roi_bin_grid_w = __half2int32_up(bin_size_w);
     } else {
-      roi_bin_grid_h = __float2int_up(bin_size_h);
-      roi_bin_grid_w = __float2int_up(bin_size_w);
+      roi_bin_grid_h = __float2int32_up(bin_size_h);
+      roi_bin_grid_w = __float2int32_up(bin_size_w);
     }
   }
 
@@ -194,11 +194,11 @@ __mlu_func__ void bilinearInterpolatePosWeight(
 
     int y_low, x_low, y_high, x_high;
     if constexpr (std::is_same<T, half>::value) {
-      y_low = __half2int(y);
-      x_low = __half2int(x);
+      y_low = __half2int32(y);
+      x_low = __half2int32(x);
     } else {
-      y_low = __float2int(y);
-      x_low = __float2int(x);
+      y_low = __float2int32(y);
+      x_low = __float2int32(x);
     }
 
     if (y_low >= height - 1) {

--- a/kernels/rotated_feature_align/rotated_feature_align_block.mlu
+++ b/kernels/rotated_feature_align/rotated_feature_align_block.mlu
@@ -50,8 +50,8 @@ __mlu_func__ void bilinearInterpolate(const int height, const int width, T x,
   if (y <= 0) y = 0;
   if (x <= 0) x = 0;
 
-  *y_low = __float2int((float)y);
-  *x_low = __float2int((float)x);
+  *y_low = __float2int32((float)y);
+  *x_low = __float2int32((float)x);
 
   if ((*y_low) >= height - 1) {
     *y_high = *y_low = height - 1;
@@ -90,8 +90,8 @@ __mlu_func__ void bilinearInterpolateGradient(const int height, const int width,
   }
   if (y <= 0) y = 0;
   if (x <= 0) x = 0;
-  *y_low = __float2int((float)y);
-  *x_low = __float2int((float)x);
+  *y_low = __float2int32((float)y);
+  *x_low = __float2int32((float)x);
   if ((*y_low) >= height - 1) {
     *y_high = *y_low = height - 1;
     y = T(*y_low);

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -155,7 +155,6 @@ function main () {
     fi
 
     parse_args "$@"
-    export MLU_VISIBLE_DEVICES=${DEVICE_ID}
     process
 }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.