### PR TITLE
[Feature](mluOpMsDeformAttnBackward): improve perf on compute_50 for specific cases

### DIFF
--- a/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward_fast_union1.mlu
+++ b/kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward_fast_union1.mlu
@@ -556,11 +556,10 @@ __mlu_func__ void backwardStageTwoLoopAlgo2(
         __memcpy_async(wram_buffer + wram_offset_0, buffer, buffer_size_pad,
                        NRAM2WRAM);
         __sync_move();
-        // inter_grad (qlpc) <= grad_out (qlpc) * weight_attn (qlp)
+        // inter_grad (qlpc) <= grad_out (buffer)(qlpc) * weight_attn (qlp)
         __bang_expand_channel_mul((T *)inter_grad, (T *)weight_attn_nram,
-                                  (T *)wram_buffer,
-            (T *)buffer,
-            nq_nl_np, channels);
+                                  (T *)wram_buffer, (T *)buffer, nq_nl_np,
+                                  channels);
         __sync_compute();
       }
 
@@ -577,12 +576,8 @@ __mlu_func__ void backwardStageTwoLoopAlgo2(
         // value_wp (qlpc) <= tmp_wp (1,qlp,1,1) x ones (c,1,1,1) *
         //                    value (v_pong) (qlpc) + value_wp (qlpc)
         __bang_expand_channel_mul_add(
-            (float *)value_wp,
-            (float *)tmp_wp,
-            (float *)wram_buffer,
-            (float *)v_pong,
-            (float *)value_wp,
-            nq_nl_np, channels);
+            (float *)value_wp, (float *)tmp_wp, (float *)wram_buffer,
+            (float *)v_pong, (float *)value_wp, nq_nl_np, channels);
         // tmp_c (qlpc) => WRAM, qlp should expand to 64(LT)-align
         /* NRAM2WRAM memcpy param:
             希望在WRAM摆下 filter (qlp,1,1,c)
@@ -683,9 +678,7 @@ __mlu_func__ void backwardStageTwoLoopAlgo2(
       __bang_expand_channel_mul(
           (float *)grad_value_buffer + k * buffer_data_num,
           (float *)weight_polation_nram + neighbor_idx * nq_nl_np,
-          (float *)wram_buffer,
-          (float *)inter_grad,
-          nq_nl_np, channels);
+          (float *)wram_buffer, (float *)inter_grad, nq_nl_np, channels);
     }
 
     // store all valid point


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Improve the performance of ms_deform_attn_backward on special cases.

## 2. Modification

        modified:   build.property
        modified:   kernels/ms_deform_attn/ms_deform_attn_backward/ms_deform_attn_backward_fast_union1.mlu

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [x] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [x] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU590

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.