### PR TITLE
[Fix](mluAdamW):fix remove_nan error

### DIFF
--- a/kernels_light/adam_w_light/adam_w_device_remove_nan.mluh
+++ b/kernels_light/adam_w_light/adam_w_device_remove_nan.mluh
@@ -23,63 +23,85 @@
 #include "adam_w_func.h"
 
 __mlu_func__ void computeAdamWRemoveNan(
-    bfloat16_t *nbuf_paramh, bfloat16_t *nbuf_grad, float *nbuf_param,
-    float *nbuf_grad_ptr, float *nbuf_momentum, float *nbuf_velocity,
-    float *temp_1, float *temp_2, float lr, float beta1, float beta2,
-    float bias1, float bias2, float epsilon, float weight_decay,
-    float scale, bool use_nesterov, int deal_num, int offset) {
-  __bang_bfloat162float(nbuf_grad_ptr + offset, nbuf_grad + offset * 2,
-                        deal_num);
+    float *nbuf_step, float *nbuf_param, float *nbuf_grad_ptr,
+    float *nbuf_momentum, float *nbuf_velocity,
+    float *output_mask, float *input_mask,
+    float *temp_param, float *temp_momentum,
+    float *temp_velocity, float lr, float beta1,
+    float beta2, float bias1, float bias2,
+    float epsilon, float weight_decay,
+    float scale, bool use_nesterov, int deal_num,
+    int offset) {  // offset is pingpong offset
   __bang_mul_scalar(nbuf_grad_ptr + offset, nbuf_grad_ptr + offset,
                     1.0f / scale, deal_num);
   // m = m * beta1 + (1 - beta1) * g
-  __bang_mul_scalar(nbuf_momentum + offset, nbuf_momentum + offset, beta1,
+  __bang_mul_scalar(temp_momentum, nbuf_momentum + offset, beta1,
                     deal_num);
-  __bang_fusion(FUSION_FMA, nbuf_momentum + offset, nbuf_grad_ptr + offset,
-                (1.0f - beta1), nbuf_momentum + offset, deal_num,
+  __bang_fusion(FUSION_FMA, temp_momentum, nbuf_grad_ptr + offset,
+                (1.0f - beta1), temp_momentum, deal_num,
                 deal_num);
 
   // v = v * beta2 + (1 - beta2) * g * g
-  __bang_mul_scalar(nbuf_velocity + offset, nbuf_velocity + offset, beta2,
+  __bang_mul_scalar(temp_velocity, nbuf_velocity + offset, beta2,
                     deal_num);
-  __bang_mul_scalar(temp_1, nbuf_grad_ptr + offset, 1.0f - beta2, deal_num);
-  __bang_fusion(FUSION_FMA, nbuf_velocity + offset, temp_1,
-                nbuf_grad_ptr + offset, nbuf_velocity + offset, deal_num,
+  __bang_mul_scalar(output_mask, nbuf_grad_ptr + offset, 1.0f - beta2,
+                    deal_num);
+  __bang_fusion(FUSION_FMA, temp_velocity, output_mask,
+                nbuf_grad_ptr + offset, temp_velocity, deal_num,
                 deal_num);
 
-  // param = param - lr * m / bias1 / (sqrt(v / bias2) + epsilon) - lr *
-  // weight_decay * param
-  bang_fusor<float>(temp_2, nbuf_velocity + offset, deal_num)
-                   .mul(1.0f / bias2)
-                   .sqrt()
-                   .add(epsilon);
-  bang_fusor<float>(temp_1, nbuf_momentum + offset, deal_num)
-                   .mul(lr)
-                   .mul(1.0f / bias1);
-  __bang_div(temp_1, temp_1, temp_2, deal_num);
-  __bang_mul_scalar(temp_2, nbuf_param + offset, (- lr * weight_decay),
-                    deal_num);
-  __bang_fusion(FUSION_FAS, nbuf_param + offset, nbuf_param + offset, temp_2,
-                temp_1, deal_num, deal_num);
-  __bang_float2bfloat16_rn(nbuf_paramh + offset, nbuf_param + offset, deal_num);
+  // param = param * (1 - lr * weight_decay) -
+  //         lr * m / bias1 / (sqrt(v / bias2) + epsilon)
+  bang_fusor<float>(input_mask, temp_velocity, deal_num)
+                  .mul(1.0f / bias2)
+                  .sqrt()
+                  .add(epsilon);
+  bang_fusor<float>(output_mask, temp_momentum, deal_num)
+                  .mul(lr)
+                  .mul(1.0f / bias1);
+  __bang_div(output_mask, output_mask, input_mask, deal_num);
+  __bang_mul_scalar(input_mask, nbuf_param + offset,
+                    (1 - lr * weight_decay), deal_num);
+  __bang_sub(temp_param, input_mask, output_mask, deal_num);
+
+  // get output_mask and input_mask
+  get_nan_inf_mask(input_mask, temp_param, deal_num);
+  get_nan_inf_mask(output_mask, temp_momentum, deal_num);
+  __bang_band(input_mask, input_mask, output_mask, deal_num);
+  get_nan_inf_mask(output_mask, temp_velocity, deal_num);
+  __bang_band(input_mask, input_mask, output_mask, deal_num);
+  __bang_not((uint32_t *)output_mask, (uint32_t *)input_mask, deal_num);
+
+  // param
+  __bang_mul((uint32_t *)temp_param, (uint32_t *)output_mask,
+             (uint32_t *)temp_param, deal_num);
+  __bang_mul((uint32_t *)(nbuf_param + offset), (uint32_t *)input_mask,
+             (uint32_t *)(nbuf_param + offset), deal_num);
+  __bang_add(nbuf_param + offset, temp_param, nbuf_param + offset,
+             deal_num);
+  // momentum
+  __bang_mul((uint32_t *)temp_momentum, (uint32_t *)output_mask,
+             (uint32_t *)temp_momentum, deal_num);
+  __bang_mul((uint32_t *)(nbuf_momentum + offset), (uint32_t *)input_mask,
+             (uint32_t *)(nbuf_momentum + offset), deal_num);
+  __bang_add(nbuf_momentum + offset, temp_momentum, nbuf_momentum + offset,
+             deal_num);
+  // velocity
+  __bang_mul((uint32_t *)temp_velocity, (uint32_t *)output_mask,
+             (uint32_t *)temp_velocity, deal_num);
+  __bang_mul((uint32_t *)(nbuf_velocity + offset), (uint32_t *)input_mask,
+             (uint32_t *)(nbuf_velocity + offset), deal_num);
+  __bang_add(nbuf_velocity + offset, temp_velocity, nbuf_velocity + offset,
+             deal_num);
 }
 
 template <typename T>
-__mlu_func__ void computeAdamWRemoveNan(
-    T *nbuf_paramh, T *nbuf_grad, float *nbuf_param, float *nbuf_grad_ptr,
-    float *nbuf_momentum, float *nbuf_velocity, float *temp_1, float *temp_2,
-    float lr, float beta1, float beta2, float bias1, float bias2,
-    float epsilon, float weight_decay, float scale, bool use_nesterov,
-    int deal_num, int offset) {
-  return;
-}
-
-template <typename T>
-__mlu_global__ void unionApplyAdamWRemoveNan(
-    T *param_h, T *grad, float *param, float *momentum, float *velocity,
-    float lr, float beta1, float beta2, float bias1, float bias2,
-    float epsilon, float weight_decay, float scale, bool use_nesterov,
-    size_t size) {
+__mlu_global__ void unionApplyAdamWRemoveNan(T *step, T *grad, float *param,
+                                            float *momentum, float *velocity, float lr,
+                                            float beta1, float beta2, float bias1,
+                                            float bias2, float epsilon,
+                                            float weight_decay, float scale,
+                                            bool use_nesterov, size_t size) {
   PERF_TIME_BEGIN();
   if (__is_mpu()) {
     return;
@@ -98,58 +120,81 @@ __mlu_global__ void unionApplyAdamWRemoveNan(
     task_offset = taskId * num_per_task + rem_idx;
     num_task = num_per_task;
   }
-  // when dtype is float, NRAM is split to 11 part for ping-pong pipeline
-  int num_nbuf_part = 11;
+  // when dtype is float, NRAM is split to 15 part for ping-pong pipeline
+  int num_nbuf_part = 13;
   int num_x =
-      PAD_DOWN(MAX_NRAM_SIZE / sizeof(float) / num_nbuf_part, num_align);
+      PAD_DOWN((MAX_NRAM_SIZE / sizeof(float) -1 ) / num_nbuf_part, num_align);
   int pong = num_x;
 
-  // | param |     |  param_h  |    |  grad  |     |   m  |     | v |    |
-  // temp_1  |  temp_2  |
+  // param: 2 * num_x
   float *nbuf_param = (float *)nbuf_head;
-  T *nbuf_paramh = (T *)(nbuf_param + 2 * num_x);
-  float *nbuf_grad = (float *)(nbuf_paramh + 2 * num_x);
+  // nbuf_grad: 2 * num_x
+  float *nbuf_grad = nbuf_param + 2 * num_x;
+  // nbuf_momentum: 2 * num_x
   float *nbuf_momentum = nbuf_grad + 2 * num_x;
+  // nbuf_velocity: 2 * num_x
   float *nbuf_velocity = nbuf_momentum + 2 * num_x;
-  float *temp_1 = nbuf_velocity + 2 * num_x;
-  float *temp_2 = nbuf_velocity + 3 * num_x;
+  // temp_param: num_x
+  float *temp_param = nbuf_velocity + 2 * num_x;
+  // temp_momentum: num_x
+  float *temp_momentum = temp_param + num_x;
+  // temp_velocity: num_x
+  float *temp_velocity = temp_momentum + num_x;
+  // output_mask: num_x
+  float *output_mask = temp_velocity + num_x;
+  // input_mask: num_x
+  float *input_mask = output_mask + num_x;
+  // step: 1
+  float *nbuf_step = input_mask + num_x;
 
-  T *ddr_paramh = param_h + task_offset;
-  T *ddr_grad = grad + task_offset;
-
+  float *ddr_step = (float *)step;
+  float *ddr_grad = (float *)grad + task_offset;
   float *ddr_param = param + task_offset;
   float *ddr_momentum = momentum + task_offset;
   float *ddr_velocity = velocity + task_offset;
   int num_iter = (num_task + num_x - 1) / num_x;
+  bias1 = 1.0f - std::pow(beta1, ((float *)step)[0]);
+  bias2 = 1.0f - std::pow(beta2, ((float *)step)[0]);
 
   // 3 stage pipeline
   for (int i = 0; i < num_iter + 2; ++i) {
     // store data
     if (i >= 2) {
-      storeData(ddr_paramh - 2 * num_x,
-                ddr_param - 2 * num_x, ddr_momentum - 2 * num_x,
-                ddr_velocity - 2 * num_x, nbuf_paramh, nbuf_param,
+      storeData(ddr_param - 2 * num_x, ddr_momentum - 2 * num_x,
+                ddr_velocity - 2 * num_x, nbuf_param,
                 nbuf_momentum, nbuf_velocity,
                 MIN(num_x, (int)(num_task - (i - 2) * num_x)),
                 (i - 2) % 2 * pong);
+      if ((i == num_iter + 1) && (taskId == taskDim - 1)) {
+        __memcpy_async(ddr_step, nbuf_step, sizeof(float), NRAM2GDRAM);
+      }
     }
     // load data
     if (i <= num_iter - 1) {
-      loadData(nbuf_paramh, (T *)(nbuf_grad + pong / 2), nbuf_param,
-               nbuf_momentum, nbuf_velocity, ddr_paramh, ddr_grad, ddr_param,
-               ddr_momentum, ddr_velocity,
-               MIN(num_x, (int)(num_task - i * num_x)), i % 2 * pong);
+      loadData(nbuf_grad, nbuf_param,
+              nbuf_momentum, nbuf_velocity, ddr_grad, ddr_param,
+              ddr_momentum, ddr_velocity,
+              MIN(num_x, (int)(num_task - i * num_x)), i % 2 * pong);
+      if ((i == num_iter - 1) && (taskId == taskDim - 1)) {
+        __memcpy_async(nbuf_step, ddr_step, sizeof(float), GDRAM2NRAM);
+      }
     }
     // compute
     if (i >= 1 && i <= num_iter) {
       computeAdamWRemoveNan(
-          nbuf_paramh, (T *)(nbuf_grad + pong / 2), nbuf_param,
-          nbuf_grad, nbuf_momentum, nbuf_velocity, temp_1, temp_2, lr,
+          nbuf_step, nbuf_param,
+          nbuf_grad, nbuf_momentum, nbuf_velocity, output_mask, input_mask,
+          temp_param, temp_momentum, temp_velocity, lr,
           beta1, beta2, bias1, bias2, epsilon, weight_decay, scale,
           use_nesterov, MIN(num_x, (int)(num_task - (i - 1) * num_x)),
           (i - 1) % 2 * pong);
+      if ((i == num_iter) && (taskId == taskDim - 1)) {
+        __bang_add_scalar(nbuf_step, nbuf_step, 1.0f, 1);
+        if (std::isinf((nbuf_step)[0])) {
+          __bang_write_value(nbuf_step, 1, std::numeric_limits<float>::max());
+        }
+      }
     }
-    ddr_paramh += num_x;
     ddr_grad += num_x;
     ddr_param += num_x;
     ddr_momentum += num_x;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. :rocket::rocket:

## 1. Motivation

Please describe your motivation and the goal you want to achieve through this pull request.

## 2. Modification

Please briefly describe what modification is made in this pull request, and indicate where to make the modification.

Are new test cases added? If so, please post the corresponding generator-PR link here.

## 3. Test Report

If you want to know how to do operator testing, you can see [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md).

### 3.1 Modification Details

#### 3.1.1 Accuracy Acceptance Standard

For static threshold standard details, see: [MLU-OPS™ Accuracy Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Accuracy-Acceptance-Standard.md).

- static threshold
  - diff1
    - [ ] float32 mlu diff1 <= 1e-5
    - [ ] float32 mlu diff1 <= 3e-3
    - [ ] float16 mlu diff1 <= 3e-3
  - diff2
    - [ ] float32 mlu diff2 <= 1e-5
    - [ ] float32 mlu diff2 <= 3e-3
    - [ ] float16 mlu diff2 <= 3e-3
  - diff3
    - [ ] mlu diff3 == 0
    - [ ] mlu diff3_1 == 0
    - [ ] mlu diff3_2 == 0
- dynamic threshold
  - [ ] diff1: mlu diff1 <= max(baseline diff1 * 10, static threshold)
  - [ ] diff2: mlu diff2 <= max(baseline diff2 * 10, static threshold)
  - [ ] diff3: mlu diff3 <= max(baseline diff3 * 10, static threshold)
    - float32, threshold = 1e-5
    - float16, threshold = 1e-3

#### 3.1.2 Operator Scheme checklist

- Supported hardware
  - [ ] MLU590
- Job types
  - [ ] BLOCK
  - [ ] UNION1
  - [ ] UNION2
  - [ ] UNION4
  - [ ] The operator will dynamically select the most suitable task type, for example, UNION8

### 3.2 Accuracy Test

#### 3.2.1 Accuracy Test

If you have checked the following items, please tick the relevant box.

- [ ] Data type test (e.g. float32/int8)
- [ ] Multi-dimensional tensor test
- [ ] Layout test
- [ ] Different size/integer remainder end segment/alignment misalignment test
- [ ] Zero dimensional tensor test/zero element test
- [ ] stability test
- [ ] Multiple platform test
- [ ] Gen_case module test, see: [Gencase-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/Gencase-User-Guide-zh.md)
- [ ] Nan/INF tests 
- [ ] Bug fix tests
- [ ] For memory leak check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For code coverage check details, see: [GTest-User-Guide-zh](https://github.com/Cambricon/mlu-ops/blob/master/docs/GTest-User-Guide-zh.md)
- [ ] For I/O calculation efficiency check details, see: [MLU-OPS™-Performance-Acceptance-Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md)

#### 3.2.2 Parameter Check

Test Point-1: `When a new operator is submitted, the test points are given and the test results are stated`. Acceptance Standard: `Normal error`.
```bash
Please fill your test results(Error Message) in here, ...
```

Test Point-2: `Whether illegal parameters are passed`. Acceptance Standard: `Normal error`.
```bash
Test results...
```


### 3.3 Performance Test

See [MLU-OPS™ Performance Acceptance Standard](https://github.com/Cambricon/mlu-ops/blob/master/docs/MLU-OPS-Performance-Acceptance-Standard.md) for details.

Platform：MLU590

```bash
# The test results should contain Op name, Shape, Data type,  
#   MLU Hardware Time(us), MLU Interface Time(us), MLU IO Efficiency, 
#   MLU Compute Efficiency, and Mlu Workspace Size(Bytes)
# 
# for example:
#
# ----------- case0 -----------
# case0
# [Op name                ]: abs
# [Shape                  ]: input.shape=[1024,1024,3,4], output.shape=[1024,1024,3,4]
# [Data type]             ]: float32
# [MLU Hardware Time      ]: 15728 (us)
# [MLU Interface Time     ]: 369.008 (us)
# [MLU IO Efficiency      ]: 0.23275
# [MLU Compute Efficiency ]: 0.5
# [Mlu Workspace Size     ]: -1 (Bytes)
# 
# ----------- case1 -----------
# ...
```

### 3.4 Summary Analysis

Please give a brief overview here, if you want to note and summarize the content.