### PR TITLE
[Feature](mlu-ops): 添加真值相关算子的test_list.

### DIFF
--- a/test/mlu_op_gtest/pb_gtest/gtest_config/internal_test_list
+++ b/test/mlu_op_gtest/pb_gtest/gtest_config/internal_test_list
@@ -1,0 +1,1 @@
+[rely_real_data]

--- a/test/mlu_op_gtest/pb_gtest/src/parser.cpp
+++ b/test/mlu_op_gtest/pb_gtest/src/parser.cpp
@@ -72,7 +72,7 @@ namespace mluoptest {
 
 // env for test negative_scale
 __attribute__((__unused__)) bool negative_scale_ =
-    getEnv("MLUOP_GTEST_NEGATIVE_SCALE", false);
+getEnv("MLUOP_GTEST_NEGATIVE_SCALE", false);
 
 Parser::~Parser() {
   if (proto_node_ != nullptr) {
@@ -844,7 +844,7 @@ void Parser::getTensorValueByFile(Tensor *pt, void *data, size_t count) {
 // random data(for cpu compute) value is fp32 definitely
 // valueh valuef valuei dtype is according dtype in proto
 void Parser::getTensorValue(Tensor *pt, void *data, ValueType value_type,
-                            size_t count) {
+size_t count) {
   switch (value_type) {
     case VALUE_H:
       getTensorValueH(pt, data, count);
@@ -933,10 +933,9 @@ bool Parser::common_threshold() {
   return res;
 }
 
-std::set<Evaluator::Criterion> Parser::criterions(
-    int index, const std::set<Evaluator::Formula> &criterions_use) {
+std::set<Evaluator::Criterion> Parser::criterions(int index,
+const std::set<Evaluator::Formula> &criterions_use) {
   std::set<Evaluator::Criterion> res;
-
   // check if there exists complex output tensor
   bool has_complex_output = false;
   for (auto i = 0; i < proto_node_->output_size(); ++i) {
@@ -1040,7 +1039,7 @@ std::set<Evaluator::Criterion> Parser::criterions(
 }
 
 static inline bool strEndsWith(const std::string &self,
-                               const std::string &pattern) {
+const std::string &pattern) {
   if (self.size() < pattern.size()) return false;
   return (self.compare(self.size() - pattern.size(), pattern.size(), pattern) ==
           0);
@@ -1100,9 +1099,17 @@ bool Parser::readMessageFromFile(const std::string &filename, Node *proto) {
 
 void Parser::getTestInfo() {
   std::unordered_map<std::string, std::vector<std::string>> test_info;
+  std::unordered_map<std::string, std::vector<std::string>> internal_test_info;
   test_info =
       readFileByLine("../../test/mlu_op_gtest/pb_gtest/gtest_config/test_list");
+  internal_test_info = readFileByLine(
+      "../../test/mlu_op_gtest/pb_gtest/gtest_config/internal_test_list");
+
   list_rely_real_data_ = test_info["rely_real_data"];
+  std::vector<std::string> temp_list = internal_test_info["rely_real_data"];
+  for (auto &internal_op_name : temp_list) {
+    list_rely_real_data_.push_back(internal_op_name);
+  }
 }
 
 Evaluator::Formula Parser::cvtProtoEvaluationCriterion(int f) {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU590

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.