### PR TITLE
fix(dynamic_point_to_voxel): fix incorrect voxel_feats_offset

### DIFF
--- a/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_union1.mlu
+++ b/kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_union1.mlu
@@ -223,13 +223,8 @@ __mlu_global__ void MLUKernelDynamicPointToVoxelForward(
         float *voxel_feats_offset = NULL;
         int reduce_to = nram_map[i];
         if (reduce_to == -1) continue;
-        if (num_feats > max_deal_h) {
-          voxel_feats_offset = voxel_feats + reduce_to * num_feats +
-                               h_iter * deal_h + num_feats * p_iter;
-        } else {
-          voxel_feats_offset =
-              voxel_feats + reduce_to * num_feats + h_iter * deal_h;
-        }
+        voxel_feats_offset =
+            voxel_feats + reduce_to * num_feats + h_iter * deal_h;
         if (reduce_mode == MLUOP_REDUCE_DMAX) {
           __bang_atomic_reduce_max(voxel_feats_offset, nram_feats + i * deal_h,
                                    deal_h_num);


### PR DESCRIPTION
## 1. Motivation
修复dynamic_point_to_voxel，正确索引应始终只由 voxel id 和 feature 块内偏移决定

## 2. Modification
modified:   kernels/dynamic_point_to_voxel/dynamic_point_to_voxel_forward/dynamic_point_to_voxel_forward_union1.mlu

## 3. Test Report

Use CI test result as report.