### PR TITLE
[Feature](mluOpExecFFT): add perf border for cooleytuky and stockham kernel.

### DIFF
--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -969,7 +969,7 @@ int findFFTOptLimit(mluOpHandle_t handle, const int n, const int batch, int &m,
   flag_stockham = findStockham(handle, L, m, L_sub, find_stockham);
   if (flag_stockham && batch > FFT_STOCK_BATCH_LIMIT &&
       L > 30 * std::pow(2, m)) {
-      // FFT_STOCK_BATCH_LIMIT & L > 30 * 2^M : Numerical
+      // FFT_STOCK_BATCH_LIMIT & L > 30 * 2^m : Numerical
       // values derived from testing experience
     flag_cooley_tukey = findCooleyTukey(handle, L, m, s);
     // try Cooley-Tukey algo, which may has better performace

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -24,8 +24,7 @@
 #include "fft_basic_ops.h"
 
 #ifndef FFT_STOCK_BATCH_LIMIT
-#define FFT_STOCK_BATCH_LIMIT \
-  512  // Numerical values derived from testing experience
+#define FFT_STOCK_BATCH_LIMIT 512
 #endif
 
 bool fftIsIntDtype(const mluOpDataType_t dtype) {
@@ -969,9 +968,11 @@ int findFFTOptLimit(mluOpHandle_t handle, const int n, const int batch, int &m,
   int flag_cooley_tukey;
   flag_stockham = findStockham(handle, L, m, L_sub, find_stockham);
   if (flag_stockham && batch > FFT_STOCK_BATCH_LIMIT &&
-      L > 30 * std::pow(2, m)) {
+      L > 30 * std::pow(2,
+                        m)) {  // FFT_STOCK_BATCH_LIMIT & L > 30 2^M : Numerical
+                               // values derived from testing experience
     flag_cooley_tukey = findCooleyTukey(handle, L, m, s);
-    // try cooleyTukey algo, which may has better performace
+    // try Cooley-Tukey algo, which may has better performace
     if (flag_cooley_tukey) {
       flag = 1;  // Cooley-Tukey algo has better performance
     }

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -966,19 +966,17 @@ int findFFTOptLimit(mluOpHandle_t handle, const int n, const int batch, int &m,
   initBasicParam(n, L, m);
   int flag = 0;
   int flag_stockham;
-  int flag_cooleyTuky;
+  int flag_cooleyTukey;
   flag_stockham = findStockham(handle, L, m, L_sub, find_stockham);
   if (flag_stockham && batch > FFT_STOCK_BATCH_LIMIT &&
       L > 30 * std::pow(2, m)) {
-    flag_cooleyTuky = findCooleyTukey(handle, L, m, s);
-    // try cooley tuky algo, which may has better performace
-    if (flag_cooleyTuky) {
-      flag = 1;  // cooley tuky algo has better performance
-    } else {
-      flag = 0;  // stockham algo has better performance
+    flag_cooleyTukey = findCooleyTukey(handle, L, m, s);
+    // try cooleyTukey algo, which may has better performace
+    if (flag_cooleyTukey) {
+      flag = 1;  // cooleyTukey algo has better performance
     }
   }
-  if (!flag_stockham) {  // if cannot deal by stockham algo, try cooley tuky
+  if (!flag_stockham) {  // if cannot deal by stockham algo, try cooleyTukey
                          // algo
     flag = findCooleyTukey(handle, L, m, s);
   }

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -966,17 +966,17 @@ int findFFTOptLimit(mluOpHandle_t handle, const int n, const int batch, int &m,
   initBasicParam(n, L, m);
   int flag = 0;
   int flag_stockham;
-  int flag_cooleyTukey;
+  int flag_cooley_tukey;
   flag_stockham = findStockham(handle, L, m, L_sub, find_stockham);
   if (flag_stockham && batch > FFT_STOCK_BATCH_LIMIT &&
       L > 30 * std::pow(2, m)) {
-    flag_cooleyTukey = findCooleyTukey(handle, L, m, s);
+    flag_cooley_tukey = findCooleyTukey(handle, L, m, s);
     // try cooleyTukey algo, which may has better performace
-    if (flag_cooleyTukey) {
-      flag = 1;  // cooleyTukey algo has better performance
+    if (flag_cooley_tukey) {
+      flag = 1;  // Cooley-Tukey algo has better performance
     }
   }
-  if (!flag_stockham) {  // if cannot deal by stockham algo, try cooleyTukey
+  if (!flag_stockham) {  // if cannot deal by Stockham algo, try Cooley-Tukey
                          // algo
     flag = findCooleyTukey(handle, L, m, s);
   }

--- a/kernels/fft/common/fft_basic_ops.cpp
+++ b/kernels/fft/common/fft_basic_ops.cpp
@@ -968,9 +968,9 @@ int findFFTOptLimit(mluOpHandle_t handle, const int n, const int batch, int &m,
   int flag_cooley_tukey;
   flag_stockham = findStockham(handle, L, m, L_sub, find_stockham);
   if (flag_stockham && batch > FFT_STOCK_BATCH_LIMIT &&
-      L > 30 * std::pow(2,
-                        m)) {  // FFT_STOCK_BATCH_LIMIT & L > 30 2^M : Numerical
-                               // values derived from testing experience
+      L > 30 * std::pow(2, m)) {
+      // FFT_STOCK_BATCH_LIMIT & L > 30 * 2^M : Numerical
+      // values derived from testing experience
     flag_cooley_tukey = findCooleyTukey(handle, L, m, s);
     // try Cooley-Tukey algo, which may has better performace
     if (flag_cooley_tukey) {

--- a/kernels/fft/common/fft_basic_ops.h
+++ b/kernels/fft/common/fft_basic_ops.h
@@ -107,6 +107,6 @@ mluOpStatus_t fftOptensor(mluOpHandle_t handle, int elem_num, void *in1_ptr,
                           cnnlOpTensorDesc_t op_type, void *workspace,
                           size_t workspace_size, const std::string api);
 
-int findFFTOptLimit(mluOpHandle_t handle, const int n, int &m, int &L, int &s,
-                    int &L_sub, bool &find_stockham);
+int findFFTOptLimit(mluOpHandle_t handle, const int n, const int batch, int &m,
+                    int &L, int &s, int &L_sub, bool &find_stockham);
 #endif  // KERNELS_FFT_COMMON_FFT_BASIC_OPS_H_

--- a/kernels/fft/fft.cpp
+++ b/kernels/fft/fft.cpp
@@ -2696,8 +2696,6 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
       fft_plan->prime ||
       ((n[0] <= 2 || n[0] == 400 || n[0] == 512 || n[0] == 48000) && rank == 1);
 
-
-  VLOG(5) << "fft_plan->prime: " << fft_plan->prime;
   /*
    * decision part
    */

--- a/kernels/fft/fft.cpp
+++ b/kernels/fft/fft.cpp
@@ -56,9 +56,11 @@ mluOpStatus_t selectFFTStrategy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan,
     // strategy_status: 0 means select MLUOP_FUNC_STOCKHAM, 1 means selelct
     // COOLEY_TUKEY,
     //                  -1 means still select CNFFT_FUNC_MATMUL.
-    int strategy_status =
-        findFFTOptLimit(handle, fft_plan->n[0], fft_plan->m, fft_plan->L,
-                        fft_plan->s, fft_plan->L_sub, find_stockham);
+    VLOG(5) << "signal_length: " << fft_plan->n[0];
+    VLOG(5) << "batch: " << fft_plan->batch;
+    int strategy_status = findFFTOptLimit(
+        handle, fft_plan->n[0], fft_plan->batch, fft_plan->m, fft_plan->L,
+        fft_plan->s, fft_plan->L_sub, find_stockham);
     if (strategy_status == 1) {
       fft_plan->fft_strategy = CNFFT_FUNC_COOLEY_TUKEY;
     } else if (strategy_status == 0) {
@@ -2694,6 +2696,8 @@ mluOpStatus_t MLUOP_WIN_API mluOpMakeFFTPlanMany(
       fft_plan->prime ||
       ((n[0] <= 2 || n[0] == 400 || n[0] == 512 || n[0] == 48000) && rank == 1);
 
+
+  VLOG(5) << "fft_plan->prime: " << fft_plan->prime;
   /*
    * decision part
    */


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Add perf border to cooley_tuky and stockham kernel
Make dft to support 4098 length.

## 2. Modification

        modified:   kernels/fft/common/fft_basic_ops.cpp
        modified:   kernels/fft/common/fft_basic_ops.h
        modified:   kernels/fft/fft.cpp
        modified:   kernels/fft/fft.h

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.