### PR TITLE
[Fix](mlu-ops): remove redundant code in the div and log operators.

### DIFF
--- a/kernels/carafe/carafe.cpp
+++ b/kernels/carafe/carafe.cpp
@@ -34,7 +34,6 @@
 #include "core/type.h"
 #include "kernels/kernel.h"
 #include "kernels/tensor_stride_process/tensor_stride_process_host.h"
-#include "kernels/tensor_stride_process/tensor_stride_process_mlu.h"
 
 // 1.creat set destroy
 mluOpStatus_t MLUOP_WIN_API

--- a/kernels/div/div.cpp
+++ b/kernels/div/div.cpp
@@ -74,17 +74,10 @@ mluOpDiv(mluOpHandle_t handle, const mluOpComputationPreference_t prefer,
   binaryOpPolicyFunc(handle, ALIGN_SIZE, &k_dim, &k_type, x_desc);
   size_t element_num = mluOpGetTensorElementNum(x_desc);
   VLOG(5) << "kernel Kernel5StagePipelineDiv.";
-  if (handle->arch == MLUOP_MLU370) {
-    CHECK_RETURN("mluOpDiv",
-                 Kernel3StagePipelineDiv(k_dim, k_type, handle->queue,
-                                         x_desc->getDtype(), prefer, (void *)x,
-                                         (void *)y, (void *)z, element_num));
-  } else {
-    CHECK_RETURN("mluOpDiv",
-                 Kernel5StagePipelineDiv(k_dim, k_type, handle->queue,
-                                         x_desc->getDtype(), prefer, (void *)x,
-                                         (void *)y, (void *)z, element_num));
-  }
+  CHECK_RETURN("mluOpDiv",
+                Kernel5StagePipelineDiv(k_dim, k_type, handle->queue,
+                                        x_desc->getDtype(), prefer, (void *)x,
+                                        (void *)y, (void *)z, element_num));
   GEN_CASE_END();
   return MLUOP_STATUS_SUCCESS;
 }

--- a/kernels/div/div.h
+++ b/kernels/div/div.h
@@ -30,9 +30,4 @@ mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineDiv(
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, const void *y, void *z, size_t num);
 
-mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineDiv(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
-    const void *x, const void *y, void *z, size_t num);
-
 #endif  // KERNELS_DIV_DIV_H

--- a/kernels/div/div_union1.mlu
+++ b/kernels/div/div_union1.mlu
@@ -23,7 +23,6 @@
 #include "div.h"
 
 #include "core/logging.h"
-#include "kernels/binary_op/binary_op_3pipeline.h"
 #include "kernels/binary_op/binary_op_5pipeline.h"
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
@@ -40,47 +39,13 @@ __mlu_shared__ int8_t sram_buffer[BINARY_SRAM_SIZE];
 
 template <typename DType_in1, typename DType_in2 = DType_in1,
           typename DType_out = DType_in1>
-__mlu_func__ void auxFunc3DivFloat(
-    size_t &output_input1_gap, size_t &output_input2_gap, size_t &ping_pong_gap,
-    size_t &auxiliary_a_gap, size_t &auxiliary_b_gap, size_t &auxiliary_c_gap,
-    size_t &span_num_deal, size_t &align_num) {
-  // ONLY FLOAT x - x_pong - y - y_pong - temp1 - temp2
-  span_num_deal = (BINARY_NRAM_SIZE / sizeof(float)) / 6;
-  span_num_deal = PAD_DOWN(span_num_deal, BINARY_ALIGN_NUM);
-  output_input1_gap = 0;
-  output_input2_gap = span_num_deal * 2 * sizeof(float);
-  ping_pong_gap = span_num_deal * sizeof(float);
-  auxiliary_a_gap = span_num_deal * 4 * sizeof(float);
-  auxiliary_b_gap = span_num_deal * 5 * sizeof(float);
-}
-
-template <typename DType_in1, typename DType_in2 = DType_in1,
-          typename DType_out = DType_in1>
-__mlu_func__ void auxFunc3DivHalf(
-    size_t &output_input1_gap, size_t &output_input2_gap, size_t &ping_pong_gap,
-    size_t &auxiliary_a_gap, size_t &auxiliary_b_gap, size_t &auxiliary_c_gap,
-    size_t &span_num_deal, size_t &align_num) {
-  // ONLY HALF fp_x - hf_x - fp_x_pong - hf_x_pong - y... - temp1 - temp2
-  span_num_deal = (BINARY_NRAM_SIZE / sizeof(half)) / 12;
-  span_num_deal = PAD_DOWN(span_num_deal, BINARY_ALIGN_NUM);
-  output_input1_gap = span_num_deal * sizeof(half);
-  output_input2_gap = span_num_deal * 5 * sizeof(half);
-  ping_pong_gap = span_num_deal * 2 * sizeof(half);
-  auxiliary_a_gap = span_num_deal * 8 * sizeof(half);
-  auxiliary_b_gap = span_num_deal * 10 * sizeof(half);
-}
-
-template <typename DType_in1, typename DType_in2 = DType_in1,
-          typename DType_out = DType_in1>
 __mlu_func__ void auxFunc5DivFloat(size_t &span_num_deal,
                                    size_t &output_input1_gap,
                                    size_t &output_input2_gap,
                                    size_t &auxiliary_a_gap,
                                    size_t &auxiliary_b_gap,
                                    size_t &auxiliary_c_gap, size_t &align_num) {
-  // split sram size 16 parts: (x - x_pong - y - y_pong) * CORE_DIM
   int32_t sram_limit = (BINARY_SRAM_SIZE / sizeof(float)) / 16;
-  // x - y - temp1 - temp2(inf check)
   span_num_deal = (BINARY_NRAM_SIZE / sizeof(float)) / 4;
   span_num_deal = span_num_deal < sram_limit ? span_num_deal : sram_limit;
   span_num_deal = PAD_DOWN(span_num_deal, BINARY_ALIGN_NUM);
@@ -121,17 +86,6 @@ __mlu_func__ void computeDivFloat(int8_t *nram_z, int8_t *nram_x,
                                   int32_t deal_num, int32_t actual_num) {
 #if __BANG_ARCH__ > 500
   __bang_div((float *)nram_x, (float *)nram_x, (DType_in2 *)nram_y, actual_num);
-#else
-  __bang_recip((float *)nram_temp1, (float *)nram_y, actual_num);
-  __bang_abs((float *)nram_temp2, (float *)nram_temp1, actual_num);
-  __bang_argmax((float *)nram_temp2, (float *)nram_temp2, actual_num);
-  if (((float *)nram_temp2)[0] == INFINITY) {
-    __cn_vector_div_f32_rn(actual_num, (float *)nram_x, (float *)nram_x,
-                           (float *)nram_y);
-  } else {
-    __bang_mul((float *)nram_x, (DType_in2 *)nram_temp1, (float *)nram_x,
-               actual_num);
-  }
 #endif
 }
 
@@ -146,48 +100,11 @@ __mlu_func__ void computeDivHalf(int8_t *nram_z, int8_t *nram_x, int8_t *nram_y,
                                  int32_t actual_num) {
 #if __BANG_ARCH__ > 500
   __bang_div((half *)nram_z, (half *)nram_x, (half *)nram_y, actual_num);
-#else
-  float *nram_fp_x = (float *)((half *)nram_x - deal_num);
-  float *nram_fp_y = (float *)((half *)nram_y - deal_num);
-  // bit-up
-  __bang_half2float(nram_fp_x, (half *)nram_x, actual_num);
-  __bang_half2float(nram_fp_y, (half *)nram_y, actual_num);
-  // compute
-  __bang_recip((float *)nram_temp1, nram_fp_y, actual_num);
-  __bang_mul(nram_fp_y, nram_fp_x, (float *)nram_temp1, actual_num);
-  // recover
-  __mluop_float2half((half *)nram_z, nram_fp_y, actual_num);
 #endif
 }
 
-BINARY_OP_KERNEL_3PIPELINE(Div, Float);
-BINARY_OP_KERNEL_3PIPELINE(Div, Half);
-
 BINARY_OP_KERNEL_5PIPELINE(Div, Float);
 BINARY_OP_KERNEL_5PIPELINE(Div, Half);
-
-mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineDiv(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
-    const void *x, const void *y, void *z, size_t num) {
-  switch (d_type) {
-    /* Only float and half data types are supported
-       in host-side CPP file fool-proof processing. */
-    case MLUOP_DTYPE_FLOAT: {
-      KERNEL_CHECK(MLUBlockKernel3StagePipelineDivFloat<float, float, float>
-                   <<<k_dim, k_type, queue>>>((int8_t *)x, (int8_t *)y,
-                                              (int8_t *)z, num));
-    }; break;
-    case MLUOP_DTYPE_HALF: {
-      KERNEL_CHECK(MLUBlockKernel3StagePipelineDivHalf<half, half, half>
-                   <<<k_dim, k_type, queue>>>((int8_t *)x, (int8_t *)y,
-                                              (int8_t *)z, num));
-    }; break;
-    default:
-      break;
-  }
-  return MLUOP_STATUS_SUCCESS;
-}
 
 mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineDiv(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,

--- a/kernels/fft/fft.h
+++ b/kernels/fft/fft.h
@@ -32,7 +32,6 @@
 #include "core/type.h"
 #include "core/tool.h"
 #include "kernels/tensor_stride_process/tensor_stride_process_host.h"
-#include "kernels/tensor_stride_process/tensor_stride_process_mlu.h"
 #include "kernels/fft/common/fft_basic_ops.h"
 #include "kernels/fft/common/fft_common_kernels.h"
 #include "kernels/debug.h"

--- a/kernels/log/log.h
+++ b/kernels/log/log.h
@@ -30,9 +30,5 @@ mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLog(
     mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
     const void *x, void *y, size_t num, float coef);
 
-mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineLog(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
-    const void *x, void *y, size_t num, float coef);
 
 #endif  // KERNELS_LOG_LOG_H

--- a/kernels/log/log_union1.mlu
+++ b/kernels/log/log_union1.mlu
@@ -26,7 +26,6 @@
 #include "kernels/debug.h"
 #include "kernels/kernel.h"
 #include "kernels/unary_op/unary_op_3pipeline.h"
-#include "kernels/unary_op/unary_op_5pipeline.h"
 
 #define LOG_LOW_BOUND 1e-8
 #define LOG_SCALE 1e12
@@ -91,43 +90,11 @@ __mlu_func__ void computeLogHalf(int8_t *nram_output, int8_t *nram_input,
   __mluop_float2half((half *)nram_output, (float *)nram_output, deal_num);
 }
 
-template <typename DType_in, typename DType_out>
-__mlu_func__ void auxFunc5LogFloat(size_t &output_input_gap,
-                                   size_t &auxiliary_a_gap,
-                                   size_t &auxiliary_b_gap, size_t &num_deal,
-                                   size_t &align_num, float coef) {
-#if __BANG_ARCH__ != 520  // TODO(sram): tp_520
-  int sram_limit = (UNARY_SRAM_SIZE / sizeof(DType_in)) / 8;
-  num_deal = (UNARY_NRAM_SIZE / sizeof(DType_in)) / 2;
-  num_deal = num_deal < sram_limit ? num_deal : sram_limit;
-  num_deal = PAD_DOWN(num_deal, align_num);
-  output_input_gap = 0;
-#endif
-}
-
-template <typename DType_in, typename DType_out>
-__mlu_func__ void auxFunc5LogHalf(size_t &output_input_gap,
-                                  size_t &auxiliary_a_gap,
-                                  size_t &auxiliary_b_gap, size_t &num_deal,
-                                  size_t &align_num, float coef) {
-#if __BANG_ARCH__ != 520  // TODO(sram): tp_520
-  int sram_limit = (UNARY_SRAM_SIZE / sizeof(DType_in)) / 16;
-  num_deal = (UNARY_NRAM_SIZE / sizeof(DType_in)) / 4;
-  num_deal = num_deal < sram_limit ? num_deal : sram_limit;
-  num_deal = PAD_DOWN(num_deal, align_num);
-  // x - hf_x
-  output_input_gap = num_deal * sizeof(DType_in);
-  auxiliary_a_gap = 0;
-  auxiliary_b_gap = 0;
-#endif
-}
 
 // function tion implementation
 UNARY_OP_KERNEL_3PIPELINE_IMPLE(Log, Float);
 UNARY_OP_KERNEL_3PIPELINE_IMPLE(Log, Half);
 
-UNARY_OP_KERNEL_5PIPELINE_IMPLE(Log, Float);
-UNARY_OP_KERNEL_5PIPELINE_IMPLE(Log, Half);
 
 mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLog(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
@@ -142,23 +109,6 @@ mluOpStatus_t MLUOP_WIN_API Kernel3StagePipelineLog(
     // half
     KERNEL_CHECK(
         MLUBlockKernel3StagePipelineLogHalf<half, half>
-        <<<k_dim, k_type, queue>>>((int8_t *)x, (int8_t *)y, num, coef));
-  }
-  return MLUOP_STATUS_SUCCESS;
-}
-
-mluOpStatus_t MLUOP_WIN_API Kernel5StagePipelineLog(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    mluOpDataType_t d_type, const mluOpComputationPreference_t prefer,
-    const void *x, void *y, size_t num, float coef) {
-  // launch kernel
-  if (d_type == mluOpDataType_t::MLUOP_DTYPE_FLOAT) {
-    KERNEL_CHECK(
-        MLUBlockKernel5StagePipelineLogFloat<float, float>
-        <<<k_dim, k_type, queue>>>((int8_t *)x, (int8_t *)y, num, coef));
-  } else {
-    KERNEL_CHECK(
-        MLUBlockKernel5StagePipelineLogHalf<half, half>
         <<<k_dim, k_type, queue>>>((int8_t *)x, (int8_t *)y, num, coef));
   }
   return MLUOP_STATUS_SUCCESS;

--- a/kernels/sqrt/sqrt_union1.mlu
+++ b/kernels/sqrt/sqrt_union1.mlu
@@ -26,7 +26,6 @@
 #include "kernels/binary_op/binary_op_3pipeline.h"
 #include "kernels/debug.h"
 #include "kernels/unary_op/unary_op_3pipeline.h"
-#include "kernels/unary_op/unary_op_5pipeline.h"
 
 #define SQRT_HIGH_BOUND 1e4
 #define SQRT_SCALE 1e-6

--- a/kernels/tensor_stride_process/tensor_stride_in_block.mlu
+++ b/kernels/tensor_stride_process/tensor_stride_in_block.mlu
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
 #include "kernels/tensor_stride_process/tensor_stride_process_common.h"
-
+#include "kernels/debug.h"
 #include "mlu.h"
 
 #define SIZE_NRAM_BUF (MAX_NRAM_SIZE + REM_FOR_STACK - 12 * 1024)

--- a/kernels/tensor_stride_process/tensor_stride_out_block.mlu
+++ b/kernels/tensor_stride_process/tensor_stride_out_block.mlu
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
 #include "kernels/tensor_stride_process/tensor_stride_process_common.h"
-
+#include "kernels/debug.h"
 #include "mlu.h"
 
 #define SIZE_NRAM_BUF (MAX_NRAM_SIZE + REM_FOR_STACK - 12 * 1024)

--- a/kernels/tensor_stride_process/tensor_stride_process_host.cpp
+++ b/kernels/tensor_stride_process/tensor_stride_process_host.cpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include "core/cnnl_helper.h"
-#include "kernels/tensor_stride_process/tensor_stride_process_mlu.h"
+
 
 using std::vector;
 

--- a/kernels/tensor_stride_process/tensor_stride_process_host.h
+++ b/kernels/tensor_stride_process/tensor_stride_process_host.h
@@ -71,4 +71,14 @@ mluOpStatus_t MLUOP_WIN_API
 mluOpContiguous(mluOpHandle_t handle, const mluOpTensorDescriptor_t input_desc,
                 const void *input, void *output);
 
+mluOpStatus_t MLUOP_WIN_API KernelTensorStrideIn(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const void *input, mluop::TensorShape input_shape, void *output,
+    mluOpDataType_t dtype);
+
+mluOpStatus_t MLUOP_WIN_API
+KernelTensorStrideOut(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
+                      cnrtQueue_t queue, const void *input, void *output,
+                      mluop::TensorShape output_shape, mluOpDataType_t dtype);
+
 #endif  // KERNELS_TENSOR_STRIDE_PROCESS_TENSOR_STRIDE_PROCESS_HOST_H_

--- a/kernels/tensor_stride_process/tensor_stride_process_mlu.h
+++ b/kernels/tensor_stride_process/tensor_stride_process_mlu.h
@@ -23,31 +23,16 @@
 #ifndef KERNELS_TENSOR_STRIDE_PROCESS_TENSOR_STRIDE_PROCESS_MLU_H_
 #define KERNELS_TENSOR_STRIDE_PROCESS_TENSOR_STRIDE_PROCESS_MLU_H_
 
-#include "kernels/tensor_stride_process/tensor_stride_process_host.h"
+#include "tensor_stride_process_host.h"
+#include "mlu.h"
 
-#include <stdint.h>
-
-#include "mlu_op.h"
-#include "kernels/debug.h"
-#include "kernels/kernel.h"
-
-// template <typename T>
-// __mlu_global__ void MLUUnionKernelTensorStrideIn(const void *input,
-//                                                  mluop::TensorShape
-//                                                  input_shape, void *output);
-// template <typename T>
-// __mlu_global__ void MLUUnionKernelTensorStrideOut(const void *input,
-//                                                   void *output,
-//   mluop::TensorShape output_shape);
-
-mluOpStatus_t MLUOP_WIN_API KernelTensorStrideIn(
-    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-    const void *input, mluop::TensorShape input_shape, void *output,
-    mluOpDataType_t dtype);
-
-mluOpStatus_t MLUOP_WIN_API
-KernelTensorStrideOut(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
-                      cnrtQueue_t queue, const void *input, void *output,
-                      mluop::TensorShape output_shape, mluOpDataType_t dtype);
+template <typename T>
+__mlu_global__ void MLUUnionKernelTensorStrideIn(const void *input,
+                                                 mluop::TensorShape
+                                                 input_shape, void *output);
+template <typename T>
+__mlu_global__ void MLUUnionKernelTensorStrideOut(const void *input,
+                                                  void *output,
+  mluop::TensorShape output_shape);
 
 #endif  // KERNELS_TENSOR_STRIDE_PROCESS_TENSOR_STRIDE_PROCESS_MLU_H_

--- a/kernels/tensor_stride_process/tensor_stride_process_mlu.mlu
+++ b/kernels/tensor_stride_process/tensor_stride_process_mlu.mlu
@@ -25,14 +25,6 @@
 
 #include "core/logging.h"
 
-template <typename T>
-__mlu_global__ void MLUUnionKernelTensorStrideIn(const void *input,
-                                                 mluop::TensorShape input_shape,
-                                                 void *output);
-
-template <typename T>
-__mlu_global__ void MLUUnionKernelTensorStrideOut(
-    const void *input, void *output, mluop::TensorShape output_shape);
 
 mluOpStatus_t MLUOP_WIN_API KernelTensorStrideIn(
     cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,

--- a/kernels/unary_op/unary_op_stride_3pipeline.h
+++ b/kernels/unary_op/unary_op_stride_3pipeline.h
@@ -24,11 +24,10 @@
 #ifndef KERNELS_UNARY_OP_UNARY_OP_STRIDE_3PIPELINE_H_
 #define KERNELS_UNARY_OP_UNARY_OP_STRIDE_3PIPELINE_H_
 
-#include "kernels/kernel.h"
+#include "kernels/debug.h"
 #include "kernels/utils/common.h"
 #include "kernels/tensor_stride_process/tensor_stride_process_common.h"
 #include "kernels/tensor_stride_process/tensor_stride_process_host.h"
-#include "kernels/tensor_stride_process/tensor_stride_process_mlu.h"
 
 #define ALIGN_NUM 64
 #define UNARY_NRAM_SIZE (MAX_NRAM_SIZE + REM_FOR_STACK - 148 * 1024)


### PR DESCRIPTION

## 1. Motivation

div中存在已经废弃的冗余代码，影响代码精简度。
log中涉及unary_op/unary_op_5pipeline.h未被使用，且实现中并未进行优化处理，可以删除。
sqrt中多引入了unary_op_5pipeline.h，实现中却未调用该头文件中的函数。
tensor_stride_process_mlu.mlu头文件引入不规范，造成重复include。

## 2. Modification
删除div中有关三级流水的冗余代码。
删除log中有关五级流水的冗余代码。
删除sqrt中对unary_op_5pipeline.h的引入。
删除tensor_stride_process_mlu.mlu中冗余的头文件，并将其中的函数声明和定义分离。


