### PR TITLE
[Fix](mlu-ops): fix redefination

### DIFF
--- a/samples/mlu-ops/abs_sample/abs_sample.cc
+++ b/samples/mlu-ops/abs_sample/abs_sample.cc
@@ -34,7 +34,7 @@ const double EPSILON = 1e-9;
 const double EPSILON_FLOAT = 1e-6;
 const double EPSILON_HALF = 1e-3;
 
-void mluOpCheck(mluOpStatus_t result, char const *const func,
+void mluOpCheckStatus(mluOpStatus_t result, char const *const func,
                 const char *const file, int const line) {
   if (result) {
     std::string error = "\"" + std::string(mluOpGetErrorString(result)) +
@@ -43,7 +43,7 @@ void mluOpCheck(mluOpStatus_t result, char const *const func,
   }
 }
 
-#define MLUOP_CHECK(val) mluOpCheck((val), #val, __FILE__, __LINE__)
+#define MLUOP_CHECK_STATUS(val) mluOpCheckStatus((val), #val, __FILE__, __LINE__)
 
 struct HostTimer {
   struct timespec t0 = {0, 0};
@@ -180,13 +180,13 @@ int main(int argc, char *argv[]) {
   mluOpDataType_t type = MLUOP_DTYPE_FLOAT;
 
   mluOpTensorDescriptor_t input_tensor_desc;
-  MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_tensor_desc));
-  MLUOP_CHECK(mluOpSetTensorDescriptor(input_tensor_desc, MLUOP_LAYOUT_ARRAY,
+  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&input_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(input_tensor_desc, MLUOP_LAYOUT_ARRAY,
                                        type, dimNb, dimSize));
 
   mluOpTensorDescriptor_t output_tensor_desc;
-  MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_tensor_desc));
-  MLUOP_CHECK(mluOpSetTensorDescriptor(output_tensor_desc, MLUOP_LAYOUT_ARRAY,
+  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&output_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(output_tensor_desc, MLUOP_LAYOUT_ARRAY,
                                        type, dimNb, dimSize));
 
   // cpu compute
@@ -215,7 +215,7 @@ int main(int argc, char *argv[]) {
 
   // call mluOpAbs interface
   interface_timer.start();
-  MLUOP_CHECK(mluOpAbs(handle, input_tensor_desc, input_tensor_ptr,
+  MLUOP_CHECK_STATUS(mluOpAbs(handle, input_tensor_desc, input_tensor_ptr,
                        output_tensor_desc, output_tensor_ptr));
   interface_timer.stop();
 
@@ -241,13 +241,13 @@ int main(int argc, char *argv[]) {
   CNRT_CHECK(cnrtFree(input_tensor_ptr));
   CNRT_CHECK(cnrtFree(output_tensor_ptr));
 
-  MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_tensor_desc));
-  MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(input_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(output_tensor_desc));
 
   CNRT_CHECK(cnrtNotifierDestroy(start));
   CNRT_CHECK(cnrtNotifierDestroy(end));
 
   CNRT_CHECK(cnrtQueueDestroy(queue));
-  MLUOP_CHECK(mluOpDestroy(handle));
+  MLUOP_CHECK_STATUS(mluOpDestroy(handle));
   return 0;
 }

--- a/samples/mlu-ops/abs_sample/abs_sample.cc
+++ b/samples/mlu-ops/abs_sample/abs_sample.cc
@@ -34,7 +34,9 @@ const double EPSILON = 1e-9;
 const double EPSILON_FLOAT = 1e-6;
 const double EPSILON_HALF = 1e-3;
 
-void mluOpCheckStatus(mluOpStatus_t result, char const *const func,
+namespace abs_sample {
+
+void mluOpCheck(mluOpStatus_t result, char const *const func,
                 const char *const file, int const line) {
   if (result) {
     std::string error = "\"" + std::string(mluOpGetErrorString(result)) +
@@ -43,7 +45,7 @@ void mluOpCheckStatus(mluOpStatus_t result, char const *const func,
   }
 }
 
-#define MLUOP_CHECK_STATUS(val) mluOpCheckStatus((val), #val, __FILE__, __LINE__)
+#define MLUOP_CHECK(val) mluOpCheck((val), #val, __FILE__, __LINE__)
 
 struct HostTimer {
   struct timespec t0 = {0, 0};
@@ -152,8 +154,10 @@ void printTestCaseShape(const ShapeParam &param) {
   }
   printf(" %d]\n", param.shape[param.dims - 1]);
 }
+}
 
 int main(int argc, char *argv[]) {
+  using namespace abs_sample;
   ShapeParam abs_param;
   HostTimer interface_timer;
   HostTimer cpu_compute_timer;
@@ -180,13 +184,13 @@ int main(int argc, char *argv[]) {
   mluOpDataType_t type = MLUOP_DTYPE_FLOAT;
 
   mluOpTensorDescriptor_t input_tensor_desc;
-  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&input_tensor_desc));
-  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(input_tensor_desc, MLUOP_LAYOUT_ARRAY,
+  MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_tensor_desc));
+  MLUOP_CHECK(mluOpSetTensorDescriptor(input_tensor_desc, MLUOP_LAYOUT_ARRAY,
                                        type, dimNb, dimSize));
 
   mluOpTensorDescriptor_t output_tensor_desc;
-  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&output_tensor_desc));
-  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(output_tensor_desc, MLUOP_LAYOUT_ARRAY,
+  MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_tensor_desc));
+  MLUOP_CHECK(mluOpSetTensorDescriptor(output_tensor_desc, MLUOP_LAYOUT_ARRAY,
                                        type, dimNb, dimSize));
 
   // cpu compute
@@ -215,7 +219,7 @@ int main(int argc, char *argv[]) {
 
   // call mluOpAbs interface
   interface_timer.start();
-  MLUOP_CHECK_STATUS(mluOpAbs(handle, input_tensor_desc, input_tensor_ptr,
+  MLUOP_CHECK(mluOpAbs(handle, input_tensor_desc, input_tensor_ptr,
                        output_tensor_desc, output_tensor_ptr));
   interface_timer.stop();
 
@@ -241,13 +245,13 @@ int main(int argc, char *argv[]) {
   CNRT_CHECK(cnrtFree(input_tensor_ptr));
   CNRT_CHECK(cnrtFree(output_tensor_ptr));
 
-  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(input_tensor_desc));
-  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(output_tensor_desc));
+  MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_tensor_desc));
+  MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_tensor_desc));
 
   CNRT_CHECK(cnrtNotifierDestroy(start));
   CNRT_CHECK(cnrtNotifierDestroy(end));
 
   CNRT_CHECK(cnrtQueueDestroy(queue));
-  MLUOP_CHECK_STATUS(mluOpDestroy(handle));
+  MLUOP_CHECK(mluOpDestroy(handle));
   return 0;
 }

--- a/samples/mlu-ops/poly_nms_sample/poly_nms_sample.cc
+++ b/samples/mlu-ops/poly_nms_sample/poly_nms_sample.cc
@@ -25,7 +25,7 @@
 
 #include "mlu_op.h"
 
-namespace abs_sample {
+namespace poly_nms_sample {
 
 void mluOpCheck(mluOpStatus_t result, char const *const func,
                 const char *const file, int const line) {
@@ -50,7 +50,7 @@ void initDevice(int &dev, cnrtQueue_t &queue, mluOpHandle_t &handle) {
 }
 
 int main(int argc, char *argv[]) {
-  using namespace abs_sample;
+  using namespace poly_nms_sample;
   int dev;
   mluOpHandle_t handle = nullptr;
   cnrtQueue_t queue = nullptr;

--- a/samples/mlu-ops/poly_nms_sample/poly_nms_sample.cc
+++ b/samples/mlu-ops/poly_nms_sample/poly_nms_sample.cc
@@ -25,7 +25,9 @@
 
 #include "mlu_op.h"
 
-void mluOpCheckStatus(mluOpStatus_t result, char const *const func,
+namespace abs_sample {
+
+void mluOpCheck(mluOpStatus_t result, char const *const func,
                 const char *const file, int const line) {
   if (result) {
     std::string error = "\"" + std::string(mluOpGetErrorString(result)) +
@@ -34,7 +36,7 @@ void mluOpCheckStatus(mluOpStatus_t result, char const *const func,
   }
 }
 
-#define MLUOP_CHECK_STATUS(val) mluOpCheckStatus((val), #val, __FILE__, __LINE__)
+#define MLUOP_CHECK(val) mluOpCheck((val), #val, __FILE__, __LINE__)
 
 void initDevice(int &dev, cnrtQueue_t &queue, mluOpHandle_t &handle) {
   CNRT_CHECK(cnrtGetDevice(&dev));
@@ -42,11 +44,13 @@ void initDevice(int &dev, cnrtQueue_t &queue, mluOpHandle_t &handle) {
 
   CNRT_CHECK(cnrtQueueCreate(&queue));
 
-  MLUOP_CHECK_STATUS(mluOpCreate(&handle));
-  MLUOP_CHECK_STATUS(mluOpSetQueue(handle, queue));
+  MLUOP_CHECK(mluOpCreate(&handle));
+  MLUOP_CHECK(mluOpSetQueue(handle, queue));
+}
 }
 
 int main(int argc, char *argv[]) {
+  using namespace abs_sample;
   int dev;
   mluOpHandle_t handle = nullptr;
   cnrtQueue_t queue = nullptr;
@@ -69,8 +73,8 @@ int main(int argc, char *argv[]) {
   mluOpDataType_t type = MLUOP_DTYPE_FLOAT;
 
   mluOpTensorDescriptor_t input_tensor_desc;
-  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&input_tensor_desc));
-  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(input_tensor_desc, layout, type, dim_num,
+  MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_tensor_desc));
+  MLUOP_CHECK(mluOpSetTensorDescriptor(input_tensor_desc, layout, type, dim_num,
                                        dim_size));
 
   int output_dim_nb = 1;
@@ -79,14 +83,14 @@ int main(int argc, char *argv[]) {
   mluOpDataType_t output_type = MLUOP_DTYPE_INT32;
 
   mluOpTensorDescriptor_t output_tensor_desc;
-  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&output_tensor_desc));
-  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(output_tensor_desc, output_layout,
+  MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_tensor_desc));
+  MLUOP_CHECK(mluOpSetTensorDescriptor(output_tensor_desc, output_layout,
                                        output_type, output_dim_nb,
                                        output_dim_size));
 
   // get workspace size
   size_t workspace_size = 0;
-  MLUOP_CHECK_STATUS(
+  MLUOP_CHECK(
       mluOpGetPolyNmsWorkspaceSize(handle, input_tensor_desc, &workspace_size));
 
   // create workspace ptr
@@ -111,7 +115,7 @@ int main(int argc, char *argv[]) {
   const float iou_threshold = 0.5;
 
   // call mluOpPolyNms interface
-  MLUOP_CHECK_STATUS(mluOpPolyNms(
+  MLUOP_CHECK(mluOpPolyNms(
       handle, input_tensor_desc, input_tensor_ptr, iou_threshold, workspace_ptr,
       workspace_size, output_tensor_desc, output_tensor_ptr, output_size_ptr));
 
@@ -146,10 +150,10 @@ int main(int argc, char *argv[]) {
   CNRT_CHECK(cnrtFree(workspace_ptr));
   CNRT_CHECK(cnrtFree(output_size_ptr));
 
-  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(input_tensor_desc));
-  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(output_tensor_desc));
+  MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_tensor_desc));
+  MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_tensor_desc));
 
   CNRT_CHECK(cnrtQueueDestroy(queue));
-  MLUOP_CHECK_STATUS(mluOpDestroy(handle));
+  MLUOP_CHECK(mluOpDestroy(handle));
   return 0;
 }

--- a/samples/mlu-ops/poly_nms_sample/poly_nms_sample.cc
+++ b/samples/mlu-ops/poly_nms_sample/poly_nms_sample.cc
@@ -25,7 +25,7 @@
 
 #include "mlu_op.h"
 
-void mluOpCheck(mluOpStatus_t result, char const *const func,
+void mluOpCheckStatus(mluOpStatus_t result, char const *const func,
                 const char *const file, int const line) {
   if (result) {
     std::string error = "\"" + std::string(mluOpGetErrorString(result)) +
@@ -34,7 +34,7 @@ void mluOpCheck(mluOpStatus_t result, char const *const func,
   }
 }
 
-#define MLUOP_CHECK(val) mluOpCheck((val), #val, __FILE__, __LINE__)
+#define MLUOP_CHECK_STATUS(val) mluOpCheckStatus((val), #val, __FILE__, __LINE__)
 
 void initDevice(int &dev, cnrtQueue_t &queue, mluOpHandle_t &handle) {
   CNRT_CHECK(cnrtGetDevice(&dev));
@@ -42,8 +42,8 @@ void initDevice(int &dev, cnrtQueue_t &queue, mluOpHandle_t &handle) {
 
   CNRT_CHECK(cnrtQueueCreate(&queue));
 
-  MLUOP_CHECK(mluOpCreate(&handle));
-  MLUOP_CHECK(mluOpSetQueue(handle, queue));
+  MLUOP_CHECK_STATUS(mluOpCreate(&handle));
+  MLUOP_CHECK_STATUS(mluOpSetQueue(handle, queue));
 }
 
 int main(int argc, char *argv[]) {
@@ -69,8 +69,8 @@ int main(int argc, char *argv[]) {
   mluOpDataType_t type = MLUOP_DTYPE_FLOAT;
 
   mluOpTensorDescriptor_t input_tensor_desc;
-  MLUOP_CHECK(mluOpCreateTensorDescriptor(&input_tensor_desc));
-  MLUOP_CHECK(mluOpSetTensorDescriptor(input_tensor_desc, layout, type, dim_num,
+  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&input_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(input_tensor_desc, layout, type, dim_num,
                                        dim_size));
 
   int output_dim_nb = 1;
@@ -79,14 +79,14 @@ int main(int argc, char *argv[]) {
   mluOpDataType_t output_type = MLUOP_DTYPE_INT32;
 
   mluOpTensorDescriptor_t output_tensor_desc;
-  MLUOP_CHECK(mluOpCreateTensorDescriptor(&output_tensor_desc));
-  MLUOP_CHECK(mluOpSetTensorDescriptor(output_tensor_desc, output_layout,
+  MLUOP_CHECK_STATUS(mluOpCreateTensorDescriptor(&output_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpSetTensorDescriptor(output_tensor_desc, output_layout,
                                        output_type, output_dim_nb,
                                        output_dim_size));
 
   // get workspace size
   size_t workspace_size = 0;
-  MLUOP_CHECK(
+  MLUOP_CHECK_STATUS(
       mluOpGetPolyNmsWorkspaceSize(handle, input_tensor_desc, &workspace_size));
 
   // create workspace ptr
@@ -111,7 +111,7 @@ int main(int argc, char *argv[]) {
   const float iou_threshold = 0.5;
 
   // call mluOpPolyNms interface
-  MLUOP_CHECK(mluOpPolyNms(
+  MLUOP_CHECK_STATUS(mluOpPolyNms(
       handle, input_tensor_desc, input_tensor_ptr, iou_threshold, workspace_ptr,
       workspace_size, output_tensor_desc, output_tensor_ptr, output_size_ptr));
 
@@ -146,10 +146,10 @@ int main(int argc, char *argv[]) {
   CNRT_CHECK(cnrtFree(workspace_ptr));
   CNRT_CHECK(cnrtFree(output_size_ptr));
 
-  MLUOP_CHECK(mluOpDestroyTensorDescriptor(input_tensor_desc));
-  MLUOP_CHECK(mluOpDestroyTensorDescriptor(output_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(input_tensor_desc));
+  MLUOP_CHECK_STATUS(mluOpDestroyTensorDescriptor(output_tensor_desc));
 
   CNRT_CHECK(cnrtQueueDestroy(queue));
-  MLUOP_CHECK(mluOpDestroy(handle));
+  MLUOP_CHECK_STATUS(mluOpDestroy(handle));
   return 0;
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU590

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.