### PR TITLE
[Feature](gtest):add mluOpGetGenCaseDirectory/mluOpSetGenCaseDirector…

### DIFF
--- a/core/gen_case.h
+++ b/core/gen_case.h
@@ -521,6 +521,19 @@ class PbNode {
   void debugTensorAddress();
 };
 
+class genCaseConfig {
+ public:
+  static void setDirectory(const char *name);
+  static std::string getDirectory();
+  static std::string replacePlaceholder(std::string pathStr);
+  template <typename T>
+  static inline void setValue(T *pointer, T value) {
+    if (pointer != nullptr) {
+      *pointer = value;
+    }
+  }
+};
+
 template <>
 inline void PbNode::appendOpParam<std::string>(std::string param_name,
                                                std::string param_value,

--- a/docs/user_guide/11_env_var/index.rst
+++ b/docs/user_guide/11_env_var/index.rst
@@ -54,6 +54,21 @@ MLUOP_GEN_CASE
 
 更详细请参见 `MLU-OPS™ GEN_CASE 使用指南 <https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md>`_ 。
 
+.. _MLUOP_GEN_CASE_DIR:
+
+MLUOP_GEN_CASE_DIR
+######################
+
+**功能描述**
+
+用于指定 :ref:`MLUOP_GEN_CASE` 功能生成的目录所在的根目录。默认在当前目录下生成。
+
+**使用方法**
+
+- export MLUOP_GEN_CASE_DIR={path}: 通过环境变量设置，只在初始化阶段生效。
+
+- 在程序运行过程中也可以调用 ``mluOpSetGenCaseDirectory()`` 和 ``mluOpGetGenCaseDirectory()`` 来动态设置和获取此环境变量的值。更多内容，参见《Cambricon MLU-OPS Developer Guide》。
+
 .. _MLUOP_MIN_VLOG_LEVEL:
  
 MLUOP_MIN_VLOG_LEVEL

--- a/mlu_op.h
+++ b/mlu_op.h
@@ -13221,6 +13221,67 @@ mluOpSyncBatchNormBackwardElemtV2(mluOpHandle_t handle,
 void MLUOP_WIN_API
 mluOpSetGenCaseMode(int mode);
 
+// Group:Common Interface
+// Subgroup:Debugging
+/*!
+ * @brief Sets the gen case directory name through the \p path parameter. For more
+ * information, see "Cambricon MLU-OPS User Guide".
+ *
+ * @param[in] path
+ * Input. A NULL-terminated character string used to specify the directory name.
+ *
+ * @par Return
+ * - ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM
+ *
+ * @note
+ * - The settings of this API are valid for all threads.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+mluOpStatus_t MLUOP_WIN_API
+mluOpSetGenCaseDirectory(const char *path);
+
+// Group:Common Interface
+// Subgroup:Debugging
+/*!
+ * @brief Gets the gen case directory name. For more information, see "Cambricon MLU-OPS User Guide".
+ *
+ * @param[in] buffer
+ * Input. This is a buffer used to store the directory name. If \p buffer is NULL,
+ *        the directory name is placed in a region of memory allocated with malloc.
+ *
+ * @param[in] bufferSize
+ * Input. The size of the buffer.
+ *
+ * @param[out] pathLen
+ * Output. If \p pathLen is not NULL, the length of directory name is placed in *pathLen.
+ *
+ * @param[out] status
+ * Output. If \p status is not NULL, the execution status of this API is placed in *status.
+ *         It includes ::MLUOP_STATUS_SUCCESS, ::MLUOP_STATUS_BAD_PARAM, ::MLUOP_STATUS_ALLOC_FAILED,
+ *         ::MLUOP_STATUS_INTERNAL_ERROR.
+ *
+ * @par Return
+ * - A pointer to the start of the NULL-terminated directory name, or NULL if get
+ *   directory name failed. The API caller is responsible for deallocating this memory by using
+ *   the free() function.
+ *
+ * @note
+ * - None.
+ *
+ * @par Requirements
+ * - None.
+ *
+ * @par Example
+ * - None.
+ */
+const char MLUOP_WIN_API *
+mluOpGetGenCaseDirectory(char *buffer, size_t bufferSize, size_t *pathLen, mluOpStatus_t *status);
+
 // Group: DeformConv
 /*!
  * @brief Creates a descriptor pointed by \p dcn_desc for a deformable convolution forward


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Add two functions for gen case, to dynamically set the gencase directory path.

## 2. Modification

Added two functions, mluOpSetGenCaseDirectory() and mluOpGetGenCaseDirectory(), and modified the relevant documentation.

## 3. Test Report

https://wiki.cambricon.com/pages/viewpage.action?pageId=456561590

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

The modification does not affect accuracy.

#### 3.1.2 Operator Scheme checklist

The modification is independent of hardware platforms and task types.

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

The modification does not affect accuracy.

#### 3.2.2 Parameter Check

https://wiki.cambricon.com/pages/viewpage.action?pageId=456561590

### 3.3 Performance Test

The modification does not affect performance.

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.