### PR TITLE
[Feature](mluOpExecFFT): improve perf for 1d fft when case is 4098

### DIFF
--- a/kernels/fft/c2c_fft/c2c_fft_host.cpp
+++ b/kernels/fft/c2c_fft/c2c_fft_host.cpp
@@ -61,12 +61,17 @@ mluOpStatus_t makeFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
   size_t in_r_dtype_size = mluOpDataTypeBytes(in_r_dtype);
   int batch = fft_plan->batch;
   int n = fft_plan->n[0];
+  int FFT_L_LIMIT_MATMUL = FFT_L_LIMIT_MATMUL_300;
+  if (handle->arch > MLUOP_MLU370) {
+      FFT_L_LIMIT_MATMUL = FFT_L_LIMIT_MATMUL_500;
+  }
 
   switch (fft_plan->fft_strategy) {
     case CNFFT_FUNC_MATMUL: {
-      if (n > FFT_L_LIMIT) {
-        LOG(ERROR) << "[mluOpMakeFFTPlanMany]: FFT1d CNFFT_FUNC_MATMUL "
-                   << "length > 4096 is not supported currently.";
+      if (n > FFT_L_LIMIT_MATMUL) {
+        LOG(ERROR)
+            << "[mluOpMakeFFTPlanMany]: FFT1d CNFFT_FUNC_MATMUL length > "
+            << FFT_L_LIMIT_MATMUL << " is not supported currently.";
         return MLUOP_STATUS_NOT_SUPPORTED;
       }
 

--- a/kernels/fft/fft.h
+++ b/kernels/fft/fft.h
@@ -43,7 +43,7 @@
 #endif
 
 #ifndef FFT_L_LIMIT
-#define FFT_L_LIMIT 4096
+#define FFT_L_LIMIT 4098
 #endif
 
 #ifndef COMPLEX

--- a/kernels/fft/fft.h
+++ b/kernels/fft/fft.h
@@ -43,7 +43,15 @@
 #endif
 
 #ifndef FFT_L_LIMIT
-#define FFT_L_LIMIT 4098
+#define FFT_L_LIMIT 4096
+#endif
+
+#ifndef FFT_L_LIMIT_MATMUL_300
+#define FFT_L_LIMIT_MATMUL_300 4096
+#endif
+
+#ifndef FFT_L_LIMIT_MATMUL_500
+#define FFT_L_LIMIT_MATMUL_500 4098
 #endif
 
 #ifndef COMPLEX

--- a/kernels/fft/irfft/irfft_host.cpp
+++ b/kernels/fft/irfft/irfft_host.cpp
@@ -60,12 +60,17 @@ mluOpStatus_t makeIRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
   size_t in_r_dtype_size = mluOpDataTypeBytes(in_r_dtype);
   int batch = fft_plan->batch;
   int n = fft_plan->n[0];
+  int FFT_L_LIMIT_MATMUL = FFT_L_LIMIT_MATMUL_300;
+  if (handle->arch > MLUOP_MLU370) {
+      FFT_L_LIMIT_MATMUL = FFT_L_LIMIT_MATMUL_500;
+  }
 
   switch (fft_plan->fft_strategy) {
     case CNFFT_FUNC_MATMUL: {
-      if (n > FFT_L_LIMIT) {
-        LOG(ERROR) << "[mluOpMakeFFTPlanMany]: IRFFT1d CNFFT_FUNC_MATMUL "
-                   << "length > 4096 is not supported currently.";
+      if (n > FFT_L_LIMIT_MATMUL) {
+        LOG(ERROR)
+            << "[mluOpMakeFFTPlanMany]: FFT1d CNFFT_FUNC_MATMUL length > "
+            << FFT_L_LIMIT_MATMUL << " is not supported currently.";
         return MLUOP_STATUS_NOT_SUPPORTED;
       }
 

--- a/kernels/fft/rfft/rfft_host.cpp
+++ b/kernels/fft/rfft/rfft_host.cpp
@@ -55,12 +55,17 @@ mluOpStatus_t makeRFFT1dPolicy(mluOpHandle_t handle, mluOpFFTPlan_t fft_plan) {
   size_t in_r_dtype_size = mluOpDataTypeBytes(in_r_dtype);
   int batch = fft_plan->batch;
   int n = fft_plan->n[0];
+  int FFT_L_LIMIT_MATMUL = FFT_L_LIMIT_MATMUL_300;
+  if (handle->arch > MLUOP_MLU370) {
+      FFT_L_LIMIT_MATMUL = FFT_L_LIMIT_MATMUL_500;
+  }
 
   switch (fft_plan->fft_strategy) {
     case CNFFT_FUNC_MATMUL: {
-      if (n > FFT_L_LIMIT) {
-        LOG(ERROR) << "[mluOpMakeFFTPlanMany]: RFFT1d CNFFT_FUNC_MATMUL "
-                   << "length > 4096 is not supported currently.";
+      if (n > FFT_L_LIMIT_MATMUL) {
+        LOG(ERROR)
+            << "[mluOpMakeFFTPlanMany]: FFT1d CNFFT_FUNC_MATMUL length > "
+            << FFT_L_LIMIT_MATMUL << " is not supported currently.";
         return MLUOP_STATUS_NOT_SUPPORTED;
       }
 

--- a/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_general.cpp
+++ b/test/mlu_op_gtest/api_gtest/src/gtest/fft/fft_general.cpp
@@ -166,8 +166,8 @@ INSTANTIATE_TEST_CASE_P(
                      testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 
 INSTANTIATE_TEST_CASE_P(
-    negative_2_m_l,  // float/complex_float，n>4096, fft length can be broken
-                     // down into 2^m*l
+    negative_2_m_l_370,  // float/complex_float，n>4096, fft length can be
+                         // broken down into 2^m*l
     fft_general,
     testing::Combine(testing::Values(MLUOpTensorParamInt64{
                          MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 2,
@@ -178,6 +178,22 @@ INSTANTIATE_TEST_CASE_P(
                          std::vector<int64_t>({1, 4097}),
                          std::vector<int64_t>({1, 1})}),
                      testing::Values(1), testing::Values(4097),
+                     testing::Values(MLUOP_MLU370),
+                     testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
+
+INSTANTIATE_TEST_CASE_P(
+    negative_2_m_l,  // float/complex_float，n>4096, fft length can be broken
+                     // down into 2^m*l
+    fft_general,
+    testing::Combine(testing::Values(MLUOpTensorParamInt64{
+                         MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 2,
+                         std::vector<int64_t>({1, 4099}),
+                         std::vector<int64_t>({1, 1}), MLUOP_DTYPE_FLOAT}),
+                     testing::Values(MLUOpTensorParamInt64{
+                         MLUOP_LAYOUT_NHWC, MLUOP_DTYPE_COMPLEX_FLOAT, 2,
+                         std::vector<int64_t>({1, 4099}),
+                         std::vector<int64_t>({1, 1})}),
+                     testing::Values(1), testing::Values(4099),
                      testing::Values(MLUOP_UNKNOWN_DEVICE),
                      testing::Values(MLUOP_STATUS_NOT_SUPPORTED)));
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Improve 1d fft perf when length <= 4098 on 500.

## 2. Modification

kernels/fft/fft.cpp
kernels/fft/fft.h

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU370
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU370

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

Platform：MLU590
```bash
# ----------- case0 -----------
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.