### PR TITLE
[Fix](mluOpPriorBox): Supplement the current status of the flip param…

### DIFF
--- a/kernels/prior_box/prior_box.cpp
+++ b/kernels/prior_box/prior_box.cpp
@@ -224,7 +224,22 @@ mluOpStatus_t mluOpPriorBox(
     GEN_CASE_OP_PARAM_SINGLE(4, "prior_box", "step_h", step_h);
     GEN_CASE_OP_PARAM_SINGLE(5, "prior_box", "step_w", step_w);
     GEN_CASE_OP_PARAM_SINGLE(6, "prior_box", "offset", offset);
-    GEN_CASE_OP_PARAM_SINGLE(7, "prior_box", "flip", true);
+    /*
+    The prior_box community logic includes a flip parameter that modifies the aspect_ratios.
+
+    In mluOpPriorBox, the aspect_ratios are already the result after modification
+    (presumably handled by the framework layer),
+    and mluOpPriorBox does not directly handle the flip parameter.
+
+    However, the generator uses the flip parameter to modify the aspect_ratios.
+
+    Currently, the logic of "framework + mlu-ops" is equivalent to that of the "generator",
+    but the operator's logic is coupled, making it difficult to make lightweight modifications.
+
+    A temporary workaround is to uniformly set flip to false during case generation,
+    meaning the generated results do not require further modification.
+    */
+    GEN_CASE_OP_PARAM_SINGLE(7, "prior_box", "flip", false);
     GEN_CASE_OP_PARAM_SINGLE(8, "prior_box", "clip", clip);
     GEN_CASE_OP_PARAM_SINGLE(9, "prior_box", "min_max_aspect_ratios_order",
                              min_max_aspect_ratios_order);

--- a/kernels/prior_box/prior_box.cpp
+++ b/kernels/prior_box/prior_box.cpp
@@ -225,6 +225,8 @@ mluOpStatus_t mluOpPriorBox(
     GEN_CASE_OP_PARAM_SINGLE(5, "prior_box", "step_w", step_w);
     GEN_CASE_OP_PARAM_SINGLE(6, "prior_box", "offset", offset);
     /*
+    The community's prior_box reference link: paddle/phi/kernels/gpu/prior_box_kernel.cu
+
     The prior_box community logic includes a flip parameter that modifies the aspect_ratios.
 
     In mluOpPriorBox, the aspect_ratios are already the result after modification
@@ -238,6 +240,10 @@ mluOpStatus_t mluOpPriorBox(
 
     A temporary workaround is to uniformly set flip to false during case generation,
     meaning the generated results do not require further modification.
+
+    For the true cases dumped by the framework, if the case is regenerated through the generator,
+    the generator code can handle it correctly (aspect_ratios have been processed,
+    and the generator will not reprocess them).
     */
     GEN_CASE_OP_PARAM_SINGLE(7, "prior_box", "flip", false);
     GEN_CASE_OP_PARAM_SINGLE(8, "prior_box", "clip", clip);


### PR DESCRIPTION
## 1. Motivation

prior_box 社区逻辑有 flip 参数，该参数会对 aspect_ratios 刷值。
mluOpPriorBox 中的 aspect_ratios 已经是刷值后的结果（推测是框架层做了相应逻辑），
mluOpPriorBox 并不感知 flip 参数。
然而 generator 中会使用 flip 参数对 aspect_ratios 刷值。
目前 '框架 + mlu-ops' 等价于 'generator' 的逻辑，该算子的逻辑有耦合，难以轻量级的修改。
暂时绕过的方法是，gen_case 时，统一设置 flip 为 false，表示 gen_case 的结果不用再去刷值。

## 2. Modification

补充 flip 参数现状说明，将默认值改为 flase

